### PR TITLE
Try publishish ktlint-all.jar

### DIFF
--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -14,6 +14,10 @@ shadowJar {
   mergeServiceFiles()
 }
 
+artifacts {
+  archives shadowJar
+}
+
 dependencies {
   implementation project(':ktlint-core')
   implementation project(':ktlint-reporter-checkstyle')


### PR DESCRIPTION
@shashachu 

Closes https://github.com/pinterest/ktlint/pull/489


If you run `gradlew build`, it will generate the following:
```
$ ls ktlint/build/libs/ktlint-0.34.0-SNAPSHOT
ktlint-0.34.0-SNAPSHOT-all.jar      ktlint-0.34.0-SNAPSHOT-sources.jar  
ktlint-0.34.0-SNAPSHOT-javadoc.jar  ktlint-0.34.0-SNAPSHOT.jar
```

You can do `java -jar ktlint/build/libs/ktlint-0.34.0-SNAPSHOT-all.jar`  to run ktlint