### PR TITLE
Add "installGitPreCommitHook" sub command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ $ ktlint --reporter=plain --reporter=checkstyle,output=ktlint-report-in-checksty
 
 # install git hook to automatically check files for style violations on commit
 # use --install-git-pre-push-hook if you wish to run ktlint on push instead
-$ ktlint --install-git-pre-commit-hook
+$ ktlint installGitPreCommitHook
 ```
 
 > on Windows you'll have to use `java -jar ktlint ...`. 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ByteArrayExt.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ByteArrayExt.kt
@@ -1,0 +1,9 @@
+package com.pinterest.ktlint.internal
+
+import java.math.BigInteger
+import java.security.MessageDigest
+
+/**
+ * Generate hex string for given [ByteArray] content.
+ */
+internal val ByteArray.hex get() = BigInteger(MessageDigest.getInstance("SHA-256").digest(this)).toString(16)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/CommandLineExt.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/CommandLineExt.kt
@@ -1,0 +1,20 @@
+package com.pinterest.ktlint.internal
+
+import kotlin.system.exitProcess
+import picocli.CommandLine
+
+/**
+ * Check if user requested either help or version options, if yes - print it
+ * and exit process with [exitCode] exit code.
+ */
+internal fun CommandLine.printHelpOrVersionUsage(
+    exitCode: Int = 0
+) {
+    if (isUsageHelpRequested) {
+        usage(System.out, CommandLine.Help.Ansi.OFF)
+        exitProcess(exitCode)
+    } else if (isVersionHelpRequested) {
+        printVersionHelp(System.out, CommandLine.Help.Ansi.OFF)
+        exitProcess(exitCode)
+    }
+}

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
@@ -1,0 +1,84 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.KtlintCommandLine
+import java.io.File
+import kotlin.system.exitProcess
+import picocli.CommandLine
+
+@CommandLine.Command(
+    description = [
+        "Install git hook to automatically check files for style violations on commit",
+        "Usage of \"--install-git-pre-commit-hook\" command line option is deprecated!"
+    ],
+    aliases = ["--install-git-pre-commit-hook"],
+    mixinStandardHelpOptions = true,
+    versionProvider = KtlintVersionProvider::class
+)
+class GitPreCommitHookSubCommand : Runnable {
+    @CommandLine.ParentCommand
+    private lateinit var ktlintCommand: KtlintCommandLine
+
+    @CommandLine.Spec
+    private lateinit var commandSpec: CommandLine.Model.CommandSpec
+
+    override fun run() {
+        commandSpec.commandLine().printHelpOrVersionUsage()
+
+        val gitHooksDir = resolveGitHooksDir()
+        val preCommitHookFile = gitHooksDir.resolve("pre-commit")
+        val preCommitHook = loadGitPreCommitHookTemplate()
+
+        if (preCommitHookFile.exists()) {
+            backupExistingPreCommitHook(gitHooksDir, preCommitHookFile, preCommitHook)
+        }
+
+        // > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+        preCommitHookFile.writeBytes(preCommitHook)
+        preCommitHookFile.setExecutable(true)
+        println(".git/hooks/pre-commit installed")
+    }
+
+    private fun resolveGitHooksDir(): File {
+        val gitDir = File(".git")
+        if (!gitDir.isDirectory) {
+            System.err.println(
+                ".git directory not found. Are you sure you are inside project root directory?"
+            )
+            exitProcess(1)
+        }
+
+        val hooksDir = gitDir.resolve("hooks")
+        if (!hooksDir.exists() && !hooksDir.mkdir()) {
+            System.err.println("Failed to create .git/hooks folder")
+            exitProcess(1)
+        }
+
+        return hooksDir
+    }
+
+    private fun loadGitPreCommitHookTemplate(): ByteArray = ClassLoader
+        .getSystemClassLoader()
+        .getResourceAsStream(
+            "ktlint-git-pre-commit-hook${if (ktlintCommand.android) "-android" else ""}.sh"
+        ).use { it.readBytes() }
+
+    private fun backupExistingPreCommitHook(
+        hooksDir: File,
+        preCommitHookFile: File,
+        expectedPreCommitHook: ByteArray
+    ) {
+        // backup existing hook (if any)
+        val actualPreCommitHook = preCommitHookFile.readBytes()
+        if (actualPreCommitHook.isNotEmpty() &&
+            !actualPreCommitHook.contentEquals(expectedPreCommitHook)
+        ) {
+            val backupFile = hooksDir.resolve("pre-commit.ktlint-backup.${actualPreCommitHook.hex}")
+            println(".git/hooks/pre-commit -> $backupFile")
+            preCommitHookFile.copyTo(backupFile, overwrite = true)
+        }
+    }
+
+    companion object {
+        const val COMMAND_NAME = "installGitPreCommitHook"
+    }
+}


### PR DESCRIPTION
Move old one `--install-git-pre-commit-hook` option to be a ktlint
subcommand - new syntax: `ktlint installGitPreCommitHook`. Old option
`--install-git-pre-commit-hook` is still working, but deprecated.

This sub command acts as a separate action, that is not running checks, and should not confuse users oppose to option.