### PR TITLE
Reorganize run() method in KtlintCommandLine class.

### DIFF
--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -223,7 +223,9 @@ class KtlintCommandLine {
             if (disabledRules.isNotBlank()) "disabled_rules" to disabledRules else null
         ).toMap()
 
-        val (fileNumber, errorNumber) = Pair(AtomicInteger(), AtomicInteger())
+        val fileNumber = AtomicInteger()
+        val errorNumber = AtomicInteger()
+
         fun report(fileName: String, errList: List<LintErrorWithCorrectionInfo>) {
             fileNumber.incrementAndGet()
             val errListLimit = minOf(errList.size, maxOf(limit - errorNumber.get(), 0))

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -284,6 +284,7 @@ class KtlintCommandLine {
     /**
      * Detect custom rulesets that have not been moved to the new package.
      */
+    @Suppress("Deprecation")
     private fun failOnOldRulesetProviderUsage() {
         if (ServiceLoader.load(com.github.shyiko.ktlint.core.RuleSetProvider::class.java).any()) {
             System.err.println("[ERROR] Cannot load custom ruleset!")

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -373,13 +373,6 @@ class KtlintCommandLine {
         return result
     }
 
-    private data class ReporterTemplate(
-        val id: String,
-        val artifact: String?,
-        val config: Map<String, String>,
-        val output: String?
-    )
-
     private fun loadReporter(tripped: () -> Boolean): Reporter {
         val configuredReporters = if (reporters.isEmpty()) listOf("plain") else reporters
 
@@ -583,5 +576,15 @@ class KtlintCommandLine {
         jarFile.toURI().toURL()
     }
 
-    data class LintErrorWithCorrectionInfo(val err: LintError, val corrected: Boolean)
+    private data class LintErrorWithCorrectionInfo(
+        val err: LintError,
+        val corrected: Boolean
+    )
+
+    private data class ReporterTemplate(
+        val id: String,
+        val artifact: String?,
+        val config: Map<String, String>,
+        val output: String?
+    )
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -210,15 +210,9 @@ class KtlintCommandLine {
     private var patterns = ArrayList<String>()
 
     fun run() {
-        val start = System.currentTimeMillis()
+        failOnOldRulesetProviderUsage()
 
-        // Detect custom rulesets that have not been moved to the new package
-        if (ServiceLoader.load(com.github.shyiko.ktlint.core.RuleSetProvider::class.java).any()) {
-            System.err.println("[ERROR] Cannot load custom ruleset!")
-            System.err.println("[ERROR] RuleSetProvider has moved to com.pinterest.ktlint.core.")
-            System.err.println("[ERROR] Please rename META-INF/services/com.github.shyiko.ktlint.core.RuleSetProvider to META-INF/services/com.pinterest.ktlint.core.RuleSetProvider")
-            exitProcess(1)
-        }
+        val start = System.currentTimeMillis()
 
         val ruleSetProviders = loadRulesets(rulesets)
         val tripped = AtomicBoolean()
@@ -315,6 +309,18 @@ class KtlintCommandLine {
             )
         }
         if (tripped.get()) {
+            exitProcess(1)
+        }
+    }
+
+    /**
+     * Detect custom rulesets that have not been moved to the new package.
+     */
+    private fun failOnOldRulesetProviderUsage() {
+        if (ServiceLoader.load(com.github.shyiko.ktlint.core.RuleSetProvider::class.java).any()) {
+            System.err.println("[ERROR] Cannot load custom ruleset!")
+            System.err.println("[ERROR] RuleSetProvider has moved to com.pinterest.ktlint.core.")
+            System.err.println("[ERROR] Please rename META-INF/services/com.github.shyiko.ktlint.core.RuleSetProvider to META-INF/services/com.pinterest.ktlint.core.RuleSetProvider")
             exitProcess(1)
         }
     }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -217,7 +217,7 @@ class KtlintCommandLine {
         val ruleSetProviders = loadRulesets(rulesets)
         val tripped = AtomicBoolean()
         val reporter = loadReporter { tripped.get() }
-        data class LintErrorWithCorrectionInfo(val err: LintError, val corrected: Boolean)
+
         val userData = listOfNotNull(
             "android" to android.toString(),
             if (disabledRules.isNotBlank()) "disabled_rules" to disabledRules else null
@@ -534,4 +534,6 @@ class KtlintCommandLine {
         }
         jarFile.toURI().toURL()
     }
+
+    data class LintErrorWithCorrectionInfo(val err: LintError, val corrected: Boolean)
 }


### PR DESCRIPTION
The goal of this PR to make code more readable and specific `run()` method inside `KltintCommandLine`. The logic behind the code should not be changed.