### PR TITLE
Excluding the keyword data from annotation rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -15,6 +15,7 @@ class AnnotationRule : Rule("annotation") {
             "Multiple annotations should not be placed on the same line as the annotated construct"
         const val annotationsWithParametersAreNotOnSeparateLinesErrorMessage =
             "Annotations with parameters should all be placed on separate lines prior to the annotated construct"
+        const val DATA_KEYWORD = "data"
     }
 
     override fun visit(
@@ -23,7 +24,7 @@ class AnnotationRule : Rule("annotation") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val root =
-            node.children().firstOrNull { it.elementType == MODIFIER_LIST }
+            node.children().firstOrNull { it.elementType == MODIFIER_LIST && it.text != DATA_KEYWORD }
                 ?: return
 
         val annotations =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
@@ -320,4 +320,30 @@ class AnnotationRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `no annotation present for data class passes`() {
+        val code =
+            """
+            package com.example.application.a.b
+
+            data class FileModel(val uri: String, val name: String)
+            """.trimIndent()
+        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `no annotation present succeeds for class`() {
+        val code =
+            """
+            package com.example.application.a
+
+            import android.os.Environment
+
+            class PathProvider {
+                fun gallery(): String = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).path
+            }
+            """.trimIndent()
+        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Fixes the issue [#490](https://github.com/pinterest/ktlint/issues/490)

Annotation rule looks for element type belonging to `MODIFIER_LIST`. The keyword `data` also falls under this element type. Excluding it explicitly from the list. 