### PR TITLE
Check that class name starts with a capital letter #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea/
+**/*.iml

--- a/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRule.kt
@@ -1,0 +1,27 @@
+package com.gihub.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+class CapitalizedClassNamesRule : Rule("capitalized-class-name") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, message: String, canAutoCorrect: Boolean) -> Unit) {
+
+        val type = node.elementType
+
+        if (type == KtStubElementTypes.CLASS) {
+            val identifier = node.getChildren(null).first { it.elementType == KtTokens.IDENTIFIER }
+            if (identifier.text.toCharArray()[0].isLowerCase()) {
+                emit(identifier.startOffset, "Class `${identifier.text}` should be capitalized", false)
+            }
+        }
+
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRule.kt
@@ -1,9 +1,7 @@
 package com.gihub.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.Rule
-import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -17,7 +17,8 @@ class StandardRuleSetProvider : RuleSetProvider {
         SpacingAfterKeywordRule(),
         SpacingAroundColonRule(),
         SpacingAroundCurlyRule(),
-        SpacingAroundOperatorsRule()
+        SpacingAroundOperatorsRule(),
+        CapitalizedClassNamesRule()
     )
 
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/CapitalizedClassNamesRuleTest.kt
@@ -1,0 +1,63 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.gihub.shyiko.ktlint.ruleset.standard.CapitalizedClassNamesRule
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+
+class CapitalizedClassNamesRuleTest {
+
+    val rule = CapitalizedClassNamesRule()
+
+    @Test
+    fun `has error for non capitalized class`() {
+        assertThat(
+            """
+            class myClass
+            """.lint()
+        ).isEqualTo(
+            LintError(1, 7, "capitalized-class-name", "Class `myClass` should be capitalized").asList()
+        )
+    }
+
+    @Test
+    fun `has error for non capitalized interface`() {
+        assertThat(
+            """
+            interface myClass { fun foo() {} }
+            """.lint()
+        ).isEqualTo(
+            LintError(1, 11, "capitalized-class-name", "Class `myClass` should be capitalized").asList()
+        )
+    }
+
+    @Test
+    fun `has error for inner classes`() {
+        assertThat(
+            """
+            class MyClass {
+                data class inner(val x: String)
+            }
+            """.lint()
+        ).isEqualTo(
+            LintError(2, 16, "capitalized-class-name", "Class `inner` should be capitalized").asList()
+        )
+    }
+
+    @Test
+    fun `has no errors for capitalized classes`() {
+        assertThat("""
+            class MyClass {
+                data class Inner(val x: String)
+            }
+            """.lint()
+        ).isEqualTo(noErrors())
+    }
+
+    private fun String.lint(): List<LintError> = rule.lint(this.trimIndent())
+
+    private fun LintError.asList(): List<LintError> = listOf(this)
+
+    private fun noErrors(): List<LintError> = emptyList()
+}


### PR DESCRIPTION
Adds a standard rule to ensure that type names are capitalized.