### PR TITLE
Add baseline functionality to ktlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ $ ktlint --reporter=plain?group_by_file
 # print style violations as usual + create report in checkstyle format 
 $ ktlint --reporter=plain --reporter=checkstyle,output=ktlint-report-in-checkstyle-format.xml
 
+# check against a baseline file
+$ ktlint --baseline=ktlint-baseline.xml
+
 # install git hook to automatically check files for style violations on commit
 # Run "ktlint installGitPrePushHook" if you wish to run ktlint on push instead
 $ ktlint installGitPreCommitHook
@@ -288,6 +291,8 @@ task ktlint(type: JavaExec, group: "verification") {
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
     // "--reporter=plain", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
+    // to add a baseline to check against prepend following args:
+    // "--baseline=ktlint-baseline.xml"
     // see https://github.com/pinterest/ktlint#usage for more
 }
 check.dependsOn ktlint

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task ktlint(type: JavaExec, group: LifecycleBasePlugin.VERIFICATION_GROUP) {
   description = "Check Kotlin code style."
   classpath = configurations.ktlint
   main = 'com.pinterest.ktlint.Main'
-  args '*/src/**/*.kt'
+  args '*/src/**/*.kt', '--baseline=ktlint-baseline.xml'
 }
 
 allprojects {

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+	<file name="/ktlint/src/test/resources/TestBaselineExtraErrorFile.kt">
+		<error line="1" column="34" source="no-empty-class-body" />
+		<error line="2" column="1" source="no-blank-line-before-rbrace" />
+	</file>
+	<file name="/ktlint/src/test/resources/TestBaselineFile.kt">
+		<error line="1" column="24" source="no-empty-class-body" />
+		<error line="2" column="1" source="no-blank-line-before-rbrace" />
+	</file>
+</baseline>

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-	<file name="/ktlint/src/test/resources/TestBaselineExtraErrorFile.kt">
+	<file name="ktlint/src/test/resources/TestBaselineExtraErrorFile.kt">
 		<error line="1" column="34" source="no-empty-class-body" />
 		<error line="2" column="1" source="no-blank-line-before-rbrace" />
 	</file>
-	<file name="/ktlint/src/test/resources/TestBaselineFile.kt">
+	<file name="ktlint/src/test/resources/TestBaselineFile.kt">
 		<error line="1" column="24" source="no-empty-class-body" />
 		<error line="2" column="1" source="no-blank-line-before-rbrace" />
 	</file>

--- a/ktlint-reporter-baseline/build.gradle
+++ b/ktlint-reporter-baseline/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.vanniktech.maven.publish'
+}
+
+dependencies {
+  implementation project(':ktlint-core')
+  implementation deps.kotlin.stdlib
+
+  testImplementation deps.junit
+  testImplementation deps.assertj
+}

