### PR TITLE
fix SpacingAroundCommaRule when comma goes after comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.isPartOfString
+import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.nextSibling
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
@@ -25,8 +26,8 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
                 emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true)
                 if (autoCorrect) {
                     val isPrecededByComment = prevLeaf.prevLeaf { it !is PsiWhiteSpace } is PsiComment
-                    if (isPrecededByComment) {
-                        // If comma preceded by a comment, it should be moved before this comment
+                    if (isPrecededByComment && prevLeaf.isWhiteSpaceWithNewline()) {
+                        // If comma is on new line and preceded by a comment, it should be moved before this comment
                         // https://github.com/pinterest/ktlint/issues/367
                         val previousStatement = node.prevCodeLeaf()!!
                         previousStatement.treeParent.addChild(node.clone(), previousStatement.nextSibling { true })

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
@@ -19,9 +20,10 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
             if (prevLeaf is PsiWhiteSpace) {
-                emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true)
-                if (autoCorrect) {
-                    prevLeaf.node.treeParent.removeChild(prevLeaf.node)
+                val canBeAutoCorrected = prevLeaf.prevLeaf { it !is PsiWhiteSpace } !is PsiComment
+                emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", canBeAutoCorrected)
+                if (autoCorrect && canBeAutoCorrected) {
+                    prevLeaf.treeParent.removeChild(prevLeaf)
                 }
             }
             if (node.nextLeaf() !is PsiWhiteSpace) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -20,6 +20,8 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
             if (prevLeaf is PsiWhiteSpace) {
+                // Error can be auto corrected only if comma doesn't preceded by comment
+                // https://github.com/pinterest/ktlint/issues/367
                 val canBeAutoCorrected = prevLeaf.prevLeaf { it !is PsiWhiteSpace } !is PsiComment
                 emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", canBeAutoCorrected)
                 if (autoCorrect && canBeAutoCorrected) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
@@ -47,6 +47,8 @@ class SpacingAroundCommaRuleTest {
     fun testFormat() {
         assertThat(SpacingAroundCommaRule().format("fun main() { x(1,3); x(1, 3) }"))
             .isEqualTo("fun main() { x(1, 3); x(1, 3) }")
+        assertThat(SpacingAroundCommaRule().format("fun main() { x(1 /* comment */ , 3); x(1 /* comment */, 3) }"))
+            .isEqualTo("fun main() { x(1 /* comment */, 3); x(1 /* comment */, 3) }")
         assertThat(
             SpacingAroundCommaRule().format(
                 """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
@@ -69,5 +69,28 @@ class SpacingAroundCommaRuleTest {
             ) = Unit
             """.trimIndent()
         )
+        assertThat(
+            SpacingAroundCommaRule().format(
+                """
+                fun fn(
+                    arg1: Int ,
+                    arg2: Int // some comment
+                    , arg3: Int
+                    // other comment
+                    , arg4: Int
+                ) = Unit
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            fun fn(
+                arg1: Int,
+                arg2: Int // some comment
+                , arg3: Int
+                // other comment
+                , arg4: Int
+            ) = Unit
+            """.trimIndent()
+        )
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
@@ -85,10 +85,10 @@ class SpacingAroundCommaRuleTest {
             """
             fun fn(
                 arg1: Int,
-                arg2: Int // some comment
-                , arg3: Int
+                arg2: Int, // some comment
+                arg3: Int,
                 // other comment
-                , arg4: Int
+                arg4: Int
             ) = Unit
             """.trimIndent()
         )


### PR DESCRIPTION
Disable autocorrection for comma spacing rule if comma on newline preceded by // comment.

Fixes #367 