### PR TITLE
Allow single-line annotations in parameters/arguments

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -71,7 +73,9 @@ class AnnotationRule : Rule("annotation") {
         val annotationsWithParametersAreNotOnSeparateLines =
             annotations.any { it.valueArgumentList != null } &&
                 !whiteSpaces.all { it.textContains('\n') } &&
-                doesNotEndWithAComment(whiteSpaces)
+                doesNotEndWithAComment(whiteSpaces) &&
+                node.treeParent.elementType != VALUE_PARAMETER_LIST &&
+                node.treeParent.elementType != VALUE_ARGUMENT_LIST
 
         if (multipleAnnotationsOnSameLineAsAnnotatedConstruct) {
             emit(

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -455,4 +455,98 @@ class AnnotationRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `lint annotations on method parameters may be placed on same line`() {
+        val code =
+            """
+            interface FooService {
+
+                fun foo1(
+                    @Path("fooId") fooId: String,
+                    @Path("bar") bar: String,
+                    @Body body: Foo
+                ): Completable
+            
+                fun foo2(@Query("include") include: String? = null, @QueryMap fields: Map<String, String> = emptyMap()): Single
+            
+                fun foo3(@Path("fooId") fooId: String): Completable
+            }
+            """.trimIndent()
+        assertThat(AnnotationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format annotations on method parameters may be placed on same line`() {
+        val code =
+            """
+            interface FooService {
+
+                fun foo1(
+                    @Path("fooId") fooId: String,
+                    @Path("bar") bar: String,
+                    @Body body: Foo
+                ): Completable
+            
+                fun foo2(@Query("include") include: String? = null, @QueryMap fields: Map<String, String> = emptyMap()): Single
+            
+                fun foo3(@Path("fooId") fooId: String): Completable
+            }
+            """.trimIndent()
+        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `lint annotations on constructor parameters may be placed on same line`() {
+        val code =
+            """
+            class Foo(@Path("fooId") val fooId: String)
+            class Bar(
+                @NotNull("fooId") val fooId: String,
+                @NotNull("bar") bar: String
+            )
+            """.trimIndent()
+        assertThat(AnnotationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format annotations on constructor parameters may be placed on same line`() {
+        val code =
+            """
+            class Foo(@Path("fooId") val fooId: String)
+            class Bar(
+                @NotNull("fooId") val fooId: String,
+                @NotNull("bar") bar: String
+            )
+            """.trimIndent()
+        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `lint annotations on arguments may be placed on same line`() {
+        val code =
+            """
+            fun doSomething() {
+                actuallyDoSomething(
+                    @ExpressionStringAnn("foo") "test",
+                    @ExpressionIntAnn("bar") 42
+                )
+            }
+            """.trimIndent()
+        assertThat(AnnotationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format annotations on arguments may be placed on same line`() {
+        val code =
+            """
+            fun doSomething() {
+                actuallyDoSomething(
+                    @ExpressionStringAnn("foo") "test",
+                    @ExpressionIntAnn("bar") 42
+                )
+            }
+            """.trimIndent()
+        assertThat(AnnotationRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Resolve #556 and #608. 

As I mentioned in the issue in the [official styleguide](https://kotlinlang.org/docs/reference/coding-conventions.html#annotation-formatting) there's nothing about single-line annotations on method/constructor parameters. Also extended it a little, to allow the same thing in arguments' annotations (e.g. when you have a `@Retention(SOURCE) @Target(EXPRESSION)` for the annotation class)