### PR TITLE
Fix autocorrect for single line if/else expressions

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.ElementType.THEN
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -38,14 +39,16 @@ class MultiLineIfElseRule : Rule("multiline-if-else") {
     }
 
     private fun autocorrect(node: ASTNode) {
-        node.treeParent.replaceChild(node.treePrev, PsiWhiteSpaceImpl(" "))
-        val previousChild = node.firstChildNode
+        val bodyIndent = node.treePrev.text
+        val rightBraceIndent = (node.treeParent.treePrev as? PsiWhiteSpace)?.text ?: "\n"
+        (node.treePrev as LeafPsiElement).rawReplaceWithText(" ")
         KtBlockExpression(null).apply {
+            val previousChild = node.firstChildNode
             node.replaceChild(node.firstChildNode, this)
             addChild(LeafPsiElement(LBRACE, "{"))
-            addChild(PsiWhiteSpaceImpl("\n"))
+            addChild(PsiWhiteSpaceImpl(bodyIndent))
             addChild(previousChild)
-            addChild(PsiWhiteSpaceImpl("\n"))
+            addChild(PsiWhiteSpaceImpl(rightBraceIndent))
             addChild(LeafPsiElement(RBRACE, "}"))
         }
 

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
@@ -1,16 +1,24 @@
 package com.pinterest.ktlint.ruleset.experimental
 
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.ast.ElementType
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK
 import com.pinterest.ktlint.core.ast.ElementType.ELSE
 import com.pinterest.ktlint.core.ast.ElementType.ELSE_KEYWORD
+import com.pinterest.ktlint.core.ast.ElementType.IF
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.ElementType.THEN
+import com.pinterest.ktlint.core.ast.parent
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.psiUtil.parents
 
 /**
  * https://kotlinlang.org/docs/reference/coding-conventions.html#formatting-control-flow-statements
@@ -40,7 +48,12 @@ class MultiLineIfElseRule : Rule("multiline-if-else") {
 
     private fun autocorrect(node: ASTNode) {
         val bodyIndent = node.treePrev.text
-        val rightBraceIndent = (node.treeParent.treePrev as? PsiWhiteSpace)?.text ?: "\n"
+        val rightBraceIndent = when {
+            // in case of else if, get the indentation from the first if
+            node.treeParent.treeParent.elementType == ELSE -> node.parent({ it.elementType == IF && it.treeParent.elementType == BLOCK})!!.treePrev.text
+            node.treeParent.treePrev is PsiWhiteSpace -> node.treeParent.treePrev.text
+            else -> "\n"
+        }
         (node.treePrev as LeafPsiElement).rawReplaceWithText(" ")
         KtBlockExpression(null).apply {
             val previousChild = node.firstChildNode

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
@@ -2,9 +2,14 @@ package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ELSE
+import com.pinterest.ktlint.core.ast.ElementType.ELSE_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
+import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.ElementType.THEN
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.psi.KtBlockExpression
 
 /**
  * https://kotlinlang.org/docs/reference/coding-conventions.html#formatting-control-flow-statements
@@ -22,14 +27,31 @@ class MultiLineIfElseRule : Rule("multiline-if-else") {
             if (!node.treePrev.textContains('\n')) { // if (...) <statement>
                 return
             }
+
             if (node.firstChildNode?.firstChildNode?.elementType != LBRACE) {
                 emit(node.firstChildNode.startOffset, "Missing { ... }", true)
-                // Disabled until we autocorrect with proper formatting
-                /*if (autoCorrect) {
-                    (node.firstChildNode.firstChildNode as TreeElement).rawInsertBeforeMe(LeafPsiElement(RBRACE, "{"))
-                    (node.lastChildNode.lastChildNode as TreeElement).rawInsertAfterMe(LeafPsiElement(LBRACE, "}"))
-                }*/
+                if (autoCorrect) {
+                    autocorrect(node)
+                }
             }
+        }
+    }
+
+    private fun autocorrect(node: ASTNode) {
+        node.treeParent.replaceChild(node.treePrev, PsiWhiteSpaceImpl(" "))
+        val previousChild = node.firstChildNode
+        KtBlockExpression(null).apply {
+            node.replaceChild(node.firstChildNode, this)
+            addChild(LeafPsiElement(LBRACE, "{"))
+            addChild(PsiWhiteSpaceImpl("\n"))
+            addChild(previousChild)
+            addChild(PsiWhiteSpaceImpl("\n"))
+            addChild(LeafPsiElement(RBRACE, "}"))
+        }
+
+        // Make sure else starts on same line as newly inserted right brace
+        if (node.elementType == THEN && node.treeNext?.treeNext?.elementType == ELSE_KEYWORD) {
+            node.treeParent.replaceChild(node.treeNext, PsiWhiteSpaceImpl(" "))
         }
     }
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
@@ -1,10 +1,6 @@
 package com.pinterest.ktlint.ruleset.experimental
 
