### PR TITLE
ImportOrderingRule didn't remove blank lines when order was already correct

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -4,12 +4,13 @@ import com.github.shyiko.ktlint.core.Rule
 import com.github.shyiko.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
 import com.github.shyiko.ktlint.core.ast.ElementType.IMPORT_LIST
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 
 /**
- * Android Studio:
- *   Alphabetical within each grouping, with capital letters before lower case letters (e.g. Z before a).
- *   Separated by a blank line between each major grouping (android, com, junit, net, org, java, javax).
+ * Alphabetical with capital letters before lower case letters (e.g. Z before a).
+ * No blank lines between major groups (android, com, junit, net, org, java, javax).
+ * Single group regardless of import type.
  */
 class ImportOrderingRule : Rule("import-ordering") {
 
@@ -23,8 +24,8 @@ class ImportOrderingRule : Rule("import-ordering") {
             if (children.isNotEmpty()) {
                 val imports = children.filter { it.elementType == IMPORT_DIRECTIVE }
                 val sortedImports = imports.sortedBy { it.text }
-                if (imports != sortedImports) {
-                    emit(node.startOffset, "Imports must be ordered in lexicographic order", true)
+                if (imports != sortedImports || hasTooMuchWhitespace(children)) {
+                    emit(node.startOffset, "Imports must be ordered in lexicographic order in a single group", true)
                     if (autoCorrect) {
                         node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
                         sortedImports.forEachIndexed { i, astNode ->
@@ -37,5 +38,9 @@ class ImportOrderingRule : Rule("import-ordering") {
                 }
             }
         }
+    }
+
+    private fun hasTooMuchWhitespace(nodes: Array<ASTNode>): Boolean {
+        return nodes.any { it is PsiWhiteSpace && (it as PsiWhiteSpace).text != "\n" }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -25,7 +25,7 @@ class ImportOrderingRule : Rule("import-ordering") {
                 val imports = children.filter { it.elementType == IMPORT_DIRECTIVE }
                 val sortedImports = imports.sortedBy { it.text }
                 if (imports != sortedImports || hasTooMuchWhitespace(children)) {
-                    emit(node.startOffset, "Imports must be ordered in lexicographic order in a single group", true)
+                    emit(node.startOffset, "Imports must be ordered in lexicographic order", true)
                     if (autoCorrect) {
                         node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
                         sortedImports.forEachIndexed { i, astNode ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -25,7 +25,7 @@ class ImportOrderingRule : Rule("import-ordering") {
                 val imports = children.filter { it.elementType == IMPORT_DIRECTIVE }
                 val sortedImports = imports.sortedBy { it.text }
                 if (imports != sortedImports || hasTooMuchWhitespace(children)) {
-                    emit(node.startOffset, "Imports must be ordered in lexicographic order", true)
+                    emit(node.startOffset, "Imports must be ordered in lexicographic order without any empty lines in-between", true)
                     if (autoCorrect) {
                         node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
                         sortedImports.forEachIndexed { i, astNode ->

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -25,13 +25,14 @@ class ImportOrderingRuleTest {
         ).isEmpty()
     }
 
-    private val formattedImports = """
-            import android.app.Activity
-            import android.view.View
-            import android.view.ViewGroup
-            import java.util.List
-            import kotlin.concurrent.Thread
-            """.trimIndent()
+    private val formattedImports =
+        """
+        import android.app.Activity
+        import android.view.View
+        import android.view.ViewGroup
+        import java.util.List
+        import kotlin.concurrent.Thread
+        """.trimIndent()
 
     private val errorMessage = "Imports must be ordered in lexicographic order in a single group"
 
@@ -43,22 +44,24 @@ class ImportOrderingRuleTest {
 
     @Test
     fun testFormatWrongOrder() {
-        val imports = """
+        val imports =
+            """
             import android.view.ViewGroup
             import android.view.View
             import android.app.Activity
             import kotlin.concurrent.Thread
             import java.util.List
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
-            LintError(1, 1, "import-ordering", errorMessage)
-        ))
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
+            listOf(LintError(1, 1, "import-ordering", errorMessage))
+        )
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
     @Test
     fun testFormatWrongOrderAndBlankLines() {
-        val imports = """
+        val imports =
+            """
             import android.view.ViewGroup
 
 
@@ -69,15 +72,16 @@ class ImportOrderingRuleTest {
 
             import java.util.List
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
-            LintError(1, 1, "import-ordering", errorMessage)
-        ))
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
+            listOf(LintError(1, 1, "import-ordering", errorMessage))
+        )
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
     @Test
     fun testFormatBlankLinesForMajorGroups() {
-        val imports = """
+        val imports =
+            """
             import android.app.Activity
             import android.view.View
             import android.view.ViewGroup
@@ -86,15 +90,16 @@ class ImportOrderingRuleTest {
 
             import kotlin.concurrent.Thread
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
-            LintError(1, 1, "import-ordering", errorMessage)
-        ))
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
+            listOf(LintError(1, 1, "import-ordering", errorMessage))
+        )
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
     @Test
     fun testFormatBlankLines() {
-        val imports = """
+        val imports =
+            """
             import android.app.Activity
             import android.view.View
 
@@ -104,9 +109,9 @@ class ImportOrderingRuleTest {
 
             import kotlin.concurrent.Thread
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
-            LintError(1, 1, "import-ordering", errorMessage)
-        ))
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
+            listOf(LintError(1, 1, "import-ordering", errorMessage))
+        )
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -109,40 +109,6 @@ class ImportOrderingRuleTest {
     }
 
     @Test
-    fun testFormatBlankLinesForMajorGroups() {
-        val imports =
-            """
-            import android.app.Activity
-            import android.view.View
-            import android.view.ViewGroup
-
-            import java.util.List
-
-            import kotlin.concurrent.Thread
-            """.trimIndent()
-
-        val expectedErrors = listOf(
-            LintError(
-                1,
-                1,
-                "import-ordering",
-                "Imports must be ordered in lexicographic order in a single group"
-            )
-        )
-        val formattedImports =
-            """
-            import android.app.Activity
-            import android.view.View
-            import android.view.ViewGroup
-            import java.util.List
-            import kotlin.concurrent.Thread
-            """.trimIndent()
-
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
-    }
-
-    @Test
     fun testFormatBlankLines() {
         val imports =
             """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -25,19 +25,17 @@ class ImportOrderingRuleTest {
         ).isEmpty()
     }
 
-    private val formattedImports =
-        """
-        import android.app.Activity
-        import android.view.View
-        import android.view.ViewGroup
-        import java.util.List
-        import kotlin.concurrent.Thread
-        """.trimIndent()
-
-    private val errorMessage = "Imports must be ordered in lexicographic order in a single group"
-
     @Test
     fun testFormatOk() {
+        val formattedImports =
+            """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
         assertThat(ImportOrderingRule().lint(formattedImports)).isEmpty()
         assertThat(ImportOrderingRule().format(formattedImports)).isEqualTo(formattedImports)
     }
@@ -52,9 +50,25 @@ class ImportOrderingRuleTest {
             import kotlin.concurrent.Thread
             import java.util.List
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
-            listOf(LintError(1, 1, "import-ordering", errorMessage))
+
+        val expectedErrors = listOf(
+            LintError(
+                1,
+                1,
+                "import-ordering",
+                "Imports must be ordered in lexicographic order in a single group"
+            )
         )
+        val formattedImports =
+            """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(expectedErrors)
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
@@ -72,9 +86,25 @@ class ImportOrderingRuleTest {
 
             import java.util.List
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
-            listOf(LintError(1, 1, "import-ordering", errorMessage))
+
+        val expectedErrors = listOf(
+            LintError(
+                1,
+                1,
+                "import-ordering",
+                "Imports must be ordered in lexicographic order in a single group"
+            )
         )
+        val formattedImports =
+            """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(expectedErrors)
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
@@ -90,9 +120,25 @@ class ImportOrderingRuleTest {
 
             import kotlin.concurrent.Thread
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
-            listOf(LintError(1, 1, "import-ordering", errorMessage))
+
+        val expectedErrors = listOf(
+            LintError(
+                1,
+                1,
+                "import-ordering",
+                "Imports must be ordered in lexicographic order in a single group"
+            )
         )
+        val formattedImports =
+            """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(expectedErrors)
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 
@@ -109,9 +155,25 @@ class ImportOrderingRuleTest {
 
             import kotlin.concurrent.Thread
             """.trimIndent()
-        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(
-            listOf(LintError(1, 1, "import-ordering", errorMessage))
+
+        val expectedErrors = listOf(
+            LintError(
+                1,
+                1,
+                "import-ordering",
+                "Imports must be ordered in lexicographic order in a single group"
+            )
         )
+        val formattedImports =
+            """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(expectedErrors)
         assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -56,7 +56,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order"
+                "Imports must be ordered in lexicographic order without any empty lines in-between"
             )
         )
         val formattedImports =
@@ -92,7 +92,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order"
+                "Imports must be ordered in lexicographic order without any empty lines in-between"
             )
         )
         val formattedImports =
@@ -127,7 +127,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order"
+                "Imports must be ordered in lexicographic order without any empty lines in-between"
             )
         )
         val formattedImports =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -56,7 +56,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order in a single group"
+                "Imports must be ordered in lexicographic order"
             )
         )
         val formattedImports =
@@ -92,7 +92,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order in a single group"
+                "Imports must be ordered in lexicographic order"
             )
         )
         val formattedImports =
@@ -127,7 +127,7 @@ class ImportOrderingRuleTest {
                 1,
                 1,
                 "import-ordering",
-                "Imports must be ordered in lexicographic order in a single group"
+                "Imports must be ordered in lexicographic order"
             )
         )
         val formattedImports =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ImportOrderingRuleTest.kt
@@ -1,7 +1,10 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
+import com.github.shyiko.ktlint.core.LintError
 import com.github.shyiko.ktlint.test.diffFileFormat
 import com.github.shyiko.ktlint.test.diffFileLint
+import com.github.shyiko.ktlint.test.format
+import com.github.shyiko.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.Test
 
@@ -20,5 +23,90 @@ class ImportOrderingRuleTest {
                 "spec/import-ordering/format-expected.kt.spec"
             )
         ).isEmpty()
+    }
+
+    private val formattedImports = """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+            import java.util.List
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+
+    private val errorMessage = "Imports must be ordered in lexicographic order in a single group"
+
+    @Test
+    fun testFormatOk() {
+        assertThat(ImportOrderingRule().lint(formattedImports)).isEmpty()
+        assertThat(ImportOrderingRule().format(formattedImports)).isEqualTo(formattedImports)
+    }
+
+    @Test
+    fun testFormatWrongOrder() {
+        val imports = """
+            import android.view.ViewGroup
+            import android.view.View
+            import android.app.Activity
+            import kotlin.concurrent.Thread
+            import java.util.List
+            """.trimIndent()
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
+            LintError(1, 1, "import-ordering", errorMessage)
+        ))
+        assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
+    }
+
+    @Test
+    fun testFormatWrongOrderAndBlankLines() {
+        val imports = """
+            import android.view.ViewGroup
+
+
+            import android.view.View
+            import android.app.Activity
+
+            import kotlin.concurrent.Thread
+
+            import java.util.List
+            """.trimIndent()
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
+            LintError(1, 1, "import-ordering", errorMessage)
+        ))
+        assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
+    }
+
+    @Test
+    fun testFormatBlankLinesForMajorGroups() {
+        val imports = """
+            import android.app.Activity
+            import android.view.View
+            import android.view.ViewGroup
+
+            import java.util.List
+
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
+            LintError(1, 1, "import-ordering", errorMessage)
+        ))
+        assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
+    }
+
+    @Test
+    fun testFormatBlankLines() {
+        val imports = """
+            import android.app.Activity
+            import android.view.View
+
+            import android.view.ViewGroup
+            import java.util.List
+
+
+            import kotlin.concurrent.Thread
+            """.trimIndent()
+        assertThat(ImportOrderingRule().lint(imports)).isEqualTo(listOf(
+            LintError(1, 1, "import-ordering", errorMessage)
+        ))
+        assertThat(ImportOrderingRule().format(imports)).isEqualTo(formattedImports)
     }
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
@@ -3,4 +3,4 @@ import b.C
 import a.AB
 
 // expect
-// 1:1:Imports must be ordered in lexicographic order
+// 1:1:Imports must be ordered in lexicographic order without any empty lines in-between

--- a/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
@@ -3,4 +3,4 @@ import b.C
 import a.AB
 
 // expect
-// 1:1:Imports must be ordered in lexicographic order
+// 1:1:Imports must be ordered in lexicographic order in a single group

--- a/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/import-ordering/lint.kt.spec
@@ -3,4 +3,4 @@ import b.C
 import a.AB
 
 // expect
-// 1:1:Imports must be ordered in lexicographic order in a single group
+// 1:1:Imports must be ordered in lexicographic order


### PR DESCRIPTION
The `testFormatBlankLines` and `testFormatBlankLinesForMajorGroups` tests would have failed without the new `hasTooMuchWhitespace` check inside the rule.