### PR TITLE
Make spec file parsing working on Windows

### DIFF
--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -56,7 +56,7 @@ private typealias F = (
 ) -> String
 
 fun Rule.diffFileLint(path: String, userData: Map<String, String> = emptyMap()): String {
-    val resourceText = getResourceAsText(path)
+    val resourceText = getResourceAsText(path).replace("\r\n", "\n")
     val dividerIndex = resourceText.lastIndexOf("\n// expect\n")
     if (dividerIndex == -1) {
         throw RuntimeException("$path must contain '// expect' line")


### PR DESCRIPTION
Doing `mvn clean verify` on Windows actually does not work - due to `\r\n` usage in spec files, it fails to parse them. So I just replace it with `\n`.