### PR TITLE
Make build compatible with jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+  - ./mvnw install -DskipTests
+


### PR DESCRIPTION
**Why**
See https://jitpack.io/docs/BUILDING/
Since both gradle and maven build files are present, jitpack defaults to using the gradle build and the install target does not work there.
Errors from previous build: https://jitpack.io/com/github/shyiko/ktlint/0.29.0/build.log

**What**
- add jitpack.yml to specify that the maven build should be used instead

**Testing**
- validate by jitpack'ing repo with this change
- tested here and it works: https://jitpack.io/#jeremymailen/ktlint/jitpack-compat-SNAPSHOT