### PR TITLE
Fix AnnotationRule exception

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,11 +12,9 @@ insert_final_newline = true
 
 [*.{java,kt,kts,scala,rs,xml,kt.spec,kts.spec}]
 indent_size = 4
-# annotation - "./mvnw clean verify" fails with "Internal Error")
 # multiline-if-else - disabled until auto-correct is working properly
 #   (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
-# no-it-in-multiline-lambda - disabled until it's clear what to do in case of `import _.it`
-disabled_rules=annotation,multiline-if-else
+disabled_rules=multiline-if-else
 
 [{Makefile,*.go}]
 indent_style = tab

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -24,14 +24,16 @@ class AnnotationRule : Rule("annotation") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val root =
-            node.children().firstOrNull { it.elementType == MODIFIER_LIST && it.text != DATA_KEYWORD }
+            node.children().firstOrNull { it.elementType == MODIFIER_LIST }
                 ?: return
 
         val annotations =
             root.children()
                 .mapNotNull { it.psi as? KtAnnotationEntry }
                 .toList()
-        check(!annotations.isEmpty()) { "Annotations list should not be empty" }
+        if (annotations.isEmpty()) {
+            return
+        }
 
         // Join the nodes that immediately follow the annotations (whitespace), then add the final whitespace
         // if it's not a child of root. This happens when a new line separates the annotations from the annotated

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
@@ -329,7 +329,18 @@ class AnnotationRuleTest {
 
             data class FileModel(val uri: String, val name: String)
             """.trimIndent()
-        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+        assertThat(AnnotationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `no annotation present for function override passes`() {
+        val code =
+            """
+            package com.example.application.a.b
+
+            override fun foo()
+            """.trimIndent()
+        assertThat(AnnotationRule().lint(code)).isEmpty()
     }
 
     @Test
@@ -344,6 +355,6 @@ class AnnotationRuleTest {
                 fun gallery(): String = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).path
             }
             """.trimIndent()
-        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+        assertThat(AnnotationRule().lint(code)).isEmpty()
     }
 }


### PR DESCRIPTION
Return if there's no annotations found instead of throwing an exception
Fixes https://github.com/pinterest/ktlint/issues/490 and https://github.com/pinterest/ktlint/issues/502