### PR TITLE
Insert space around the multiplication operator

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -26,6 +26,7 @@ import com.pinterest.ktlint.core.ast.ElementType.PERCEQ
 import com.pinterest.ktlint.core.ast.ElementType.PLUS
 import com.pinterest.ktlint.core.ast.ElementType.PLUSEQ
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.nextLeaf
@@ -41,7 +42,6 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.KtSuperExpression
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
-import org.jetbrains.kotlin.psi.KtValueArgument
 
 class SpacingAroundOperatorsRule : Rule("op-spacing") {
 
@@ -59,7 +59,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
             node is LeafElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>
-            !(node.elementType == MUL && node.isPartOf(KtValueArgument::class)) && // fn(*array)
+            !(node.elementType == MUL && node.treeParent.elementType == VALUE_ARGUMENT) && // fn(*array)
             !node.isPartOf(KtImportDirective::class) && // import *
             !node.isPartOf(KtSuperExpression::class) // super<T>
         ) {

--- a/ktlint-ruleset-standard/src/test/resources/spec/op-spacing/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/op-spacing/lint.kt.spec
@@ -4,6 +4,10 @@ fun main() {
     val v1 = 0-1*2
     val v2 = -0 - 1
     val v3 = v * 2
+    fn(1 + 1 - 1 * 1 / 1)
+    fn(1+1-1*1/1)
+    fn(v1+1*v2)
+    run { v1*2 }
     i++
     val y = +1
     var x = 1 in 3..4
@@ -14,6 +18,7 @@ fun main() {
     val a= ""
     d *= 1
     call(*v)
+    call(1, *v, 2)
     open class A<T> {
         open fun x() {}
     }
@@ -25,4 +30,11 @@ fun main() {
 // expect
 // 4:15:Missing spacing around "-"
 // 4:17:Missing spacing around "*"
-// 14:10:Missing spacing before "="
+// 8:9:Missing spacing around "+"
+// 8:11:Missing spacing around "-"
+// 8:13:Missing spacing around "*"
+// 8:15:Missing spacing around "/"
+// 9:10:Missing spacing around "+"
+// 9:12:Missing spacing around "*"
+// 10:13:Missing spacing around "*"
+// 18:10:Missing spacing before "="


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/576

Inserts space around the multiplication operator, but not for spread operator.

#### Current
```kotlin
// No error
fun main() {
    test(*array)
    test(1, *array, 2)
    test(1*value)
    test.run { 1*value }
}
```

#### Patched
```kotlin
fun main() {
    test(*array)
    test(1, *array, 2)
    // Missing spacing around "*"
    test(1*value)
    // Missing spacing around "*"
    test.run { 1*value }
}

// Formatted result
fun main() {
    test(*array)
    test(1, *array, 2)
    test(1 * value)
    test.run { 1 * value }
}
```