### PR TITLE
Remove code that was inserting newline after = in a chained call

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -164,7 +164,6 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                 LPAR, LBRACE, LBRACKET -> rearrangeBlock(n, autoCorrect, emit) // TODO: LT
                 SUPER_TYPE_LIST -> rearrangeSuperTypeList(n, autoCorrect, emit)
                 VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(n, autoCorrect, emit)
-                EQ -> rearrangeEq(n, autoCorrect, emit)
                 ARROW -> rearrangeArrow(n, autoCorrect, emit)
                 WHITE_SPACE -> line += n.text.count { it == '\n' }
             }
@@ -313,37 +312,6 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                     requireNewlineAfterLeaf(nextSibling, autoCorrect, emit)
                 }
             }
-        }
-    }
-
-    private fun rearrangeEq(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-    ) {
-        if (
-            !node.nextCodeSibling()?.elementType.let {
-                it == DOT_QUALIFIED_EXPRESSION ||
-                    it == SAFE_ACCESS_EXPRESSION ||
-                    it == BINARY_EXPRESSION ||
-                    it == BINARY_WITH_TYPE
-            } ||
-            !node.nextSubstringContains('\n') ||
-            (
-                mustBeFollowedByNewline(node) &&
-                    // force """ to be on a separate line
-                    !node.nextCodeLeaf().let { it?.elementType == OPEN_QUOTE && it.text == "\"\"\"" }
-                )
-        ) {
-            return
-        }
-        val nextCodeLeaf = node.nextCodeLeaf()!!
-        // val v = (...
-        if (nextCodeLeaf.elementType in lTokenSet) {
-            return
-        }
-        if (!nextCodeLeaf.prevLeaf().isWhiteSpaceWithNewline()) {
-            requireNewlineAfterLeaf(node, autoCorrect, emit)
         }
     }
 

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -164,6 +164,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                 LPAR, LBRACE, LBRACKET -> rearrangeBlock(n, autoCorrect, emit) // TODO: LT
                 SUPER_TYPE_LIST -> rearrangeSuperTypeList(n, autoCorrect, emit)
                 VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(n, autoCorrect, emit)
+                EQ -> rearrangeEq(n, autoCorrect, emit)
                 ARROW -> rearrangeArrow(n, autoCorrect, emit)
                 WHITE_SPACE -> line += n.text.count { it == '\n' }
             }
@@ -315,15 +316,23 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
         }
     }
 
-    private fun ASTNode.nextSubstringContains(c: Char): Boolean {
-        var n = this.treeNext
-        while (n != null) {
-            if (n.textContains(c)) {
-                return true
-            }
-            n = n.treeNext
+    private fun rearrangeEq(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        // force """ to be on a separate line
+        if (!node.nextCodeLeaf().isRawString()) {
+            return
         }
-        return false
+        val nextCodeLeaf = node.nextCodeLeaf()!!
+        if (!nextCodeLeaf.prevLeaf().isWhiteSpaceWithNewline()) {
+            requireNewlineAfterLeaf(node, autoCorrect, emit)
+        }
+    }
+
+    private fun ASTNode?.isRawString(): Boolean {
+        return this?.elementType == OPEN_QUOTE && this.text == "\"\"\""
     }
 
     private fun mustBeFollowedByNewline(node: ASTNode): Boolean {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRuleTest.kt
@@ -285,7 +285,7 @@ class IndentationRuleTest {
     }
 
     @Test
-    fun testLintNewlineAfterEqALlowed() {
+    fun testLintNewlineAfterEqAllowed() {
         assertThat(
             IndentationRule().lint(
                 // Previously the IndentationRule would force the line break after the `=`. Verify that it is

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRuleTest.kt
@@ -283,4 +283,22 @@ class IndentationRuleTest {
         assertThat(IndentationRule().format(ktScript, mapOf("indent_size" to "2")))
             .isEqualTo("fun main() {\n  return 0\n}")
     }
+
+    @Test
+    fun testLintNewlineAfterEqALlowed() {
+        assertThat(
+            IndentationRule().lint(
+                // Previously the IndentationRule would force the line break after the `=`. Verify that it is
+                // still allowed.
+                """
+                private fun getImplementationVersion() =
+                    javaClass.`package`.implementationVersion
+                        ?: javaClass.getResourceAsStream("/META-INF/MANIFEST.MF")
+                            ?.let { stream ->
+                                Manifest(stream).mainAttributes.getValue("Implementation-Version")
+                            }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-dot-qualified-expression-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-dot-qualified-expression-expected.kt.spec
@@ -1,10 +1,9 @@
 class A {
-    private fun getImplementationVersion() =
-        javaClass.`package`.implementationVersion
-            ?: javaClass.getResourceAsStream("/META-INF/MANIFEST.MF")
-                ?.let { stream ->
-                    Manifest(stream).mainAttributes.getValue("Implementation-Version")
-                }
+    private fun getImplementationVersion() = javaClass.`package`.implementationVersion
+        ?: javaClass.getResourceAsStream("/META-INF/MANIFEST.MF")
+            ?.let { stream ->
+                Manifest(stream).mainAttributes.getValue("Implementation-Version")
+            }
 
     fun f() {
         x()?.apply {

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-eq-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-eq-expected.kt.spec
@@ -5,21 +5,19 @@ class C {
 }
 
 fun f() {
-    val x =
-        "a" +
-            "b2"
+    val x = "a" +
+        "b2"
     val x =
         "a" +
             "b2"
 
-    val x =
-        paths.flatMap { dir ->
-            "hello"
-        } + f0(
-            "there"
-        ) + f1(
-            "sssss"
-        )
+    val x = paths.flatMap { dir ->
+        "hello"
+    } + f0(
+        "there"
+    ) + f1(
+        "sssss"
+    )
 
     fun Exception.toLintError(): LintError = this.let { e ->
         //

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-property-accessor-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-property-accessor-expected.kt.spec
@@ -1,9 +1,8 @@
 class C {
 
     private val Any.className
-        get() =
-            this.javaClass.name
-                .fn()
+        get() = this.javaClass.name
+            .fn()
 
     private fun String.escape() =
         this.fn()

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -87,10 +87,11 @@ fun f() {
 }
 
 class C {
-    val CONFIG_COMPACT = """
-    {
-    }
-    """.trimIndent()
+    val CONFIG_COMPACT =
+        """
+        {
+        }
+        """.trimIndent()
     val CONFIG_COMPACT = // comment
         """
         {

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -87,11 +87,10 @@ fun f() {
 }
 
 class C {
-    val CONFIG_COMPACT =
-        """
-        {
-        }
-        """.trimIndent()
+    val CONFIG_COMPACT = """
+    {
+    }
+    """.trimIndent()
     val CONFIG_COMPACT = // comment
         """
         {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -53,7 +53,8 @@ import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 
 @Command(
-    headerHeading = """An anti-bikeshedding Kotlin linter with built-in formatter
+    headerHeading =
+"""An anti-bikeshedding Kotlin linter with built-in formatter
 (https://github.com/shyiko/ktlint).
 
 Usage:


### PR DESCRIPTION
* Fixes https://github.com/pinterest/ktlint/issues/368 and https://github.com/pinterest/ktlint/issues/380
* Kotlin styleguide: https://kotlinlang.org/docs/reference/coding-conventions.html#chained-call-wrapping
  * Says 'The first call in the chain usually should have a line break before it, but it's OK to omit it if the code makes more sense that way.' 