### PR TITLE
No newline after arrow when the expression is one-line

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -363,6 +363,9 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             val lf = rToken?.nextLeaf { it.isWhiteSpaceWithNewline() }
             return lf?.parent({ it == p }) == null
         }
+        if (nextCodeSibling?.textContains('\n') == false) {
+            return true
+        }
         return false
     }
 

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow-expected.kt.spec
@@ -23,6 +23,10 @@ fun main() {
         2 // second element
         -> true
     }
+    when {
+        1,
+        2 -> true
+    }
     foo.func {
         param1, param2 ->
         doSomething()

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-arrow.kt.spec
@@ -20,6 +20,10 @@ fun main() {
         2 // second element
         -> true
     }
+    when {
+        1,
+        2 -> true
+    }
     foo.func {
         param1, param2 ->
             doSomething()


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/586

Do not insert newline after arrow, when following expression is one-line.

#### Current
```kotlin
fun test(status: A): B {
    return when (status) {
        A.A,
        // Missing newline after "->"
        A.B -> B.A
    }
}

// Formatted
fun test(status: A): B? {
    return when (status) {
        A.A,
        A.B ->
            B.A
    }
}
```

#### Patched
```kotlin
fun test(status: A): B {
    return when (status) {
        A.A,
        //  No error
        A.B -> B.A
    }
}
```