### PR TITLE
Allow whitespace after lpar followed by a comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
@@ -1,7 +1,10 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
+import com.pinterest.ktlint.core.ast.ElementType.KDOC_START
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_KEYWORD
@@ -29,23 +32,19 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
             val nextLeaf = node.nextLeaf()
             val spacingBefore = if (node.elementType == LPAR) {
                 prevLeaf is PsiWhiteSpace && !prevLeaf.textContains('\n') &&
-                    (
-                        prevLeaf.prevLeaf()?.elementType == IDENTIFIER ||
-                            // Super keyword needs special-casing
-                            prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD
-                        ) && (
-                    node.treeParent?.elementType == VALUE_PARAMETER_LIST ||
-                        node.treeParent?.elementType == VALUE_ARGUMENT_LIST
-                    )
+                    (prevLeaf.prevLeaf()?.elementType == IDENTIFIER ||
+                        // Super keyword needs special-casing
+                        prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD) &&
+                    (node.treeParent?.elementType == VALUE_PARAMETER_LIST ||
+                        node.treeParent?.elementType == VALUE_ARGUMENT_LIST)
             } else {
                 prevLeaf is PsiWhiteSpace && !prevLeaf.textContains('\n') &&
                     prevLeaf.prevLeaf()?.elementType != LPAR
             }
             val spacingAfter = if (node.elementType == LPAR) {
-                nextLeaf is PsiWhiteSpace && (
-                    !nextLeaf.textContains('\n') ||
-                        nextLeaf.nextLeaf()?.elementType == RPAR
-                    )
+                nextLeaf is PsiWhiteSpace &&
+                    (!nextLeaf.textContains('\n') || nextLeaf.nextLeaf()?.elementType == RPAR) &&
+                    !nextLeaf.isNextLeafAComment()
             } else {
                 nextLeaf is PsiWhiteSpace && !nextLeaf.textContains('\n') &&
                     nextLeaf.nextLeaf()?.elementType == RPAR
@@ -72,5 +71,10 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
                 }
             }
         }
+    }
+
+    private fun ASTNode.isNextLeafAComment(): Boolean {
+        val commentTypes = setOf(EOL_COMMENT, BLOCK_COMMENT, KDOC_START)
+        return nextLeaf()?.elementType in commentTypes
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
@@ -60,6 +60,11 @@ class CommentSpacingRuleTest {
                 var debugging = false// comment
                 var debugging = false //comment
                 var debugging = false//comment
+                fun main() {
+                    System.out.println(//123
+                        "test"
+                    )
+                }
                     //comment
                 """.trimIndent()
             )
@@ -69,6 +74,11 @@ class CommentSpacingRuleTest {
             var debugging = false // comment
             var debugging = false // comment
             var debugging = false // comment
+            fun main() {
+                System.out.println( // 123
+                    "test"
+                )
+            }
                 // comment
             """.trimIndent()
         )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -20,5 +22,40 @@ class SpacingAroundParensRuleTest {
                 "spec/paren-spacing/format-expected.kt.spec"
             )
         ).isEmpty()
+    }
+
+    @Test
+    fun `lint spacing after lpar followed by a comment is allowed`() {
+        assertThat(SpacingAroundParensRule().lint("""
+            fun main() {
+                System.out.println( /** 123 */
+                    "test kdoc"
+                )
+                System.out.println( /* 123 */
+                    "test comment block"
+                )
+                System.out.println( // 123
+                    "test single comment"
+                )
+            }
+        """.trimIndent())).isEmpty()
+    }
+
+    @Test
+    fun `format spacing after lpar followed by a comment is allowed`() {
+        val code = """
+            fun main() {
+                System.out.println( /** 123 */
+                    "test kdoc"
+                )
+                System.out.println( /* 123 */
+                    "test comment block"
+                )
+                System.out.println( // 123
+                    "test single comment"
+                )
+            }            
+        """.trimIndent()
+        assertThat(SpacingAroundParensRule().format(code)).isEqualTo(code)
     }
 }


### PR DESCRIPTION
Fix #653.

Technically, IDEA actually allows both
```
System.out.println( // 123
    "test single comment"
)
```
And
```
System.out.println(// 123
    "test single comment"
)
```

This PR is only targeting to fix the former case, whilst the latter will still be violated by the `comment-spacing` rule. I think it's a good tradeoff between readability and compatibility with idea. Let me know, if you think we should also change `comment-spacing` to allow both cases.