### PR TITLE
Allow keyword without back quote in KDoc

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet.create
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.KtWhenEntry
 
@@ -41,7 +42,7 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node is LeafPsiElement) {
-            if (tokenSet.contains(node.elementType) && node.nextLeaf() !is PsiWhiteSpace) {
+            if (tokenSet.contains(node.elementType) && node.parent !is KDocName && node.nextLeaf() !is PsiWhiteSpace) {
                 emit(node.startOffset + node.text.length, "Missing spacing after \"${node.text}\"", true)
                 if (autoCorrect) {
                     node.upsertWhitespaceAfterMe(" ")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
@@ -152,4 +152,18 @@ class SpacingAroundKeywordRuleTest {
             )
         )
     }
+
+    @Test
+    fun keywordInKDoc() {
+        assertThat(
+            SpacingAroundKeywordRule().lint(
+                """
+                 /**
+                 * Convenience wrapper around [Mockito.when] to avoid special `when` notation.
+                 */
+                fun <T> whenever(call: T): OngoingStubbing<T> = Mockito.`when`(call)
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
Fix #671

#### Current
Error: `7:43: Missing spacing after "when"`
```kotlin
package pckg.name.testcommon

import org.mockito.Mockito
import org.mockito.stubbing.OngoingStubbing

/**
* Convenience wrapper around [Mockito.when] to avoid special `when` notation.
*/
fun <T> whenever(call: T): OngoingStubbing<T> = Mockito.`when`(call)
```

#### Patched
No error with same code