### PR TITLE
Move EOL comment after left curly brace so code remains compilable

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -1,6 +1,5 @@
 package com.pinterest.ktlint.ruleset.standard
 
-import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.AT
 import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
@@ -20,7 +19,6 @@ import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.SAFE_ACCESS
 import com.pinterest.ktlint.core.ast.ElementType.SEMICOLON
 import com.pinterest.ktlint.core.ast.isPartOfString
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
@@ -34,18 +32,12 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
-    private var indentSize = -1
 
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
-            return
-        }
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
             val nextLeaf = node.nextLeaf()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -88,8 +88,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
                             }
                             (node.treeParent.treeParent as TreeElement).removeChild(commentLeaf)
                             (node.treeParent as TreeElement).addChild(commentLeaf, node.treeNext)
-                            val indent = (prevLeaf as PsiWhiteSpace).text.filter { it == ' ' }
-                            node.upsertWhitespaceAfterMe("\n" + indent + " ".repeat(indentSize))
+                            node.upsertWhitespaceAfterMe(" ")
                         }
                         (prevLeaf as LeafPsiElement).rawReplaceWithText(" ")
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -1,11 +1,13 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.AT
 import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
 import com.pinterest.ktlint.core.ast.ElementType.COLONCOLON
 import com.pinterest.ktlint.core.ast.ElementType.COMMA
 import com.pinterest.ktlint.core.ast.ElementType.DOT
+import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.EXCLEXCL
 import com.pinterest.ktlint.core.ast.ElementType.FUN
 import com.pinterest.ktlint.core.ast.ElementType.LAMBDA_EXPRESSION
@@ -18,23 +20,32 @@ import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.SAFE_ACCESS
 import com.pinterest.ktlint.core.ast.ElementType.SEMICOLON
 import com.pinterest.ktlint.core.ast.isPartOfString
+import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
+    private var indentSize = -1
 
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
+        if (node.isRoot()) {
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            indentSize = editorConfig.indentSize
+            return
+        }
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = node.prevLeaf()
             val nextLeaf = node.nextLeaf()
@@ -67,6 +78,19 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
                 ) {
                     emit(node.startOffset, "Unexpected newline before \"${node.text}\"", true)
                     if (autoCorrect) {
+                        val eolCommentExists = prevLeaf.prevLeaf()?.let {
+                            it is PsiComment && it.elementType == EOL_COMMENT
+                        } ?: false
+                        if (eolCommentExists) {
+                            val commentLeaf = prevLeaf.prevLeaf()!!
+                            if (commentLeaf.prevLeaf() is PsiWhiteSpace) {
+                                (commentLeaf.prevLeaf() as LeafPsiElement).rawRemove()
+                            }
+                            (node.treeParent.treeParent as TreeElement).removeChild(commentLeaf)
+                            (node.treeParent as TreeElement).addChild(commentLeaf, node.treeNext)
+                            val indent = (prevLeaf as PsiWhiteSpace).text.filter { it == ' ' }
+                            node.upsertWhitespaceAfterMe("\n" + indent + " ".repeat(indentSize))
+                        }
                         (prevLeaf as LeafPsiElement).rawReplaceWithText(" ")
                     }
                 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
@@ -209,4 +209,71 @@ class SpacingAroundCurlyRuleTest {
                 { 42 }
         """.trimIndent())
     }
+
+    @Test
+    fun `eol comment placed after curly brace`() {
+        assertThat(
+            SpacingAroundCurlyRule().format(
+                """
+                class MyClass()// a comment
+                {
+                    val x = 0
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+                class MyClass() {
+                    // a comment
+                    val x = 0
+                }
+                """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `eol comment with preceding whitespace placed after curly brace`() {
+        assertThat(
+            SpacingAroundCurlyRule().format(
+                """
+                class MyClass() // a comment
+                {
+                    val x = 0
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+                class MyClass() {
+                    // a comment
+                    val x = 0
+                }
+                """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `eol comment placed after curly brace with nested indent`() {
+        assertThat(
+            SpacingAroundCurlyRule().format(
+                """
+                class MyClass() {
+                    class InnerClass() // a comment
+                    {
+                        val x = 0
+                    }
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+                class MyClass() {
+                    class InnerClass() {
+                        // a comment
+                        val x = 0
+                    }
+                }
+                """.trimIndent()
+        )
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
@@ -223,8 +223,7 @@ class SpacingAroundCurlyRuleTest {
             )
         ).isEqualTo(
             """
-                class MyClass() {
-                    // a comment
+                class MyClass() { // a comment
                     val x = 0
                 }
                 """.trimIndent()
@@ -244,34 +243,8 @@ class SpacingAroundCurlyRuleTest {
             )
         ).isEqualTo(
             """
-                class MyClass() {
-                    // a comment
+                class MyClass() { // a comment
                     val x = 0
-                }
-                """.trimIndent()
-        )
-    }
-
-    @Test
-    fun `eol comment placed after curly brace with nested indent`() {
-        assertThat(
-            SpacingAroundCurlyRule().format(
-                """
-                class MyClass() {
-                    class InnerClass() // a comment
-                    {
-                        val x = 0
-                    }
-                }
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            """
-                class MyClass() {
-                    class InnerClass() {
-                        // a comment
-                        val x = 0
-                    }
                 }
                 """.trimIndent()
         )


### PR DESCRIPTION
This is a potential fix for #728. When pulling a left curly brace up to previous line, move EOL comment after curly brace.