### PR TITLE
Fix exerimental ruleset dependency on ktlint-test.

### DIFF
--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -5,9 +5,9 @@ plugins {
 
 dependencies {
   implementation project(':ktlint-core')
-  implementation project(':ktlint-test')
   implementation deps.kotlin.stdlib
 
+  testImplementation project(':ktlint-test')
   testImplementation deps.junit
   testImplementation deps.assertj
 }


### PR DESCRIPTION
Move it from compile scope to test scope.

Partial fix for #678 