### PR TITLE
Insert spacing after annotation

### DIFF
--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -173,6 +173,23 @@ class AnnotationRuleTest {
     }
 
     @Test
+    fun `lint spacing after annotations`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                class A {
+                    @SomeAnnotation("value")val x: String
+                }
+                """.trimIndent()
+            )
+        ).containsExactly(
+            LintError(
+                2, 28, "annotation", "Missing spacing after @SomeAnnotation(\"value\")"
+            )
+        )
+    }
+
+    @Test
     fun `lint annotations with params should not be placed on same line before annotated construct`() {
         assertThat(
             AnnotationRule().lint(


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/559

Insert spacing after annotation.

#### Current
```kotlin
// No error
data class A(
    @Annotation(0)val property: Type 
)
```

#### Patched
```kotlin
data class A(
    // Missing spacing after @Annotation(0)
    @Annotation(0)val property: Type 
)

// Formatted
data class A(
    @Annotation(0) val property: Type 
)
```