### PR TITLE
AnnotationRule: disallow empty line between annotation and annotated target

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -172,7 +172,8 @@ class AnnotationRule : Rule("annotation") {
                     removeExtraLineBreaks(node)
                 }
             }
-        } else if (whiteSpaces.isNotEmpty() && !node.text.contains("@file")) {
+        }
+        if (whiteSpaces.isNotEmpty() && annotations.size > 1 && !node.text.contains("@file")) {
             // Check to make sure there are multi breaks between annotations
             if (whiteSpaces.any { psi -> psi.textToCharArray().filter { it == '\n' }.count() > 1 }) {
                 val psi = node.psi

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -252,8 +252,8 @@ class AnnotationRule : Rule("annotation") {
         val lastTxt = last.text
         // Pull the next before raw replace or it will blow up
         val lNext = node.nextLeaf()
-        if (node is PsiWhiteSpaceImpl){
-            if (txt.toCharArray().count { it == '\n' } > 1 ) {
+        if (node is PsiWhiteSpaceImpl) {
+            if (txt.toCharArray().count { it == '\n' } > 1) {
                 rawReplaceExtraLineBreaks(node)
             }
         }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -39,6 +39,8 @@ class AnnotationRule : Rule("annotation") {
             "Annotations with parameters should all be placed on separate lines prior to the annotated construct"
         const val fileAnnotationsShouldBeSeparated =
             "File annotations should be separated from file contents with a blank line"
+        const val fileAnnotationsLineBreaks =
+            "There should not be empty lines between an annotation and the object that it's annotating"
     }
 
     override fun visit(

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -1,18 +1,26 @@
 package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.Rule
-import com.pinterest.ktlint.core.ast.*
 import com.pinterest.ktlint.core.ast.ElementType.FILE_ANNOTATION_LIST
 import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.core.ast.isPartOf
+import com.pinterest.ktlint.core.ast.isPartOfComment
+import com.pinterest.ktlint.core.ast.isWhiteSpace
+import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.core.ast.lineNumber
+import com.pinterest.ktlint.core.ast.nextSibling
+import com.pinterest.ktlint.core.ast.prevSibling
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.psiUtil.children
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
@@ -138,11 +146,11 @@ class AnnotationRule : Rule("annotation") {
 
         // Check to make sure no trailing line breaks between annotation and object
         val lineNumber = node.lineNumber()
-        val next = node.nextSiblingWithAtLeastOneOf( {
-            !it.isWhiteSpace()
-                && it.textLength > 0
-                && !(it.isPartOfComment() && it.lineNumber() == lineNumber)
-                && !it.isPartOf(FILE_ANNOTATION_LIST)
+        val next = node.nextSiblingWithAtLeastOneOf({
+            !it.isWhiteSpace() &&
+                it.textLength > 0 &&
+                !(it.isPartOfComment() && it.lineNumber() == lineNumber) &&
+                !it.isPartOf(FILE_ANNOTATION_LIST)
         }, {
             val s = it.text
             // Ensure at least one occurrence of two line breaks

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -142,6 +142,21 @@ class AnnotationRule : Rule("annotation") {
                 }
             }
         }
+
+        // Check to make sure no trailing line breaks between annotation and object
+        val lineNumber = node.lineNumber()
+        val next = node.nextSibling {
+            !it.isWhiteSpace() && it.textLength > 0 && !(it.isPartOfComment() && it.lineNumber() == lineNumber)
+        }
+        val nextLineNumber = next?.lineNumber()
+        if (lineNumber != null && nextLineNumber != null) {
+            val diff = nextLineNumber - lineNumber
+            // Ensure declaration is not on the same line and there is a line break in between
+            if (lineNumber != nextLineNumber && diff > 1) {
+                val psi = node.psi
+                emit(psi.endOffset - 1, fileAnnotationsLineBreaks, true)
+            }
+        }
     }
 
     private fun getNewlineWithIndent(modifierListRoot: ASTNode): String {

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -1,19 +1,12 @@
 package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.*
 import com.pinterest.ktlint.core.ast.ElementType.FILE_ANNOTATION_LIST
 import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
-import com.pinterest.ktlint.core.ast.children
-import com.pinterest.ktlint.core.ast.isPartOf
-import com.pinterest.ktlint.core.ast.isPartOfComment
-import com.pinterest.ktlint.core.ast.isWhiteSpace
-import com.pinterest.ktlint.core.ast.lineNumber
-import com.pinterest.ktlint.core.ast.nextSibling
-import com.pinterest.ktlint.core.ast.prevSibling
-import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -155,6 +148,13 @@ class AnnotationRule : Rule("annotation") {
             if (lineNumber != nextLineNumber && diff > 1) {
                 val psi = node.psi
                 emit(psi.endOffset - 1, fileAnnotationsLineBreaks, true)
+                if (autoCorrect) {
+                    val next = node.nextSibling {
+                            it.isWhiteSpaceWithNewline()
+                        } as? LeafPsiElement
+                    // Replace the extra white space with a single break
+                    next?.rawReplaceWithText("\n")
+                }
             }
         }
     }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -165,7 +165,7 @@ class AnnotationRule : Rule("annotation") {
             val diff = nextLineNumber - lineNumber
             // Ensure declaration is not on the same line, there is a line break in between, and it is not an
             // annotation we explicitly want to have a line break between
-            if (lineNumber != nextLineNumber && diff > 1 && !node.text.contains("@file")) {
+            if (diff > 1 && node.elementType != FILE_ANNOTATION_LIST) {
                 val psi = node.psi
                 emit(psi.endOffset - 1, fileAnnotationsLineBreaks, true)
                 if (autoCorrect) {
@@ -173,7 +173,7 @@ class AnnotationRule : Rule("annotation") {
                 }
             }
         }
-        if (whiteSpaces.isNotEmpty() && annotations.size > 1 && !node.text.contains("@file")) {
+        if (whiteSpaces.isNotEmpty() && annotations.size > 1 && node.elementType != FILE_ANNOTATION_LIST) {
             // Check to make sure there are multi breaks between annotations
             if (whiteSpaces.any { psi -> psi.textToCharArray().filter { it == '\n' }.count() > 1 }) {
                 val psi = node.psi
@@ -232,7 +232,7 @@ class AnnotationRule : Rule("annotation") {
     private fun rawReplaceExtraLineBreaks(leaf: LeafPsiElement) {
         // Replace the extra white space with a single break
         val text = leaf.text
-        val firstIndex = (text.indexOf("\n") ?: 0) + 1
+        val firstIndex = text.indexOf("\n") + 1
         val replacementText = text.substring(0, firstIndex) +
             text.substringAfter("\n").replace("\n", "")
 
@@ -249,7 +249,6 @@ class AnnotationRule : Rule("annotation") {
         last: KtAnnotationEntry
     ) {
         val txt = node.text
-        val lastTxt = last.text
         // Pull the next before raw replace or it will blow up
         val lNext = node.nextLeaf()
         if (node is PsiWhiteSpaceImpl) {
@@ -258,7 +257,6 @@ class AnnotationRule : Rule("annotation") {
             }
         }
 
-        val lTxt = lNext?.text
         if (lNext != null && !last.text.endsWith(lNext.text)) {
             removeIntraLineBreaks(lNext, last)
         }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -146,16 +146,19 @@ class AnnotationRule : Rule("annotation") {
 
         // Check to make sure no trailing line breaks between annotation and object
         val lineNumber = node.lineNumber()
-        val next = node.nextSiblingWithAtLeastOneOf({
-            !it.isWhiteSpace() &&
-                it.textLength > 0 &&
-                !(it.isPartOfComment() && it.lineNumber() == lineNumber) &&
-                !it.isPartOf(FILE_ANNOTATION_LIST)
-        }, {
-            val s = it.text
-            // Ensure at least one occurrence of two line breaks
-            s.indexOf("\n") != s.lastIndexOf("\n")
-        })
+        val next = node.nextSiblingWithAtLeastOneOf(
+            {
+                !it.isWhiteSpace() &&
+                    it.textLength > 0 &&
+                    !(it.isPartOfComment() && it.lineNumber() == lineNumber) &&
+                    !it.isPartOf(FILE_ANNOTATION_LIST)
+            },
+            {
+                val s = it.text
+                // Ensure at least one occurrence of two line breaks
+                s.indexOf("\n") != s.lastIndexOf("\n")
+            }
+        )
         val nextLineNumber = next?.lineNumber()
         if (lineNumber != null && nextLineNumber != null) {
             val diff = nextLineNumber - lineNumber
@@ -178,7 +181,9 @@ class AnnotationRule : Rule("annotation") {
         var n = this.treeNext
         var occurrenceCount = 0
         while (n != null) {
-            if (needsToOccur(n)) { occurrenceCount++ }
+            if (needsToOccur(n)) {
+                occurrenceCount++
+            }
             if (p(n)) {
                 return if (occurrenceCount > 0) {
                     n

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -934,4 +934,22 @@ class AnnotationRuleTest {
         ).isEmpty()
     }
 
+
+    @Test
+    fun `lint there should not be empty lines between an annotation and object`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                @JvmField
+
+                fun foo() {}
+
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(1, 13, "annotation", AnnotationRule.fileAnnotationsLineBreaks)
+            )
+        )
+    }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -920,4 +920,18 @@ class AnnotationRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun `lint no empty lines between an annotation and object`() {
+        assertThat(
+            AnnotationRule().lint(
+                """
+                @JvmField
+                fun foo() {}
+
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -956,9 +956,9 @@ class AnnotationRuleTest {
     fun `lint there should not be empty lines between an annotation and object autocorrected`() {
         val code =
             """
-                @JvmField
+            @JvmField
 
-                fun foo() {}
+            fun foo() {}
 
             """.trimIndent()
 
@@ -966,8 +966,8 @@ class AnnotationRuleTest {
             AnnotationRule().format(code)
         ).isEqualTo(
             """
-                @JvmField
-                fun foo() {}
+            @JvmField
+            fun foo() {}
 
             """.trimIndent()
         )
@@ -977,12 +977,12 @@ class AnnotationRuleTest {
     fun `lint there should not be empty lines between an annotation and object autocorrected with control`() {
         val code =
             """
-                @JvmField
+            @JvmField
 
-                fun foo() {
-                  @JvmStatic
-                  val r = A()
-                }
+            fun foo() {
+              @JvmStatic
+              val r = A()
+            }
 
             """.trimIndent()
 
@@ -990,11 +990,11 @@ class AnnotationRuleTest {
             AnnotationRule().format(code)
         ).isEqualTo(
             """
-                @JvmField
-                fun foo() {
-                  @JvmStatic
-                  val r = A()
-                }
+            @JvmField
+            fun foo() {
+              @JvmStatic
+              val r = A()
+            }
 
             """.trimIndent()
         )
@@ -1004,11 +1004,11 @@ class AnnotationRuleTest {
     fun `lint there should not be empty lines between an annotation and object autocorrected multiple lines`() {
         val code =
             """
-                @JvmField
+            @JvmField
 
 
 
-                fun foo() {}
+            fun foo() {}
 
             """.trimIndent()
 
@@ -1016,8 +1016,8 @@ class AnnotationRuleTest {
             AnnotationRule().format(code)
         ).isEqualTo(
             """
-                @JvmField
-                fun foo() {}
+            @JvmField
+            fun foo() {}
 
             """.trimIndent()
         )
@@ -1027,15 +1027,15 @@ class AnnotationRuleTest {
     fun `lint there should not be empty lines between an annotation and object autocorrected multiple annotations`() {
         val code =
             """
-                @JvmField
+            @JvmField
 
 
 
-                fun foo() {
-                  @JvmStatic
+            fun foo() {
+              @JvmStatic
 
-                  val foo = Foo()
-                }
+              val foo = Foo()
+            }
 
             """.trimIndent()
 
@@ -1043,11 +1043,11 @@ class AnnotationRuleTest {
             AnnotationRule().format(code)
         ).isEqualTo(
             """
-                @JvmField
-                fun foo() {
-                  @JvmStatic
-                  val foo = Foo()
-                }
+            @JvmField
+            fun foo() {
+              @JvmStatic
+              val foo = Foo()
+            }
 
             """.trimIndent()
         )

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -1024,6 +1024,50 @@ class AnnotationRuleTest {
     }
 
     @Test
+    fun `lint there should not be empty lines between multiple annotations`() {
+        val code =
+            """
+            @JvmField @JvmStatic
+
+            fun foo() = Unit
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            @JvmField @JvmStatic
+            fun foo() = Unit
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between multiple annotations on multiple lines`() {
+        val code =
+            """
+            @JvmField
+            @JvmStatic
+
+            fun foo() = Unit
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            @JvmField
+            @JvmStatic
+            fun foo() = Unit
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun `lint there should not be empty lines between an annotation and object autocorrected multiple annotations`() {
         val code =
             """

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -1024,6 +1024,24 @@ class AnnotationRuleTest {
     }
 
     @Test
+    fun `lint annotation on the same line remains there`() {
+        val code =
+            """
+            @JvmField fun foo() {}
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            @JvmField fun foo() {}
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun `lint there should not be empty lines between multiple annotations`() {
         val code =
             """
@@ -1060,6 +1078,60 @@ class AnnotationRuleTest {
         ).isEqualTo(
             """
             @JvmField
+            @JvmStatic
+            fun foo() = Unit
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between multiple annotations with inline annotation`() {
+        val code =
+            """
+            @JvmField
+
+            @JvmName
+
+            @JvmStatic fun foo() = Unit
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            @JvmField
+            @JvmName
+            @JvmStatic
+            fun foo() = Unit
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between two or more annotations`() {
+        val code =
+            """
+            @JvmField
+
+            @JvmName
+
+
+            @JvmStatic
+
+
+            fun foo() = Unit
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            @JvmField
+            @JvmName
             @JvmStatic
             fun foo() = Unit
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -974,10 +974,38 @@ class AnnotationRuleTest {
     }
 
     @Test
-    fun `lint there should not be empty lines between an annotation and object autocorrected multiple`() {
+    fun `lint there should not be empty lines between an annotation and object autocorrected with control`() {
         val code =
             """
                 @JvmField
+
+                fun foo() {
+                  @JvmStatic
+                  val r = A()
+                }
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+                @JvmField
+                fun foo() {
+                  @JvmStatic
+                  val r = A()
+                }
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between an annotation and object autocorrected multiple lines`() {
+        val code =
+            """
+                @JvmField
+
 
 
                 fun foo() {}
@@ -990,6 +1018,36 @@ class AnnotationRuleTest {
             """
                 @JvmField
                 fun foo() {}
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between an annotation and object autocorrected multiple annotations`() {
+        val code =
+            """
+                @JvmField
+
+
+
+                fun foo() {
+                  @JvmStatic
+
+                  val foo = Foo()
+                }
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+                @JvmField
+                fun foo() {
+                  @JvmStatic
+                  val foo = Foo()
+                }
 
             """.trimIndent()
         )

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -972,4 +972,26 @@ class AnnotationRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `lint there should not be empty lines between an annotation and object autocorrected multiple`() {
+        val code =
+            """
+                @JvmField
+
+
+                fun foo() {}
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+                @JvmField
+                fun foo() {}
+
+            """.trimIndent()
+        )
+    }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -948,7 +948,7 @@ class AnnotationRuleTest {
             )
         ).isEqualTo(
             listOf(
-                LintError(1, 13, "annotation", AnnotationRule.fileAnnotationsLineBreaks)
+                LintError(1, 9, "annotation", AnnotationRule.fileAnnotationsLineBreaks)
             )
         )
     }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -934,7 +934,6 @@ class AnnotationRuleTest {
         ).isEmpty()
     }
 
-
     @Test
     fun `lint there should not be empty lines between an annotation and object`() {
         assertThat(
@@ -950,6 +949,27 @@ class AnnotationRuleTest {
             listOf(
                 LintError(1, 9, "annotation", AnnotationRule.fileAnnotationsLineBreaks)
             )
+        )
+    }
+
+    @Test
+    fun `lint there should not be empty lines between an annotation and object autocorrected`() {
+        val code =
+            """
+                @JvmField
+
+                fun foo() {}
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+                @JvmField
+                fun foo() {}
+
+            """.trimIndent()
         )
     }
 }


### PR DESCRIPTION
This PR fixes #688 

In essence, we should not have empty lines between an annotation and the thing that it's "annotating". 

My fix adds an extra check in the annotation file that will ensure there is no duplicate spaces between Annotations and the elements that they are annotating. In addition, a suite of new tests have verified this assertion and the auto correct.