### PR TITLE
Added support for customizing the output color for #582.

### DIFF
--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
@@ -13,7 +13,8 @@ class PlainReporter(
     val out: PrintStream,
     val verbose: Boolean = false,
     val groupByFile: Boolean = false,
-    val color: Boolean = false,
+    val shouldColorOutput: Boolean = false,
+    val outputColor: Color = Color.DARK_GRAY,
     val pad: Boolean = false
 ) : Reporter {
 
@@ -25,9 +26,9 @@ class PlainReporter(
                 acc.getOrPut(file) { ArrayList<LintError>() }.add(err)
             } else {
                 out.println(
-                    "${colorFileName(file)}${":".gray()}${err.line}${
-                    ":${"${err.col}:".let { if (pad) String.format("%-4s", it) else it}}".gray()
-                    } ${err.detail}${if (verbose) " (${err.ruleId})".gray() else ""}"
+                    "${colorFileName(file)}${":".colored()}${err.line}${
+                    ":${"${err.col}:".let { if (pad) String.format("%-4s", it) else it}}".colored()
+                    } ${err.detail}${if (verbose) " (${err.ruleId})".colored() else ""}"
                 )
             }
         }
@@ -40,8 +41,8 @@ class PlainReporter(
             for ((line, col, ruleId, detail) in errList) {
                 out.println(
                     "  $line${
-                    ":${if (pad) String.format("%-3s", col) else "$col"}".gray()
-                    } $detail${if (verbose) " ($ruleId)".gray() else ""}"
+                    ":${if (pad) String.format("%-3s", col) else "$col"}".colored()
+                    } $detail${if (verbose) " ($ruleId)".colored() else ""}"
                 )
             }
         }
@@ -49,9 +50,9 @@ class PlainReporter(
 
     private fun colorFileName(fileName: String): String {
         val name = fileName.substringAfterLast(File.separator)
-        return fileName.substring(0, fileName.length - name.length).gray() + name
+        return fileName.substring(0, fileName.length - name.length).colored() + name
     }
 
-    private fun String.gray() =
-        if (color) this.color(Color.DARK_GRAY) else this
+    private fun String.colored() =
+        if (shouldColorOutput) this.color(outputColor) else this
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
+import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.PrintStream
 
 class PlainReporterProvider : ReporterProvider {
@@ -13,9 +14,14 @@ class PlainReporterProvider : ReporterProvider {
             out,
             verbose = opt["verbose"]?.emptyOrTrue() ?: false,
             groupByFile = opt["group_by_file"]?.emptyOrTrue() ?: false,
-            color = opt["color"]?.emptyOrTrue() ?: false,
+            shouldColorOutput = opt["color"]?.emptyOrTrue() ?: false,
+            outputColor = getColor(opt["color_name"]),
             pad = opt["pad"]?.emptyOrTrue() ?: false
         )
 
     private fun String.emptyOrTrue() = this == "" || this == "true"
+
+    private fun getColor(colorInput: String?): Color {
+        return Color.values().firstOrNull { it.name == colorInput } ?: throw IllegalArgumentException("Invalid color parameter.")
+    }
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/internal/Color.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/internal/Color.kt
@@ -7,8 +7,19 @@ fun String.color(foreground: Color) = "\u001B[${foreground.code}m$this\u001B[0m"
 
 enum class Color(val code: Int) {
     BLACK(30),
-    RED(31), GREEN(32), YELLOW(33), BLUE(34), MAGENTA(35), CYAN(36),
-    LIGHT_GRAY(37), DARK_GRAY(90),
-    LIGHT_RED(91), LIGHT_GREEN(92), LIGHT_YELLOW(93), LIGHT_BLUE(94), LIGHT_MAGENTA(95), LIGHT_CYAN(96),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    LIGHT_GRAY(37),
+    DARK_GRAY(90),
+    LIGHT_RED(91),
+    LIGHT_GREEN(92),
+    LIGHT_YELLOW(93),
+    LIGHT_BLUE(94),
+    LIGHT_MAGENTA(95),
+    LIGHT_CYAN(96),
     WHITE(97)
 }

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -1,0 +1,68 @@
+package com.pinterest.ktlint.reporter.plain
+
+import com.pinterest.ktlint.reporter.plain.internal.Color
+import java.io.PrintStream
+import java.lang.System.out
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class PlainReporterProviderTest {
+    @Test
+    fun testNoColorNameProvided() {
+        try {
+            PlainReporterProvider().get(
+                out = PrintStream(out, true),
+                opt = mapOf()
+            ) as PlainReporter
+
+            fail("Expected IllegalArgumentException.")
+        } catch (iae: IllegalArgumentException) {
+            // Expected case
+        } catch (e: Exception) {
+            fail("Expected IllegalArgumentException but was: $e")
+        }
+    }
+
+    @Test
+    fun testEmptyColorNameProvided() {
+        try {
+            PlainReporterProvider().get(
+                out = PrintStream(out, true),
+                opt = mapOf("color_name" to "")
+            ) as PlainReporter
+
+            fail("Expected IllegalArgumentException.")
+        } catch (iae: IllegalArgumentException) {
+            // Expected case
+        } catch (e: Exception) {
+            fail("Expected IllegalArgumentException but was: $e")
+        }
+    }
+
+    @Test
+    fun testValidColorNameProvided() {
+        val plainReporter = PlainReporterProvider().get(
+            out = PrintStream(out, true),
+            opt = mapOf("color_name" to "RED")
+        ) as PlainReporter
+
+        assertEquals(Color.RED, plainReporter.color)
+    }
+
+    @Test
+    fun testInvalidColorNameProvided() {
+        try {
+            PlainReporterProvider().get(
+                out = PrintStream(out, true),
+                opt = mapOf("colo_namer" to "GARBAGE_INPUT")
+            ) as PlainReporter
+
+            fail("Expected IllegalArgumentException.")
+        } catch (iae: IllegalArgumentException) {
+            // Expected case
+        } catch (e: Exception) {
+            fail("Expected IllegalArgumentException but was: $e")
+        }
+    }
+}

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -47,7 +47,7 @@ class PlainReporterProviderTest {
             opt = mapOf("color_name" to "RED")
         ) as PlainReporter
 
-        assertEquals(Color.RED, plainReporter.color)
+        assertEquals(Color.RED, plainReporter.outputColor)
     }
 
     @Test

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -1,9 +1,12 @@
 package com.pinterest.ktlint.reporter.plain
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.reporter.plain.internal.Color
+import com.pinterest.ktlint.reporter.plain.internal.color
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class PlainReporterTest {
@@ -55,12 +58,44 @@ class PlainReporterTest {
             true
         )
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
+            """
 /one-fixed-and-one-not.kt:1:1: <"&'>
 /two-not-fixed.kt:1:10: I thought I would again
 /two-not-fixed.kt:2:20: A single thin straight line
 """.trimStart().replace("\n", System.lineSeparator())
         )
+    }
+
+    @Test
+    fun testColoredOutput() {
+        val out = ByteArrayOutputStream()
+        val outputColor = Color.DARK_GRAY
+        val reporter = PlainReporter(
+            PrintStream(out, true),
+            shouldColorOutput = true,
+            color = outputColor
+        )
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                1, 1, "rule-1",
+                "<\"&'>"
+            ),
+            false
+        )
+
+        val outputString = String(out.toByteArray())
+
+        // We don't expect class name, or first line to be colored
+        val expectedOutput =
+            "/".color(outputColor) +
+                "one-fixed-and-one-not.kt" +
+                ":".color(outputColor) +
+                "1" +
+                ":1:".color(outputColor) +
+                " <\"&'>\n"
+
+        assertEquals(expectedOutput, outputString)
     }
 
     @Test
