### PR TITLE
Remove spacing between "}" and "]"

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -12,6 +12,7 @@ import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.LBRACKET
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
+import com.pinterest.ktlint.core.ast.ElementType.RBRACKET
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.SAFE_ACCESS
 import com.pinterest.ktlint.core.ast.ElementType.SEMICOLON
@@ -116,6 +117,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
         return (
             nextElementType == DOT ||
                 nextElementType == COMMA ||
+                nextElementType == RBRACKET ||
                 nextElementType == RPAR ||
                 nextElementType == SEMICOLON ||
                 nextElementType == SAFE_ACCESS ||

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
@@ -50,6 +50,14 @@ class SpacingAroundCurlyRuleTest {
                     LintError(2, 37, "curly-spacing", "Unexpected space after \"}\"")
                 )
             )
+        assertThat(SpacingAroundCurlyRule().lint("fun main() { map[1 + list.count { it != true }] = 1 }"))
+            .isEmpty()
+        assertThat(SpacingAroundCurlyRule().lint("fun main() { map[1 + list.count { it != true } ] = 1 }"))
+            .isEqualTo(
+                listOf(
+                    LintError(1, 46, "curly-spacing", "Unexpected space after \"}\"")
+                )
+            )
     }
 
     @Test
@@ -109,6 +117,7 @@ class SpacingAroundCurlyRuleTest {
                     )
                     val f =
                         { true }
+                    map[1 + list.count { it != true } ] = 1
                 }
                 class A { private val shouldEjectBlock = block@ { (pathProgress ?: return@block false) >= 0.85 } }
                 """.trimIndent()
@@ -152,6 +161,7 @@ class SpacingAroundCurlyRuleTest {
                 )
                 val f =
                     { true }
+                map[1 + list.count { it != true }] = 1
             }
             class A { private val shouldEjectBlock = block@{ (pathProgress ?: return@block false) >= 0.85 } }
             """.trimIndent()


### PR DESCRIPTION
Fix https://github.com/pinterest/ktlint/issues/564

Remove spacing after "}" when it's map key.

#### Current
```kotlin
// Missing spacing after "}"
fun main() { map[1 + list.count { it != true }] = 1 }
```

#### Patched
```kotlin
// No error
fun main() { map[1 + list.count { it != true }] = 1 }

// Unexpected space after "}"
fun main() { map[1 + list.count { it != true } ] = 1 }
```