### PR TITLE
Added unary-op-spacing rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
@@ -1,0 +1,53 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.EXCL
+import com.pinterest.ktlint.core.ast.ElementType.EXCLEXCL
+import com.pinterest.ktlint.core.ast.ElementType.MINUS
+import com.pinterest.ktlint.core.ast.ElementType.MINUSMINUS
+import com.pinterest.ktlint.core.ast.ElementType.PLUS
+import com.pinterest.ktlint.core.ast.ElementType.PLUSPLUS
+import com.pinterest.ktlint.core.ast.ElementType.POSTFIX_EXPRESSION
+import com.pinterest.ktlint.core.ast.ElementType.PREFIX_EXPRESSION
+import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.parent
+import com.pinterest.ktlint.core.ast.prevLeaf
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+
+class SpacingAroundUnaryOperatorsRule : Rule("unary-op-spacing") {
+
+    private val tokenSet = TokenSet.create(PLUS, PLUSPLUS, MINUS, MINUSMINUS, EXCL, EXCLEXCL)
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node is LeafElement && tokenSet.contains(node.elementType)) {
+            val unaryExpressionNode = node.parent({ it.elementType in listOf(POSTFIX_EXPRESSION, PREFIX_EXPRESSION) })
+            when (unaryExpressionNode?.elementType) {
+                PREFIX_EXPRESSION -> {
+                    val nextLeaf = node.nextLeaf()
+                    if (nextLeaf is PsiWhiteSpace) {
+                        emit(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true)
+                        if (autoCorrect) {
+                            nextLeaf.treeParent.removeChild(nextLeaf)
+                        }
+                    }
+                }
+                POSTFIX_EXPRESSION -> {
+                    val prevLeaf = node.prevLeaf()
+                    if (prevLeaf is PsiWhiteSpace) {
+                        emit(node.startOffset - 1, "Unexpected spacing before \"${node.text}\"", true)
+                        if (autoCorrect) {
+                            prevLeaf.treeParent.removeChild(prevLeaf)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
@@ -17,6 +17,11 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 
+/**
+ * Ensures there are no spaces around unary operators
+ *
+ * @see [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html#horizontal-whitespace)
+ */
 class SpacingAroundUnaryOperatorsRule : Rule("unary-op-spacing") {
 
     private val tokenSet = TokenSet.create(PLUS, PLUSPLUS, MINUS, MINUSMINUS, EXCL, EXCLEXCL)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRuleTest.kt
@@ -1,0 +1,24 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.test.diffFileFormat
+import com.pinterest.ktlint.test.diffFileLint
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+
+class SpacingAroundUnaryOperatorsRuleTest {
+
+    @Test
+    fun testLint() {
+        assertThat(SpacingAroundUnaryOperatorsRule().diffFileLint("spec/unary-op-spacing/lint.kt.spec")).isEmpty()
+    }
+
+    @Test
+    fun testFormat() {
+        assertThat(
+            SpacingAroundUnaryOperatorsRule().diffFileFormat(
+                "spec/unary-op-spacing/format.kt.spec",
+                "spec/unary-op-spacing/format-expected.kt.spec"
+            )
+        ).isEmpty()
+    }
+}

--- a/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/format-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/format-expected.kt.spec
@@ -1,0 +1,8 @@
+fun main() {
+    val v1 = 1 + i++
+    val v2 = --a++
+    val v3 = s!!
+    !flag
+    val y = +1
+    var x = -1 in 3..4
+}

--- a/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/format.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/format.kt.spec
@@ -1,0 +1,8 @@
+fun main() {
+    val v1 = 1 + i ++
+    val v2 = -- a++
+    val v3 = s !!
+    ! flag
+    val y = + 1
+    var x = - 1 in 3..4
+}

--- a/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/unary-op-spacing/lint.kt.spec
@@ -1,0 +1,27 @@
+import a.b.*
+fun main() {
+    c!!
+    c !!
+    i++
+    i--
+    i++--
+    i --
+    i ++
+    i ++ --
+    val y = + 1
+    ! q
+    !q
+    - a
+    + c
+}
+
+// expect
+4:6:Unexpected spacing before "!!"
+8:6:Unexpected spacing before "--"
+9:6:Unexpected spacing before "++"
+10:6:Unexpected spacing before "++"
+10:9:Unexpected spacing before "--"
+11:14:Unexpected spacing after "+"
+12:6:Unexpected spacing after "!"
+14:6:Unexpected spacing after "-"
+15:6:Unexpected spacing after "+"


### PR DESCRIPTION
Added a rule, that check spacing around unary operators according to kotlin style guide (addresses an issue #412).