### PR TITLE
Add support for disabled_rules property in .editorconfig for globally disabling rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,11 @@ insert_final_newline = true
 
 [*.{java,kt,kts,scala,rs,xml,kt.spec,kts.spec}]
 indent_size = 4
+# annotation - "./mvnw clean verify" fails with "Internal Error")
+# multiline-if-else - disabled until auto-correct is working properly
+#   (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
+# no-it-in-multiline-lambda - disabled until it's clear what to do in case of `import _.it`
+disabled_rules=annotation,multiline-if-else,no-it-in-multiline-lambda
 
 [{Makefile,*.go}]
 indent_style = tab

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 
   testImplementation deps.junit
   testImplementation deps.assertj
+  testImplementation deps.jimfs
 }

--- a/ktlint-core/pom.xml
+++ b/ktlint-core/pom.xml
@@ -35,6 +35,12 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>${jimfs.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
@@ -5,20 +5,21 @@ package com.pinterest.ktlint.core
  */
 interface EditorConfig {
 
-    enum class IntentStyle { SPACE, TAB }
+    enum class IndentStyle { SPACE, TAB }
 
-    val indentStyle: IntentStyle
+    val indentStyle: IndentStyle
     val indentSize: Int
     val tabWidth: Int
     val maxLineLength: Int
     val insertFinalNewline: Boolean
+    val disabledRules: Set<String>
     fun get(key: String): String?
 
     companion object {
         fun fromMap(map: Map<String, String>): EditorConfig {
             val indentStyle = when {
-                map["indent_style"]?.toLowerCase() == "tab" -> IntentStyle.TAB
-                else -> IntentStyle.SPACE
+                map["indent_style"]?.toLowerCase() == "tab" -> IndentStyle.TAB
+                else -> IndentStyle.SPACE
             }
             val indentSize = map["indent_size"].let { v ->
                 if (v?.toLowerCase() == "unset") -1 else v?.toIntOrNull() ?: 4
@@ -26,12 +27,14 @@ interface EditorConfig {
             val tabWidth = map["indent_size"]?.toIntOrNull()
             val maxLineLength = map["max_line_length"]?.toIntOrNull() ?: -1
             val insertFinalNewline = map["insert_final_newline"]?.toBoolean() ?: true
+            val disabledRules = map["disabled_rules"]?.split(",")?.toSet() ?: emptySet()
             return object : EditorConfig {
                 override val indentStyle = indentStyle
                 override val indentSize = indentSize
                 override val tabWidth = tabWidth ?: indentSize
                 override val maxLineLength = maxLineLength
                 override val insertFinalNewline = insertFinalNewline
+                override val disabledRules: Set<String> = disabledRules
                 override fun get(key: String): String? = map[key]
             }
         }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint.core
 
 /**
  * @see [EditorConfig](http://editorconfig.org/)
+ *
+ * This class is injected into the user data, so it is available to rules via [KtLint.EDITOR_CONFIG_USER_DATA_KEY]
  */
 interface EditorConfig {
 
@@ -12,7 +14,6 @@ interface EditorConfig {
     val tabWidth: Int
     val maxLineLength: Int
     val insertFinalNewline: Boolean
-    val disabledRules: Set<String>
     fun get(key: String): String?
 
     companion object {
@@ -27,14 +28,12 @@ interface EditorConfig {
             val tabWidth = map["indent_size"]?.toIntOrNull()
             val maxLineLength = map["max_line_length"]?.toIntOrNull() ?: -1
             val insertFinalNewline = map["insert_final_newline"]?.toBoolean() ?: true
-            val disabledRules = map["disabled_rules"]?.split(",")?.toSet() ?: emptySet()
             return object : EditorConfig {
                 override val indentStyle = indentStyle
                 override val indentSize = indentSize
                 override val tabWidth = tabWidth ?: indentSize
                 override val maxLineLength = maxLineLength
                 override val insertFinalNewline = insertFinalNewline
-                override val disabledRules: Set<String> = disabledRules
                 override fun get(key: String): String? = map[key]
             }
         }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -1,8 +1,14 @@
 package com.pinterest.ktlint.core
 
 import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.internal.EditorConfigInternal
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.ArrayList
 import java.util.HashSet
+import java.util.concurrent.ConcurrentHashMap
+import org.jetbrains.kotlin.backend.common.onlyIf
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -40,6 +46,27 @@ object KtLint {
 
     private val psiFileFactory: PsiFileFactory
     private val nullSuppression = { _: Int, _: String, _: Boolean -> false }
+
+    /**
+     * @param fileName path of file to lint/format
+     * @param text Contents of file to lint/format
+     * @param ruleSets a collection of "RuleSet"s used to validate source
+     * @param userData Map of user options
+     * @param cb callback invoked for each lint error
+     * @param script true if this is a Kotlin script file
+     * @param editorConfigPath optional path of the .editorconfig file (otherwise will use working directory)
+     * @param debug True if invoked with the --debug flag
+     */
+    data class Params(
+        val fileName: String? = null,
+        val text: String,
+        val ruleSets: Iterable<RuleSet>,
+        val userData: Map<String, String> = emptyMap(),
+        val cb: (e: LintError, corrected: Boolean) -> Unit,
+        val script: Boolean = false,
+        val editorConfigPath: String? = null,
+        val debug: Boolean = false
+    )
 
     init {
         // do not print anything to the stderr when lexer is unable to match input
@@ -93,65 +120,25 @@ object KtLint {
     /**
      * Check source for lint errors.
      *
-     * @param text source
-     * @param ruleSets a collection of "RuleSet"s used to validate source
-     * @param cb callback that is going to be executed for every lint error
-     *
      * @throws ParseException if text is not a valid Kotlin code
      * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
      */
-    fun lint(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError) -> Unit) {
-        lint(text, ruleSets, emptyMap(), cb, script = false)
-    }
-
-    fun lint(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>, cb: (e: LintError) -> Unit) {
-        lint(text, ruleSets, userData, cb, script = false)
-    }
-
-    /**
-     * Check source for lint errors.
-     *
-     * @param text script source
-     * @param ruleSets a collection of "RuleSet"s used to validate source
-     * @param cb callback that is going to be executed for every lint error
-     *
-     * @throws ParseException if text is not a valid Kotlin code
-     * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
-     */
-    fun lintScript(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError) -> Unit) {
-        lint(text, ruleSets, emptyMap(), cb, script = true)
-    }
-
-    fun lintScript(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        userData: Map<String, String>,
-        cb: (e: LintError) -> Unit
-    ) {
-        lint(text, ruleSets, userData, cb, script = true)
-    }
-
-    private fun lint(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        userData: Map<String, String>,
-        cb: (e: LintError) -> Unit,
-        script: Boolean
-    ) {
-        val normalizedText = text.replace("\r\n", "\n").replace("\r", "\n")
+    fun lint(params: Params) {
+        val normalizedText = params.text.replace("\r\n", "\n").replace("\r", "\n")
         val positionByOffset = calculateLineColByOffset(normalizedText)
-        val fileName = if (script) "file.kts" else "file.kt"
-        val psiFile = psiFileFactory.createFileFromText(fileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile
+        val psiFileName = if (params.script) "file.kts" else "file.kt"
+        val psiFile = psiFileFactory.createFileFromText(psiFileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile
         val errorElement = psiFile.findErrorElement()
         if (errorElement != null) {
             val (line, col) = positionByOffset(errorElement.textOffset)
             throw ParseException(line, col, errorElement.errorDescription)
         }
         val rootNode = psiFile.node
-        injectUserData(rootNode, userData)
+        val mergedUserData = params.userData + userDataResolver(params.editorConfigPath, params.debug)(params.fileName)
+        injectUserData(rootNode, mergedUserData)
         val isSuppressed = calculateSuppressedRegions(rootNode)
         val errors = mutableListOf<LintError>()
-        visitor(rootNode, ruleSets).invoke { node, rule, fqRuleId ->
+        visitor(rootNode, params.ruleSets).invoke { node, rule, fqRuleId ->
             // fixme: enforcing suppression based on node.startOffset is wrong
             // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
             if (!isSuppressed(node.startOffset, fqRuleId, node === rootNode)) {
@@ -172,7 +159,59 @@ object KtLint {
         }
         errors
             .sortedWith(Comparator { l, r -> if (l.line != r.line) l.line - r.line else l.col - r.col })
-            .forEach(cb)
+            .forEach { e -> params.cb(e, false) }
+    }
+
+    private fun userDataResolver(editorConfigPath: String?, debug: Boolean): (String?) -> Map<String, String> {
+        if (editorConfigPath != null) {
+            val userData = (
+                EditorConfigInternal.of(File(editorConfigPath).canonicalPath)
+                    ?.onlyIf({ debug }) { printEditorConfigChain(it) }
+                    ?: emptyMap<String, String>()
+                )
+            return fun (fileName: String?) = if (fileName != null) {
+                userData + ("file_path" to fileName)
+            } else {
+                emptyMap()
+            }
+        }
+        val workDir = File(".").canonicalPath
+        val workdirUserData = lazy {
+            (
+                EditorConfigInternal.of(workDir)
+                    ?.onlyIf({ debug }) { printEditorConfigChain(it) }
+                    ?: emptyMap<String, String>()
+                )
+        }
+        val editorConfig = EditorConfigInternal.cached()
+        val editorConfigSet = ConcurrentHashMap<Path, Boolean>()
+        return fun (fileName: String?): Map<String, String> {
+            if (fileName == null) {
+                return emptyMap()
+            }
+
+            if (fileName == "<text>") {
+                return workdirUserData.value
+            }
+            return (
+                editorConfig.of(Paths.get(fileName).parent)
+                    ?.onlyIf({ debug }) {
+                        printEditorConfigChain(it) {
+                            editorConfigSet.put(it.path, true) != true
+                        }
+                    }
+                    ?: emptyMap<String, String>()
+                ) + ("file_path" to fileName)
+        }
+    }
+
+    private fun printEditorConfigChain(ec: EditorConfigInternal, predicate: (EditorConfigInternal) -> Boolean = { true }) {
+        for (lec in generateSequence(ec) { it.parent }.takeWhile(predicate)) {
+            System.err.println(
+                "[DEBUG] Discovered .editorconfig (${lec.path.parent.toFile().path})" +
+                    " {${lec.entries.joinToString(", ")}}"
+            )
+        }
     }
 
     private fun injectUserData(node: ASTNode, userData: Map<String, String>) {
@@ -194,7 +233,8 @@ object KtLint {
         rootNode: ASTNode,
         ruleSets: Iterable<RuleSet>,
         concurrent: Boolean = true,
-        filter: (fqRuleId: String) -> Boolean = { true }
+        filter: (rootNode: ASTNode, fqRuleId: String) -> Boolean = this::filterDisabledRules
+
     ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
         val fqrsRestrictedToRoot = mutableListOf<Pair<String, Rule>>()
         val fqrs = mutableListOf<Pair<String, Rule>>()
@@ -204,7 +244,7 @@ object KtLint {
             val prefix = if (ruleSet.id === "standard") "" else "${ruleSet.id}:"
             for (rule in ruleSet) {
                 val fqRuleId = "$prefix${rule.id}"
-                if (!filter(fqRuleId)) {
+                if (!filter(rootNode, fqRuleId)) {
                     continue
                 }
                 val fqr = fqRuleId to rule
@@ -254,6 +294,10 @@ object KtLint {
         }
     }
 
+    private fun filterDisabledRules(rootNode: ASTNode, fqRuleId: String): Boolean {
+        return rootNode.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.disabledRules?.contains(fqRuleId) == false
+    }
+
     private fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {
         var i = -1
         val e = text.length
@@ -292,69 +336,26 @@ object KtLint {
     /**
      * Fix style violations.
      *
-     * @param text source
-     * @param ruleSets a collection of "RuleSet"s used to validate source
-     * @param cb callback that is going to be executed for every lint error
-     *
      * @throws ParseException if text is not a valid Kotlin code
      * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
      */
-    fun format(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError, corrected: Boolean) -> Unit): String =
-        format(text, ruleSets, emptyMap<String, String>(), cb, script = false)
-
-    fun format(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit
-    ): String = format(text, ruleSets, userData, cb, script = false)
-
-    /**
-     * Fix style violations.
-     *
-     * @param text script source
-     * @param ruleSets a collection of "RuleSet"s used to validate source
-     * @param cb callback that is going to be executed for every lint error
-     *
-     * @throws ParseException if text is not a valid Kotlin code
-     * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
-     */
-    fun formatScript(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        cb: (e: LintError, corrected: Boolean) -> Unit
-    ): String =
-        format(text, ruleSets, emptyMap(), cb, script = true)
-
-    fun formatScript(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit
-    ): String = format(text, ruleSets, userData, cb, script = true)
-
-    private fun format(
-        text: String,
-        ruleSets: Iterable<RuleSet>,
-        userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit,
-        script: Boolean
-    ): String {
-        val normalizedText = text.replace("\r\n", "\n").replace("\r", "\n")
+    fun format(params: Params): String {
+        val normalizedText = params.text.replace("\r\n", "\n").replace("\r", "\n")
         val positionByOffset = calculateLineColByOffset(normalizedText)
-        val fileName = if (script) "file.kts" else "file.kt"
-        val psiFile = psiFileFactory.createFileFromText(fileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile
+        val psiFileName = if (params.script) "file.kts" else "file.kt"
+        val psiFile = psiFileFactory.createFileFromText(psiFileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile
         val errorElement = psiFile.findErrorElement()
         if (errorElement != null) {
             val (line, col) = positionByOffset(errorElement.textOffset)
             throw ParseException(line, col, errorElement.errorDescription)
         }
         val rootNode = psiFile.node
-        injectUserData(rootNode, userData)
+        val mergedUserData = params.userData + userDataResolver(params.editorConfigPath, params.debug)(params.fileName)
+        injectUserData(rootNode, mergedUserData)
         var isSuppressed = calculateSuppressedRegions(rootNode)
         var tripped = false
         var mutated = false
-        visitor(rootNode, ruleSets, concurrent = false)
+        visitor(rootNode, params.ruleSets, concurrent = false)
             .invoke { node, rule, fqRuleId ->
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
@@ -378,7 +379,7 @@ object KtLint {
             }
         if (tripped) {
             val errors = mutableListOf<Pair<LintError, Boolean>>()
-            visitor(rootNode, ruleSets).invoke { node, rule, fqRuleId ->
+            visitor(rootNode, params.ruleSets).invoke { node, rule, fqRuleId ->
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (!isSuppressed(node.startOffset, fqRuleId, node === rootNode)) {
@@ -399,9 +400,9 @@ object KtLint {
             }
             errors
                 .sortedWith(Comparator { (l), (r) -> if (l.line != r.line) l.line - r.line else l.col - r.col })
-                .forEach { (e, corrected) -> cb(e, corrected) }
+                .forEach { (e, corrected) -> params.cb(e, corrected) }
         }
-        return if (mutated) rootNode.text.replace("\n", determineLineSeparator(text, userData)) else text
+        return if (mutated) rootNode.text.replace("\n", determineLineSeparator(params.text, params.userData)) else params.text
     }
 
     private fun determineLineSeparator(fileContent: String, userData: Map<String, String>): String {

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -352,7 +352,8 @@ object KtLint {
             throw ParseException(line, col, errorElement.errorDescription)
         }
         val rootNode = psiFile.node
-        val mergedUserData = params.userData + userDataResolver(params.editorConfigPath, params.debug)(params.fileName)
+        // Passed-in userData overrides .editorconfig
+        val mergedUserData = userDataResolver(params.editorConfigPath, params.debug)(params.fileName) + params.userData
         injectUserData(rootNode, mergedUserData)
         var isSuppressed = calculateSuppressedRegions(rootNode)
         var tripped = false

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -43,6 +43,7 @@ object KtLint {
     val EDITOR_CONFIG_USER_DATA_KEY = Key<EditorConfig>("EDITOR_CONFIG")
     val ANDROID_USER_DATA_KEY = Key<Boolean>("ANDROID")
     val FILE_PATH_USER_DATA_KEY = Key<String>("FILE_PATH")
+    val DISABLED_RULES = Key<Set<String>>("DISABLED_RULES")
 
     private val psiFileFactory: PsiFileFactory
     private val nullSuppression = { _: Int, _: String, _: Boolean -> false }
@@ -227,6 +228,7 @@ object KtLint {
         node.putUserData(FILE_PATH_USER_DATA_KEY, userData["file_path"])
         node.putUserData(EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(editorConfigMap - "android" - "file_path"))
         node.putUserData(ANDROID_USER_DATA_KEY, android)
+        node.putUserData(DISABLED_RULES, userData["disabled_rules"]?.split(",")?.toSet() ?: emptySet())
     }
 
     private fun visitor(
@@ -295,7 +297,7 @@ object KtLint {
     }
 
     private fun filterDisabledRules(rootNode: ASTNode, fqRuleId: String): Boolean {
-        return rootNode.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.disabledRules?.contains(fqRuleId) == false
+        return rootNode.getUserData(DISABLED_RULES)?.contains(fqRuleId) == false
     }
 
     private fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigInternal.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigInternal.kt
@@ -8,6 +8,9 @@ import java.util.Properties
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * This class handles traversing the filetree and parsing and merging the contents of any discovered .editorconfig files
+ */
 class EditorConfigInternal private constructor (
     val parent: EditorConfigInternal?,
     val path: Path,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
@@ -1,17 +1,16 @@
 package com.pinterest.ktlint.core
 
 import com.pinterest.ktlint.core.ast.ElementType
+import java.util.ArrayList
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.junit.Test
-import java.util.ArrayList
 
 class DisabledRulesTest {
 
     @Test
     fun testDisabledRule() {
         class NoVarRule : Rule("no-var") {
-
             override fun visit(
                 node: ASTNode,
                 autoCorrect: Boolean,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
@@ -1,0 +1,68 @@
+package com.pinterest.ktlint.core
+
+import com.pinterest.ktlint.core.ast.ElementType
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.junit.Test
+import java.util.ArrayList
+
+class DisabledRulesTest {
+
+    @Test
+    fun testDisabledRule() {
+        class NoVarRule : Rule("no-var") {
+
+            override fun visit(
+                node: ASTNode,
+                autoCorrect: Boolean,
+                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+            ) {
+                if (node.elementType == ElementType.VAR_KEYWORD) {
+                    emit(node.startOffset, "Unexpected var, use val instead", false)
+                }
+            }
+        }
+
+        assertThat(
+            ArrayList<LintError>().apply {
+                KtLint.lint(
+                    KtLint.Params(
+                        text = "var foo",
+                        ruleSets = listOf(RuleSet("standard", NoVarRule())),
+                        cb = { e, _ -> add(e) }
+                    )
+                )
+            }
+        ).isEqualTo(
+            listOf(
+                LintError(1, 1, "no-var", "Unexpected var, use val instead")
+            )
+        )
+
+        assertThat(
+            ArrayList<LintError>().apply {
+                KtLint.lint(
+                    KtLint.Params(
+                        text = "var foo",
+                        ruleSets = listOf(RuleSet("standard", NoVarRule())),
+                        cb = { e, _ -> add(e) },
+                        userData = mapOf(("disabled_rules" to "no-var"))
+                    )
+                )
+            }
+        ).isEmpty()
+
+        assertThat(
+            ArrayList<LintError>().apply {
+                KtLint.lint(
+                    KtLint.Params(
+                        text = "var foo",
+                        ruleSets = listOf(RuleSet("experimental", NoVarRule())),
+                        cb = { e, _ -> add(e) },
+                        userData = mapOf(("disabled_rules" to "experimental:no-var"))
+                    )
+                )
+            }
+        ).isEmpty()
+    }
+}

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
@@ -25,7 +25,13 @@ class ErrorSuppressionTest {
         }
         fun lint(text: String) =
             ArrayList<LintError>().apply {
-                KtLint.lint(text, listOf(RuleSet("standard", NoWildcardImportsRule()))) { e -> add(e) }
+                KtLint.lint(
+                    KtLint.Params(
+                        text = text,
+                        ruleSets = listOf(RuleSet("standard", NoWildcardImportsRule())),
+                        cb = { e, _ -> add(e) }
+                    )
+                )
             }
         assertThat(
             lint(

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -26,17 +26,20 @@ class KtLintTest {
         }
         val bus = mutableListOf<String>()
         KtLint.lint(
-            "fun main() {}",
-            listOf(
-                RuleSet(
-                    "standard",
-                    object : R(bus, "d"), Rule.Modifier.RestrictToRootLast {},
-                    R(bus, "b"),
-                    object : R(bus, "a"), Rule.Modifier.RestrictToRoot {},
-                    R(bus, "c")
-                )
+            KtLint.Params(
+                text = "fun main() {}",
+                ruleSets = listOf(
+                    RuleSet(
+                        "standard",
+                        object : R(bus, "d"), Rule.Modifier.RestrictToRootLast {},
+                        R(bus, "b"),
+                        object : R(bus, "a"), Rule.Modifier.RestrictToRoot {},
+                        R(bus, "c")
+                    )
+                ),
+                cb = { _, _ -> }
             )
-        ) {}
+        )
         assertThat(bus).isEqualTo(listOf("file:a", "file:b", "file:c", "b", "c", "file:d"))
     }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigInternalTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigInternalTest.kt
@@ -1,4 +1,4 @@
-package com.pinterest.ktlint.internal
+package com.pinterest.ktlint.core.internal
 
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
@@ -6,7 +6,7 @@ import java.nio.file.Files
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class EditorConfigTest {
+class EditorConfigInternalTest {
 
     @Test
     fun testParentDirectoryFallback() {
@@ -38,7 +38,7 @@ class EditorConfigTest {
             )
         ) {
             Files.write(fs.getPath("/projects/project-1/.editorconfig"), cfg.trimIndent().toByteArray())
-            val editorConfig = EditorConfig.of(fs.getPath("/projects/project-1/project-1-subdirectory"))
+            val editorConfig = EditorConfigInternal.of(fs.getPath("/projects/project-1/project-1-subdirectory"))
             assertThat(editorConfig?.parent).isNull()
             assertThat(editorConfig?.toMap())
                 .overridingErrorMessage("Expected \n%s\nto yield indent_size = 2", cfg.trimIndent())
@@ -74,7 +74,7 @@ class EditorConfigTest {
             indent_size = 2
             """.trimIndent().toByteArray()
         )
-        EditorConfig.of(fs.getPath("/projects/project-1/project-1-subdirectory")).let { editorConfig ->
+        EditorConfigInternal.of(fs.getPath("/projects/project-1/project-1-subdirectory")).let { editorConfig ->
             assertThat(editorConfig?.parent).isNotNull()
             assertThat(editorConfig?.parent?.parent).isNull()
             assertThat(editorConfig?.toMap()).isEqualTo(
@@ -84,7 +84,7 @@ class EditorConfigTest {
                 )
             )
         }
-        EditorConfig.of(fs.getPath("/projects/project-1")).let { editorConfig ->
+        EditorConfigInternal.of(fs.getPath("/projects/project-1")).let { editorConfig ->
             assertThat(editorConfig?.parent).isNull()
             assertThat(editorConfig?.toMap()).isEqualTo(
                 mapOf(
@@ -93,7 +93,7 @@ class EditorConfigTest {
                 )
             )
         }
-        EditorConfig.of(fs.getPath("/projects")).let { editorConfig ->
+        EditorConfigInternal.of(fs.getPath("/projects")).let { editorConfig ->
             assertThat(editorConfig?.parent).isNull()
             assertThat(editorConfig?.toMap()).isEqualTo(
                 mapOf(
@@ -105,22 +105,22 @@ class EditorConfigTest {
 
     @Test
     fun testSectionParsing() {
-        assertThat(EditorConfig.parseSection("*")).isEqualTo(listOf("*"))
-        assertThat(EditorConfig.parseSection("*.{js,py}")).isEqualTo(listOf("*.js", "*.py"))
-        assertThat(EditorConfig.parseSection("*.py")).isEqualTo(listOf("*.py"))
-        assertThat(EditorConfig.parseSection("Makefile")).isEqualTo(listOf("Makefile"))
-        assertThat(EditorConfig.parseSection("lib/**.js")).isEqualTo(listOf("lib/**.js"))
-        assertThat(EditorConfig.parseSection("{package.json,.travis.yml}"))
+        assertThat(EditorConfigInternal.parseSection("*")).isEqualTo(listOf("*"))
+        assertThat(EditorConfigInternal.parseSection("*.{js,py}")).isEqualTo(listOf("*.js", "*.py"))
+        assertThat(EditorConfigInternal.parseSection("*.py")).isEqualTo(listOf("*.py"))
+        assertThat(EditorConfigInternal.parseSection("Makefile")).isEqualTo(listOf("Makefile"))
+        assertThat(EditorConfigInternal.parseSection("lib/**.js")).isEqualTo(listOf("lib/**.js"))
+        assertThat(EditorConfigInternal.parseSection("{package.json,.travis.yml}"))
             .isEqualTo(listOf("package.json", ".travis.yml"))
     }
 
     @Test
     fun testMalformedSectionParsing() {
-        assertThat(EditorConfig.parseSection("")).isEqualTo(listOf(""))
-        assertThat(EditorConfig.parseSection(",*")).isEqualTo(listOf("", "*"))
-        assertThat(EditorConfig.parseSection("*,")).isEqualTo(listOf("*", ""))
-        assertThat(EditorConfig.parseSection("*.{js,py")).isEqualTo(listOf("*.js", "*.py"))
-        assertThat(EditorConfig.parseSection("*.{js,{py")).isEqualTo(listOf("*.js", "*.{py"))
-        assertThat(EditorConfig.parseSection("*.py}")).isEqualTo(listOf("*.py}"))
+        assertThat(EditorConfigInternal.parseSection("")).isEqualTo(listOf(""))
+        assertThat(EditorConfigInternal.parseSection(",*")).isEqualTo(listOf("", "*"))
+        assertThat(EditorConfigInternal.parseSection("*,")).isEqualTo(listOf("*", ""))
+        assertThat(EditorConfigInternal.parseSection("*.{js,py")).isEqualTo(listOf("*.js", "*.py"))
+        assertThat(EditorConfigInternal.parseSection("*.{js,{py")).isEqualTo(listOf("*.js", "*.{py"))
+        assertThat(EditorConfigInternal.parseSection("*.py}")).isEqualTo(listOf("*.py}"))
     }
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -131,7 +131,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-        if (editorConfig.indentStyle == EditorConfig.IntentStyle.TAB || editorConfig.indentSize <= 1) {
+        if (editorConfig.indentStyle == EditorConfig.IndentStyle.TAB || editorConfig.indentSize <= 1) {
             return
         }
         reset()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.RuleSetProvider
 
 class StandardRuleSetProvider : RuleSetProvider {
 
+    // Note: some of these rules may be disabled by default. See the default .editorconfig.
     override fun get(): RuleSet = RuleSet(
         "standard",
         AnnotationRule(),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -7,25 +7,20 @@ class StandardRuleSetProvider : RuleSetProvider {
 
     override fun get(): RuleSet = RuleSet(
         "standard",
-        // disabled ("./mvnw clean verify" fails with "Internal Error")
-        // AnnotationRule(),
+        AnnotationRule(),
         ChainWrappingRule(),
         CommentSpacingRule(),
         FilenameRule(),
         FinalNewlineRule(),
-        // disabled until there is a way to suppress rules globally (https://git.io/fhxnm)
-        // PackageNameRule(),
-        // disabled until auto-correct is working properly
-        // (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
-        // MultiLineIfElseRule(),
+        PackageNameRule(),
+        MultiLineIfElseRule(),
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),
         NoBlankLineBeforeRbraceRule(),
         NoConsecutiveBlankLinesRule(),
         NoEmptyClassBodyRule(),
-        // disabled until it's clear what to do in case of `import _.it`
-        // NoItParamInMultilineLambdaRule(),
+        NoItParamInMultilineLambdaRule(),
         NoLineBreakAfterElseRule(),
         NoLineBreakBeforeAssignmentRule(),
         NoMultipleSpacesRule(),
@@ -33,11 +28,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         NoTrailingSpacesRule(),
         NoUnitReturnRule(),
         NoUnusedImportsRule(),
-        // Disabling because it is now allowed by the Jetbrains styleguide, although it is still disallowed by
-        // the Android styleguide.
-        // Re-enable when there is a way to globally disable rules
-        // See discussion here: https://github.com/pinterest/ktlint/issues/48
-        // NoWildcardImportsRule(),
+        NoWildcardImportsRule(),
         ParameterListWrappingRule(),
         SpacingAroundColonRule(),
         SpacingAroundCommaRule(),

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -39,5 +39,4 @@ dependencies {
 
   testImplementation deps.junit
   testImplementation deps.assertj
-  testImplementation deps.jimfs
 }

--- a/ktlint/pom.xml
+++ b/ktlint/pom.xml
@@ -175,12 +175,6 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-            <version>${jimfs.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -14,8 +14,8 @@ import com.pinterest.ktlint.internal.KtlintVersionProvider
 import com.pinterest.ktlint.internal.MavenDependencyResolver
 import com.pinterest.ktlint.internal.PrintASTSubCommand
 import com.pinterest.ktlint.internal.expandTilde
-import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.fileSequence
+import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.lintFile
 import com.pinterest.ktlint.internal.location
 import com.pinterest.ktlint.internal.printHelpOrVersionUsage

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -1,8 +1,7 @@
 package com.pinterest.ktlint.internal
 
 import com.github.shyiko.klob.Glob
-import com.pinterest.ktlint.core.KtLint.lint
-import com.pinterest.ktlint.core.KtLint.lintScript
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.RuleSet
 import java.io.File
@@ -42,14 +41,50 @@ internal fun File.location(
  */
 internal fun lintFile(
     fileName: String,
-    fileContent: String,
-    ruleSetList: List<RuleSet>,
+    fileContents: String,
+    ruleSets: List<RuleSet>,
     userData: Map<String, String> = emptyMap(),
+    editorConfigPath: String? = null,
+    debug: Boolean = false,
     lintErrorCallback: (LintError) -> Unit = {}
 ) {
-    if (fileName.endsWith(".kt", ignoreCase = true)) {
-        lint(fileContent, ruleSetList, userData, lintErrorCallback)
-    } else {
-        lintScript(fileContent, ruleSetList, userData, lintErrorCallback)
-    }
+    KtLint.lint(
+        KtLint.Params(
+            fileName = fileName,
+            text = fileContents,
+            ruleSets = ruleSets,
+            userData = userData,
+            script = !fileName.endsWith(".kt", ignoreCase = true),
+            editorConfigPath = editorConfigPath,
+            cb = { e, _ ->
+                lintErrorCallback(e)
+            },
+            debug = debug
+        )
+    )
 }
+
+/**
+ * Format a kotlin file or script file
+ */
+internal fun formatFile(
+    fileName: String,
+    fileContents: String,
+    ruleSets: Iterable<RuleSet>,
+    userData: Map<String, String>,
+    editorConfigPath: String?,
+    debug: Boolean,
+    cb: (e: LintError, corrected: Boolean) -> Unit
+): String =
+    KtLint.format(
+        KtLint.Params(
+            fileName = fileName,
+            text = fileContents,
+            ruleSets = ruleSets,
+            userData = userData,
+            script = !fileName.endsWith(".kt", ignoreCase = true),
+            editorConfigPath = editorConfigPath,
+            cb = cb,
+            debug = debug
+        )
+    )

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.internal
 
 import com.github.shyiko.klob.Glob
+import com.pinterest.ktlint.core.internal.EditorConfigInternal
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -26,7 +27,7 @@ object IntellijIDEAIntegration {
         if (!Files.isDirectory(workDir.resolve(".idea"))) {
             throw ProjectNotFoundException()
         }
-        val editorConfig: Map<String, String> = EditorConfig.of(".") ?: emptyMap()
+        val editorConfig: Map<String, String> = EditorConfigInternal.of(".") ?: emptyMap()
         val indentSize = editorConfig["indent_size"]?.toIntOrNull() ?: 4
         val continuationIndentSize = editorConfig["continuation_indent_size"]?.toIntOrNull() ?: 4
         val updates = if (local) {


### PR DESCRIPTION
Fixes #208

* Takes in a comma-separated list of rule ids, with namespaces (e.g. `experimental:indent`)
* Re-enabled `NoWildcardImports`, `PackageNameRule`
* Un-commented `AnnotationRule`, `MultiLineIfElseRule`, and `NoItParamInMultilineLambdaRule`, and moved disabling into default `.editorconfig`
* Moved `.editorconfig` parsing into `ktlint-core` so that plugins that don't invoke ktlint on the command line can take advantage of rule disabling
* Also cleaned up params passed to lint and format