### PR TITLE
Update picoli depenedency to 3.9.6 version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext.deps = [
   // Used to silence aether-transport-http
   'slf4j'          : 'org.slf4j:slf4j-nop:1.6.2',
   'aetherProvider': 'org.apache.maven:maven-aether-provider:3.2.5',
-  'picocli'       : 'info.picocli:picocli:2.3.0',
+  'picocli'       : 'info.picocli:picocli:3.9.6',
   // Testing libraries
   'junit'         : 'junit:junit:4.12',
   'assertj'       : 'org.assertj:assertj-core:3.9.0',

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -55,7 +55,7 @@ import picocli.CommandLine.Parameters
 @Command(
     headerHeading =
 """An anti-bikeshedding Kotlin linter with built-in formatter
-(https://github.com/shyiko/ktlint).
+(https://github.com/pinterest/ktlint).
 
 Usage:
   ktlint <flags> [patterns]
@@ -565,7 +565,7 @@ object Main {
                 LintError(
                     e.line, e.col, "",
                     "Internal Error (${e.ruleId}). " +
-                        "Please create a ticket at https://github.com/shyiko/ktlint/issue " +
+                        "Please create a ticket at https://github.com/pinterest/ktlint/issue " +
                         "(if possible, provide the source code that triggered an error)"
                 )
             }
@@ -695,7 +695,7 @@ object Main {
         }
         System.err.println("(updated)")
         System.err.println("\nPlease restart your IDE")
-        System.err.println("(if you experience any issues please report them at https://github.com/shyiko/ktlint)")
+        System.err.println("(if you experience any issues please report them at https://github.com/pinterest/ktlint)")
     }
 
     private fun hex(input: ByteArray) = BigInteger(MessageDigest.getInstance("SHA-256").digest(input)).toString(16)
@@ -788,7 +788,7 @@ object Main {
                         if (result.any { it.toString().substringAfterLast("/").startsWith("ktlint-core-") }) {
                             System.err.println(
                                 "\"$artifact\" appears to have a runtime/compile dependency on \"ktlint-core\".\n" +
-                                    "Please inform the author that \"com.github.shyiko:ktlint*\" should be marked " +
+                                    "Please inform the author that \"com.pinterest:ktlint*\" should be marked " +
                                     "compileOnly (Gradle) / provided (Maven).\n" +
                                     "(to suppress this warning use --skip-classpath-check)"
                             )

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <klob.version>0.2.1</klob.version>
         <aether.version>1.1.0</aether.version>
         <aether.maven.provider.version>3.3.9</aether.maven.provider.version>
-        <picocli.version>2.3.0</picocli.version>
+        <picocli.version>3.9.6</picocli.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.9.0</assertj.version>
         <jimfs.version>1.1</jimfs.version>


### PR DESCRIPTION
This dependency provides support for parsing command line arguments  and printing help message.

IMHO, most interesting changes since current version, that I would like to add in followup PRs:
- [Improved help message layout](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-improved-usage-help-message-layout)
- [Help command](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-help-command)
- [Standard help options](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-standard-help-options)
- [Programmatic api](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-programmatic-api)
- [Command aliases](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#command-aliases)
- [Option completion candidates](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-completion-candidates)
- [Command line completion](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#-jline-tab-completion-support)
- [Internationalization](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#internationalization)
- [Command line methods](https://github.com/remkop/picocli/blob/master/RELEASE-NOTES.md#command-methods)