### PR TITLE
Add "installGitPrePushHook" sub command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ ktlint --reporter=plain?group_by_file
 $ ktlint --reporter=plain --reporter=checkstyle,output=ktlint-report-in-checkstyle-format.xml
 
 # install git hook to automatically check files for style violations on commit
-# use --install-git-pre-push-hook if you wish to run ktlint on push instead
+# Run "ktlint installGitPrePushHook" if you wish to run ktlint on push instead
 $ ktlint installGitPreCommitHook
 ```
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
@@ -1,0 +1,62 @@
+package com.pinterest.ktlint.internal
+
+import java.io.File
+import java.io.IOException
+import kotlin.system.exitProcess
+
+object GitHookInstaller {
+    fun installGitHook(
+        gitHookName: String,
+        gitHookLoader: () -> ByteArray
+    ) {
+        val gitHooksDir = try {
+            resolveGitHooksDir()
+        } catch (e: IOException) {
+            System.err.println(e.message)
+            exitProcess(1)
+        }
+
+        val gitHookFile = gitHooksDir.resolve(gitHookName)
+        val hookContent = gitHookLoader()
+
+        if (gitHookFile.exists()) {
+            backupExistingHook(gitHooksDir, gitHookFile, hookContent, gitHookName)
+        }
+
+        gitHookFile.writeBytes(hookContent)
+        gitHookFile.setExecutable(true)
+        println(".git/hooks/$gitHookName installed")
+    }
+
+    @Throws(IOException::class)
+    private fun resolveGitHooksDir(): File {
+        val gitDir = File(".git")
+        if (!gitDir.isDirectory) {
+            throw IOException(".git directory not found. Are you sure you are inside project root directory?")
+        }
+
+        val hooksDir = gitDir.resolve("hooks")
+        if (!hooksDir.exists() && !hooksDir.mkdir()) {
+            throw IOException("Failed to create .git/hooks folder")
+        }
+
+        return hooksDir
+    }
+
+    private fun backupExistingHook(
+        hooksDir: File,
+        hookFile: File,
+        expectedHookContent: ByteArray,
+        gitHookName: String
+    ) {
+        // backup existing hook (if any)
+        val actualHookContent = hookFile.readBytes()
+        if (actualHookContent.isNotEmpty() &&
+            !actualHookContent.contentEquals(expectedHookContent)
+        ) {
+            val backupFile = hooksDir.resolve("$gitHookName.ktlint-backup.${actualHookContent.hex}")
+            println(".git/hooks/$gitHookName -> $backupFile")
+            hookFile.copyTo(backupFile, overwrite = true)
+        }
+    }
+}

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
@@ -5,14 +5,14 @@ import picocli.CommandLine
 
 @CommandLine.Command(
     description = [
-        "Install git hook to automatically check files for style violations on commit",
-        "Usage of \"--install-git-pre-commit-hook\" command line option is deprecated!"
+        "Install git hook to automatically check files for style violations before push",
+        "Usage of \"--install-git-pre-push-hook\" command line option is deprecated!"
     ],
-    aliases = ["--install-git-pre-commit-hook"],
+    aliases = ["--install-git-pre-push-hook"],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class
 )
-class GitPreCommitHookSubCommand : Runnable {
+class GitPrePushHookSubCommand : Runnable {
     @CommandLine.ParentCommand
     private lateinit var ktlintCommand: KtlintCommandLine
 
@@ -22,18 +22,19 @@ class GitPreCommitHookSubCommand : Runnable {
     override fun run() {
         commandSpec.commandLine().printHelpOrVersionUsage()
 
-        GitHookInstaller.installGitHook("pre-commit") {
+        GitHookInstaller.installGitHook("pre-push") {
             loadHookContent()
         }
     }
 
-    private fun loadHookContent(): ByteArray = ClassLoader
+    private fun loadHookContent() = ClassLoader
         .getSystemClassLoader()
         .getResourceAsStream(
-            "ktlint-git-pre-commit-hook${if (ktlintCommand.android) "-android" else ""}.sh"
-        ).use { it.readBytes() }
+            "ktlint-git-pre-push-hook${if (ktlintCommand.android) "-android" else ""}.sh"
+        )
+        .readBytes()
 
     companion object {
-        const val COMMAND_NAME = "installGitPreCommitHook"
+        const val COMMAND_NAME = "installGitPrePushHook"
     }
 }


### PR DESCRIPTION
Move old one (`--install-git-pre-push-hook`) option to be a ktlint
subcommand - new syntax: `ktlint installGitPrePushHook`. Old one
`--install-git-pre-commit-hook` is still working, but deprecated.

Unified code between commit and push hooks subcommands to actually
install git hook in `GitHookInstaller`.