### PR TITLE
Adding experimental rule for detecting first line blank in method block

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -8,6 +8,7 @@ class ExperimentalRuleSetProvider : RuleSetProvider {
     override fun get(): RuleSet = RuleSet(
         "experimental",
         ImportOrderingRule(),
-        IndentationRule()
+        IndentationRule(),
+        NoFirstLineBlankInMethodBlockRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoFirstLineBlankInMethodBlockRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoFirstLineBlankInMethodBlockRule.kt
@@ -1,0 +1,34 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType
+import com.pinterest.ktlint.core.ast.ElementType.FUN
+import com.pinterest.ktlint.core.ast.isPartOf
+import com.pinterest.ktlint.core.ast.prevLeaf
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+
+class NoFirstLineBlankInMethodBlockRule : Rule("no-first-line-blank-in-method-block-rule") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node is PsiWhiteSpace && node.textContains('\n') &&
+            node.prevLeaf()?.elementType == ElementType.LBRACE && node.isPartOf(FUN)
+        ) {
+            val split = node.getText().split("\n")
+            if (split.size > 2) {
+                emit(
+                    node.startOffset + 1,
+                    "First line in a method block should not be empty", true
+                )
+                if (autoCorrect) {
+                    (node as LeafPsiElement).rawReplaceWithText("${split.first()}\n${split.last()}")
+                }
+            }
+        }
+    }
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoFirstLineBlankInMethodBlockRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoFirstLineBlankInMethodBlockRuleTest.kt
@@ -1,0 +1,143 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class NoFirstLineBlankInMethodBlockRuleTest {
+
+    @Test
+    fun testFormatIsCorrect() {
+        val formattedFunction =
+            """
+            fun bar() {
+               val a = 2
+            }
+            """.trimIndent()
+
+        assertThat(NoFirstLineBlankInMethodBlockRule().lint(formattedFunction)).isEmpty()
+        assertThat(NoFirstLineBlankInMethodBlockRule().format(formattedFunction)).isEqualTo(formattedFunction)
+    }
+
+    @Test
+    fun testFormatWhenFirstLineIsEmptyInMethod() {
+        val unformattedFunction =
+            """
+            fun bar() {
+
+               val a = 2
+            }
+            """.trimIndent()
+        val formattedFunction =
+            """
+            fun bar() {
+               val a = 2
+            }
+            """.trimIndent()
+
+        assertThat(NoFirstLineBlankInMethodBlockRule().lint(unformattedFunction)).isEqualTo(
+            listOf(
+                LintError(2, 1, "no-first-line-blank-in-method-block-rule", "First line in a method block should not be empty")
+            )
+        )
+        assertThat(NoFirstLineBlankInMethodBlockRule().format(unformattedFunction)).isEqualTo(formattedFunction)
+    }
+
+    @Test
+    fun testFormatWhenFirstLineIsEmptyInABlockWithinMethod() {
+        val unformattedFunction =
+            """
+            fun funA() {
+
+                if (conditionA()) {
+
+                    doSomething()
+                } else if (conditionB()) {
+                    doAnotherThing()
+                }
+            }
+            """.trimIndent()
+        val formattedFunction =
+            """
+            fun funA() {
+                if (conditionA()) {
+                    doSomething()
+                } else if (conditionB()) {
+                    doAnotherThing()
+                }
+            }
+            """.trimIndent()
+
+        assertThat(NoFirstLineBlankInMethodBlockRule().lint(unformattedFunction)).isEqualTo(
+            listOf(
+                LintError(2, 1, "no-first-line-blank-in-method-block-rule", "First line in a method block should not be empty"),
+                LintError(4, 1, "no-first-line-blank-in-method-block-rule", "First line in a method block should not be empty")
+            )
+        )
+        assertThat(NoFirstLineBlankInMethodBlockRule().format(unformattedFunction)).isEqualTo(formattedFunction)
+    }
+
+    @Test
+    fun testFormatWhenFirstLineIsEmptyOnlyInABlockWithinMethod() {
+        val unformattedFunction =
+            """
+            fun funA() {
+                if (conditionA()) {
+
+                    doSomething()
+                } else if (conditionB()) {
+                    doAnotherThing()
+                }
+            }
+            """.trimIndent()
+        val formattedFunction =
+            """
+            fun funA() {
+                if (conditionA()) {
+                    doSomething()
+                } else if (conditionB()) {
+                    doAnotherThing()
+                }
+            }
+            """.trimIndent()
+
+        assertThat(NoFirstLineBlankInMethodBlockRule().lint(unformattedFunction)).isEqualTo(
+            listOf(
+                LintError(3, 1, "no-first-line-blank-in-method-block-rule", "First line in a method block should not be empty")
+            )
+        )
+        assertThat(NoFirstLineBlankInMethodBlockRule().format(unformattedFunction)).isEqualTo(formattedFunction)
+    }
+
+    @Test
+    fun testFormatWhenFirstLineIsEmptyInFunctionButIgnoreAtClassLevel() {
+        val unformattedFunction =
+            """
+            class A {
+
+                fun bar() {
+
+                   val a = 2
+                }
+            }
+            """.trimIndent()
+        val formattedFunction =
+            """
+            class A {
+
+                fun bar() {
+                   val a = 2
+                }
+            }
+            """.trimIndent()
+
+        assertThat(NoFirstLineBlankInMethodBlockRule().lint(unformattedFunction)).isEqualTo(
+            listOf(
+                LintError(4, 1, "no-first-line-blank-in-method-block-rule", "First line in a method block should not be empty")
+            )
+        )
+        assertThat(NoFirstLineBlankInMethodBlockRule().format(unformattedFunction)).isEqualTo(formattedFunction)
+    }
+}

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -887,7 +887,6 @@ object Main {
         numberOfThreads: Int = Runtime.getRuntime().availableProcessors()
     ) {
         val pill = object : Future<T> {
-
             override fun isDone(): Boolean { throw UnsupportedOperationException() }
             override fun get(timeout: Long, unit: TimeUnit): T { throw UnsupportedOperationException() }
             override fun get(): T { throw UnsupportedOperationException() }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/EditorConfig.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/EditorConfig.kt
@@ -40,7 +40,6 @@ class EditorConfig private constructor (
                 }
 
         fun cached(): EditorConfigLookup = object : EditorConfigLookup {
-
             // todo: concurrent radix tree can potentially save a lot of memory here
             private val cache = ConcurrentHashMap<Path, CompletableFuture<EditorConfig?>>()
 
@@ -115,7 +114,6 @@ class EditorConfig private constructor (
         private fun load(path: Path) =
             linkedMapOf<String, Map<String, String>>().also { map ->
                 object : Properties() {
-
                     private var section: MutableMap<String, String>? = null
 
                     override fun put(key: Any, value: Any): Any? {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/MavenDependencyResolver.kt
@@ -53,7 +53,6 @@ class MavenDependencyResolver(
 
     fun setTransferEventListener(listener: (event: TransferEvent) -> Unit) {
         (session as DefaultRepositorySystemSession).transferListener = object : TransferListener {
-
             override fun transferProgressed(event: TransferEvent) = listener(event)
             override fun transferStarted(event: TransferEvent) = listener(event)
             override fun transferInitiated(event: TransferEvent) = listener(event)


### PR DESCRIPTION
This experimental rule addresses issue Issue [#440](https://github.com/pinterest/ktlint/issues/440)
In addition to checking for first line blank in a method block, it will check for any first blank line in code blocks of the method.Please let me know if the subsequent code blocks in the method need to be ignored from this check.

Due to this new rule, there were violations reported in the code. Have fixed them also.

This is same as PR [#461](https://github.com/pinterest/ktlint/pull/461).