### PR TITLE
Allow // ktlint-disable directives to exceed the max line length

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -48,15 +48,18 @@ class MaxLineLengthRule : Rule("max-line-length"), Rule.Modifier.Last {
                                 errorOffset.add(offset)
                             }
                         } else {
-                            // if comment is the only thing on the line - fine, otherwise emit an error
-                            val prevLeaf = el.prevCodeSibling()
-                            if (prevLeaf != null && prevLeaf.startOffset >= offset) {
-                                // fixme:
-                                // normally we would emit here but due to API limitations we need to hold off until
-                                // node spanning the same offset is 'visit'ed
-                                // (for ktlint-disable directive to have effect (when applied))
-                                // this will be rectified in the upcoming release(s)
-                                errorOffset.add(offset)
+                            // Allow ktlint-disable comments to exceed max line length
+                            if (!el.text.startsWith("// ktlint-disable")) {
+                                // if comment is the only thing on the line - fine, otherwise emit an error
+                                val prevLeaf = el.prevCodeSibling()
+                                if (prevLeaf != null && prevLeaf.startOffset >= offset) {
+                                    // fixme:
+                                    // normally we would emit here but due to API limitations we need to hold off until
+                                    // node spanning the same offset is 'visit'ed
+                                    // (for ktlint-disable directive to have effect (when applied))
+                                    // this will be rectified in the upcoming release(s)
+                                    errorOffset.add(offset)
+                                }
                             }
                         }
                     }
@@ -73,7 +76,7 @@ class MaxLineLengthRule : Rule("max-line-length"), Rule.Modifier.Last {
         }
     }
 
-    fun ASTNode.isPartOfRawMultiLineString() =
+    private fun ASTNode.isPartOfRawMultiLineString() =
         parent(ElementType.STRING_TEMPLATE, strict = false)
             ?.let { it.firstChildNode.text == "\"\"\"" && it.textContains('\n') } == true
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/max-line-length/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/max-line-length/lint.kt.spec
@@ -1,4 +1,8 @@
-package com.omg.sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.long
+package com.omgsooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.long
+
+import com.omg.sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.superduper.long
+import com.omg.kindof.long // ktlint-disable fake-rule-with-a-super-duper-long-name
+import com.omg.kindof.long // some other comment that is really long why is this here?
 
 // http://______________________________________________________________________.
 fun main() {
@@ -31,7 +35,8 @@ fun main() {
  */
 
 // expect
-// 6:1:Exceeded max line length (80) (cannot be auto-corrected)
-// 7:1:Exceeded max line length (80) (cannot be auto-corrected)
-// 8:1:Exceeded max line length (80) (cannot be auto-corrected)
+// 5:1:Exceeded max line length (80) (cannot be auto-corrected)
 // 10:1:Exceeded max line length (80) (cannot be auto-corrected)
+// 11:1:Exceeded max line length (80) (cannot be auto-corrected)
+// 12:1:Exceeded max line length (80) (cannot be auto-corrected)
+// 14:1:Exceeded max line length (80) (cannot be auto-corrected)


### PR DESCRIPTION
Normally we only allow comments to exceed the max line length if they're the only thing on the line, but we should add an exception for `// ktlint-disable` since that can be used to suppress a rule on a single line, and we don't have control over the line length.