### PR TITLE
Fix error on formatting annotation for primary constructor

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -94,7 +94,8 @@ class AnnotationRule : Rule("annotation") {
             // text in the file
             val newLineWithIndent = (nodeBeforeAnnotations?.text ?: "\n").let {
                 // Make sure we only insert a single newline
-                it.substring(it.lastIndexOf('\n'))
+                if (it.contains('\n')) it.substring(it.lastIndexOf('\n'))
+                else it
             }
 
             if (noWhiteSpaceAfterAnnotation) {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -440,4 +440,19 @@ class AnnotationRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `no error with formatting annotation for primary constructor`() {
+        val code =
+            """
+            class Foo @Inject internal constructor()
+            """.trimIndent()
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            class Foo @Inject internal constructor()
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Resolve #625 

Fix error on formatting annotation for primary constructor.

#### Current
Formatting following code causes the error.
```kotlin
class Foo @Inject internal constructor()
```
```stacktrace
com.pinterest.ktlint.core.RuleExecutionException: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at com.pinterest.ktlint.core.KtLint$format$1.invoke(KtLint.kt:384)
	at com.pinterest.ktlint.core.KtLint$format$1.invoke(KtLint.kt:41)
	at com.pinterest.ktlint.core.KtLint$visitor$2$2.invoke(KtLint.kt:279)
	at com.pinterest.ktlint.core.KtLint$visitor$2$2.invoke(KtLint.kt:41)
	at com.pinterest.ktlint.core.KtLint.visit(KtLint.kt:536)
	at com.pinterest.ktlint.core.KtLint.visit(KtLint.kt:537)
	at com.pinterest.ktlint.core.KtLint.visit(KtLint.kt:537)
	at com.pinterest.ktlint.core.KtLint.access$visit(KtLint.kt:41)
	at com.pinterest.ktlint.core.KtLint$visitor$2.invoke(KtLint.kt:278)
	at com.pinterest.ktlint.core.KtLint$visitor$2.invoke(KtLint.kt:41)
	at com.pinterest.ktlint.core.KtLint.format(KtLint.kt:367)
	at com.pinterest.ktlint.internal.FileUtilsKt.formatFile(FileUtils.kt:79)
	at com.pinterest.ktlint.KtlintCommandLine$run$1.invoke(Main.kt:240)
	at com.pinterest.ktlint.KtlintCommandLine$run$4$1.call(Main.kt:306)
	at com.pinterest.ktlint.KtlintCommandLine$run$4$1.call(Main.kt:115)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1929)
	at com.pinterest.ktlint.ruleset.experimental.AnnotationRule.visit(AnnotationRule.kt:97)
	at com.pinterest.ktlint.core.KtLint$format$1.invoke(KtLint.kt:372)
	... 18 more
```

#### Patched
Format without any errors.
```kotlin
class Foo @Inject internal constructor()
```