### PR TITLE
Add missing SpacingAroundUnaryOperatorsRule to standard rule set

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -47,6 +47,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         SpacingAroundOperatorsRule(),
         SpacingAroundParensRule(),
         SpacingAroundRangeOperatorRule(),
+        SpacingAroundUnaryOperatorsRule(),
         StringTemplateRule()
     )
 }


### PR DESCRIPTION
I guess you'd also like to update the release changelog, and maybe release a new patch version where the rule is included :) 

As this happens not for the first time, that newly implemented rules are not being added to the ruleset, I came up with a test which checks whether a provider returns all the rules from the `src` folder or not. I will follow on this up with a PR.