### PR TITLE
Add support for custom output colors

### DIFF
--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
@@ -13,7 +13,8 @@ class PlainReporter(
     val out: PrintStream,
     val verbose: Boolean = false,
     val groupByFile: Boolean = false,
-    val color: Boolean = false,
+    val shouldColorOutput: Boolean = false,
+    val outputColor: Color = Color.DARK_GRAY,
     val pad: Boolean = false
 ) : Reporter {
 
@@ -25,9 +26,9 @@ class PlainReporter(
                 acc.getOrPut(file) { ArrayList<LintError>() }.add(err)
             } else {
                 out.println(
-                    "${colorFileName(file)}${":".gray()}${err.line}${
-                    ":${"${err.col}:".let { if (pad) String.format("%-4s", it) else it}}".gray()
-                    } ${err.detail}${if (verbose) " (${err.ruleId})".gray() else ""}"
+                    "${colorFileName(file)}${":".colored()}${err.line}${
+                    ":${"${err.col}:".let { if (pad) String.format("%-4s", it) else it}}".colored()
+                    } ${err.detail}${if (verbose) " (${err.ruleId})".colored() else ""}"
                 )
             }
         }
@@ -40,8 +41,8 @@ class PlainReporter(
             for ((line, col, ruleId, detail) in errList) {
                 out.println(
                     "  $line${
-                    ":${if (pad) String.format("%-3s", col) else "$col"}".gray()
-                    } $detail${if (verbose) " ($ruleId)".gray() else ""}"
+                    ":${if (pad) String.format("%-3s", col) else "$col"}".colored()
+                    } $detail${if (verbose) " ($ruleId)".colored() else ""}"
                 )
             }
         }
