### PR TITLE
Consider comments when searching for multiline annotations

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -52,7 +52,7 @@ class AnnotationRule : Rule("annotation") {
         val annotationsWithParametersAreNotOnSeparateLines =
             annotations.any { it.valueArgumentList != null } &&
                 !whiteSpaces.all { it.textContains('\n') } &&
-                whiteSpaces.lastOrNull()?.nextLeaf() !is PsiComment
+                doesNotEndWithAComment(whiteSpaces)
 
         if (multipleAnnotationsOnSameLineAsAnnotatedConstruct) {
             emit(
@@ -83,5 +83,10 @@ class AnnotationRule : Rule("annotation") {
                 (whiteSpaces.last() as LeafPsiElement).rawReplaceWithText(newLineWithIndent)
             }
         }
+    }
+
+    private fun doesNotEndWithAComment(whiteSpaces: List<PsiWhiteSpace>): Boolean {
+        val lastNode = whiteSpaces.lastOrNull()?.nextLeaf()
+        return lastNode !is PsiComment || lastNode.nextLeaf()?.textContains('\n') == false
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -4,9 +4,11 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.core.ast.children
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
 
 class AnnotationRule : Rule("annotation") {
 
@@ -49,7 +51,8 @@ class AnnotationRule : Rule("annotation") {
             annotations.size > 1 && !whiteSpaces.last().textContains('\n')
         val annotationsWithParametersAreNotOnSeparateLines =
             annotations.any { it.valueArgumentList != null } &&
-                !whiteSpaces.all { it.textContains('\n') }
+                !whiteSpaces.all { it.textContains('\n') } &&
+                whiteSpaces.lastOrNull()?.nextLeaf() !is PsiComment
 
         if (multipleAnnotationsOnSameLineAsAnnotatedConstruct) {
             emit(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
@@ -23,6 +23,18 @@ class AnnotationRuleTest {
     }
 
     @Test
+    fun `lint single annotation with parameters ends with a comment`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                @Suppress("AnnotationRule") // this is a comment
+                class A
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
     fun `format single annotation may be placed on line before annotated construct`() {
         val code =
             """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
@@ -35,6 +35,28 @@ class AnnotationRuleTest {
     }
 
     @Test
+    fun `lint single annotation with parameters on the same line with a comment`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                @Suppress("AnnotationRule") /* this is a comment */ class A
+                """.trimIndent()
+            )
+        ).hasSize(1)
+    }
+
+    @Test
+    fun `lint single annotation with parameters on the same line with a comment and many spaces`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                @Suppress("AnnotationRule") /* this is a comment */    class A
+                """.trimIndent()
+            )
+        ).hasSize(1)
+    }
+
+    @Test
     fun `format single annotation may be placed on line before annotated construct`() {
         val code =
             """


### PR DESCRIPTION
Closes #498 

Edit: Well after reading the property name again, do we want single parameter annotations also be on separate lines?
Imo the checks need a `it.valueParameters.size > 1`.