### PR TITLE
Process of migrating to gradle - organize gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,39 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm" version "1.3.31" apply false
+  id 'org.jetbrains.kotlin.jvm' version '1.3.31' apply false
 }
 
-ext.libraries = [
-  "kotlin_stdlib": "org.jetbrains.kotlin:kotlin-stdlib:1.3.31",
-  "kotlin_compiler_embeddable": "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.31",
-  "klob": "com.github.shyiko.klob:klob:0.2.1",
-  "aether_api": "org.eclipse.aether:aether-api:1.1.0",
-  "aether_spi": "org.eclipse.aether:aether-spi:1.1.0",
-  "aether_util": "org.eclipse.aether:aether-util:1.1.0",
-  "aether_impl": "org.eclipse.aether:aether-impl:1.1.0",
-  "aether_connector_basic": "org.eclipse.aether:aether-connector-basic:1.1.0",
-  "aether_transport_file": "org.eclipse.aether:aether-transport-file:1.1.0",
-  "aether_transport_http": "org.eclipse.aether:aether-transport-http:1.1.0",
-  // Used to silence aether-transport-http
-  "slf4j_nop": "org.slf4j:slf4j-nop:1.6.2",
-  "maven_aether_provider": "org.apache.maven:maven-aether-provider:3.2.5",
-  "picocli": "info.picocli:picocli:2.3.0",
+ext.versions = [
+  'kotlin': '1.3.31',
+  'aether': '1.1.0'
+]
 
+ext.deps = [
+  'kotlin'        : [
+    'stdlib'  : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
+    'compiler': "org.jetbrains.kotlin:kotlin-compiler-embeddable:${versions.kotlin}"
+  ],
+  'klob'          : 'com.github.shyiko.klob:klob:0.2.1',
+  'aether'        : [
+    'api'      : "org.eclipse.aether:aether-api:${versions.aether}",
+    'spi'      : "org.eclipse.aether:aether-spi:${versions.aether}",
+    'util'     : "org.eclipse.aether:aether-util:${versions.aether}",
+    'impl'     : "org.eclipse.aether:aether-impl:${versions.aether}",
+    'connector': [
+      'basic': "org.eclipse.aether:aether-connector-basic:${versions.aether}",
+    ],
+    'transport': [
+      'file': "org.eclipse.aether:aether-transport-file:${versions.aether}",
+      'http': "org.eclipse.aether:aether-transport-http:${versions.aether}",
+    ]
+  ],
+  // Used to silence aether-transport-http
+  'slf4j'          : 'org.slf4j:slf4j-nop:1.6.2',
+  'aetherProvider': 'org.apache.maven:maven-aether-provider:3.2.5',
+  'picocli'       : 'info.picocli:picocli:2.3.0',
   // Testing libraries
-  "junit": "junit:junit:4.12",
-  "assertj_core": "org.assertj:assertj-core:3.9.0",
-  "jimfs": "com.google.jimfs:jimfs:1.1"
+  'junit'         : 'junit:junit:4.12',
+  'assertj'       : 'org.assertj:assertj-core:3.9.0',
+  'jimfs'         : 'com.google.jimfs:jimfs:1.1'
 ]
 
 subprojects {

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
-  compile libraries.kotlin_stdlib
-  compile libraries.kotlin_compiler_embeddable
+  compile deps.kotlin.stdlib
+  compile deps.kotlin.compiler
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-reporter-checkstyle/build.gradle
+++ b/ktlint-reporter-checkstyle/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
-  compile project(":ktlint-core")
-  compile libraries.kotlin_stdlib
+  compile project(':ktlint-core')
+  compile deps.kotlin.stdlib
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-reporter-json/build.gradle
+++ b/ktlint-reporter-json/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
   compile project(':ktlint-core')
-  compile libraries.kotlin_stdlib
+  compile deps.kotlin.stdlib
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-reporter-plain/build.gradle
+++ b/ktlint-reporter-plain/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
   compile project(':ktlint-core')
-  compile libraries.kotlin_stdlib
+  compile deps.kotlin.stdlib
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
   compile project(':ktlint-core')
   compile project(':ktlint-test')
-  compile libraries.kotlin_stdlib
+  compile deps.kotlin.stdlib
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
   compile project(':ktlint-core')
   compile project(':ktlint-test')
-  compile libraries.kotlin_stdlib
+  compile deps.kotlin.stdlib
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
+  testCompile deps.junit
+  testCompile deps.assertj
 }

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
+  id 'org.jetbrains.kotlin.jvm'
 }
 
 dependencies {
   compile project(':ktlint-core')
-  compile libraries.kotlin_stdlib
-  compile libraries.assertj_core
+  compile deps.kotlin.stdlib
+  compile deps.assertj
 }

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm"
-  id "application"
+  id 'org.jetbrains.kotlin.jvm'
+  id 'application'
   // applied after mainClassName per https://github.com/johnrengelman/shadow/issues/336
-  id "com.github.johnrengelman.shadow" version "4.0.2" apply false
+  id 'com.github.johnrengelman.shadow' version '4.0.2' apply false
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
@@ -15,29 +15,29 @@ shadowJar {
 }
 
 dependencies {
-  compile project(":ktlint-core")
-  compile project(":ktlint-reporter-checkstyle")
-  compile project(":ktlint-reporter-json")
-  compile project(":ktlint-reporter-plain")
-  compile project(":ktlint-ruleset-experimental")
-  compile project(":ktlint-ruleset-standard")
-  compile project(":ktlint-test")
-  compile libraries.kotlin_stdlib
-  compile libraries.klob
-  compile libraries.aether_api
-  compile libraries.aether_spi
-  compile libraries.aether_util
-  compile libraries.aether_impl
-  compile libraries.aether_connector_basic
-  compile libraries.aether_transport_file
-  compile libraries.aether_transport_http
-  compile libraries.slf4j_nop
-  compile libraries.maven_aether_provider
-  compile libraries.picocli
+  compile project(':ktlint-core')
+  compile project(':ktlint-reporter-checkstyle')
+  compile project(':ktlint-reporter-json')
+  compile project(':ktlint-reporter-plain')
+  compile project(':ktlint-ruleset-experimental')
+  compile project(':ktlint-ruleset-standard')
+  compile project(':ktlint-test')
+  compile deps.kotlin.stdlib
+  compile deps.klob
+  compile deps.aether.api
+  compile deps.aether.spi
+  compile deps.aether.util
+  compile deps.aether.impl
+  compile deps.aether.connector.basic
+  compile deps.aether.transport.file
+  compile deps.aether.transport.http
+  compile deps.slf4j
+  compile deps.aetherProvider
+  compile deps.picocli
 
-  testCompile libraries.junit
-  testCompile libraries.assertj_core
-  testCompile libraries.jimfs
+  testCompile deps.junit
+  testCompile deps.assertj
+  testCompile deps.jimfs
 }
 
 compileKotlin {
@@ -45,6 +45,6 @@ compileKotlin {
   targetCompatibility = JavaVersion.VERSION_1_8
 
   kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = '1.8'
   }
 }


### PR DESCRIPTION
#445

@shashachu

Clean up and organize Gradle dependencies across the project. This is similar to other open source Gradle projects such as https://github.com/JakeWharton/SdkSearch/blob/master/build.gradle#L18.