### PR TITLE
Implement a rule to lint enum entry name

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
@@ -1,0 +1,59 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
+import org.jetbrains.kotlin.psi.KtEnumEntry
+
+class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
+
+    companion object {
+        const val ERROR_MESSAGE = "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""
+    }
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node !is CompositeElement) {
+            return
+        }
+        val enumEntry = node.psi as? KtEnumEntry ?: return
+        val name = enumEntry.name ?: return
+
+        if (name.containsLowerCase()) {
+            // In case of lower camel case like "enumName", or all lower case like "enumname"
+            if (!name.startsWithUpperCase()) {
+                emit(
+                    node.startOffset,
+                    ERROR_MESSAGE, true
+                )
+
+                if (autoCorrect) correct(enumEntry, name)
+            }
+
+            // In case of lower case with underscore like "enum_name"
+            else if (name.contains("_") && name.containsLowerCase()) {
+                emit(
+                    node.startOffset,
+                    ERROR_MESSAGE, true
+                )
+
+                if (autoCorrect) correct(enumEntry, name)
+            }
+        }
+    }
+
+    private fun correct(enumEntry: KtEnumEntry, originalName: String) {
+        enumEntry.setName(originalName.toUpperCase())
+    }
+
+    private fun String.startsWithUpperCase(): Boolean {
+        return this.isNotEmpty() && this[0].isUpperCase()
+    }
+
+    private fun String.containsLowerCase(): Boolean {
+        return this.any { it.isLowerCase() }
+    }
+}

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
@@ -27,7 +27,7 @@ class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
             if (!name.startsWithUpperCase()) {
                 emit(
                     node.startOffset,
-                    ERROR_MESSAGE, true
+                    ERROR_MESSAGE, false
                 )
 
                 if (autoCorrect) correct(enumEntry, name)
@@ -37,7 +37,7 @@ class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
             else if (name.contains("_") && name.containsLowerCase()) {
                 emit(
                     node.startOffset,
-                    ERROR_MESSAGE, true
+                    ERROR_MESSAGE, false
                 )
 
                 if (autoCorrect) correct(enumEntry, name)

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -11,6 +11,7 @@ class ExperimentalRuleSetProvider : RuleSetProvider {
         IndentationRule(),
         MultiLineIfElseRule(),
         NoEmptyFirstLineInMethodBlockRule(),
-        PackageNameRule()
+        PackageNameRule(),
+        EnumEntryNameCaseRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 
 class EnumEntryNameCaseRuleTest {
@@ -25,6 +26,7 @@ class EnumEntryNameCaseRuleTest {
     }
 
     @Test
+    @Ignore("https://github.com/pinterest/ktlint/pull/638#issuecomment-558119749")
     fun testFormat() {
         val unformatted =
             """

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
@@ -1,0 +1,56 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class EnumEntryNameCaseRuleTest {
+
+    @Test
+    fun testFormatIsCorrect() {
+        val formatted =
+            """
+            enum class FirstEnum {
+                ENUM_ENTRY
+            }
+            enum class SecondEnum {
+                EnumEntry
+            }
+            """.trimIndent()
+
+        assertThat(EnumEntryNameCaseRule().lint(formatted)).isEmpty()
+        assertThat(EnumEntryNameCaseRule().format(formatted)).isEqualTo(formatted)
+    }
+
+    @Test
+    fun testFormat() {
+        val unformatted =
+            """
+            enum class FirstEnum {
+                enumEntry
+            }
+            enum class SecondEnum {
+                enum_entry
+            }
+            """.trimIndent()
+        val formatted =
+            """
+            enum class FirstEnum {
+                ENUMENTRY
+            }
+            enum class SecondEnum {
+                ENUM_ENTRY
+            }
+            """.trimIndent()
+
+        assertThat(EnumEntryNameCaseRule().lint(unformatted)).isEqualTo(
+            listOf(
+                LintError(2, 5, "enum-entry-name-case", EnumEntryNameCaseRule.ERROR_MESSAGE),
+                LintError(5, 5, "enum-entry-name-case", EnumEntryNameCaseRule.ERROR_MESSAGE)
+            )
+        )
+        assertThat(EnumEntryNameCaseRule().format(unformatted)).isEqualTo(formatted)
+    }
+}


### PR DESCRIPTION
Resolve #635 

Implement an experimental rule to lint enum entry name.
This rule enforces enum entry names to 
1. contains no lower case letter if it contains under score.
2. starts with upper case if it contains lower case letter.

So, "ENTRY_NAME" and "EntryName" are valid, "Entry_Name", "entry_name" and "entryName" are invalid.

Currently auto-format will convert entry name to all upper case, but this behavior is highly debatable.

#### Before format
```kotlin
enum class FirstEnum {
    enum_entry
}
enum class SecondEnum {
    entry
}
```

#### formatted
```kotlin
enum class FirstEnum {
    ENUM_ENTRY
}
enum class SecondEnum {
    ENTRY
}
```