### PR TITLE
Fix 'Missing newline before ")"' when no params

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -39,6 +39,8 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
             return
         }
         if (node.elementType == VALUE_PARAMETER_LIST &&
+            // skip when there are no parameters
+            node.firstChildNode?.treeNext?.elementType != RPAR &&
             // skip lambda parameters
             node.treeParent?.elementType != FUNCTION_LITERAL
         ) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -10,7 +10,6 @@ import com.github.shyiko.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
 import com.github.shyiko.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.github.shyiko.ktlint.core.ast.children
 import com.github.shyiko.ktlint.core.ast.isRoot
-import com.github.shyiko.ktlint.core.ast.prevCodeLeaf
 import com.github.shyiko.ktlint.core.ast.prevLeaf
 import com.github.shyiko.ktlint.core.ast.visit
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -101,7 +100,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                                     paramInnerIndentAdjustment = adjustedIndent.length - prevLeaf.getTextLength()
                                     (prevLeaf as LeafPsiElement).rawReplaceWithText(adjustedIndent)
                                 }
-                            } else if (prevLeaf?.prevCodeLeaf()?.elementType != LPAR) {
+                            } else {
                                 emit(child.startOffset, errorMessage(child), true)
                                 if (autoCorrect) {
                                     paramInnerIndentAdjustment = intendedIndent.length - child.column

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -63,6 +63,20 @@ class ParameterListWrappingRuleTest {
     }
 
     @Test
+    fun testLintClassParameterListWhenMaxLineLengthExceededAndNoParameters() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ClassAWithALongName()
+                """.trimIndent(),
+                userData = mapOf("max_line_length" to "10")
+            )
+        ).doesNotContain(
+            LintError(1, 27, "parameter-list-wrapping", """Missing newline before ")"""")
+        )
+    }
+
+    @Test
     fun testLintClassParameterListValid() {
         assertThat(
             ParameterListWrappingRule().lint(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -151,8 +151,6 @@ class ParameterListWrappingRuleTest {
                       b: Any,
                       c: Any) {
                 }
-                fun f() {}
-                fun f(/**/) {}
                 """.trimIndent()
             )
         ).isEqualTo(


### PR DESCRIPTION
Fix an issue where the `Exceeded max line length` rule is always trying to put parameters on separate lines, even when there are no parameters, causing the rule `Missing newline before ")"` to break.

Fixes #327 