### PR TITLE
Deprecate MavenDependencyResolver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,11 +315,6 @@ Once packaged in a JAR <sup>[e.g. via `./gradlew build`](https://github.com/pint
 ```sh
 # enable additional 3rd party ruleset by pointing ktlint to its location on the file system
 $ ktlint -R /path/to/custom/rulseset.jar "src/test/**/*.kt"
-
-# you can also use <groupId>:<artifactId>:<version> triple in which case artifact is
-# downloaded from Maven Central, JCenter or JitPack (depending on where it's located and 
-# whether or not it's already present in local Maven cache)
-$ ktlint -R com.github.username:rulseset:master-SNAPSHOT
 ```
 
 A complete sample project (with tests and build files) is included in this repo under the [ktlint-ruleset-template](ktlint-ruleset-template) directory 
@@ -367,7 +362,7 @@ In short, all you need to do is to implement a
 a custom [ReporterProvider](ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt) using
 `META-INF/services/com.pinterest.ktlint.core.ReporterProvider`. Pack all of that into a JAR and you're done.
 
-To load a custom (3rd party) reporter use `ktlint --reporter=name,artifact=groupId:artifactId:version` / `ktlint --reporter=name,artifact=/path/to/custom-ktlint-reporter.jar`
+To load a custom (3rd party) reporter use `ktlint --reporter=name,artifact=/path/to/custom-ktlint-reporter.jar`
 (see `ktlint --help` for more).
 
 Third-party:

--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ Once packaged in a JAR <sup>[e.g. via `./gradlew build`](https://github.com/pint
 $ ktlint -R /path/to/custom/rulseset.jar "src/test/**/*.kt"
 ```
 
+Loading custom (3rd party) ruleset via built-in maven dependency resolver is deprecated,
+see https://github.com/pinterest/ktlint/issues/451.
+
 A complete sample project (with tests and build files) is included in this repo under the [ktlint-ruleset-template](ktlint-ruleset-template) directory 
 (make sure to check [NoVarRuleTest](ktlint-ruleset-template/src/test/kotlin/yourpkgname/NoVarRuleTest.kt) as it contains some useful information). 
 
@@ -364,6 +367,9 @@ a custom [ReporterProvider](ktlint-core/src/main/kotlin/com/pinterest/ktlint/cor
 
 To load a custom (3rd party) reporter use `ktlint --reporter=name,artifact=/path/to/custom-ktlint-reporter.jar`
 (see `ktlint --help` for more).
+
+Loading custom (3rd party) reporter via built-in maven dependency resolver is deprecated,
+see https://github.com/pinterest/ktlint/issues/451.
 
 Third-party:
 * [mcassiano/ktlint-html-reporter](https://github.com/mcassiano/ktlint-html-reporter)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -175,21 +175,19 @@ object Main {
         names = ["--reporter"],
         description = [
             "A reporter to use (built-in: plain (default), plain?group_by_file, json, checkstyle). " +
-                "To use a third-party reporter specify either a path to a JAR file on the filesystem or a" +
-                "<groupId>:<artifactId>:<version> triple pointing to a remote artifact " +
-                "(in which case ktlint will first check local cache (~/.m2/repository) and then, " +
-                "if not found, attempt downloading it from Maven Central/JCenter/JitPack/user-provided repository)\n" +
-                "e.g. \"html,artifact=com.github.username:ktlint-reporter-html:master-SNAPSHOT\""
+                "To use a third-party reporter specify a path to a JAR file on the filesystem."
         ]
     )
     private var reporters = ArrayList<String>()
 
+    @Deprecated("See https://github.com/pinterest/ktlint/issues/451")
     @Option(
         names = ["--repository"],
         description = [
             "An additional Maven repository (Maven Central/JCenter/JitPack are active by default) " +
                 "(value format: <id>=<url>)"
-        ]
+        ],
+        hidden = true
     )
     private var repositories = ArrayList<String>()
 
@@ -213,12 +211,7 @@ object Main {
 
     @Option(
         names = ["--ruleset", "-R"],
-        description = [
-            "A path to a JAR file containing additional ruleset(s) or a " +
-                "<groupId>:<artifactId>:<version> triple pointing to a remote artifact " +
-                "(in which case ktlint will first check local cache (~/.m2/repository) and then, " +
-                "if not found, attempt downloading it from Maven Central/JCenter/JitPack/user-provided repository)"
-        ]
+        description = ["A path to a JAR file containing additional ruleset(s)"]
     )
     private var rulesets = ArrayList<String>()
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/MavenDependencyResolver.kt
@@ -64,6 +64,8 @@ class MavenDependencyResolver(
     }
 
     fun resolve(vararg artifacts: Artifact): Collection<File> {
+        System.err.println("[WARNING] Resolving third party rules/reporters from artifactory is deprecated!")
+        System.err.println("[WARNING] See: https://github.com/pinterest/ktlint/issues/451")
         val collectRequest = CollectRequest()
         artifacts.forEach {
             collectRequest.addDependency(Dependency(it, "compile"))


### PR DESCRIPTION
- print warning message with link to the issue #451, when resolver is used
- hide related command-line options
- remove mentioning from project readme

To see warning message run:
```sh
$ ./ktlint/target/ktlint --debug --reporter=html,artifact=me.cassiano:ktlint-html-reporter:0.2.3,output=ktlint.html ktlint/src/**/*.kt
```
On using direct jar file, message should not be visible:
```sh
$ ./ktlint/target/ktlint --debug --reporter=html,artifact=~/.m2/repository/me/cassiano/ktlint-html-reporter/0.2.3/ktlint-html-reporter-0.2.3.jar,output=ktlint.html ktlint/src/**/*.kt
```