### PR TITLE
Allow  'it' for variable and function names  in multiline lambda rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRule.kt
@@ -2,9 +2,15 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK
+import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
+import com.pinterest.ktlint.core.ast.ElementType.PROPERTY
 import com.pinterest.ktlint.core.ast.parent
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
 class NoItParamInMultilineLambdaRule : Rule("no-it-in-multiline-lambda") {
 
@@ -13,12 +19,23 @@ class NoItParamInMultilineLambdaRule : Rule("no-it-in-multiline-lambda") {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        // fixme: we are not accounting for "it" variable that can be defined in the same scope
         if (node.elementType == IDENTIFIER && node.text == "it") {
             val block = node.parent(BLOCK)
-            if (block != null && block.textContains('\n')) {
+            if (block != null && block.textContains('\n') && !isValidItParam(node, block)) {
                 emit(node.startOffset, "Multiline lambda must explicitly name \"it\" parameter", false)
             }
         }
+    }
+
+    private fun isValidItParam(node: ASTNode, block: ASTNode): Boolean {
+        val containsItInProperty = block.findChildByType(PROPERTY)?.text?.split("=")?.first()?.split(" ")?.contains("it")
+            ?: false
+        val parentElement = (node as LeafPsiElement).parent
+        val partOfDotQualifiedExpression = parentElement is KtNameReferenceExpression &&
+            parentElement.parent is KtDotQualifiedExpression &&
+            (parentElement.parent as KtDotQualifiedExpression).elementType == DOT_QUALIFIED_EXPRESSION
+        val isACallExpression = parentElement?.parent is KtCallExpression
+
+        return containsItInProperty || isACallExpression || (containsItInProperty && partOfDotQualifiedExpression)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoItParamInMultilineLambdaRuleTest.kt
@@ -1,6 +1,8 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.diffFileLint
+import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -13,5 +15,120 @@ class NoItParamInMultilineLambdaRuleTest {
                 "spec/no-it-in-multiline-lambda/lint.kt.spec"
             )
         ).isEmpty()
+    }
+
+    @Test
+    fun testShouldNotReportWhenItAsAVariableIsUsed() {
+        val itParamText =
+            """
+            fun main() {
+                appendCommaSeparated(properties) { prop ->
+                    val it = prop.get(obj)
+                    it.get()
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText)).isEmpty()
+    }
+
+    @Test
+    fun testShouldNotReportWhenItIsFunctionName() {
+        val itParamText =
+            """
+            fun main() {
+                describe("if this") {
+                    it("does that") { 
+                       //     
+                    }
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText)).isEmpty()
+    }
+
+    @Test
+    fun testShouldNotReportWhenItIsBeingAssignedToAVariableAndPassedToFunction() {
+        val itParamText =
+            """
+            fun main() {
+                appendCommaSeparated(properties) { 
+                    val it = 4
+                    bar(it)
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText)).isEmpty()
+    }
+
+    @Test
+    fun testShouldReportWhenNonIsBeingAssignedToAVariableAndItIsPassedToFunction() {
+        val itParamText =
+            """
+            fun main() {
+                appendCommaSeparated(properties) { 
+                    val iit = 4
+                    bar(it)
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText))
+            .isEqualTo(
+                listOf(
+                    LintError(
+                        line = 4,
+                        col = 13,
+                        ruleId = "no-it-in-multiline-lambda",
+                        detail = "Multiline lambda must explicitly name \"it\" parameter"
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun testShouldReportWhenItIsBeingAssignedToAVariable() {
+        val itParamText =
+            """
+            fun main() {
+                appendCommaSeparated(properties) { 
+                    val foo = 4
+                    val bar = it
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText))
+            .isEqualTo(
+                listOf(
+                    LintError(
+                        line = 4,
+                        col = 19,
+                        ruleId = "no-it-in-multiline-lambda",
+                        detail = "Multiline lambda must explicitly name \"it\" parameter"
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun testShouldReportWhenItIsBeingSendInAFunction() {
+        val itParamText =
+            """
+            fun main() {
+                appendCommaSeparated(properties) { 
+                    val foo = 4
+                    bar(foo, it)
+                }
+            }
+            """.trimIndent()
+        assertThat(NoItParamInMultilineLambdaRule().lint(itParamText))
+            .isEqualTo(
+                listOf(
+                    LintError(
+                        line = 4,
+                        col = 18,
+                        ruleId = "no-it-in-multiline-lambda",
+                        detail = "Multiline lambda must explicitly name \"it\" parameter"
+                    )
+                )
+            )
     }
 }


### PR DESCRIPTION
Fixes [#306](https://github.com/pinterest/ktlint/issues/306)

In multiline lambda we can now 
- Allow variables named `it`
- function call of `it` for test frameworks like `Kotlintest `
- Ignore when function calls are made on variable `it` or when it is passed in a function.