### PR TITLE
Fix failing on KDoc semicolon after other nodes.

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -1,6 +1,7 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.Rule
+import com.github.shyiko.ktlint.core.ast.ElementType.KDOC_TEXT
 import com.github.shyiko.ktlint.core.ast.ElementType.OBJECT_KEYWORD
 import com.github.shyiko.ktlint.core.ast.isPartOf
 import com.github.shyiko.ktlint.core.ast.isPartOfString
@@ -20,6 +21,9 @@ class NoSemicolonsRule : Rule("no-semi") {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
+        if (node.elementType == KDOC_TEXT) {
+            return
+        }
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
             !node.isPartOf(KtEnumEntry::class)
         ) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
@@ -101,4 +101,19 @@ class NoSemicolonsRuleTest {
             )
         )
     }
+
+    @Test
+    fun testSemicolonAllowedInKDocAfterIdentifiers() {
+        assertThat(
+            NoSemicolonsRule().lint(
+                """
+                /**
+                 * [x];
+                 */
+                fun foo() {
+                }
+                """
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
```
/**
 * x;
 */
```
was working fine because the text was processed as "x;" but
```
/**
 * [x];
 */
```
failed because the left bracket, the identifier, and the right racket were processed as separate nodes, and then the node with the single ";" text was checked and failed.
Simply opting out of the check for all KDOC_TEXT seems fine.

Fixes #362.