### PR TITLE
Fixing ClassCastException with NoLineBreakBeforeAssignmentRule when there is no space after assignment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.EQ
+import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -14,7 +15,14 @@ class NoLineBreakBeforeAssignmentRule : Rule("no-line-break-before-assignment") 
             if (prevElement is PsiWhiteSpace && prevElement.text.contains("\n")) {
                 emit(node.startOffset, "Line break before assignment is not allowed", true)
                 if (autoCorrect) {
-                    (node.treeNext?.psi as LeafPsiElement).rawReplaceWithText(prevElement.text)
+                    val leaf = node.treeNext?.psi as? LeafPsiElement
+                    if (leaf != null) {
+                        leaf.rawReplaceWithText(prevElement.text)
+                    } else {
+                        (node.psi as LeafPsiElement).rawInsertAfterMe(
+                            LeafPsiElement(REGULAR_STRING_PART, prevElement.text)
+                        )
+                    }
                     (prevElement as LeafPsiElement).rawReplaceWithText(" ")
                 }
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
@@ -80,4 +80,21 @@ class NoLineBreakBeforeAssignmentRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test assignment with no following space issue #693`() {
+        assertThat(
+            NoLineBreakBeforeAssignmentRule().format(
+                """
+                fun a()
+                        =f()
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            fun a() =
+                    f()
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Fixes #693