### PR TITLE
Mention Ktlint uses .gitignore pattern style syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Usually simple `http_proxy=http://proxy-server:port https_proxy=http://proxy-ser
 $ ktlint --color
   src/main/kotlin/Main.kt:10:10: Unused import
   
-# check only certain locations (prepend ! to negate the pattern) 
+# check only certain locations (prepend ! to negate the pattern,
+# Ktlint uses .gitignore pattern style syntax)
 $ ktlint "src/**/*.kt" "!src/**/*Test.kt"
 
 # auto-correct style violations

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -91,7 +91,8 @@ Examples:
   # (hidden folders will be skipped)
   ktlint
 
-  # check only certain locations (prepend ! to negate the pattern)
+  # check only certain locations (prepend ! to negate the pattern,
+  # Ktlint uses .gitignore pattern style syntax)
   ktlint "src/**/*.kt" "!src/**/*Test.kt"
 
   # auto-correct style violations


### PR DESCRIPTION
Followup of #602 issue.