### PR TITLE
Add line and column to ParseException message

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ParseException.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ParseException.kt
@@ -5,4 +5,4 @@ package com.pinterest.ktlint.core
  * @param col column number (one-based)
  * @param message message
  */
-class ParseException(val line: Int, val col: Int, message: String) : RuntimeException(message)
+class ParseException(val line: Int, val col: Int, message: String) : RuntimeException("$line:$col $message")


### PR DESCRIPTION
For build environments where normal exception printing is all we can see, this info is getting lost...