### PR TITLE
Keep empty brace of companion object

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.nextLeaf
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -22,7 +23,8 @@ class NoEmptyClassBodyRule : Rule("no-empty-class-body") {
                 n.elementType == LBRACE &&
                     n.nextLeaf { it.elementType != WHITE_SPACE }?.elementType == RBRACE
             } == true &&
-            !node.isPartOf(KtObjectLiteralExpression::class)
+            !node.isPartOf(KtObjectLiteralExpression::class) &&
+            node.treeParent.firstChildNode.children().none { it.text == "companion" }
         ) {
             emit(node.startOffset, "Unnecessary block (\"{}\")", true)
             if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/test/resources/spec/no-empty-class-body/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/no-empty-class-body/lint.kt.spec
@@ -18,6 +18,10 @@ val o = object : TypeReference<HashMap<String, String>>() {}
 
 fun main() {}
 
+class C3 {
+    companion object {}
+}
+
 // expect
 // 1:10:Unnecessary block ("{}")
 // 2:28:Unnecessary block ("{}")


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/411

keep empty brace of companion object from removing, because the removing causes compile error.

#### Current
```kotlin
class test {
    // Unnecessary block ("{}")
    companion object {}
    enum class ExampleEnum {
        EXAMPLE
    }
}

// Formatted
class test {
    companion object
    enum class ExampleEnum {
        // Compile error
        EXAMPLE
    }
}
```

#### Patched
```kotlin
class test {
    // No error
    companion object {}
    enum class ExampleEnum {
        EXAMPLE
    }
}
```