--- a/ktlint-reporter-baseline/build.gradle
+++ b/ktlint-reporter-baseline/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'org.jetbrains.kotlin.jvm'
-  id 'com.vanniktech.maven.publish'
+  id 'ktlint-publication'
 }
 
 dependencies {

--- a/ktlint-reporter-baseline/gradle.properties
+++ b/ktlint-reporter-baseline/gradle.properties
@@ -1,0 +1,4 @@
+GROUP=com.pinterest.ktlint
+POM_NAME=ktlint-reporter-baseline
+POM_ARTIFACT_ID=ktlint-reporter-baseline
+POM_PACKAGING=jar

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
@@ -2,7 +2,9 @@ package com.pinterest.ktlint.reporter.baseline
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Reporter
+import java.io.File
 import java.io.PrintStream
+import java.nio.file.Paths
 import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 
@@ -20,7 +22,12 @@ class BaselineReporter(val out: PrintStream) : Reporter {
         out.println("""<?xml version="1.0" encoding="utf-8"?>""")
         out.println("""<baseline version="1.0">""")
         for ((file, errList) in acc.entries.sortedBy { it.key }) {
-            out.println("""	<file name="${file.escapeXMLAttrValue()}">""")
+            val fileName = try {
+                Paths.get("").toAbsolutePath().relativize(File(file).toPath()).toString()
+            } catch (e: IllegalArgumentException) {
+                file
+            }
+            out.println("""	<file name="${fileName.escapeXMLAttrValue()}">""")
             for ((line, col, ruleId, _) in errList) {
                 out.println(
                     """		<error line="$line" column="$col" source="$ruleId" />"""

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
@@ -23,15 +23,11 @@ class BaselineReporter(val out: PrintStream) : Reporter {
         out.println("""<baseline version="1.0">""")
         for ((file, errList) in acc.entries.sortedBy { it.key }) {
             val fileName = try {
-                Paths.get("").toAbsolutePath().relativize(File(file).toPath()).toString().replace('\\', '/')
+                val rootPath = Paths.get("").toAbsolutePath()
+                val filePath = Paths.get(file)
+                rootPath.relativize(filePath).toString().replace(File.separatorChar, '/')
             } catch (e: IllegalArgumentException) {
                 file
-            }.let { name ->
-                if (name[0] != '/') {
-                    "/$name"
-                } else {
-                    name
-                }
             }
             out.println("""	<file name="${fileName.escapeXMLAttrValue()}">""")
             for ((line, col, ruleId, _) in errList) {

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
@@ -23,7 +23,7 @@ class BaselineReporter(val out: PrintStream) : Reporter {
         out.println("""<baseline version="1.0">""")
         for ((file, errList) in acc.entries.sortedBy { it.key }) {
             val fileName = try {
-                Paths.get("").toAbsolutePath().relativize(File(file).toPath()).toString()
+                Paths.get("").toAbsolutePath().relativize(File(file).toPath()).toString().replace('\\', '/')
             } catch (e: IllegalArgumentException) {
                 file
             }

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
@@ -26,6 +26,12 @@ class BaselineReporter(val out: PrintStream) : Reporter {
                 Paths.get("").toAbsolutePath().relativize(File(file).toPath()).toString().replace('\\', '/')
             } catch (e: IllegalArgumentException) {
                 file
+            }.let { name ->
+                if (name[0] != '/') {
+                    "/$name"
+                } else {
+                    name
+                }
             }
             out.println("""	<file name="${fileName.escapeXMLAttrValue()}">""")
             for ((line, col, ruleId, _) in errList) {

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporter.kt
@@ -1,0 +1,37 @@
+package com.pinterest.ktlint.reporter.baseline
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.Reporter
+import java.io.PrintStream
+import java.util.ArrayList
+import java.util.concurrent.ConcurrentHashMap
+
+class BaselineReporter(val out: PrintStream) : Reporter {
+
+    private val acc = ConcurrentHashMap<String, MutableList<LintError>>()
+
+    override fun onLintError(file: String, err: LintError, corrected: Boolean) {
+        if (!corrected) {
+            acc.getOrPut(file) { ArrayList<LintError>() }.add(err)
+        }
+    }
+
+    override fun afterAll() {
+        out.println("""<?xml version="1.0" encoding="utf-8"?>""")
+        out.println("""<baseline version="1.0">""")
+        for ((file, errList) in acc.entries.sortedBy { it.key }) {
+            out.println("""	<file name="${file.escapeXMLAttrValue()}">""")
+            for ((line, col, ruleId, _) in errList) {
+                out.println(
+                    """		<error line="$line" column="$col" source="$ruleId" />"""
+                )
+            }
+            out.println("""	</file>""")
+        }
+        out.println("""</baseline>""")
+    }
+
+    private fun String.escapeXMLAttrValue() =
+        this.replace("&", "&amp;").replace("\"", "&quot;").replace("'", "&apos;")
+            .replace("<", "&lt;").replace(">", "&gt;")
+}

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
@@ -1,0 +1,10 @@
+package com.pinterest.ktlint.reporter.baseline
+
+import com.pinterest.ktlint.core.Reporter
+import com.pinterest.ktlint.core.ReporterProvider
+import java.io.PrintStream
+
+class BaselineReporterProvider : ReporterProvider {
+    override val id: String = "baseline"
+    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = BaselineReporter(out)
+}

--- a/ktlint-reporter-baseline/src/main/resources/META-INF/services/com.pinterest.ktlint.core.ReporterProvider
+++ b/ktlint-reporter-baseline/src/main/resources/META-INF/services/com.pinterest.ktlint.core.ReporterProvider
@@ -1,0 +1,1 @@
+com.pinterest.ktlint.reporter.baseline.BaselineReporterProvider

--- a/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
+++ b/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
@@ -1,0 +1,73 @@
+package com.pinterest.ktlint.reporter.baseline
+
+import com.pinterest.ktlint.core.LintError
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class BaselineReporterTest {
+
+    @Test
+    fun testReportGeneration() {
+        val out = ByteArrayOutputStream()
+        val reporter = BaselineReporter(PrintStream(out, true))
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                1, 1, "rule-1",
+                "<\"&'>"
+            ),
+            false
+        )
+        reporter.onLintError(
+            "/one-fixed-and-one-not.kt",
+            LintError(
+                2, 1, "rule-2",
+                "And if you see my friend"
+            ),
+            true
+        )
+
+        reporter.onLintError(
+            "/two-not-fixed.kt",
+            LintError(
+                1, 10, "rule-1",
+                "I thought I would again"
+            ),
+            false
+        )
+        reporter.onLintError(
+            "/two-not-fixed.kt",
+            LintError(
+                2, 20, "rule-2",
+                "A single thin straight line"
+            ),
+            false
+        )
+
+        reporter.onLintError(
+            "/all-corrected.kt",
+            LintError(
+                1, 1, "rule-1",
+                "I thought we had more time"
+            ),
+            true
+        )
+        reporter.afterAll()
+        assertThat(String(out.toByteArray())).isEqualTo(
+"""
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+	<file name="/one-fixed-and-one-not.kt">
+		<error line="1" column="1" source="rule-1" />
+	</file>
+	<file name="/two-not-fixed.kt">
+		<error line="1" column="10" source="rule-1" />
+		<error line="2" column="20" source="rule-2" />
+	</file>
+</baseline>
+""".trimStart().replace("\n", System.lineSeparator())
+        )
+    }
+}

--- a/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
+++ b/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
@@ -61,10 +61,10 @@ class BaselineReporterTest {
 """
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-	<file name="/one-fixed-and-one-not.kt">
+	<file name="one-fixed-and-one-not.kt">
 		<error line="1" column="1" source="rule-1" />
 	</file>
-	<file name="/two-not-fixed.kt">
+	<file name="two-not-fixed.kt">
 		<error line="1" column="10" source="rule-1" />
 		<error line="2" column="20" source="rule-2" />
 	</file>

--- a/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
+++ b/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.reporter.baseline
 import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -10,10 +11,11 @@ class BaselineReporterTest {
 
     @Test
     fun testReportGeneration() {
+        val basePath = Paths.get("").toAbsolutePath()
         val out = ByteArrayOutputStream()
         val reporter = BaselineReporter(PrintStream(out, true))
         reporter.onLintError(
-            "/one-fixed-and-one-not.kt",
+            "$basePath/one-fixed-and-one-not.kt",
             LintError(
                 1, 1, "rule-1",
                 "<\"&'>"
@@ -21,7 +23,7 @@ class BaselineReporterTest {
             false
         )
         reporter.onLintError(
-            "/one-fixed-and-one-not.kt",
+            "$basePath/one-fixed-and-one-not.kt",
             LintError(
                 2, 1, "rule-2",
                 "And if you see my friend"
@@ -30,7 +32,7 @@ class BaselineReporterTest {
         )
 
         reporter.onLintError(
-            "/two-not-fixed.kt",
+            "$basePath/two-not-fixed.kt",
             LintError(
                 1, 10, "rule-1",
                 "I thought I would again"
@@ -38,7 +40,7 @@ class BaselineReporterTest {
             false
         )
         reporter.onLintError(
-            "/two-not-fixed.kt",
+            "$basePath/two-not-fixed.kt",
             LintError(
                 2, 20, "rule-2",
                 "A single thin straight line"
@@ -47,7 +49,7 @@ class BaselineReporterTest {
         )
 
         reporter.onLintError(
-            "/all-corrected.kt",
+            "$basePath/all-corrected.kt",
             LintError(
                 1, 1, "rule-1",
                 "I thought we had more time"

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -25,6 +25,7 @@ publishing.publications.named("maven").configure {
 
 dependencies {
   implementation project(':ktlint-core')
+  implementation project(':ktlint-reporter-baseline')
   implementation project(':ktlint-reporter-checkstyle')
   implementation project(':ktlint-reporter-json')
   implementation project(':ktlint-reporter-html')

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -278,7 +278,7 @@ class KtlintCommandLine {
                         file.readText(),
                         ruleSetProviders,
                         userData,
-                        baseline?.get(file.path)
+                        baseline?.get(file.relativeRoute)
                     )
                 }
             }
@@ -580,19 +580,6 @@ class KtlintCommandLine {
                 }
             }
         }
-
-    /**
-     * Checks if the list contains the lint error. We cannot use the contains function
-     * as the `checkstyle` reporter formats the details string and hence the comparison
-     * normally fails
-     */
-    private fun List<LintError>.containsLintError(error: LintError): Boolean {
-        return firstOrNull { lintError ->
-            lintError.col == error.col &&
-                lintError.line == error.line &&
-                lintError.ruleId == error.ruleId
-        } != null
-    }
 
     private data class LintErrorWithCorrectionInfo(
         val err: LintError,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -20,6 +20,7 @@ import com.pinterest.ktlint.internal.PrintASTSubCommand
 import com.pinterest.ktlint.internal.fileSequence
 import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.lintFile
+import com.pinterest.ktlint.internal.loadBaseline
 import com.pinterest.ktlint.internal.loadRulesets
 import com.pinterest.ktlint.internal.location
 import com.pinterest.ktlint.internal.printHelpOrVersionUsage
@@ -212,6 +213,12 @@ class KtlintCommandLine {
     )
     var experimental: Boolean = false
 
+    @Option(
+        names = ["--baseline"],
+        description = ["Defines a baseline file to check against"]
+    )
+    private var baseline: String = ""
+
     @Parameters(hidden = true)
     private var patterns = ArrayList<String>()
 
@@ -224,6 +231,14 @@ class KtlintCommandLine {
 
         val start = System.currentTimeMillis()
 
+        val baselineResults = loadBaseline(baseline)
+        if (baselineResults.baselineGenerationNeeded) {
+            if (reporters.isEmpty()) {
+                reporters.add("plain")
+            }
+            reporters.add("baseline,output=$baseline")
+        }
+
         val ruleSetProviders = rulesets.loadRulesets(experimental, debug)
         val reporter = loadReporter()
         val userData = listOfNotNull(
@@ -235,7 +250,7 @@ class KtlintCommandLine {
         if (stdin) {
             lintStdin(ruleSetProviders, userData, reporter)
         } else {
-            lintFiles(ruleSetProviders, userData, reporter)
+            lintFiles(ruleSetProviders, userData, baselineResults.baselineRules, reporter)
         }
         reporter.afterAll()
         if (debug) {
@@ -253,6 +268,7 @@ class KtlintCommandLine {
     private fun lintFiles(
         ruleSetProviders: Map<String, RuleSetProvider>,
         userData: Map<String, String>,
+        baseline: Map<String, List<LintError>>?,
         reporter: Reporter
     ) {
         patterns.fileSequence()
@@ -263,7 +279,8 @@ class KtlintCommandLine {
                         file.path,
                         file.readText(),
                         ruleSetProviders,
-                        userData
+                        userData,
+                        baseline?.get(file.path)
                     )
                 }
             }
@@ -281,7 +298,8 @@ class KtlintCommandLine {
                 KtLint.STDIN_FILE,
                 String(System.`in`.readBytes()),
                 ruleSetProviders,
-                userData
+                userData,
+                null
             ),
             reporter
         )
@@ -324,7 +342,8 @@ class KtlintCommandLine {
         fileName: String,
         fileContent: String,
         ruleSetProviders: Map<String, RuleSetProvider>,
-        userData: Map<String, String>
+        userData: Map<String, String>,
+        baselineErrors: List<LintError>?
     ): List<LintErrorWithCorrectionInfo> {
         if (debug) {
             val fileLocation = if (fileName != KtLint.STDIN_FILE) File(fileName).location(relative) else fileName
@@ -342,8 +361,10 @@ class KtlintCommandLine {
                     debug
                 ) { err, corrected ->
                     if (!corrected) {
-                        result.add(LintErrorWithCorrectionInfo(err, corrected))
-                        tripped.set(true)
+                        if (baselineErrors == null || !baselineErrors.containsLintError(err)) {
+                            result.add(LintErrorWithCorrectionInfo(err, corrected))
+                            tripped.set(true)
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -368,8 +389,10 @@ class KtlintCommandLine {
                     editorConfigPath,
                     debug
                 ) { err ->
-                    result.add(LintErrorWithCorrectionInfo(err, false))
-                    tripped.set(true)
+                    if (baselineErrors == null || !baselineErrors.containsLintError(err)) {
+                        result.add(LintErrorWithCorrectionInfo(err, false))
+                        tripped.set(true)
+                    }
                 }
             } catch (e: Exception) {
                 result.add(LintErrorWithCorrectionInfo(e.toLintError(), false))
@@ -401,7 +424,8 @@ class KtlintCommandLine {
     private fun ReporterTemplate.toReporter(
         reporterProviderById: Map<String, ReporterProvider>
     ): Reporter {
-        val reporterProvider = reporterProviderById[id]
+        val innerId = if (id == "baseline") "checkstyle" else id
+        val reporterProvider = reporterProviderById[innerId]
         if (reporterProvider == null) {
             System.err.println(
                 "Error: reporter \"$id\" wasn't found (available: ${
@@ -559,6 +583,19 @@ class KtlintCommandLine {
                 }
             }
         }
+
+    /**
+     * Checks if the list contains the lint error. We cannot use the contains function
+     * as the `checkstyle` reporter formats the details string and hence the comparison
+     * normally fails
+     */
+    private fun List<LintError>.containsLintError(error: LintError): Boolean {
+        return firstOrNull { lintError ->
+            lintError.col == error.col &&
+                lintError.line == error.line &&
+                lintError.ruleId == error.ruleId
+        } != null
+    }
 
     private data class LintErrorWithCorrectionInfo(
         val err: LintError,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -235,15 +235,8 @@ class KtlintCommandLine {
         val ruleSetProviders = rulesets.loadRulesets(experimental, debug)
         var reporter = loadReporter()
         if (baselineResults.baselineGenerationNeeded) {
-            val baselineReporter = ReporterTemplate(
-                "baseline",
-                null,
-                emptyMap(),
-                baseline
-            )
-            val reporterProviderById = loadReporters(emptyList()).mapKeys { entry ->
-                if (entry.key == "checkstyle") "baseline" else entry.key
-            }
+            val baselineReporter = ReporterTemplate("baseline", null, emptyMap(), baseline)
+            val reporterProviderById = loadReporters(emptyList())
             reporter = Reporter.from(reporter, baselineReporter.toReporter(reporterProviderById))
         }
         val userData = listOfNotNull(

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -17,6 +17,7 @@ import com.pinterest.ktlint.internal.GitPrePushHookSubCommand
 import com.pinterest.ktlint.internal.JarFiles
 import com.pinterest.ktlint.internal.KtlintVersionProvider
 import com.pinterest.ktlint.internal.PrintASTSubCommand
+import com.pinterest.ktlint.internal.containsLintError
 import com.pinterest.ktlint.internal.fileSequence
 import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.lintFile
@@ -24,6 +25,7 @@ import com.pinterest.ktlint.internal.loadBaseline
 import com.pinterest.ktlint.internal.loadRulesets
 import com.pinterest.ktlint.internal.location
 import com.pinterest.ktlint.internal.printHelpOrVersionUsage
+import com.pinterest.ktlint.internal.relativeRoute
 import com.pinterest.ktlint.internal.toFilesURIList
 import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.File

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -1,13 +1,13 @@
 package com.pinterest.ktlint.internal
 
 import com.pinterest.ktlint.core.LintError
-import org.w3c.dom.Element
-import org.xml.sax.SAXException
 import java.io.File
 import java.io.IOException
 import java.nio.file.Paths
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
+import org.w3c.dom.Element
+import org.xml.sax.SAXException
 
 /**
  * Loads the baseline file if one is provided.

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -113,10 +113,8 @@ internal fun List<LintError>.containsLintError(error: LintError): Boolean {
  * Also adjusts the slashes for uniformity between file systems
  */
 internal val File.relativeRoute: String
-    get() = Paths.get("").toAbsolutePath().relativize(this.toPath()).toString().replace('\\', '/').let { name ->
-        if (name[0] != '/') {
-            "/$name"
-        } else {
-            name
-        }
+    get() {
+        val rootPath = Paths.get("").toAbsolutePath()
+        val filePath = this.toPath()
+        return rootPath.relativize(filePath).toString().replace(File.separatorChar, '/')
     }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -113,4 +113,10 @@ internal fun List<LintError>.containsLintError(error: LintError): Boolean {
  * Also adjusts the slashes for uniformity between file systems
  */
 internal val File.relativeRoute: String
-    get() = Paths.get("").toAbsolutePath().relativize(this.toPath()).toString().replace('\\', '/')
+    get() = Paths.get("").toAbsolutePath().relativize(this.toPath()).toString().replace('\\', '/').let { name ->
+        if (name[0] != '/') {
+            "/$name"
+        } else {
+            name
+        }
+    }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -80,12 +80,14 @@ private fun parseBaselineErrorsByFile(element: Element): MutableList<LintError> 
     val errorsList = element.getElementsByTagName("error")
     for (i in 0 until errorsList.length) {
         val errorElement = errorsList.item(i) as Element
-        errors.add(LintError(
-            line = errorElement.getAttribute("line").toInt(),
-            col = errorElement.getAttribute("column").toInt(),
-            ruleId = errorElement.getAttribute("source"),
-            detail = "" // we don't have details in the baseline file
-        ))
+        errors.add(
+            LintError(
+                line = errorElement.getAttribute("line").toInt(),
+                col = errorElement.getAttribute("column").toInt(),
+                ruleId = errorElement.getAttribute("source"),
+                detail = "" // we don't have details in the baseline file
+            )
+        )
     }
     return errors
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -1,0 +1,95 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.core.LintError
+import org.w3c.dom.Element
+import org.xml.sax.SAXException
+import java.io.File
+import java.io.IOException
+import java.nio.file.Paths
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.parsers.ParserConfigurationException
+
+/**
+ * Loads the baseline file if one is provided.
+ *
+ * @param baselineFilePath the path to the xml baseline file
+ * @return a [CurrentBaseline] with the file details
+ */
+internal fun loadBaseline(baselineFilePath: String): CurrentBaseline {
+    if (baselineFilePath.isBlank()) {
+        return CurrentBaseline(null, false)
+    }
+
+    var baselineRules: Map<String, List<LintError>>? = null
+    var baselineGenerationNeeded = true
+    val baselineFile = Paths.get(baselineFilePath).toFile()
+    if (baselineFile.exists()) {
+        try {
+            baselineRules = parseBaseline(baselineFile)
+            baselineGenerationNeeded = false
+        } catch (e: IOException) {
+            System.err.println("Unable to parse baseline file: $baselineFilePath")
+            baselineGenerationNeeded = true
+        } catch (e: ParserConfigurationException) {
+            System.err.println("Unable to parse baseline file: $baselineFilePath")
+            baselineGenerationNeeded = true
+        } catch (e: SAXException) {
+            System.err.println("Unable to parse baseline file: $baselineFilePath")
+            baselineGenerationNeeded = true
+        }
+    }
+
+    // delete the old file if one exists
+    if (baselineGenerationNeeded && baselineFile.exists()) {
+        baselineFile.delete()
+    }
+
+    return CurrentBaseline(baselineRules, baselineGenerationNeeded)
+}
+
+/**
+ * Parses the file to generate a mapping of [LintError]
+ *
+ * @param baselineFile the file containing the current baseline
+ * @return a mapping of file names to a list of all [LintError] in that file
+ */
+private fun parseBaseline(baselineFile: File): Map<String, List<LintError>> {
+    val baselineRules = HashMap<String, MutableList<LintError>>()
+    val builderFactory = DocumentBuilderFactory.newInstance()
+    val docBuilder = builderFactory.newDocumentBuilder()
+    val doc = docBuilder.parse(baselineFile)
+    val filesList = doc.getElementsByTagName("file")
+    for (i in 0 until filesList.length) {
+        val fileElement = filesList.item(i) as Element
+        val fileName = fileElement.getAttribute("name")
+        val baselineErrors = parseBaselineErrorsByFile(fileElement)
+        baselineRules[fileName] = baselineErrors
+    }
+    return baselineRules
+}
+
+/**
+ * Parses the errors inside each file tag in the xml
+ *
+ * @param element the xml "file" element
+ * @return a list of [LintError] for that file
+ */
+private fun parseBaselineErrorsByFile(element: Element): MutableList<LintError> {
+    val errors = mutableListOf<LintError>()
+    val errorsList = element.getElementsByTagName("error")
+    for (i in 0 until errorsList.length) {
+        val errorElement = errorsList.item(i) as Element
+        errors.add(LintError(
+            line = errorElement.getAttribute("line").toInt(),
+            col = errorElement.getAttribute("column").toInt(),
+            ruleId = errorElement.getAttribute("source"),
+            detail = errorElement.getAttribute("message")
+        ))
+    }
+    return errors
+}
+
+internal class CurrentBaseline(
+    val baselineRules: Map<String, List<LintError>>?,
+    val baselineGenerationNeeded: Boolean
+)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -83,7 +83,7 @@ private fun parseBaselineErrorsByFile(element: Element): MutableList<LintError> 
             line = errorElement.getAttribute("line").toInt(),
             col = errorElement.getAttribute("column").toInt(),
             ruleId = errorElement.getAttribute("source"),
-            detail = errorElement.getAttribute("message")
+            detail = "" // we don't have details in the baseline file
         ))
     }
     return errors

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/BaselineUtils.kt
@@ -110,6 +110,7 @@ internal fun List<LintError>.containsLintError(error: LintError): Boolean {
 
 /**
  * Gets the relative route of the file for baselines
+ * Also adjusts the slashes for uniformity between file systems
  */
 internal val File.relativeRoute: String
-    get() = Paths.get("").toAbsolutePath().relativize(this.toPath()).toString()
+    get() = Paths.get("").toAbsolutePath().relativize(this.toPath()).toString().replace('\\', '/')

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/BaselineTests.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/BaselineTests.kt
@@ -1,0 +1,81 @@
+package com.pinterest.ktlint
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.security.Permission
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BaselineTests {
+
+    @Before
+    fun setup() {
+        System.setSecurityManager(object : SecurityManager() {
+            override fun checkPermission(perm: Permission?) { // allow anything.
+            }
+
+            override fun checkPermission(perm: Permission?, context: Any?) { // allow anything.
+            }
+
+            override fun checkExit(status: Int) {
+                super.checkExit(status)
+                throw ExitException(status)
+            }
+        })
+    }
+
+    @Test
+    fun testNoBaseline() {
+        val stream = ByteArrayOutputStream()
+        val ps = PrintStream(stream)
+        System.setOut(ps)
+
+        try {
+            main(arrayOf("src/test/resources/TestBaselineFile.kt"))
+        } catch (e: ExitException) {
+            // handle System.exit
+        }
+
+        val output = String(stream.toByteArray())
+        assertTrue(output.contains(".*:1:24: Unnecessary block".toRegex()))
+        assertTrue(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+    }
+
+    @Test
+    fun testBaselineReturnsNoErrors() {
+        val stream = ByteArrayOutputStream()
+        val ps = PrintStream(stream)
+        System.setOut(ps)
+
+        try {
+            main(arrayOf("src/test/resources/TestBaselineFile.kt", "--baseline=src/test/resources/test-baseline.xml"))
+        } catch (e: ExitException) {
+            // handle System.exit
+        }
+
+        val output = String(stream.toByteArray())
+        assertFalse(output.contains(".*:1:24: Unnecessary block".toRegex()))
+        assertFalse(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+    }
+
+    @Test
+    fun testExtraErrorNotInBaseline() {
+        val stream = ByteArrayOutputStream()
+        val ps = PrintStream(stream)
+        System.setOut(ps)
+
+        try {
+            main(arrayOf("src/test/resources/TestBaselineExtraErrorFile.kt", "--baseline=src/test/resources/test-baseline.xml"))
+        } catch (e: ExitException) {
+            // handle System.exit
+        }
+
+        val output = String(stream.toByteArray())
+        assertFalse(output.contains(".*:1:24: Unnecessary block".toRegex()))
+        assertTrue(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+    }
+
+    private class ExitException(val status: Int) : SecurityException("Should not exit in tests")
+}

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/BaselineUtilsKtTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/BaselineUtilsKtTest.kt
@@ -25,12 +25,14 @@ class BaselineUtilsKtTest {
             detail = ""
         )
 
-        val baseline: InputStream = ByteArrayInputStream("""
-            <file name="$filename">
-            		<error line="${errorOne.line}" column="${errorOne.col}" source="${errorOne.ruleId}" />
-                    <error line="${errorTwo.line}" column="${errorTwo.col}" source="${errorTwo.ruleId}" />
-            	</file>
-        """.toByteArray())
+        val baseline: InputStream = ByteArrayInputStream(
+            """
+                <file name="$filename">
+                        <error line="${errorOne.line}" column="${errorOne.col}" source="${errorOne.ruleId}" />
+                        <error line="${errorTwo.line}" column="${errorTwo.col}" source="${errorTwo.ruleId}" />
+                    </file>
+            """.toByteArray()
+        )
 
         val baselineFiles = parseBaseline(baseline)
 

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/BaselineUtilsKtTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/BaselineUtilsKtTest.kt
@@ -1,0 +1,42 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.core.LintError
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BaselineUtilsKtTest {
+
+    @Test
+    fun testParseBaselineFile() {
+        val filename = "TestBaselineFile.kt"
+        val errorOne = LintError(
+            line = 1,
+            col = 1,
+            ruleId = "final-new-line",
+            detail = ""
+        )
+        val errorTwo = LintError(
+            line = 62,
+            col = 1,
+            ruleId = "no-blank-line-before-rbrace",
+            detail = ""
+        )
+
+        val baseline: InputStream = ByteArrayInputStream("""
+            <file name="$filename">
+            		<error line="${errorOne.line}" column="${errorOne.col}" source="${errorOne.ruleId}" />
+                    <error line="${errorTwo.line}" column="${errorTwo.col}" source="${errorTwo.ruleId}" />
+            	</file>
+        """.toByteArray())
+
+        val baselineFiles = parseBaseline(baseline)
+
+        assertTrue(baselineFiles.containsKey(filename))
+        assertEquals(2, baselineFiles[filename]?.size)
+        assertTrue(true == baselineFiles[filename]?.containsLintError(errorOne))
+        assertTrue(true == baselineFiles[filename]?.containsLintError(errorTwo))
+    }
+}

--- a/ktlint/src/test/resources/TestBaselineExtraErrorFile.kt
+++ b/ktlint/src/test/resources/TestBaselineExtraErrorFile.kt
@@ -1,0 +1,3 @@
+class TestBaselineExtraErrorFile {
+
+}

--- a/ktlint/src/test/resources/TestBaselineFile.kt
+++ b/ktlint/src/test/resources/TestBaselineFile.kt
@@ -1,0 +1,3 @@
+class TestBaselineFile {
+
+}

--- a/ktlint/src/test/resources/test-baseline.xml
+++ b/ktlint/src/test/resources/test-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="src\test\resources\TestBaselineFile.kt">
+        <error line="1" column="24" source="no-empty-class-body" />
+        <error line="2" column="1" source="no-blank-line-before-rbrace" />
+    </file>
+    <file name="src\test\resources\TestBaselineExtraErrorFile.kt">
+        <error line="1" column="24" source="no-empty-class-body" />
+    </file>
+</baseline>

--- a/ktlint/src/test/resources/test-baseline.xml
+++ b/ktlint/src/test/resources/test-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="/src/test/resources/TestBaselineFile.kt">
+    <file name="src/test/resources/TestBaselineFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
         <error line="2" column="1" source="no-blank-line-before-rbrace" />
     </file>
-    <file name="/src/test/resources/TestBaselineExtraErrorFile.kt">
+    <file name="src/test/resources/TestBaselineExtraErrorFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
     </file>
 </baseline>

--- a/ktlint/src/test/resources/test-baseline.xml
+++ b/ktlint/src/test/resources/test-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="src\test\resources\TestBaselineFile.kt">
+    <file name="src/test/resources/TestBaselineFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
         <error line="2" column="1" source="no-blank-line-before-rbrace" />
     </file>
-    <file name="src\test\resources\TestBaselineExtraErrorFile.kt">
+    <file name="src/test/resources/TestBaselineExtraErrorFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
     </file>
 </baseline>

--- a/ktlint/src/test/resources/test-baseline.xml
+++ b/ktlint/src/test/resources/test-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="src/test/resources/TestBaselineFile.kt">
+    <file name="/src/test/resources/TestBaselineFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
         <error line="2" column="1" source="no-blank-line-before-rbrace" />
     </file>
-    <file name="src/test/resources/TestBaselineExtraErrorFile.kt">
+    <file name="/src/test/resources/TestBaselineExtraErrorFile.kt">
         <error line="1" column="24" source="no-empty-class-body" />
     </file>
 </baseline>

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ rootProject.name = 'ktlint'
 
 include ':ktlint'
 include ':ktlint-core'
+include ':ktlint-reporter-baseline'
 include ':ktlint-reporter-checkstyle'
 include ':ktlint-reporter-json'
 include ':ktlint-reporter-html'


### PR DESCRIPTION
Adds in a new flag, `baseline`, that allows you to specify a baseline to check again when running your report.

The functionality is similar to [Android lint's baseline](https://developer.android.com/studio/write/lint#snapshot). It creates a snapshot file of the current errors in the project on the first run using the checkstyle reporter. On all following runs it checks against that baseline file and only reports errors that do not exist inside that file.