### PR TITLE
Fix typo from IntentStyle to IndentStyle in EditorConfig

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
@@ -5,9 +5,9 @@ package com.pinterest.ktlint.core
  */
 interface EditorConfig {
 
-    enum class IntentStyle { SPACE, TAB }
+    enum class IndentStyle { SPACE, TAB }
 
-    val indentStyle: IntentStyle
+    val indentStyle: IndentStyle
     val indentSize: Int
     val tabWidth: Int
     val maxLineLength: Int
@@ -17,8 +17,8 @@ interface EditorConfig {
     companion object {
         fun fromMap(map: Map<String, String>): EditorConfig {
             val indentStyle = when {
-                map["indent_style"]?.toLowerCase() == "tab" -> IntentStyle.TAB
-                else -> IntentStyle.SPACE
+                map["indent_style"]?.toLowerCase() == "tab" -> IndentStyle.TAB
+                else -> IndentStyle.SPACE
             }
             val indentSize = map["indent_size"].let { v ->
                 if (v?.toLowerCase() == "unset") -1 else v?.toIntOrNull() ?: 4

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -131,7 +131,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-        if (editorConfig.indentStyle == EditorConfig.IntentStyle.TAB || editorConfig.indentSize <= 1) {
+        if (editorConfig.indentStyle == EditorConfig.IndentStyle.TAB || editorConfig.indentSize <= 1) {
             return
         }
         reset()


### PR DESCRIPTION
This seems to be a typo of `IntentStyle` instead of `IndentStyle` as it's referenced by the variables below it.