### PR TITLE
Align dependencies scopes in Gradle configuration with Maven.

### DIFF
--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -4,8 +4,9 @@ plugins {
 }
 
 dependencies {
+  api deps.kotlin.compiler
+
   implementation deps.kotlin.stdlib
-  implementation deps.kotlin.compiler
   implementation deps.ec4j
 
   testImplementation deps.junit

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   implementation project(':ktlint-core')
   implementation project(':ktlint-test')
   implementation deps.kotlin.stdlib
-  implementation deps.kotlin.compiler
 
   testImplementation deps.junit
   testImplementation deps.assertj

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   implementation project(':ktlint-core')
   implementation project(':ktlint-test')
   implementation deps.kotlin.stdlib
-  implementation deps.kotlin.compiler
 
   testImplementation deps.junit
   testImplementation deps.assertj

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -26,11 +26,12 @@ configurations {
 }
 
 dependencies {
-  api project(':ktlint-core')
-  api deps.kotlin.stdlib
-  api deps.kotlin.compiler
+  compileOnly project(':ktlint-core')
+  compileOnly deps.kotlin.stdlib
 
+  testImplementation project(':ktlint-core')
   testImplementation project(':ktlint-test')
+  testImplementation deps.kotlin.stdlib
   testImplementation deps.assertj
   testImplementation('org.jetbrains.spek:spek-junit-platform-engine:1.1.5') {
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
   implementation deps.kotlin.stdlib
-  implementation deps.kotlin.compiler
+
   implementation deps.assertj
   implementation deps.junit
 }


### PR DESCRIPTION
This should allow to produce similar to Maven build artefacts from Gradle build.