### PR TITLE
Properly handle --stdin flag for printAST command

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -44,6 +44,7 @@ object KtLint {
     val ANDROID_USER_DATA_KEY = Key<Boolean>("ANDROID")
     val FILE_PATH_USER_DATA_KEY = Key<String>("FILE_PATH")
     val DISABLED_RULES = Key<Set<String>>("DISABLED_RULES")
+    const val STDIN_FILE = "<stdin>"
 
     private val psiFileFactory: PsiFileFactory
     private val nullSuppression = { _: Int, _: String, _: Boolean -> false }
@@ -191,7 +192,7 @@ object KtLint {
                 return emptyMap()
             }
 
-            if (fileName == "<text>") {
+            if (fileName == STDIN_FILE) {
                 return workdirUserData.value
             }
             return (

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -241,8 +241,6 @@ class KtlintCommandLine {
     @Parameters(hidden = true)
     private var patterns = ArrayList<String>()
 
-    private val workDir = File(".").canonicalPath
-
     fun run() {
         if (apply || applyToProject) {
             applyToIDEA()

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -1,6 +1,7 @@
 @file:JvmName("Main")
 package com.pinterest.ktlint
 
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.ParseException
 import com.pinterest.ktlint.core.Reporter
@@ -277,7 +278,7 @@ class KtlintCommandLine {
         val userData = mapOf("android" to android.toString())
         fun process(fileName: String, fileContent: String): List<LintErrorWithCorrectionInfo> {
             if (debug) {
-                val fileLocation = if (fileName != "<text>") File(fileName).location(relative) else fileName
+                val fileLocation = if (fileName != KtLint.STDIN_FILE) File(fileName).location(relative) else fileName
                 System.err.println("[DEBUG] Checking $fileLocation")
             }
             val result = ArrayList<LintErrorWithCorrectionInfo>()
@@ -345,7 +346,7 @@ class KtlintCommandLine {
         }
         reporter.beforeAll()
         if (stdin) {
-            report("<text>", process("<text>", String(System.`in`.readBytes())))
+            report(KtLint.STDIN_FILE, process(KtLint.STDIN_FILE, String(System.`in`.readBytes())))
         } else {
             patterns.fileSequence()
                 .takeWhile { errorNumber.get() < limit }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.internal
 
 import com.pinterest.ktlint.KtlintCommandLine
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.ParseException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.test.DumpAST
@@ -44,7 +45,7 @@ internal class PrintASTSubCommand : Runnable {
         commandSpec.commandLine().printHelpOrVersionUsage()
 
         if (stdin) {
-            printAST(STDIN_FILE, String(System.`in`.readBytes()))
+            printAST(KtLint.STDIN_FILE, String(System.`in`.readBytes()))
         } else {
             for (file in patterns.fileSequence()) {
                 printAST(file.path, file.readText())
@@ -57,7 +58,7 @@ internal class PrintASTSubCommand : Runnable {
         fileContent: String
     ) {
         if (ktlintCommand.debug) {
-            val fileLocation = if (fileName != STDIN_FILE) {
+            val fileLocation = if (fileName != KtLint.STDIN_FILE) {
                 File(fileName).location(ktlintCommand.relative)
             } else {
                 "stdin"
@@ -77,6 +78,5 @@ internal class PrintASTSubCommand : Runnable {
 
     companion object {
         internal const val COMMAND_NAME = "printAST"
-        private const val STDIN_FILE = "<text>"
     }
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
@@ -66,7 +66,7 @@ internal class PrintASTSubCommand : Runnable {
         }
 
         try {
-            lintFile(fileName, fileContent, astRuleSet)
+            lintFile(fileName, fileContent, astRuleSet, debug = ktlintCommand.debug)
         } catch (e: Exception) {
             if (e is ParseException) {
                 throw ParseException(e.line, e.col, "Not a valid Kotlin file (${e.message?.toLowerCase()})")
@@ -77,6 +77,6 @@ internal class PrintASTSubCommand : Runnable {
 
     companion object {
         internal const val COMMAND_NAME = "printAST"
-        private const val STDIN_FILE = "<stdin>"
+        private const val STDIN_FILE = "<text>"
     }
 }


### PR DESCRIPTION
* Fixes https://github.com/pinterest/ktlint/issues/528
* Also properly pass through `--debug` flag from `printAST` command
* Small cleanup of unused variable