### PR TITLE
Fix indentation with lambda argument, Fix #622

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/IndentationRule.kt
@@ -613,7 +613,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     }
 
     private fun adjustExpectedIndentInsideQualifiedExpression(n: ASTNode, ctx: IndentContext) {
-        val p = n.treeParent
+        val p = n.parent({ it.treeParent.elementType != DOT_QUALIFIED_EXPRESSION }) ?: return
         val nextSibling = n.treeNext
         if (!ctx.ignored.contains(p) && nextSibling != null) {
             expectedIndent++
@@ -628,7 +628,8 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             } else {
                 nextSibling
             }
-            ctx.exitAdjBy(e, -1)
+            ctx.ignored.add(p)
+            ctx.exitAdjBy(p, -1)
         }
     }
 

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-expected.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format-expected.kt.spec
@@ -42,6 +42,13 @@ public class ThisIsASampleClass :
         }
     }
 
+    fun foo3() {
+        Integer
+            .parseInt("32").let {
+                println("parsed $it")
+            }
+    }
+
     private val f =
         { a: Int -> a * 2 }
 

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/format.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/format.kt.spec
@@ -42,6 +42,13 @@ return 2
 }
 }
 
+fun foo3() {
+Integer
+.parseInt("32").let {
+println("parsed $it")
+}
+}
+
 private val f =
 { a: Int -> a * 2 }
 

--- a/ktlint-ruleset-experimental/src/test/resources/spec/indent/lint-string.kt.spec
+++ b/ktlint-ruleset-experimental/src/test/resources/spec/indent/lint-string.kt.spec
@@ -19,4 +19,11 @@ fun f4() = "${
 true
 }"
 
+fun f5() {
+    Integer
+        .parseInt("32").let {
+            println("parsed $it")
+        }
+}
+
 // expect


### PR DESCRIPTION
Resolve #622

#### Current
```kotlin
// 5:1: Unexpected indentation (16) (should be 12)
// 6:1: Unexpected indentation (12) (should be 8)
class Example {
    fun example() {
        Integer
            .parseInt("32").let {
                println("parsed $it")
            }
    }
}

// Formatted
class Example {
    fun example() {
        Integer
            .parseInt("32").let {
            println("parsed $it")
        }
    }
}
```

#### Patched
```kotlin
// No Error
class Example {
    fun example() {
        Integer
            .parseInt("32").let {
                println("parsed $it")
            }
    }
}
```