### PR TITLE
Added utf-8 BOM removal

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -420,13 +420,12 @@ object KtLint {
                 .forEach { (e, corrected) -> params.cb(e, corrected) }
         }
 
-        if(!mutated) {
+        if (!mutated) {
             return params.text
         }
 
-        return if(hasUTF8BOM) UTF8_BOM else "" + // Restore UTF8 BOM if it was present
+        return if (hasUTF8BOM) UTF8_BOM else "" + // Restore UTF8 BOM if it was present
             rootNode.text.replace("\n", determineLineSeparator(params.text, params.userData))
-
     }
 
     private fun determineLineSeparator(fileContent: String, userData: Map<String, String>): String {

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -126,7 +126,7 @@ object KtLint {
      * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
      */
     fun lint(params: Params) {
-        val normalizedText = params.text.replace("\r\n", "\n").replace("\r", "\n")
+        val normalizedText = normalizeText(params.text)
         val positionByOffset = calculateLineColByOffset(normalizedText)
         val psiFileName = if (params.script) "file.kts" else "file.kt"
         val psiFile = psiFileFactory.createFileFromText(psiFileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile
@@ -163,6 +163,13 @@ object KtLint {
         errors
             .sortedWith(Comparator { l, r -> if (l.line != r.line) l.line - r.line else l.col - r.col })
             .forEach { e -> params.cb(e, false) }
+    }
+
+    private fun normalizeText(text: String): String {
+        return text
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+            .replaceFirst("\uFEFF", "") // Remove UTF-8 BOM
     }
 
     private fun userDataResolver(editorConfigPath: String?, debug: Boolean): (String?) -> Map<String, String> {
@@ -347,7 +354,7 @@ object KtLint {
      * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
      */
     fun format(params: Params): String {
-        val normalizedText = params.text.replace("\r\n", "\n").replace("\r", "\n")
+        val normalizedText = normalizeText(params.text)
         val positionByOffset = calculateLineColByOffset(normalizedText)
         val psiFileName = if (params.script) "file.kts" else "file.kt"
         val psiFile = psiFileFactory.createFileFromText(psiFileName, KotlinLanguage.INSTANCE, normalizedText) as KtFile


### PR DESCRIPTION
This fixes #272 by adding explicit removal of the UTF-8 BOM from the content of the files being parsed; it also introduces a minor refactoring that reduces code duplication.

Note that this also removes the BOM from the output when formatting files; it shouldn't be a big deal, as UTF-8 files can work without it and it is in fact suggested not to include it.