### PR TITLE
Fixing bug with improper indentation for enums with multi-line initializers

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -689,6 +689,11 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     }
 
     private fun adjustExpectedIndentInsideSuperTypeCall(n: ASTNode, ctx: IndentContext) {
+        // Don't adjust indents for initializer lists
+        if (n.treeParent?.elementType != SUPER_TYPE_LIST) {
+            return
+        }
+
         if (
             // n.treePrev == null &&
             // n.treeParent.elementType == SUPER_TYPE_LIST &&

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-supertype-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-supertype-expected.kt.spec
@@ -61,3 +61,15 @@ class AndroidModuleDependency()
 class AndroidModuleDependency()
     : ModuleDependency(name, methodToCall, method),
     ModuleDependency(name, methodToCall, method)
+
+// https://github.com/pinterest/ktlint/issues/518
+enum class Color(val displayName: String, val value: Int) {
+    RED(
+        displayName = "Red",
+        value = 1
+    ),
+    BLUE(
+        displayName = "Blue",
+        value = 2
+    );
+}

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-supertype.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-supertype.kt.spec
@@ -56,3 +56,15 @@ class AndroidModuleDependency()
 class AndroidModuleDependency()
     : ModuleDependency(name, methodToCall, method),
     ModuleDependency(name, methodToCall, method)
+
+// https://github.com/pinterest/ktlint/issues/518
+enum class Color(val displayName: String, val value: Int) {
+    RED(
+        displayName = "Red",
+        value = 1
+    ),
+    BLUE(
+        displayName = "Blue",
+        value = 2
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/518