### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 !ktlint/src/main/resources/config/.idea
 /.idea
 *.iml
+out


### PR DESCRIPTION
The `out` folders are tracked by git once they are generated. Adding them to .gitignore