### PR TITLE
Fixing bug where ktlint would unexpectedly force a newline after an ->

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -404,7 +404,14 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             //     m -> 0 + d({
             //     })
             // }
-            (p.elementType == WHEN_ENTRY && mustBeFollowedByNewline(node))
+            (p.elementType == WHEN_ENTRY && mustBeFollowedByNewline(node)) ||
+            // permit
+            // when (this) {
+            //     in 0x1F600..0x1F64F, // Emoticons
+            //     0x200D // Zero-width Joiner
+            //     -> true
+            // }
+            (p.elementType == WHEN_ENTRY && node.prevLeaf()?.textContains('\n') == true)
         ) {
             return
         }

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow-expected.kt.spec
@@ -18,4 +18,9 @@ fun main() {
 
         }
     }
+    when {
+        1, // first element
+        2 // second element
+        -> true
+    }
 }

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow.kt.spec
@@ -15,4 +15,9 @@ fun main() {
 
         }
     }
+    when {
+        1, // first element
+        2 // second element
+        -> true
+    }
 }


### PR DESCRIPTION
Fixing a bug we noticed in our own code base where:
```
when {
    1, // first element
    2 // second element
    -> true
}
```

would become:
```
when {
    1, // first element
    2 // second element
    -> 
        true
}
```