### PR TITLE
Add tests for missing rules in a ruleset

### DIFF
--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProviderTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProviderTest.kt
@@ -1,0 +1,8 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.test.RuleSetProviderTest
+
+class ExperimentalRuleSetProviderTest : RuleSetProviderTest(
+    rulesetClass = ExperimentalRuleSetProvider::class.java,
+    packageName = "com.pinterest.ktlint.ruleset.experimental"
+)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProviderTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProviderTest.kt
@@ -1,0 +1,8 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.test.RuleSetProviderTest
+
+class StandardRuleSetProviderTest : RuleSetProviderTest(
+    rulesetClass = StandardRuleSetProvider::class.java,
+    packageName = "com.pinterest.ktlint.ruleset.standard"
+)

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -8,4 +8,5 @@ dependencies {
   implementation deps.kotlin.stdlib
   implementation deps.kotlin.compiler
   implementation deps.assertj
+  implementation deps.junit
 }

--- a/ktlint-test/pom.xml
+++ b/ktlint-test/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
@@ -1,0 +1,29 @@
+package com.pinterest.ktlint.test
+
+import com.pinterest.ktlint.core.RuleSetProvider
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+open class RuleSetProviderTest(
+    private val rulesetClass: Class<out RuleSetProvider>,
+    private val packageName: String
+) {
+
+    @Test
+    fun checkAllRulesProvided() {
+        val srcLocation = rulesetClass.protectionDomain.codeSource.location.path
+        val rulesDir = File(srcLocation + packageName.replace(".", "/"))
+        val packageRules = rulesDir.listFiles()
+            ?.map { it.name.removeSuffix(".class") }
+            ?.filter { it.endsWith("Rule") }
+            ?: arrayListOf()
+
+        val provider = rulesetClass
+        val providerRules = provider.newInstance().get().rules.map { it::class.java.simpleName }
+        val diff = packageRules - providerRules
+        assertThat(diff)
+            .withFailMessage("%s is missing to provide the following rules: \n%s", provider.simpleName, diff.joinToString(separator = "\n"))
+            .hasSize(0)
+    }
+}


### PR DESCRIPTION
This is a follow up for #476. I would suggest merging this after the `.ktlintignore` landed on `master`. Or I could also implement ignores list for this kind of tests for now, but I would rather wait for global ignores. It just grabs the source files from the specified location and then checks that all of them are being returned from the specified ruleset.