### PR TITLE
Implement .ktlintignore for globally disabling rules

### DIFF
--- a/.ktlintignore
+++ b/.ktlintignore
@@ -1,0 +1,7 @@
+// disabled ("./mvnw clean verify" fails with "Internal Error")
+annotation
+// disabled until auto-correct is working properly
+// (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
+multiline-if-else
+// disabled until it's clear what to do in case of `import _.it`
+no-it-in-multiline-lambda

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -7,25 +7,20 @@ class StandardRuleSetProvider : RuleSetProvider {
 
     override fun get(): RuleSet = RuleSet(
         "standard",
-        // disabled ("./mvnw clean verify" fails with "Internal Error")
-        // AnnotationRule(),
+        AnnotationRule(),
         ChainWrappingRule(),
         CommentSpacingRule(),
         FilenameRule(),
         FinalNewlineRule(),
-        // disabled until there is a way to suppress rules globally (https://git.io/fhxnm)
-        // PackageNameRule(),
-        // disabled until auto-correct is working properly
-        // (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
-        // MultiLineIfElseRule(),
+        PackageNameRule(),
+        MultiLineIfElseRule(),
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),
         NoBlankLineBeforeRbraceRule(),
         NoConsecutiveBlankLinesRule(),
         NoEmptyClassBodyRule(),
-        // disabled until it's clear what to do in case of `import _.it`
-        // NoItParamInMultilineLambdaRule(),
+        NoItParamInMultilineLambdaRule(),
         NoLineBreakAfterElseRule(),
         NoLineBreakBeforeAssignmentRule(),
         NoMultipleSpacesRule(),
@@ -33,11 +28,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         NoTrailingSpacesRule(),
         NoUnitReturnRule(),
         NoUnusedImportsRule(),
-        // Disabling because it is now allowed by the Jetbrains styleguide, although it is still disallowed by
-        // the Android styleguide.
-        // Re-enable when there is a way to globally disable rules
-        // See discussion here: https://github.com/pinterest/ktlint/issues/48
-        // NoWildcardImportsRule(),
+        NoWildcardImportsRule(),
         ParameterListWrappingRule(),
         SpacingAroundColonRule(),
         SpacingAroundCommaRule(),


### PR DESCRIPTION
Fixes #208

* Added support for .ktlintignore file - takes a list of rule Ids to disable (ignores comments)
* Currently only supports globally disabling rules, but added some plumbing so that it's easier to support per-file/per-path disabling, or multiple .ktlintignore files
* Re-enabled NoWildcardImports, PackageNameRule
* Un-commented AnnotationRule, MultiLineIfElseRule, and NoItParamInMultilineLambdaRule, and moved disabling into .ktlintignore