-import com.pinterest.ktlint.core.KtLint
-import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Rule
-import com.pinterest.ktlint.core.RuleSet
-import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK
 import com.pinterest.ktlint.core.ast.ElementType.ELSE
 import com.pinterest.ktlint.core.ast.ElementType.ELSE_KEYWORD
@@ -18,7 +14,6 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.psiUtil.parents
 
 /**
  * https://kotlinlang.org/docs/reference/coding-conventions.html#formatting-control-flow-statements
@@ -50,7 +45,7 @@ class MultiLineIfElseRule : Rule("multiline-if-else") {
         val bodyIndent = node.treePrev.text
         val rightBraceIndent = when {
             // in case of else if, get the indentation from the first if
-            node.treeParent.treeParent.elementType == ELSE -> node.parent({ it.elementType == IF && it.treeParent.elementType == BLOCK})!!.treePrev.text
+            node.treeParent.treeParent.elementType == ELSE -> node.parent({ it.elementType == IF && it.treeParent.elementType == BLOCK })!!.treePrev.text
             node.treeParent.treePrev is PsiWhiteSpace -> node.treeParent.treePrev.text
             else -> "\n"
         }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -89,6 +89,41 @@ class MultiLineIfElseRuleTest {
         )
     }
 
+    @Test
+    fun testMultilineCondition() {
+        val ifElseWithoutCurlyBrace =
+            """
+            fun main() {
+                if (i2 > 0 &&
+                    i3 < 0
+                )
+                    return 2
+                else
+                    return 3
+            }
+            """.trimIndent()
+
+        assertThat(lint(ifElseWithoutCurlyBrace)).isEqualTo(
+            listOf(
+                LintError(5, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(7, 9, "multiline-if-else", "Missing { ... }")
+            )
+        )
+        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(
+            """
+            fun main() {
+                if (i2 > 0 &&
+                    i3 < 0
+                ) {
+                    return 2
+                } else {
+                    return 3
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
     private fun assertOK(kotlinScript: String) {
         Assertions.assertThat(format(kotlinScript)).isEqualTo(kotlinScript)
         Assertions.assertThat(lint(kotlinScript)).isEqualTo(emptyList<LintError>())

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -36,17 +36,20 @@ class MultiLineIfElseRuleTest {
     @Test
     fun tesMultiLineWithoutCurlyBraces() {
         val ifWithoutCurlyBrace = "fun main() { if (true) \n return 0 }"
-        val ifWithoutCurlyBraceExpected = "fun main() { if (true) \n {return 0} }"
+        val ifWithoutCurlyBraceExpected = "fun main() { if (true) {\nreturn 0\n} }"
         // If-Then block with multiple lines and curly brace.
-        // assertThat(format(ifWithoutCurlyBrace)).isEqualTo(ifWithoutCurlyBraceExpected)
+        assertThat(format(ifWithoutCurlyBrace)).isEqualTo(ifWithoutCurlyBraceExpected)
         assertThat(lint(ifWithoutCurlyBrace)).isEqualTo(
             listOf(
                 LintError(2, 2, "multiline-if-else", "Missing { ... }")
             )
         )
         val ifElseWithoutCurlyBrace = "fun main() { if (true) \n return 0 \n else \n return 1 }"
-        val ifElseWithoutCurlyBraceExpected = "fun main() { if (true) \n {return 0} \n else \n {return 1} }"
-        // assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(ifElseWithoutCurlyBraceExpected)
+        val ifElseWithoutCurlyBraceExpected = "fun main() { if (true) {\nreturn 0\n} else {\nreturn 1\n} }"
+
+        val raw = format(ifElseWithoutCurlyBrace)
+
+        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(ifElseWithoutCurlyBraceExpected)
         assertThat(lint(ifElseWithoutCurlyBrace)).isEqualTo(
             listOf(
                 LintError(2, 2, "multiline-if-else", "Missing { ... }"),

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -3,7 +3,6 @@ package com.pinterest.ktlint.ruleset.experimental
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -124,9 +123,137 @@ class MultiLineIfElseRuleTest {
         )
     }
 
+    @Test
+    fun testMultiLineIfElseIfElseWithoutCurlyBraces() {
+        val ifElseWithoutCurlyBrace =
+            """
+            fun main() {
+                if (true)
+                    return 0
+                else if (false)
+                    return 1
+                else
+                    return -1
+            }
+            """.trimIndent()
+
+        assertThat(lint(ifElseWithoutCurlyBrace)).isEqualTo(
+            listOf(
+                LintError(3, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(5, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(7, 9, "multiline-if-else", "Missing { ... }")
+            )
+        )
+        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(
+            """
+            fun main() {
+                if (true) {
+                    return 0
+                } else if (false) {
+                    return 1
+                } else {
+                    return -1
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testNestedMultiLineIfElse() {
+        val ifElseWithoutCurlyBrace =
+            """
+            fun main() {
+                if (outerCondition1)
+                    if (innerCondition1)
+                        if (innerCondition11)
+                            return 0
+                        else if (innerCondition12)
+                            return 12
+                        else if (innerCondition13)
+                            return 13
+                        else
+                            return 14
+                    else if (innerCondition44)
+                        return 1
+                    else {
+                        return 16
+                    }
+                else if (outerCondition2)
+                    if (innerCondition2)
+                        return 2
+                    else if (innerCondition3)
+                        return 3
+                    else
+                        return 4
+                else
+                    if (innerCondition4)
+                        return 5
+                    else
+                        return -1
+            }
+            """.trimIndent()
+
+        assertThat(lint(ifElseWithoutCurlyBrace)).isEqualTo(
+            listOf(
+                LintError(3, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(4, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(5, 17, "multiline-if-else", "Missing { ... }"),
+                LintError(7, 17, "multiline-if-else", "Missing { ... }"),
+                LintError(9, 17, "multiline-if-else", "Missing { ... }"),
+                LintError(11, 17, "multiline-if-else", "Missing { ... }"),
+                LintError(13, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(18, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(19, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(21, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(23, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(25, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(26, 13, "multiline-if-else", "Missing { ... }"),
+                LintError(28, 13, "multiline-if-else", "Missing { ... }")
+            )
+        )
+        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(
+            """
+            fun main() {
+                if (outerCondition1) {
+                    if (innerCondition1) {
+                        if (innerCondition11) {
+                            return 0
+                        } else if (innerCondition12) {
+                            return 12
+                        } else if (innerCondition13) {
+                            return 13
+                        } else {
+                            return 14
+                        }
+                    } else if (innerCondition44) {
+                        return 1
+                    } else {
+                        return 16
+                    }
+                } else if (outerCondition2) {
+                    if (innerCondition2) {
+                        return 2
+                    } else if (innerCondition3) {
+                        return 3
+                    } else {
+                        return 4
+                    }
+                } else {
+                    if (innerCondition4) {
+                        return 5
+                    } else {
+                        return -1
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
     private fun assertOK(kotlinScript: String) {
-        Assertions.assertThat(format(kotlinScript)).isEqualTo(kotlinScript)
-        Assertions.assertThat(lint(kotlinScript)).isEqualTo(emptyList<LintError>())
+        assertThat(format(kotlinScript)).isEqualTo(kotlinScript)
+        assertThat(lint(kotlinScript)).isEqualTo(emptyList<LintError>())
     }
 
     private fun format(kotlinScript: String): String {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -34,27 +34,58 @@ class MultiLineIfElseRuleTest {
     }
 
     @Test
-    fun tesMultiLineWithoutCurlyBraces() {
-        val ifWithoutCurlyBrace = "fun main() { if (true) \n return 0 }"
-        val ifWithoutCurlyBraceExpected = "fun main() { if (true) {\nreturn 0\n} }"
-        // If-Then block with multiple lines and curly brace.
-        assertThat(format(ifWithoutCurlyBrace)).isEqualTo(ifWithoutCurlyBraceExpected)
+    fun testMultiLineIfWithoutCurlyBraces() {
+        val ifWithoutCurlyBrace =
+            """
+            fun main() {
+                if (true)
+                    return 0
+            }
+            """.trimIndent()
         assertThat(lint(ifWithoutCurlyBrace)).isEqualTo(
             listOf(
-                LintError(2, 2, "multiline-if-else", "Missing { ... }")
+                LintError(3, 9, "multiline-if-else", "Missing { ... }")
             )
         )
-        val ifElseWithoutCurlyBrace = "fun main() { if (true) \n return 0 \n else \n return 1 }"
-        val ifElseWithoutCurlyBraceExpected = "fun main() { if (true) {\nreturn 0\n} else {\nreturn 1\n} }"
+        assertThat(format(ifWithoutCurlyBrace)).isEqualTo(
+            """
+            fun main() {
+                if (true) {
+                    return 0
+                }
+            }
+            """.trimIndent()
+        )
+    }
 
-        val raw = format(ifElseWithoutCurlyBrace)
+    @Test
+    fun testMultiLineIfElseWithoutCurlyBraces() {
+        val ifElseWithoutCurlyBrace =
+            """
+            fun main() {
+                if (true)
+                    return 0
+                else
+                    return 1
+            }
+            """.trimIndent()
 
-        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(ifElseWithoutCurlyBraceExpected)
         assertThat(lint(ifElseWithoutCurlyBrace)).isEqualTo(
             listOf(
-                LintError(2, 2, "multiline-if-else", "Missing { ... }"),
-                LintError(4, 2, "multiline-if-else", "Missing { ... }")
+                LintError(3, 9, "multiline-if-else", "Missing { ... }"),
+                LintError(5, 9, "multiline-if-else", "Missing { ... }")
             )
+        )
+        assertThat(format(ifElseWithoutCurlyBrace)).isEqualTo(
+            """
+            fun main() {
+                if (true) {
+                    return 0
+                } else {
+                    return 1
+                }
+            }
+            """.trimIndent()
         )
     }
 


### PR DESCRIPTION
This fixes the autocorrect functionality in MultiLineIfElseRule that was partially implemented but commented out. It should resolve #174.