### PR TITLE
Implementing the concept of Issue Types

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Issue.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Issue.kt
@@ -1,0 +1,19 @@
+package com.pinterest.ktlint.core
+
+data class Issue(
+    val offset: Int,
+    val errorMessage: String,
+    val canBeAutoCorrected: Boolean,
+    val type: IssueType = IssueType.ERROR
+) {
+    fun toLintIssue(line: Int, col: Int, ruleId: String): LintIssue {
+        return when (type) {
+            IssueType.ERROR -> LintError(line, col, ruleId, errorMessage, canBeAutoCorrected)
+            IssueType.WARNING -> LintWarning(line, col, ruleId, errorMessage, canBeAutoCorrected)
+        }
+    }
+}
+
+enum class IssueType {
+    ERROR, WARNING
+}

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintIssue.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintIssue.kt
@@ -1,0 +1,16 @@
+package com.pinterest.ktlint.core
+
+interface LintIssue {
+    val line: Int
+    val col: Int
+    val ruleId: String
+    val detail: String
+    val canBeAutoCorrected: Boolean
+
+    operator fun component1() = line
+    operator fun component2() = col
+    operator fun component3() = ruleId
+    operator fun component4() = detail
+
+    fun asNonCorrectableIfItIs(): LintIssue
+}

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintWarning.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintWarning.kt
@@ -1,21 +1,7 @@
 package com.pinterest.ktlint.core
 
