### PR TITLE
Add task "shadowJarExecutable" to generate self-running ktlint jar.

### DIFF
--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -44,3 +44,22 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
 }
+
+// Implements https://github.com/brianm/really-executable-jars-maven-plugin maven plugin behaviour.
+// To check details how it works, see http://skife.org/java/unix/2011/06/20/really_executable_jars.html.
+tasks.register("shadowJarExecutable", DefaultTask.class) {
+  description = "Creates self-executable file, that runs generated shadow jar"
+  group = "Distribution"
+
+  inputs.files tasks.named("shadowJar")
+  outputs.file "$buildDir/run/ktlint"
+
+  doLast {
+    File execFile = outputs.files.singleFile
+    execFile.withOutputStream {
+      it.write "#!/bin/sh\n\nexec java -Xmx512m -jar \"\$0\" \"\$@\"\n\n".bytes
+      it.write inputs.files.singleFile.bytes
+    }
+    execFile.setExecutable(true, false)
+  }
+}


### PR DESCRIPTION
This task behaves similar to https://github.com/brianm/really-executable-jars-maven-plugin maven plugin - it creates unix runnable file, that executes `ktlint-all.jar` without need of additional shell script.

Generated file could be checked by executing `ktlint/build/run/ktlint --help` command.

Additional flag `-Xmx512m` was added as per current maven configuration: https://github.com/pinterest/ktlint/blob/e5fd74cba3cb8c12bbd81b8103c5db82f75c6c68/ktlint/pom.xml#L347