### PR TITLE
Allow annotated function types in paren-spacing rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_TYPE
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.KDOC_START
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
@@ -32,7 +33,9 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
             val nextLeaf = node.nextLeaf()
             val spacingBefore = if (node.elementType == LPAR) {
                 prevLeaf is PsiWhiteSpace && !prevLeaf.textContains('\n') &&
-                    (prevLeaf.prevLeaf()?.elementType == IDENTIFIER ||
+                    (prevLeaf.prevLeaf()?.elementType == IDENTIFIER &&
+                        // val foo: @Composable () -> Unit
+                        node.treeParent?.treeParent?.elementType != FUNCTION_TYPE ||
                         // Super keyword needs special-casing
                         prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD) &&
                     (node.treeParent?.elementType == VALUE_PARAMETER_LIST ||

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
@@ -54,7 +54,28 @@ class SpacingAroundParensRuleTest {
                 System.out.println( // 123
                     "test single comment"
                 )
-            }            
+            }
+        """.trimIndent()
+        assertThat(SpacingAroundParensRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `lint spacing before annotated function type is allowed`() {
+        assertThat(SpacingAroundParensRule().lint("""
+            val myFun1: @Foo () -> Unit = {}
+            val myFun2: @Foo() () -> Unit = {}
+            val typeParameter1: (@Foo () -> Unit) -> Unit = { {} }
+            val typeParameter2: (@Foo() () -> Unit) -> Unit = { { } }
+        """.trimIndent())).isEmpty()
+    }
+
+    @Test
+    fun `format spacing before annotated function type is allowed`() {
+        val code = """
+            val myFun1: @Foo () -> Unit = {}
+            val myFun2: @Foo() () -> Unit = {}
+            val typeParameter1: (@Foo () -> Unit) -> Unit = { {} }
+            val typeParameter2: (@Foo() () -> Unit) -> Unit = { { } }
         """.trimIndent()
         assertThat(SpacingAroundParensRule().format(code)).isEqualTo(code)
     }


### PR DESCRIPTION
Fix #737 