### PR TITLE
Allow empty first line in function that returns anonymous object

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType
+import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
 import com.pinterest.ktlint.core.ast.ElementType.FUN
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.prevLeaf
@@ -17,7 +18,8 @@ class NoEmptyFirstLineInMethodBlockRule : Rule("no-empty-first-line-in-method-bl
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node is PsiWhiteSpace && node.textContains('\n') &&
-            node.prevLeaf()?.elementType == ElementType.LBRACE && node.isPartOf(FUN)
+            node.prevLeaf()?.elementType == ElementType.LBRACE && node.isPartOf(FUN) &&
+            node.treeParent.elementType != CLASS_BODY // fun fn() = object : Builder {\n\n fun stuff() = Unit }
         ) {
             val split = node.getText().split("\n")
             if (split.size > 2) {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRuleTest.kt
@@ -140,4 +140,32 @@ class NoEmptyFirstLineInMethodBlockRuleTest {
         )
         assertThat(NoEmptyFirstLineInMethodBlockRule().format(unformattedFunction)).isEqualTo(formattedFunction)
     }
+
+    @Test
+    fun `lint empty first line may be placed in function inside anonymous object`() {
+        val code =
+            """
+            fun fooBuilder() = object : Foo {
+            
+                override fun foo() {
+                    TODO()
+                }
+            }
+            """.trimIndent()
+        assertThat(NoEmptyFirstLineInMethodBlockRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format empty first line may be placed in function inside anonymous object`() {
+        val code =
+            """
+            fun fooBuilder() = object : Foo {
+            
+                override fun foo() {
+                    TODO()
+                }
+            }
+            """.trimIndent()
+        assertThat(NoEmptyFirstLineInMethodBlockRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Fix #647.