### PR TITLE
Adding two new experimental rules that follow new formatting rules introduced in Kotlin 1.3.70.

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -13,6 +13,8 @@ class ExperimentalRuleSetProvider : RuleSetProvider {
         NoEmptyFirstLineInMethodBlockRule(),
         PackageNameRule(),
         EnumEntryNameCaseRule(),
-        SpacingAroundDoubleColonRule()
+        SpacingAroundDoubleColonRule(),
+        SpacingBetweenDeclarationsWithCommentsRule(),
+        SpacingBetweenDeclarationsWithAnnotationsRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -1,0 +1,42 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.FILE
+import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.prevSibling
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+
+/**
+ * @see https://youtrack.jetbrains.com/issue/KT-35106
+ */
+class SpacingBetweenDeclarationsWithAnnotationsRule : Rule("spacing-between-declarations-with-annotations") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == MODIFIER_LIST && node.hasAnnotationsAsChildren()) {
+            val prevSibling = node.psi.parent.node.prevSibling { it.elementType != WHITE_SPACE }
+            if (prevSibling != null &&
+                prevSibling.elementType != FILE &&
+                prevSibling !is PsiComment) {
+                if (node.psi.parent.prevSibling is PsiWhiteSpace && node.psi.parent.prevSibling.text == "\n") {
+                    emit(node.startOffset,
+                        "Declarations and declarations with annotations should have an empty space between.", true)
+                    if (autoCorrect) {
+                        (node.psi.parent.prevSibling.node as LeafPsiElement).rawReplaceWithText("\n\n")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun ASTNode.hasAnnotationsAsChildren(): Boolean = children().find { it.psi is KtAnnotationEntry } != null
+}

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -1,0 +1,37 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.FILE
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.prevSibling
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+
+/**
+ * @see https://youtrack.jetbrains.com/issue/KT-35088
+ */
+class SpacingBetweenDeclarationsWithCommentsRule : Rule("spacing-between-declarations-with-comments") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node is PsiComment) {
+            val prevSibling = node.parent.node.prevSibling { it.elementType != WHITE_SPACE }
+            if (prevSibling != null &&
+                prevSibling.elementType != FILE &&
+                prevSibling !is PsiComment) {
+                if (node.parent.prevSibling is PsiWhiteSpace && node.parent.prevSibling.text == "\n") {
+                    emit(node.startOffset,
+                        "Declarations and declarations with comments should have an empty space between.", true)
+                    if (autoCorrect) {
+                        (node.parent.prevSibling.node as LeafPsiElement).rawReplaceWithText("\n\n")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
@@ -1,0 +1,113 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
+    @Test
+    fun `annotation at top of file should do nothing`() {
+        Assertions.assertThat(SpacingBetweenDeclarationsWithAnnotationsRule().lint(
+            """
+                @Foo
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun `multiple annotations should do nothing`() {
+        Assertions.assertThat(SpacingBetweenDeclarationsWithAnnotationsRule().lint(
+            """
+                @Foo
+                @Bar
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun `missing space after comment should do nothing`() {
+        Assertions.assertThat(SpacingBetweenDeclarationsWithAnnotationsRule().lint(
+            """
+                // hello
+                @Foo
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun `missing space before declaration with annotation should cause error`() {
+        Assertions.assertThat(SpacingBetweenDeclarationsWithAnnotationsRule().lint(
+            """
+                fun a()
+                @Foo
+                fun b()
+            """.trimIndent()
+        )).isEqualTo(
+            listOf(
+                LintError(
+                    2,
+                    1,
+                    "spacing-between-declarations-with-annotations",
+                    "Declarations and declarations with annotations should have an empty space between."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `missing space before declaration with multiple annotations should cause error`() {
+        Assertions.assertThat(SpacingBetweenDeclarationsWithAnnotationsRule().lint(
+            """
+                fun a()
+                @Foo
+                @Bar
+                fun b()
+            """.trimIndent()
+        )).isEqualTo(
+            listOf(
+                LintError(
+                    2,
+                    1,
+                    "spacing-between-declarations-with-annotations",
+                    "Declarations and declarations with annotations should have an empty space between."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `autoformat should work correctly`() {
+        assertEquals(
+            """
+                @Annotation1
+                fun one() = 1
+                
+                @Annotation1
+                @Annotation2
+                fun two() = 2
+                fun three() = 42
+                
+                @Annotation1
+                fun four() = 44
+            """.trimIndent(),
+            SpacingBetweenDeclarationsWithAnnotationsRule().format(
+                """
+                @Annotation1
+                fun one() = 1
+                @Annotation1
+                @Annotation2
+                fun two() = 2
+                fun three() = 42
+                @Annotation1
+                fun four() = 44
+            """.trimIndent()
+            )
+        )
+    }
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
@@ -1,0 +1,137 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpacingBetweenDeclarationsWithCommentsRuleTest {
+    @Test
+    fun `comment at top of file should do nothing`() {
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                /**
+                 * foo
+                 */
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun `multiple comments should do nothing`() {
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                /**
+                 * boo
+                 */
+                /**
+                 * foo
+                 */
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                // bar
+                /**
+                 * foo
+                 */
+                fun a()
+            """.trimIndent()
+        )).isEmpty()
+
+        // This matches the Kotlin plugin behavior although I sort of think it violates the spirit of the rule.
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                fun blah()
+                // foo
+                /**
+                 * Doc 1
+                 */
+                const val bar = 1
+            """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun `missing space before declaration with kdoc should cause error`() {
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                fun a()
+                /**
+                 * foo
+                 */
+                fun b()
+            """.trimIndent()
+        )).isEqualTo(
+            listOf(
+                LintError(
+                    2,
+                    1,
+                    "spacing-between-declarations-with-comments",
+                    "Declarations and declarations with comments should have an empty space between."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `missing space before declaration with eol comment should cause error`() {
+        assertThat(SpacingBetweenDeclarationsWithCommentsRule().lint(
+            """
+                fun a()
+                // foo
+                fun b()
+            """.trimIndent()
+        )).isEqualTo(
+            listOf(
+                LintError(
+                    2,
+                    1,
+                    "spacing-between-declarations-with-comments",
+                    "Declarations and declarations with comments should have an empty space between."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `autoformat should work correctly`() {
+        assertEquals(
+            """
+                /**
+                 * Doc 1
+                 */
+                fun one() = 1
+                
+                /**
+                 * Doc 2
+                 */
+                fun two() = 2
+                fun three() = 42
+                
+                // comment
+                fun four() = 44
+            """.trimIndent(),
+            SpacingBetweenDeclarationsWithCommentsRule().format(
+                """
+                /**
+                 * Doc 1
+                 */
+                fun one() = 1
+                /**
+                 * Doc 2
+                 */
+                fun two() = 2
+                fun three() = 42
+                // comment
+                fun four() = 44
+            """.trimIndent()
+            )
+        )
+    }
+}


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-35106 and https://youtrack.jetbrains.com/issue/KT-35088

Fixes #721