@@ -113,7 +148,7 @@ class PlainReporterTest {
         reporter.after("/two-not-fixed.kt")
         reporter.after("/all-corrected.kt")
         assertThat(String(out.toByteArray())).isEqualTo(
-"""
+            """
 /one-fixed-and-one-not.kt
   1:1 <"&'>
 /two-not-fixed.kt

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -73,7 +73,7 @@ class PlainReporterTest {
         val reporter = PlainReporter(
             PrintStream(out, true),
             shouldColorOutput = true,
-            color = outputColor
+            outputColor = outputColor
         )
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -20,6 +20,7 @@ import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.lintFile
 import com.pinterest.ktlint.internal.location
 import com.pinterest.ktlint.internal.printHelpOrVersionUsage
+import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.File
 import java.io.IOException
 import java.io.PrintStream
@@ -131,6 +132,12 @@ class KtlintCommandLine {
         description = ["Make output colorful"]
     )
     var color: Boolean = false
+
+    @Option(
+        names = ["--color-name"],
+        description = ["Customize the output color"]
+    )
+    var colorName: String = Color.DARK_GRAY.name
 
     @Option(
         names = ["--debug"],
@@ -346,7 +353,7 @@ class KtlintCommandLine {
                 ReporterTemplate(
                     reporterId,
                     split.lastOrNull { it.startsWith("artifact=") }?.let { it.split("=")[1] },
-                    mapOf("verbose" to verbose.toString(), "color" to color.toString()) + parseQuery(rawReporterConfig),
+                    mapOf("verbose" to verbose.toString(), "color" to color.toString(), "color_name" to colorName) + parseQuery(rawReporterConfig),
                     split.lastOrNull { it.startsWith("output=") }?.let { it.split("=")[1] }
                 )
             }


### PR DESCRIPTION
# Summary

This resolves the issue discussed here, that the default DARK_GRAY background color was hard to read against dark terminals: #582 

# Usage

I made sure this was a non breaking change by allowing the current usage of KtLint to behave the way it does now. For example:

- ./ktlint 
  - Will output without color as it does now
- ./ktlint --color
  - Will color the output in DARK_GRAY as it does now
- ./ktlint --color --color-name="RED"
  - Will color the output in RED, or whatever was supplied.

# How it was tested

I've added unit tests to `PlainReporterTest` to validate the colored output. I also added `PlainReporterProviderTest` which ensures the input for a color maps to the expected output. 

I also ran this manually. Here is KtLint with no command args:

<img width="1556" alt="Screen Shot 2019-09-17 at 2 07 40 PM" src="https://user-images.githubusercontent.com/9515997/65067610-e4c35e80-d954-11e9-8462-8449eabf75e0.png">

Here it is with `--color`:

<img width="1027" alt="Screen Shot 2019-09-17 at 12 20 09 PM" src="https://user-images.githubusercontent.com/9515997/65067645-f7d62e80-d954-11e9-9be1-2cdfa5a6db49.png">

Here it is with `--color --colorName="RED"`:

<img width="1022" alt="Screen Shot 2019-09-17 at 12 20 34 PM" src="https://user-images.githubusercontent.com/9515997/65067655-fd337900-d954-11e9-8426-56e4a2229919.png">

