### PR TITLE
Try to discover `.git` instead of hardcoding.

### DIFF
--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
@@ -30,9 +30,21 @@ object GitHookInstaller {
 
     @Throws(IOException::class)
     private fun resolveGitHooksDir(): File {
-        val gitDir = File(".git")
+        // Try to find the .git directory automatically, falling back to `./.git`
+        val gitDir = try {
+            val root = Runtime.getRuntime().exec("git rev-parse --show-toplevel")
+                .inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+
+            File(root).resolve(".git")
+        } catch (ex: IOException) {
+            File(".git")
+        }
+
         if (!gitDir.isDirectory) {
-            throw IOException(".git directory not found. Are you sure you are inside project root directory?")
+            throw IOException(".git directory not found. Are you sure you are inside project directory?")
         }
 
         val hooksDir = gitDir.resolve("hooks")


### PR DESCRIPTION
Very minor convenience improvement.

Previously we assumed that we were always in the root of the repo for
installing Git hooks. Instead, call `rev-parse --show-toplevel` to
discover the root of the repo, which lets us call
`--install-pre-{commit,push}-hook` from anywhere inside a Git repository.