### PR TITLE
Add "printAST" sub command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,12 +326,12 @@ A complete sample project (with tests and build files) is included in this repo 
 #### AST
 
 While writing/debugging [Rule](ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt)s it's often helpful to have an AST
-printed out to see the structure rules have to work with. ktlint >= 0.15.0 has `--print-ast` flag specifically for this purpose
-(usage: `ktlint --color --print-ast <file>`).  
+printed out to see the structure rules have to work with. ktlint >= 0.15.0 has `printAST` subcommand specifically for this purpose
+(usage: `ktlint --color printAST <file>`).
 An example of the output is shown below. 
 
 ```sh
-$ printf "fun main() {}" | ktlint --color --print-ast --stdin
+$ printf "fun main() {}" | ktlint --color printAST --stdin
 
 1: ~.psi.KtFile (~.psi.stubs.elements.KtFileElementType.kotlin.FILE)
 1:   ~.psi.KtPackageDirective (~.psi.stubs.elements.KtPlaceHolderStubElementType.PACKAGE_DIRECTIVE) ""

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -1,0 +1,55 @@
+package com.pinterest.ktlint.internal
+
+import com.github.shyiko.klob.Glob
+import com.pinterest.ktlint.core.KtLint.lint
+import com.pinterest.ktlint.core.KtLint.lintScript
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.RuleSet
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+internal val workDir: String = File(".").canonicalPath
+
+internal fun List<String>.fileSequence(): Sequence<File> {
+    val kotlinFiles = if (isEmpty()) {
+        Glob.from("**/*.kt", "**/*.kts")
+            .iterate(
+                Paths.get(workDir),
+                Glob.IterationOption.SKIP_HIDDEN
+            )
+    } else {
+        val normalizedPatterns = map(::expandTilde).toTypedArray()
+        Glob.from(*normalizedPatterns)
+            .iterate(Paths.get(workDir))
+    }
+
+    return kotlinFiles
+        .asSequence()
+        .map(Path::toFile)
+}
+
+// a complete solution would be to implement https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
+// this implementation takes care only of the most commonly used case (~/)
+internal fun expandTilde(path: String): String = path.replaceFirst(Regex("^~"), System.getProperty("user.home"))
+
+internal fun File.location(
+    relative: Boolean
+) = if (relative) this.toRelativeString(File(workDir)) else this.path
+
+/**
+ * Run lint over common kotlin file or kotlin script file.
+ */
+internal fun lintFile(
+    fileName: String,
+    fileContent: String,
+    ruleSetList: List<RuleSet>,
+    userData: Map<String, String> = emptyMap(),
+    lintErrorCallback: (LintError) -> Unit = {}
+) {
+    if (fileName.endsWith(".kt", ignoreCase = true)) {
+        lint(fileContent, ruleSetList, userData, lintErrorCallback)
+    } else {
+        lintScript(fileContent, ruleSetList, userData, lintErrorCallback)
+    }
+}

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
@@ -1,0 +1,82 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.KtlintCommandLine
+import com.pinterest.ktlint.core.ParseException
+import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.test.DumpAST
+import java.io.File
+import picocli.CommandLine
+
+@CommandLine.Command(
+    description = [
+        "Print AST (useful when writing/debugging rules)",
+        "Usage of \"--print-ast\" command line option is deprecated!"
+    ],
+    aliases = ["--print-ast"],
+    mixinStandardHelpOptions = true,
+    versionProvider = KtlintVersionProvider::class
+)
+internal class PrintASTSubCommand : Runnable {
+    @CommandLine.ParentCommand
+    private lateinit var ktlintCommand: KtlintCommandLine
+
+    @CommandLine.Spec
+    private lateinit var commandSpec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Parameters(
+        description = ["include all files under this .gitignore-like patterns"]
+    )
+    private var patterns = ArrayList<String>()
+
+    @CommandLine.Option(
+        names = ["--stdin"],
+        description = ["Read file content from stdin"]
+    )
+    private var stdin: Boolean = false
+
+    private val astRuleSet by lazy(LazyThreadSafetyMode.NONE) {
+        listOf(
+            RuleSet("debug", DumpAST(System.out, ktlintCommand.color))
+        )
+    }
+
+    override fun run() {
+        commandSpec.commandLine().printHelpOrVersionUsage()
+
+        if (stdin) {
+            printAST(STDIN_FILE, String(System.`in`.readBytes()))
+        } else {
+            for (file in patterns.fileSequence()) {
+                printAST(file.path, file.readText())
+            }
+        }
+    }
+
+    private fun printAST(
+        fileName: String,
+        fileContent: String
+    ) {
+        if (ktlintCommand.debug) {
+            val fileLocation = if (fileName != STDIN_FILE) {
+                File(fileName).location(ktlintCommand.relative)
+            } else {
+                "stdin"
+            }
+            println("[DEBUG] Analyzing $fileLocation")
+        }
+
+        try {
+            lintFile(fileName, fileContent, astRuleSet)
+        } catch (e: Exception) {
+            if (e is ParseException) {
+                throw ParseException(e.line, e.col, "Not a valid Kotlin file (${e.message?.toLowerCase()})")
+            }
+            throw e
+        }
+    }
+
+    companion object {
+        internal const val COMMAND_NAME = "printAST"
+        private const val STDIN_FILE = "<stdin>"
+    }
+}


### PR DESCRIPTION
Move old one (--print-ast) option to be a ktlint sub command - new syntax:
`ktlint printAST`. Old one `--print-ast` is still working, but
deprecated.