-/**
- * Lint error.
- *
- * @param line line number (one-based)
- * @param col column number (one-based)
- * @param ruleId rule id (prepended with "&lt;ruleSetId&gt;:" in case of non-standard ruleset)
- * @param detail error message
- */
-data class LintError(
-    override val line: Int,
-    override val col: Int,
-    override val ruleId: String,
-    override val detail: String
-) :
+data class LintWarning(override val line: Int, override val col: Int, override val ruleId: String, override val detail: String) :
     LintIssue {
-
     // fixme:
     // not included in equals/hashCode for backward-compatibility with ktlint < 0.25.0
     // subject to change in 1.0.0
@@ -35,5 +21,5 @@ data class LintError(
     }
 
     override fun asNonCorrectableIfItIs(): LintIssue =
-        copy(detail = detail + if (!canBeAutoCorrected) " (cannot be auto-corrected)" else "")
+        copy(detail = detail + if (!canBeAutoCorrected)" (cannot be auto-corrected)" else "")
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Reporter.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Reporter.kt
@@ -18,7 +18,7 @@ interface Reporter {
      * Called when file (matching the pattern) is found but before it's parsed.
      */
     fun before(file: String) {}
-    fun onLintError(file: String, err: LintError, corrected: Boolean)
+    fun onLintError(file: String, err: LintIssue, corrected: Boolean)
     /**
      * Called after ktlint is done with the file.
      */
@@ -34,7 +34,7 @@ interface Reporter {
             return object : Reporter {
                 override fun beforeAll() { reporters.forEach(Reporter::beforeAll) }
                 override fun before(file: String) { reporters.forEach { it.before(file) } }
-                override fun onLintError(file: String, err: LintError, corrected: Boolean) =
+                override fun onLintError(file: String, err: LintIssue, corrected: Boolean) =
                     reporters.forEach { it.onLintError(file, err, corrected) }
                 override fun after(file: String) { reporters.forEach { it.after(file) } }
                 override fun afterAll() { reporters.forEach(Reporter::afterAll) }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -29,7 +29,7 @@ abstract class Rule(val id: String) {
     abstract fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     )
 
     object Modifier {

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -14,7 +14,7 @@ class KtLintTest {
             override fun visit(
                 node: ASTNode,
                 autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+                emit: (issue: Issue) -> Unit
             ) {
                 if (node.isRoot()) {
                     bus.add("file:$id")

--- a/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporter.kt
+++ b/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporter.kt
@@ -1,6 +1,6 @@
 package com.pinterest.ktlint.reporter.checkstyle
 
-import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintIssue
 import com.pinterest.ktlint.core.Reporter
 import java.io.PrintStream
 import java.util.ArrayList
@@ -8,11 +8,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 class CheckStyleReporter(val out: PrintStream) : Reporter {
 
-    private val acc = ConcurrentHashMap<String, MutableList<LintError>>()
+    private val acc = ConcurrentHashMap<String, MutableList<LintIssue>>()
 
-    override fun onLintError(file: String, err: LintError, corrected: Boolean) {
+    override fun onLintError(file: String, err: LintIssue, corrected: Boolean) {
         if (!corrected) {
-            acc.getOrPut(file) { ArrayList<LintError>() }.add(err)
+            acc.getOrPut(file) { ArrayList() }.add(err)
         }
     }
 

--- a/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporter.kt
+++ b/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporter.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.reporter.json
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintIssue
 import com.pinterest.ktlint.core.Reporter
 import java.io.PrintStream
 import java.util.ArrayList
@@ -8,9 +9,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 class JsonReporter(val out: PrintStream) : Reporter {
 
-    private val acc = ConcurrentHashMap<String, MutableList<LintError>>()
+    private val acc = ConcurrentHashMap<String, MutableList<LintIssue>>()
 
-    override fun onLintError(file: String, err: LintError, corrected: Boolean) {
+    override fun onLintError(file: String, err: LintIssue, corrected: Boolean) {
         if (!corrected) {
             acc.getOrPut(file) { ArrayList() }.add(err)
         }
@@ -28,6 +29,7 @@ class JsonReporter(val out: PrintStream) : Reporter {
             for ((errIndex, err) in errList.withIndex()) {
                 val (line, col, ruleId, detail) = err
                 out.println("""			{""")
+                out.println("""				"type": "${err.tag()}",""")
                 out.println("""				"line": $line,""")
                 out.println("""				"column": $col,""")
                 out.println("""				"message": "${detail.escapeJsonValue()}",""")
@@ -39,6 +41,8 @@ class JsonReporter(val out: PrintStream) : Reporter {
         }
         out.println("]")
     }
+
+    private fun LintIssue.tag() = if (this is LintError) "ERROR" else "WARNING"
 
     private fun String.escapeJsonValue() =
         this

--- a/ktlint-reporter-json/src/test/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterTest.kt
+++ b/ktlint-reporter-json/src/test/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.reporter.json
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintWarning
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
@@ -62,6 +63,7 @@ class JsonReporterTest {
 		"file": "/one-fixed-and-one-not.kt",
 		"errors": [
 			{
+				"type": "ERROR",
 				"line": 1,
 				"column": 1,
 				"message": "<\"&'>",
@@ -73,12 +75,14 @@ class JsonReporterTest {
 		"file": "/two-not-fixed.kt",
 		"errors": [
 			{
+				"type": "ERROR",
 				"line": 1,
 				"column": 10,
 				"message": "I thought I would again",
 				"rule": "rule-1"
 			},
 			{
+				"type": "ERROR",
 				"line": 2,
 				"column": 20,
 				"message": "A single thin straight line",
@@ -104,6 +108,33 @@ class JsonReporterTest {
 		"file": "src\\main\\all\\corrected.kt",
 		"errors": [
 			{
+				"type": "ERROR",
+				"line": 4,
+				"column": 7,
+				"message": "\\n\n\r\t\"",
+				"rule": "rule-7"
+			}
+		]
+	}
+]
+""".trimStart().replace("\n", System.lineSeparator())
+        )
+    }
+
+    @Test
+    fun testWarnings() {
+        val out = ByteArrayOutputStream()
+        val reporter = JsonReporter(PrintStream(out, true))
+        reporter.onLintError("src\\main\\all\\corrected.kt", LintWarning(4, 7, "rule-7", "\\n\n\r\t\""), false)
+        reporter.afterAll()
+        assertThat(String(out.toByteArray())).isEqualTo(
+            """
+[
+	{
+		"file": "src\\main\\all\\corrected.kt",
+		"errors": [
+			{
+				"type": "WARNING",
 				"line": 4,
 				"column": 7,
 				"message": "\\n\n\r\t\"",

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintWarning
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
@@ -55,10 +56,10 @@ class PlainReporterTest {
             true
         )
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
-/one-fixed-and-one-not.kt:1:1: <"&'>
-/two-not-fixed.kt:1:10: I thought I would again
-/two-not-fixed.kt:2:20: A single thin straight line
+            """
+[ERROR] /one-fixed-and-one-not.kt:1:1: <"&'>
+[ERROR] /two-not-fixed.kt:1:10: I thought I would again
+[ERROR] /two-not-fixed.kt:2:20: A single thin straight line
 """.trimStart().replace("\n", System.lineSeparator())
         )
     }
@@ -113,12 +114,72 @@ class PlainReporterTest {
         reporter.after("/two-not-fixed.kt")
         reporter.after("/all-corrected.kt")
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
+            """
 /one-fixed-and-one-not.kt
-  1:1 <"&'>
+ [ERROR] 1:1 <"&'>
 /two-not-fixed.kt
-  1:10 I thought I would again
-  2:20 A single thin straight line
+ [ERROR] 1:10 I thought I would again
+ [ERROR] 2:20 A single thin straight line
+""".trimStart().replace("\n", System.lineSeparator())
+        )
+    }
+
+    @Test
+    fun testReportGenerationGroupedByFileWithWarnings() {
+        val out = ByteArrayOutputStream()
+        val reporter = PlainReporter(PrintStream(out, true), groupByFile = true)
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                1, 1, "rule-1",
+                "<\"&'>"
+            ),
+            false
+        )
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                2, 1, "rule-2",
+                "And if you see my friend"
+            ),
+            true
+        )
+
+        reporter.onLintError(
+            "/two-not-fixed.kt",
+            LintError(
+                1, 10, "rule-1",
+                "I thought I would again"
+            ),
+            false
+        )
+        reporter.onLintError(
+            "/two-not-fixed.kt",
+            LintWarning(
+                2, 20, "rule-2",
+                "A single thin straight line"
+            ),
+            false
+        )
+
+        reporter.onLintError(
+            "/all-corrected.kt",
+            LintError(
+                1, 1, "rule-1",
+                "I thought we had more time"
+            ),
+            true
+        )
+        reporter.after("/one-fixed-and-one-not.kt")
+        reporter.after("/two-not-fixed.kt")
+        reporter.after("/all-corrected.kt")
+        assertThat(String(out.toByteArray())).isEqualTo(
+            """
+/one-fixed-and-one-not.kt
+ [ERROR] 1:1 <"&'>
+/two-not-fixed.kt
+ [ERROR] 1:10 I thought I would again
+ [WARNING] 2:20 A single thin straight line
 """.trimStart().replace("\n", System.lineSeparator())
         )
     }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ImportOrderingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ImportOrderingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.experimental
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_LIST
@@ -17,7 +18,7 @@ class ImportOrderingRule : Rule("import-ordering") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == IMPORT_LIST) {
             val children = node.getChildren(null)
@@ -25,7 +26,7 @@ class ImportOrderingRule : Rule("import-ordering") {
                 val imports = children.filter { it.elementType == IMPORT_DIRECTIVE }
                 val sortedImports = imports.sortedBy { it.text }
                 if (imports != sortedImports || hasTooMuchWhitespace(children)) {
-                    emit(node.startOffset, "Imports must be ordered in lexicographic order without any empty lines in-between", true)
+                    emit(Issue(node.startOffset, "Imports must be ordered in lexicographic order without any empty lines in-between", true))
                     if (autoCorrect) {
                         node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
                         sortedImports.forEachIndexed { i, astNode ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.core.ast.children
@@ -20,7 +21,7 @@ class AnnotationRule : Rule("annotation") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         val root =
             node.children().firstOrNull { it.elementType == MODIFIER_LIST }
@@ -53,16 +54,20 @@ class AnnotationRule : Rule("annotation") {
 
         if (multipleAnnotationsOnSameLineAsAnnotatedConstruct) {
             emit(
-                annotations.first().node.startOffset,
-                multipleAnnotationsOnSameLineAsAnnotatedConstructErrorMessage,
-                true
+                Issue(
+                    annotations.first().node.startOffset,
+                    multipleAnnotationsOnSameLineAsAnnotatedConstructErrorMessage,
+                    true
+                )
             )
         }
         if (annotationsWithParametersAreNotOnSeparateLines) {
             emit(
-                annotations.first().node.startOffset,
-                annotationsWithParametersAreNotOnSeparateLinesErrorMessage,
-                true
+                Issue(
+                    annotations.first().node.startOffset,
+                    annotationsWithParametersAreNotOnSeparateLinesErrorMessage,
+                    true
+                )
             )
         }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ANDAND
 import com.pinterest.ktlint.core.ast.ElementType.COMMA
@@ -41,7 +42,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
@@ -57,7 +58,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
             if (nextLeaf?.elementType == WHITE_SPACE &&
                 nextLeaf.textContains('\n')
             ) {
-                emit(node.startOffset, "Line must not end with \"${node.text}\"", true)
+                emit(Issue(node.startOffset, "Line must not end with \"${node.text}\"", true))
                 if (autoCorrect) {
                     // rewriting
                     // <prevLeaf><node="."><nextLeaf="\n"> to
@@ -91,7 +92,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
                 // LeafPsiElement->KtOperationReferenceExpression->KtPrefixExpression->KtWhenConditionWithExpression
                 !node.isPartOfWhenCondition()
             ) {
-                emit(node.startOffset, "Line must not begin with \"${node.text}\"", true)
+                emit(Issue(node.startOffset, "Line must not begin with \"${node.text}\"", true))
                 if (autoCorrect) {
                     // rewriting
                     // <insertionPoint><prevLeaf="\n"><node="&&"><nextLeaf=" "> to

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
@@ -13,12 +14,12 @@ class CommentSpacingRule : Rule("comment-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiComment && node is LeafPsiElement && node.getText().startsWith("//")) {
             val prevLeaf = node.prevLeaf()
             if (prevLeaf !is PsiWhiteSpace && prevLeaf is LeafPsiElement) {
-                emit(node.startOffset, "Missing space before //", true)
+                emit(Issue(node.startOffset, "Missing space before //", true))
                 if (autoCorrect) {
                     node.upsertWhitespaceBeforeMe(" ")
                 }
@@ -31,7 +32,7 @@ class CommentSpacingRule : Rule("comment-spacing") {
                 !text.startsWith("//endregion") &&
                 !text.startsWith("//language=")
             ) {
-                emit(node.startOffset, "Missing space after //", true)
+                emit(Issue(node.startOffset, "Missing space after //", true))
                 if (autoCorrect) {
                     node.rawReplaceWithText("// " + text.removePrefix("//"))
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
@@ -38,7 +39,7 @@ class FilenameRule : Rule("filename"), Rule.Modifier.RestrictToRoot {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         val filePath = node.getUserData(KtLint.FILE_PATH_USER_DATA_KEY)
         if (filePath?.endsWith(".kt") != true) {
@@ -68,7 +69,7 @@ class FilenameRule : Rule("filename"), Rule.Modifier.RestrictToRoot {
             val unescapedClassName = className.replace("`", "")
             val name = Paths.get(filePath).fileName.toString().substringBefore(".")
             if (name != "package" && name != unescapedClassName) {
-                emit(0, "$type $className should be declared in a file named $unescapedClassName.kt", false)
+                emit(Issue(0, "$type $className should be declared in a file named $unescapedClassName.kt", false))
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.isRoot
@@ -12,7 +13,7 @@ class FinalNewlineRule : Rule("final-newline"), Rule.Modifier.RestrictToRoot {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
@@ -20,14 +21,14 @@ class FinalNewlineRule : Rule("final-newline"), Rule.Modifier.RestrictToRoot {
             val lastNode = lastChildNodeOf(node)
             if (insertFinalNewline) {
                 if (lastNode !is PsiWhiteSpace || !lastNode.textContains('\n')) {
-                    emit(0, "File must end with a newline (\\n)", true)
+                    emit(Issue(0, "File must end with a newline (\\n)", true))
                     if (autoCorrect) {
                         node.addChild(PsiWhiteSpaceImpl("\n"), null)
                     }
                 }
             } else {
                 if (lastNode is PsiWhiteSpace && lastNode.textContains('\n')) {
-                    emit(lastNode.startOffset, "Redundant newline (\\n) at the end of file", true)
+                    emit(Issue(lastNode.startOffset, "Redundant newline (\\n) at the end of file", true))
                     if (autoCorrect) {
                         lastNode.node.treeParent.removeChild(lastNode.node)
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CONSTRUCTOR_DELEGATION_CALL
@@ -22,7 +23,7 @@ class IndentationRule : Rule("indent") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
@@ -41,9 +42,11 @@ class IndentationRule : Rule("indent") {
                     if (indent.isNotEmpty() && (indent.length - previousIndentSize) % indentSize != 0) {
                         if (!node.isPartOf(KtParameterList::class)) { // parameter list wrapping enforced by ParameterListWrappingRule
                             emit(
-                                offset,
-                                "Unexpected indentation (${indent.length}) (it should be ${previousIndentSize + indentSize})",
-                                false
+                                Issue(
+                                    offset,
+                                    "Unexpected indentation (${indent.length}) (it should be ${previousIndentSize + indentSize})",
+                                    false
+                                )
                             )
                         }
                     }
@@ -52,7 +55,7 @@ class IndentationRule : Rule("indent") {
             }
             if (node.textContains('\t')) {
                 val text = node.getText()
-                emit(node.startOffset + text.indexOf('\t'), "Unexpected Tab character(s)", true)
+                emit(Issue(node.startOffset + text.indexOf('\t'), "Unexpected Tab character(s)", true))
                 if (autoCorrect) {
                     (node as LeafPsiElement).rawReplaceWithText(text.replace("\t", " ".repeat(indentSize)))
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType
@@ -22,7 +23,7 @@ class MaxLineLengthRule : Rule("max-line-length"), Rule.Modifier.Last {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
@@ -68,7 +69,7 @@ class MaxLineLengthRule : Rule("max-line-length"), Rule.Modifier.Last {
             rangeTree
                 .query(node.startOffset, node.startOffset + node.textLength)
                 .forEach { offset ->
-                    emit(offset, "Exceeded max line length ($maxLineLength)", false)
+                    emit(Issue(offset, "Exceeded max line length ($maxLineLength)", false))
                 }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ABSTRACT_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.ACTUAL_KEYWORD
@@ -62,7 +63,7 @@ class ModifierOrderRule : Rule("modifier-order") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.psi is KtDeclarationModifierList) {
             val modifierArr = node.getChildren(tokenSet)
@@ -71,11 +72,13 @@ class ModifierOrderRule : Rule("modifier-order") {
                 // Since annotations can be fairly lengthy and/or span multiple lines we are
                 // squashing them into a single placeholder text to guarantee a single line output
                 emit(
-                    node.startOffset,
-                    "Incorrect modifier order (should be \"${
-                    squashAnnotations(sorted).joinToString(" ")
-                    }\")",
-                    true
+                    Issue(
+                        node.startOffset,
+                        "Incorrect modifier order (should be \"${
+                        squashAnnotations(sorted).joinToString(" ")
+                        }\")",
+                        true
+                    )
                 )
                 if (autoCorrect) {
                     modifierArr.forEachIndexed { i, n ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ELSE
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
@@ -18,14 +19,14 @@ class MultiLineIfElseRule : Rule("multiline-if-else") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == THEN || node.elementType == ELSE) {
             if (!node.treePrev.textContains('\n')) { // if (...) <statement>
                 return
             }
             if (node.firstChildNode?.firstChildNode?.elementType != LBRACE) {
-                emit(node.firstChildNode.startOffset, "Missing { ... }", true)
+                emit(Issue(node.firstChildNode.startOffset, "Missing { ... }", true))
                 if (autoCorrect) {
                     (node.firstChildNode.firstChildNode as TreeElement).rawInsertBeforeMe(LeafPsiElement(RBRACE, "{"))
                     (node.lastChildNode.lastChildNode as TreeElement).rawInsertAfterMe(LeafPsiElement(LBRACE, "}"))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.nextLeaf
@@ -12,7 +13,7 @@ class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
@@ -21,8 +22,10 @@ class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
             val split = node.getText().split("\n")
             if (split.size > 2) {
                 emit(
-                    node.startOffset + split[0].length + split[1].length + 1,
-                    "Unexpected blank line(s) before \"}\"", true
+                    Issue(
+                        node.startOffset + split[0].length + split[1].length + 1,
+                        "Unexpected blank line(s) before \"}\"", true
+                    )
                 )
                 if (autoCorrect) {
                     (node as LeafPsiElement).rawReplaceWithText("${split.first()}\n${split.last()}")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.nextLeaf
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -11,7 +12,7 @@ class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiWhiteSpace) {
             val text = node.getText()
@@ -22,7 +23,7 @@ class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
             val eof = node.nextLeaf() == null
             if (lfcount > 2 || eof) {
                 val split = text.split("\n")
-                emit(node.startOffset + split[0].length + split[1].length + 2, "Needless blank line(s)", true)
+                emit(Issue(node.startOffset + split[0].length + split[1].length + 2, "Needless blank line(s)", true))
                 if (autoCorrect) {
                     (node as LeafPsiElement)
                         .rawReplaceWithText("${split.first()}\n${if (eof) "" else "\n"}${split.last()}")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
@@ -15,7 +16,7 @@ class NoEmptyClassBodyRule : Rule("no-empty-class-body") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == CLASS_BODY &&
             node.firstChildNode?.let { n ->
@@ -24,7 +25,7 @@ class NoEmptyClassBodyRule : Rule("no-empty-class-body") {
             } == true &&
             !node.isPartOf(KtObjectLiteralExpression::class)
         ) {
-            emit(node.startOffset, "Unnecessary block (\"{}\")", true)
+            emit(Issue(node.startOffset, "Unnecessary block (\"{}\")", true))
             if (autoCorrect) {
                 val prevNode = node.treePrev
                 if (prevNode.elementType == WHITE_SPACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
@@ -11,13 +12,13 @@ class NoItParamInMultilineLambdaRule : Rule("no-it-in-multiline-lambda") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         // fixme: we are not accounting for "it" variable that can be defined in the same scope
         if (node.elementType == IDENTIFIER && node.text == "it") {
             val block = node.parent(BLOCK)
             if (block != null && block.textContains('\n')) {
-                emit(node.startOffset, "Multiline lambda must explicitly name \"it\" parameter", false)
+                emit(Issue(node.startOffset, "Multiline lambda must explicitly name \"it\" parameter", false))
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ELSE_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.IF_KEYWORD
@@ -15,7 +16,7 @@ class NoLineBreakAfterElseRule : Rule("no-line-break-after-else") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n')
@@ -23,7 +24,7 @@ class NoLineBreakAfterElseRule : Rule("no-line-break-after-else") {
             if (node.prevLeaf()?.elementType == ELSE_KEYWORD &&
                 node.nextLeaf()?.elementType.let { it == IF_KEYWORD || it == LBRACE }
             ) {
-                emit(node.startOffset + 1, "Unexpected line break after \"else\"", true)
+                emit(Issue(node.startOffset + 1, "Unexpected line break after \"else\"", true))
                 if (autoCorrect) {
                     (node as LeafPsiElement).rawReplaceWithText(" ")
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.EQ
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -8,11 +9,11 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class NoLineBreakBeforeAssignmentRule : Rule("no-line-break-before-assignment") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (issue: Issue) -> Unit) {
         if (node.elementType == EQ) {
             val prevElement = node.treePrev?.psi
             if (prevElement is PsiWhiteSpace && prevElement.text.contains("\n")) {
-                emit(node.startOffset, "Line break before assignment is not allowed", true)
+                emit(Issue(node.startOffset, "Line break before assignment is not allowed", true))
                 if (autoCorrect) {
                     (node.treeNext?.psi as LeafPsiElement).rawReplaceWithText(prevElement.text)
                     (prevElement as LeafPsiElement).rawReplaceWithText(" ")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -10,10 +11,10 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiWhiteSpace && !node.textContains('\n') && node.getTextLength() > 1) {
-            emit(node.startOffset + 1, "Unnecessary space(s)", true)
+            emit(Issue(node.startOffset + 1, "Unnecessary space(s)", true))
             if (autoCorrect) {
                 (node as LeafPsiElement).rawReplaceWithText(" ")
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.KDOC_TEXT
 import com.pinterest.ktlint.core.ast.ElementType.OBJECT_KEYWORD
@@ -19,7 +20,7 @@ class NoSemicolonsRule : Rule("no-semi") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == KDOC_TEXT) {
             return
@@ -33,7 +34,7 @@ class NoSemicolonsRule : Rule("no-semi") {
                     // https://github.com/shyiko/ktlint/issues/281
                     return
                 }
-                emit(node.startOffset, "Unnecessary semicolon", true)
+                emit(Issue(node.startOffset, "Unnecessary semicolon", true))
                 if (autoCorrect) {
                     node.treeParent.removeChild(node)
                 }
@@ -43,7 +44,7 @@ class NoSemicolonsRule : Rule("no-semi") {
                     return
                 }
                 // todo: move to a separate rule
-                emit(node.startOffset + 1, "Missing spacing after \";\"", true)
+                emit(Issue(node.startOffset + 1, "Missing spacing after \";\"", true))
                 if (autoCorrect) {
                     node.upsertWhitespaceAfterMe(" ")
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.nextLeaf
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -11,7 +12,7 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
@@ -32,13 +33,13 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     private fun checkForTrailingSpaces(
         lines: List<String>,
         offset: Int,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ): Boolean {
         var violated = false
         var violationOffset = offset
         lines.forEach { line ->
-            if (!line.isEmpty()) {
-                emit(violationOffset, "Trailing space(s)", true)
+            if (line.isNotEmpty()) {
+                emit(Issue(violationOffset, "Trailing space(s)", true))
                 violated = true
             }
             violationOffset += line.length + 1

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.FUN
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
@@ -13,14 +14,14 @@ class NoUnitReturnRule : Rule("no-unit-return") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == TYPE_REFERENCE &&
             node.treeParent.elementType == FUN &&
             node.text == "Unit" &&
             node.nextCodeLeaf(skipSubtree = true)?.elementType == LBRACE
         ) {
-            emit(node.startOffset, "Unnecessary \"Unit\" return type", true)
+            emit(Issue(node.startOffset, "Unnecessary \"Unit\" return type", true))
             if (autoCorrect) {
                 var prevNode = node
                 while (prevNode.treePrev.elementType != VALUE_PARAMETER_LIST) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
 import com.pinterest.ktlint.core.ast.ElementType.OPERATION_REFERENCE
@@ -48,7 +49,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
@@ -76,12 +77,12 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
                 (packageName.isEmpty() || importPath.startsWith("$packageName.")) &&
                 importPath.substring(packageName.length + 1).indexOf('.') == -1
             ) {
-                emit(node.startOffset, "Unnecessary import", true)
+                emit(Issue(node.startOffset, "Unnecessary import", true))
                 if (autoCorrect) {
                     importDirective.delete()
                 }
             } else if (name != null && !ref.contains(name) && !operatorSet.contains(name) && !name.isComponentN()) {
-                emit(node.startOffset, "Unused import", true)
+                emit(Issue(node.startOffset, "Unused import", true))
                 if (autoCorrect) {
                     importDirective.delete()
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -10,13 +11,13 @@ class NoWildcardImportsRule : Rule("no-wildcard-imports") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr
             if (path != null && !path.startsWith("kotlinx.android.synthetic") && path.contains('*')) {
-                emit(node.startOffset, "Wildcard import", false)
+                emit(Issue(node.startOffset, "Wildcard import", false))
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/PackageNameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/PackageNameRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.PACKAGE_DIRECTIVE
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -15,7 +16,7 @@ class PackageNameRule : Rule("package-name") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == PACKAGE_DIRECTIVE) {
             val qualifiedName = (node.psi as KtPackageDirective).qualifiedName
@@ -32,7 +33,7 @@ class PackageNameRule : Rule("package-name") {
             }
 */
             if (qualifiedName.contains('_')) {
-                emit(node.startOffset, "Package name must not contain underscore", false)
+                emit(Issue(node.startOffset, "Package name must not contain underscore", false))
                 // "package name must be in lowercase" is violated by too many to projects in the wild to forbid
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
@@ -26,7 +27,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
@@ -63,7 +64,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                         LPAR -> {
                             val prevLeaf = child.prevLeaf()
                             if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
-                                emit(child.startOffset, errorMessage(child), true)
+                                emit(Issue(child.startOffset, errorMessage(child), true))
                                 if (autoCorrect) {
                                     prevLeaf.delete()
                                 }
@@ -87,13 +88,15 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                                         continue@nextChild
                                     }
                                     emit(
-                                        child.startOffset,
-                                        "Unexpected indentation" +
-                                            " (expected ${intendedIndent.length - 1}, actual ${childIndent.length - 1})",
-                                        true
+                                        Issue(
+                                            child.startOffset,
+                                            "Unexpected indentation" +
+                                                " (expected ${intendedIndent.length - 1}, actual ${childIndent.length - 1})",
+                                            true
+                                        )
                                     )
                                 } else {
-                                    emit(child.startOffset, errorMessage(child), true)
+                                    emit(Issue(child.startOffset, errorMessage(child), true))
                                 }
                                 if (autoCorrect) {
                                     val adjustedIndent = (if (cut > -1) spacing.substring(0, cut) else "") + intendedIndent
@@ -101,7 +104,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                                     (prevLeaf as LeafPsiElement).rawReplaceWithText(adjustedIndent)
                                 }
                             } else {
-                                emit(child.startOffset, errorMessage(child), true)
+                                emit(Issue(child.startOffset, errorMessage(child), true))
                                 if (autoCorrect) {
                                     paramInnerIndentAdjustment = intendedIndent.length - child.column
                                     node.addChild(PsiWhiteSpaceImpl(intendedIndent), child)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION_ENTRY
@@ -23,7 +24,7 @@ class SpacingAroundColonRule : Rule("colon-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString() && !node.isPartOfComment()) {
             if (node.isPartOf(ANNOTATION) || node.isPartOf(ANNOTATION_ENTRY)) {
@@ -42,7 +43,7 @@ class SpacingAroundColonRule : Rule("colon-spacing") {
                 // (see SpacingAroundColonRuleTest.testFormatEOF & ChainWrappingRule)
                 prevLeaf.prevLeaf()?.isPartOfComment() != true
             ) {
-                emit(prevLeaf.startOffset, "Unexpected newline before \":\"", true)
+                emit(Issue(prevLeaf.startOffset, "Unexpected newline before \":\"", true))
                 val text = prevLeaf.text
                 if (autoCorrect) {
                     if (removeSpacingBefore) {
@@ -54,7 +55,7 @@ class SpacingAroundColonRule : Rule("colon-spacing") {
                 }
             }
             if (node.prevSibling is PsiWhiteSpace && removeSpacingBefore) {
-                emit(node.startOffset, "Unexpected spacing before \":\"", true)
+                emit(Issue(node.startOffset, "Unexpected spacing before \":\"", true))
                 if (autoCorrect) {
                     node.prevSibling.node.treeParent.removeChild(node.prevSibling.node)
                 }
@@ -68,20 +69,20 @@ class SpacingAroundColonRule : Rule("colon-spacing") {
             val missingSpacingAfter = node.nextSibling !is PsiWhiteSpace
             when {
                 missingSpacingBefore && missingSpacingAfter -> {
-                    emit(node.startOffset, "Missing spacing around \":\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing around \":\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                         node.upsertWhitespaceAfterMe(" ")
                     }
                 }
                 missingSpacingBefore -> {
-                    emit(node.startOffset, "Missing spacing before \":\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing before \":\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                     }
                 }
                 missingSpacingAfter -> {
-                    emit(node.startOffset + 1, "Missing spacing after \":\"", true)
+                    emit(Issue(node.startOffset + 1, "Missing spacing after \":\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceAfterMe(" ")
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.isPartOfString
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
@@ -18,12 +19,12 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
             if (prevLeaf is PsiWhiteSpace) {
-                emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true)
+                emit(Issue(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true))
                 if (autoCorrect) {
                     val isPrecededByComment = prevLeaf.prevLeaf { it !is PsiWhiteSpace } is PsiComment
                     if (isPrecededByComment && prevLeaf.isWhiteSpaceWithNewline()) {
@@ -42,7 +43,7 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
                 }
             }
             if (node.nextLeaf() !is PsiWhiteSpace) {
-                emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)
+                emit(Issue(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true))
                 if (autoCorrect) {
                     node.upsertWhitespaceAfterMe(" ")
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.AT
 import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
@@ -31,7 +32,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
@@ -53,7 +54,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
                         it.elementType == LPAR || it.elementType == AT
                     } == true
                 ) {
-                    emit(node.startOffset, "Unexpected space before \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Unexpected space before \"${node.text}\"", true))
                     if (autoCorrect) {
                         prevLeaf.node.treeParent.removeChild(prevLeaf.node)
                     }
@@ -68,7 +69,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
                             prevLeaf.treeParent.elementType == FUN
                         )
                 ) {
-                    emit(node.startOffset, "Unexpected newline before \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Unexpected newline before \"${node.text}\"", true))
                     if (autoCorrect) {
                         (prevLeaf as LeafPsiElement).rawReplaceWithText(" ")
                     }
@@ -79,7 +80,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
                 if (nextLeaf is PsiWhiteSpace && !nextLeaf.textContains('\n') &&
                     shouldNotToBeSeparatedBySpace(nextLeaf.nextLeaf())
                 ) {
-                    emit(node.startOffset, "Unexpected space after \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Unexpected space after \"${node.text}\"", true))
                     if (autoCorrect) {
                         nextLeaf.node.treeParent.removeChild(nextLeaf.node)
                     }
@@ -89,20 +90,20 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
             }
             when {
                 !spacingBefore && !spacingAfter -> {
-                    emit(node.startOffset, "Missing spacing around \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing around \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                         node.upsertWhitespaceAfterMe(" ")
                     }
                 }
                 !spacingBefore -> {
-                    emit(node.startOffset, "Missing spacing before \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing before \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                     }
                 }
                 !spacingAfter -> {
-                    emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)
+                    emit(Issue(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceAfterMe(" ")
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.isPartOfComment
 import com.pinterest.ktlint.core.ast.isPartOfString
@@ -14,19 +15,19 @@ class SpacingAroundDotRule : Rule("dot-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is LeafPsiElement && node.textMatches(".") && !node.isPartOfString() && !node.isPartOfComment()) {
             val prevLeaf = node.prevLeaf()
             if (prevLeaf is PsiWhiteSpace && !prevLeaf.textContains('\n')) {
-                emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true)
+                emit(Issue(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true))
                 if (autoCorrect) {
                     prevLeaf.node.treeParent.removeChild(prevLeaf.node)
                 }
             }
             val nextLeaf = node.nextLeaf()
             if (nextLeaf is PsiWhiteSpace) {
-                emit(nextLeaf.startOffset, "Unexpected spacing after \"${node.text}\"", true)
+                emit(Issue(nextLeaf.startOffset, "Unexpected spacing after \"${node.text}\"", true))
                 if (autoCorrect) {
                     nextLeaf.node.treeParent.removeChild(nextLeaf.node)
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CATCH_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.DO_KEYWORD
@@ -38,11 +39,11 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node is LeafPsiElement) {
             if (tokenSet.contains(node.elementType) && node.nextLeaf() !is PsiWhiteSpace) {
-                emit(node.startOffset + node.text.length, "Missing spacing after \"${node.text}\"", true)
+                emit(Issue(node.startOffset + node.text.length, "Missing spacing after \"${node.text}\"", true))
                 if (autoCorrect) {
                     node.upsertWhitespaceAfterMe(" ")
                 }
@@ -50,7 +51,7 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
                 val parent = node.parent
                 val nextLeaf = node.nextLeaf()
                 if (parent is KtPropertyAccessor && parent.hasBody() && nextLeaf != null) {
-                    emit(node.startOffset, "Unexpected spacing after \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Unexpected spacing after \"${node.text}\"", true))
                     if (autoCorrect) {
                         nextLeaf.treeParent.removeChild(nextLeaf)
                     }
@@ -72,7 +73,7 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
                                 presumablyCurly.treeParent?.treeParent?.treeParent == node.treeParent
                             )
                     ) {
-                        emit(node.startOffset, "Unexpected newline before \"${node.text}\"", true)
+                        emit(Issue(node.startOffset, "Unexpected newline before \"${node.text}\"", true))
                         if (autoCorrect) {
                             (prevLeaf as LeafElement).rawReplaceWithText(" ")
                         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ANDAND
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
@@ -53,7 +54,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (tokenSet.contains(node.elementType) &&
             node is LeafElement &&
@@ -70,7 +71,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
                         // ensure no space after < in <T>
                         val nextLeaf = node.nextLeaf()
                         if (nextLeaf?.elementType == WHITE_SPACE && !nextLeaf.textContains('\n')) {
-                            emit(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true)
+                            emit(Issue(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true))
                             if (autoCorrect) {
                                 nextLeaf.treeParent.removeChild(nextLeaf)
                             }
@@ -79,7 +80,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
                         // ensure no space before > in <T>
                         val prevLeaf = node.prevLeaf()
                         if (prevLeaf?.elementType == WHITE_SPACE && !prevLeaf.textContains('\n')) {
-                            emit(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true)
+                            emit(Issue(prevLeaf.startOffset, "Unexpected spacing before \"${node.text}\"", true))
                             if (autoCorrect) {
                                 prevLeaf.treeParent.removeChild(prevLeaf)
                             }
@@ -94,20 +95,20 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
             val spacingAfter = node.nextLeaf() is PsiWhiteSpace || node.elementType == LT
             when {
                 !spacingBefore && !spacingAfter -> {
-                    emit(node.startOffset, "Missing spacing around \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing around \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                         node.upsertWhitespaceAfterMe(" ")
                     }
                 }
                 !spacingBefore -> {
-                    emit(node.startOffset, "Missing spacing before \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Missing spacing before \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceBeforeMe(" ")
                     }
                 }
                 !spacingAfter -> {
-                    emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)
+                    emit(Issue(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true))
                     if (autoCorrect) {
                         node.upsertWhitespaceAfterMe(" ")
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
@@ -22,7 +23,7 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == LPAR || node.elementType == RPAR) {
             val prevLeaf = node.prevLeaf()
@@ -52,20 +53,20 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
             }
             when {
                 spacingBefore && spacingAfter -> {
-                    emit(node.startOffset, "Unexpected spacing around \"${node.text}\"", true)
+                    emit(Issue(node.startOffset, "Unexpected spacing around \"${node.text}\"", true))
                     if (autoCorrect) {
                         prevLeaf!!.treeParent.removeChild(prevLeaf)
                         nextLeaf!!.treeParent.removeChild(nextLeaf)
                     }
                 }
                 spacingBefore -> {
-                    emit(prevLeaf!!.startOffset, "Unexpected spacing before \"${node.text}\"", true)
+                    emit(Issue(prevLeaf!!.startOffset, "Unexpected spacing before \"${node.text}\"", true))
                     if (autoCorrect) {
                         prevLeaf.treeParent.removeChild(prevLeaf)
                     }
                 }
                 spacingAfter -> {
-                    emit(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true)
+                    emit(Issue(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true))
                     if (autoCorrect) {
                         nextLeaf!!.treeParent.removeChild(nextLeaf)
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.RANGE
 import com.pinterest.ktlint.core.ast.nextLeaf
@@ -12,27 +13,27 @@ class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.elementType == RANGE) {
             val prevLeaf = node.prevLeaf()
             val nextLeaf = node.nextLeaf()
             when {
                 prevLeaf is PsiWhiteSpace && nextLeaf is PsiWhiteSpace -> {
-                    emit(node.startOffset, "Unexpected spacing around \"..\"", true)
+                    emit(Issue(node.startOffset, "Unexpected spacing around \"..\"", true))
                     if (autoCorrect) {
                         prevLeaf.node.treeParent.removeChild(prevLeaf.node)
                         nextLeaf.node.treeParent.removeChild(nextLeaf.node)
                     }
                 }
                 prevLeaf is PsiWhiteSpace -> {
-                    emit(prevLeaf.node.startOffset, "Unexpected spacing before \"..\"", true)
+                    emit(Issue(prevLeaf.node.startOffset, "Unexpected spacing before \"..\"", true))
                     if (autoCorrect) {
                         prevLeaf.node.treeParent.removeChild(prevLeaf.node)
                     }
                 }
                 nextLeaf is PsiWhiteSpace -> {
-                    emit(nextLeaf.node.startOffset, "Unexpected spacing after \"..\"", true)
+                    emit(Issue(nextLeaf.node.startOffset, "Unexpected spacing after \"..\"", true))
                     if (autoCorrect) {
                         nextLeaf.node.treeParent.removeChild(nextLeaf.node)
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorsRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.EXCL
 import com.pinterest.ktlint.core.ast.ElementType.EXCLEXCL
@@ -29,7 +30,7 @@ class SpacingAroundUnaryOperatorsRule : Rule("unary-op-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (Issue) -> Unit
     ) {
         if (node is LeafElement && tokenSet.contains(node.elementType)) {
             val unaryExpressionNode = node.parent({ it.elementType in listOf(POSTFIX_EXPRESSION, PREFIX_EXPRESSION) })
@@ -37,7 +38,7 @@ class SpacingAroundUnaryOperatorsRule : Rule("unary-op-spacing") {
                 PREFIX_EXPRESSION -> {
                     val nextLeaf = node.nextLeaf()
                     if (nextLeaf is PsiWhiteSpace) {
-                        emit(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true)
+                        emit(Issue(node.startOffset + 1, "Unexpected spacing after \"${node.text}\"", true))
                         if (autoCorrect) {
                             nextLeaf.treeParent.removeChild(nextLeaf)
                         }
@@ -46,7 +47,7 @@ class SpacingAroundUnaryOperatorsRule : Rule("unary-op-spacing") {
                 POSTFIX_EXPRESSION -> {
                     val prevLeaf = node.prevLeaf()
                     if (prevLeaf is PsiWhiteSpace) {
-                        emit(node.startOffset - 1, "Unexpected spacing before \"${node.text}\"", true)
+                        emit(Issue(node.startOffset - 1, "Unexpected spacing before \"${node.text}\"", true))
                         if (autoCorrect) {
                             prevLeaf.treeParent.removeChild(prevLeaf)
                         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CLOSING_QUOTE
 import com.pinterest.ktlint.core.ast.ElementType.DOT
@@ -15,7 +16,7 @@ class StringTemplateRule : Rule("string-template") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         val elementType = node.elementType
         // code below is commented out because (setting aside potentially dangerous replaceChild part)
@@ -39,7 +40,7 @@ class StringTemplateRule : Rule("string-template") {
                     callExpression.text == "toString()" &&
                     dotQualifiedExpression.firstChildNode?.elementType != SUPER_EXPRESSION
                 ) {
-                    emit(dot.startOffset, "Redundant \"toString()\" call in string template", true)
+                    emit(Issue(dot.startOffset, "Redundant \"toString()\" call in string template", true))
                     if (autoCorrect) {
                         node.removeChild(dot)
                         node.removeChild(callExpression)
@@ -56,7 +57,7 @@ class StringTemplateRule : Rule("string-template") {
                             )
                 }
             ) {
-                emit(node.treePrev.startOffset + 2, "Redundant curly braces", true)
+                emit(Issue(node.treePrev.startOffset + 2, "Redundant curly braces", true))
                 if (autoCorrect) {
                     // fixme: a proper way would be to downcast to SHORT_STRING_TEMPLATE_ENTRY
                     (node.firstChildNode as LeafPsiElement).rawReplaceWithText("$") // entry start

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintIssue
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions
@@ -64,7 +65,7 @@ class MultiLineIfElseRuleTest {
         return MultiLineIfElseRule().format(kotlinScript)
     }
 
-    private fun lint(kotlinScript: String): List<LintError> {
+    private fun lint(kotlinScript: String): List<LintIssue> {
         return MultiLineIfElseRule().lint(kotlinScript)
     }
 }

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/DumpAST.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/DumpAST.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.test
 
+import com.pinterest.ktlint.core.Issue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.isRoot
@@ -31,7 +32,7 @@ class DumpAST @JvmOverloads constructor(
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit
+        emit: (issue: Issue) -> Unit
     ) {
         if (node.isRoot()) {
             lineNumberColumnLength =

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -2,14 +2,15 @@ package com.pinterest.ktlint.test
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.LintIssue
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.RuleSet
 import java.util.ArrayList
 import org.assertj.core.util.diff.DiffUtils.diff
 import org.assertj.core.util.diff.DiffUtils.generateUnifiedDiff
 
-fun Rule.lint(text: String, userData: Map<String, String> = emptyMap(), script: Boolean = false): List<LintError> {
-    val res = ArrayList<LintError>()
+fun Rule.lint(text: String, userData: Map<String, String> = emptyMap(), script: Boolean = false): List<LintIssue> {
+    val res = ArrayList<LintIssue>()
     val debug = debugAST()
     val f: L = if (script) KtLint::lintScript else KtLint::lint
     f(
@@ -30,13 +31,13 @@ private typealias L = (
     text: String,
     ruleSets: Iterable<RuleSet>,
     userData: Map<String, String>,
-    cb: (e: LintError) -> Unit
+    cb: (e: LintIssue) -> Unit
 ) -> Unit
 
 fun Rule.format(
     text: String,
     userData: Map<String, String> = emptyMap(),
-    cb: (e: LintError, corrected: Boolean) -> Unit = { _, _ -> },
+    cb: (e: LintIssue, corrected: Boolean) -> Unit = { _, _ -> },
     script: Boolean = false
 ): String {
     val f: F = if (script) KtLint::formatScript else KtLint::format
@@ -52,7 +53,7 @@ private typealias F = (
     text: String,
     ruleSets: Iterable<RuleSet>,
     userData: Map<String, String>,
-    cb: (e: LintError, corrected: Boolean) -> Unit
+    cb: (e: LintIssue, corrected: Boolean) -> Unit
 ) -> String
 
 fun Rule.diffFileLint(path: String, userData: Map<String, String> = emptyMap()): String {
@@ -78,7 +79,7 @@ fun Rule.diffFileLint(path: String, userData: Map<String, String> = emptyMap()):
         }
     }
     val actual = lint(input, userData, script = true)
-    val str = { err: LintError ->
+    val str = { err: LintIssue ->
         val ruleId = if (err.ruleId != id) " (${err.ruleId})" else ""
         val correctionStatus = if (!err.canBeAutoCorrected) " (cannot be auto-corrected)" else ""
         "${err.line}:${err.col}:${err.detail}$ruleId$correctionStatus"


### PR DESCRIPTION
After i start using ktlint i was amazed how easy it was to write my own rules.
Since my team was planing to use it on our PR build pipeline the tool would be perfect for us to enforce all the constraints that we agree to follow.

But, given that some agreements can be very aggressive to be enforce suddenly, we decided that they should appear as Warning only until we could put it for real.

Searching through the code base i wasn't able to find any configuration for this so i decided to customize it and it's working very well for us.

**So how does it works?**

I had to change the way we emit the problems encountered on the code evaluation. Instead of emitting line, col and ruleId we now have to emit an Issue. It contains all three mentioned parameters plus an IssueType parameter (defaults to Error) that can be used to inform if it's an Error or a Warning.

All the code was refactored to emit Issues and the reporter classes now can also provide this information. For example, when using plain reporter we receive this:

```
/path/to/file
[ERROR] 12:3 Issue description
```

I believe in the future it can be improved to allow the user to configure which rules should be treated as Warnings or Erros, or even create new types of Issue

