### PR TITLE
KtLint: Make functions needed to calculate line / column public

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -170,7 +170,7 @@ object KtLint {
             .forEach { e -> params.cb(e, false) }
     }
 
-    private fun normalizeText(text: String): String {
+    fun normalizeText(text: String): String {
         return text
             .replace("\r\n", "\n")
             .replace("\r", "\n")
@@ -317,7 +317,7 @@ object KtLint {
         return rootNode.getUserData(DISABLED_RULES)?.contains(fqRuleId) == false
     }
 
-    private fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {
+    fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {
         var i = -1
         val e = text.length
         val arr = ArrayList<Int>()


### PR DESCRIPTION
In order to avoid duplicating code, make these functions public for use
by tools that use KtLint programmatically and need to convert an offset
to line / column, like detekt.