### PR TITLE
Fix indent with get/set and line-separated variable assignment

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -965,6 +965,16 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                 node.treeParent?.elementType.let { it == TYPE_PARAMETER_LIST || it == TYPE_ARGUMENT_LIST } ->
                 0
             nextLeafElementType in rTokenSet -> -1
+            // IDEA quirk:
+            // var value: DataClass =
+            //     DataClass("too long line")
+            //     private set
+            //
+            //  instead of expected:
+            //  var value: DataClass =
+            //      DataClass("too long line")
+            //          private set
+            node.nextCodeSibling()?.elementType == PROPERTY_ACCESSOR && node.treeParent.findChildByType(EQ)?.nextLeaf().isWhiteSpaceWithNewline() -> -1
             else -> 0
         }
         // indentation with all \t replaced

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/lint-property-accessor.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/lint-property-accessor.kt.spec
@@ -28,7 +28,12 @@ class A {
 
     var setterWithAnnotation: Any? = null
         @Inject set
+
+    var multilineInitialValue: String =
+        "tooooooooooooo loooooooooooooooong"
+            private set
 }
 
 // expect
 // 3:1:Unexpected indentation (4) (should be 8)
+// 34:1:Unexpected indentation (12) (should be 8)


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/550

Fix indent before get/set in case of variable assignment is in separated line, to follow IDEA's formatting.

#### Current
```kotlin
object TestObject {
    var value: String =
        "tooooooooooooooooo looooooooooooooooooooooooooong line"
        // Unexpected indentation (8) (should be 12)
        private set
}

```

#### Patched
```kotlin
object TestObject {
    var value: String =
        "tooooooooooooooooo looooooooooooooooooooooooooong line"
        // No error
        private set
}

```