@@ -49,9 +50,9 @@ class PlainReporter(
 
     private fun colorFileName(fileName: String): String {
         val name = fileName.substringAfterLast(File.separator)
-        return fileName.substring(0, fileName.length - name.length).gray() + name
+        return fileName.substring(0, fileName.length - name.length).colored() + name
     }
 
-    private fun String.gray() =
-        if (color) this.color(Color.DARK_GRAY) else this
+    private fun String.colored() =
+        if (shouldColorOutput) this.color(outputColor) else this
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
@@ -13,7 +13,7 @@ class PlainReporterProvider : ReporterProvider {
             out,
             verbose = opt["verbose"]?.emptyOrTrue() ?: false,
             groupByFile = opt["group_by_file"]?.emptyOrTrue() ?: false,
-            color = opt["color"]?.emptyOrTrue() ?: false,
+            shouldColorOutput = opt["color"]?.emptyOrTrue() ?: false,
             pad = opt["pad"]?.emptyOrTrue() ?: false
         )
 

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
+import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.PrintStream
 
 class PlainReporterProvider : ReporterProvider {
@@ -14,8 +15,11 @@ class PlainReporterProvider : ReporterProvider {
             verbose = opt["verbose"]?.emptyOrTrue() ?: false,
             groupByFile = opt["group_by_file"]?.emptyOrTrue() ?: false,
             shouldColorOutput = opt["color"]?.emptyOrTrue() ?: false,
+            outputColor = opt["outputColor"]?.toColor() ?: Color.DARK_GRAY,
             pad = opt["pad"]?.emptyOrTrue() ?: false
         )
 
     private fun String.emptyOrTrue() = this == "" || this == "true"
+
+    private fun String.toColor() = Color.values().firstOrNull { it.name == this } ?: Color.DARK_GRAY
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/internal/Color.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/internal/Color.kt
@@ -7,8 +7,19 @@ fun String.color(foreground: Color) = "\u001B[${foreground.code}m$this\u001B[0m"
 
 enum class Color(val code: Int) {
     BLACK(30),
-    RED(31), GREEN(32), YELLOW(33), BLUE(34), MAGENTA(35), CYAN(36),
-    LIGHT_GRAY(37), DARK_GRAY(90),
-    LIGHT_RED(91), LIGHT_GREEN(92), LIGHT_YELLOW(93), LIGHT_BLUE(94), LIGHT_MAGENTA(95), LIGHT_CYAN(96),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    LIGHT_GRAY(37),
+    DARK_GRAY(90),
+    LIGHT_RED(91),
+    LIGHT_GREEN(92),
+    LIGHT_YELLOW(93),
+    LIGHT_BLUE(94),
+    LIGHT_MAGENTA(95),
+    LIGHT_CYAN(96),
     WHITE(97)
 }

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -1,10 +1,12 @@
 package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.reporter.plain.internal.Color
-import org.junit.Assert.*
-import org.junit.Test
 import java.io.PrintStream
 import java.lang.System.out
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 class PlainReporterProviderTest {
     @Test
@@ -19,7 +21,7 @@ class PlainReporterProviderTest {
     }
 
     @Test
-    fun testValidColor() {
+    fun testValidShouldColorBoolean() {
         val plainReporter = PlainReporterProvider().get(
             out = PrintStream(out, true),
             opt = mapOf("color" to "true")

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -1,0 +1,52 @@
+package com.pinterest.ktlint.reporter.plain
+
+import com.pinterest.ktlint.reporter.plain.internal.Color
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.PrintStream
+import java.lang.System.out
+
+class PlainReporterProviderTest {
+    @Test
+    fun testColorDefaults() {
+        val plainReporter = PlainReporterProvider().get(
+            out = PrintStream(out, true),
+            opt = mapOf()
+        ) as PlainReporter
+
+        assertFalse(plainReporter.shouldColorOutput)
+        assertEquals(Color.DARK_GRAY, plainReporter.outputColor)
+    }
+
+    @Test
+    fun testValidColor() {
+        val plainReporter = PlainReporterProvider().get(
+            out = PrintStream(out, true),
+            opt = mapOf("color" to "true")
+        ) as PlainReporter
+
+        assertTrue(plainReporter.shouldColorOutput)
+    }
+
+    @Test
+    fun testInvalidOutputColor() {
+        val plainReporter = PlainReporterProvider().get(
+            out = PrintStream(out, true),
+            opt = mapOf("outputColor" to "GarbageInput")
+        ) as PlainReporter
+
+        assertEquals(Color.DARK_GRAY, plainReporter.outputColor)
+    }
+
+    @Test
+    fun testValidOutputColor() {
+        val outputColor = Color.RED
+
+        val plainReporter = PlainReporterProvider().get(
+            out = PrintStream(out, true),
+            opt = mapOf("outputColor" to outputColor.name)
+        ) as PlainReporter
+
+        assertEquals(outputColor, plainReporter.outputColor)
+    }
+}

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -1,9 +1,12 @@
 package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.reporter.plain.internal.Color
+import com.pinterest.ktlint.reporter.plain.internal.color
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class PlainReporterTest {
@@ -55,12 +58,44 @@ class PlainReporterTest {
             true
         )
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
+            """
 /one-fixed-and-one-not.kt:1:1: <"&'>
 /two-not-fixed.kt:1:10: I thought I would again
 /two-not-fixed.kt:2:20: A single thin straight line
 """.trimStart().replace("\n", System.lineSeparator())
         )
+    }
+
+    @Test
+    fun testColoredOutput() {
+        val out = ByteArrayOutputStream()
+        val outputColor = Color.DARK_GRAY
+        val reporter = PlainReporter(
+            PrintStream(out, true),
+            shouldColorOutput = true,
+            outputColor = outputColor
+        )
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                1, 1, "rule-1",
+                "<\"&'>"
+            ),
+            false
+        )
+
+        val outputString = String(out.toByteArray())
+
+        // We don't expect class name, or first line to be colored
+        val expectedOutput =
+            "/".color(outputColor) +
+                "one-fixed-and-one-not.kt" +
+                ":".color(outputColor) +
+                "1" +
+                ":1:".color(outputColor) +
+                " <\"&'>\n"
+
+        assertEquals(expectedOutput, outputString)
     }
 
     @Test
@@ -113,7 +148,7 @@ class PlainReporterTest {
         reporter.after("/two-not-fixed.kt")
         reporter.after("/all-corrected.kt")
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
+            """
 /one-fixed-and-one-not.kt
   1:1 <"&'>
 /two-not-fixed.kt

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -133,6 +133,12 @@ class KtlintCommandLine {
     var color: Boolean = false
 
     @Option(
+        names = ["--outputColor"],
+        description = ["The name of the color to use for console output if --color is true. Defaults to DARK_GRAY"]
+    )
+    var outputColor: String = ""
+
+    @Option(
         names = ["--debug"],
         description = ["Turn on debug output"]
     )
@@ -346,7 +352,7 @@ class KtlintCommandLine {
                 ReporterTemplate(
                     reporterId,
                     split.lastOrNull { it.startsWith("artifact=") }?.let { it.split("=")[1] },
-                    mapOf("verbose" to verbose.toString(), "color" to color.toString()) + parseQuery(rawReporterConfig),
+                    mapOf("verbose" to verbose.toString(), "color" to color.toString(), "outputColor" to outputColor) + parseQuery(rawReporterConfig),
                     split.lastOrNull { it.startsWith("output=") }?.let { it.split("=")[1] }
                 )
             }


### PR DESCRIPTION
## Summary

I recently submitted this issue because the console output colors were difficult to read against a dark terminal: #582 

For a proposed solution, I added a new flag called `outputColor` that end users can supply any color name found here: https://github.com/pinterest/ktlint/blob/master/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/internal/Color.kt

If not supplied, or an invalid name is supplied, we default to DARK_GRAY, which was the hardcoded value from before. 

## How This Was Tested

I've added unit tests on `PlainReporterProvider` which verify the color values passed in the map of strings get mapped to the correct values. I also added a new test on `PlainReporter` which verifies the color output is what we expect. 

I also tested this manually. Here it is with just `--color` set:

<img width="1027" alt="Screen Shot 2019-09-17 at 12 20 09 PM" src="https://user-images.githubusercontent.com/9515997/65060550-15e86280-d946-11e9-8d6e-58c3da5a51f7.png">

And here is one with `--color --outputColor="RED"`:

<img width="1022" alt="Screen Shot 2019-09-17 at 12 20 34 PM" src="https://user-images.githubusercontent.com/9515997/65060570-20a2f780-d946-11e9-959c-a31b8d34d06b.png">
