### PR TITLE
Fix loading .editorconfig properties on windows fs fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Invalid path exception error on windows machines when loading properties from .editorconfig ([#761](https://github.com/pinterest/ktlint/issues/761))
+
 ## [0.37.0] - 2020-06-02
 
 Thank you to [Tapchicoma](https://github.com/Tapchicoma) and [romtsn](https://github.com/romtsn) for all their hard work on this release!

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.nio.charset.Charset
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -27,7 +28,8 @@ object IntellijIDEAIntegration {
         if (!Files.isDirectory(workDir.resolve(".idea"))) {
             throw ProjectNotFoundException()
         }
-        val editorConfig: Map<String, String> = EditorConfigLoader().loadPropertiesForFile(Paths.get("."))
+        val editorConfig: Map<String, String> = EditorConfigLoader(FileSystems.getDefault())
+            .loadPropertiesForFile(null, isStdIn = true)
         val indentSize = editorConfig["indent_size"]?.toIntOrNull() ?: 4
         val continuationIndentSize = editorConfig["continuation_indent_size"]?.toIntOrNull() ?: 4
         val updates = if (local) {


### PR DESCRIPTION
Introduce additional parameter `isStdIn` to indicate properties are loaded for code that is coming from input.

Previous approach used `<stdin>` as a last path segment. Apparently `<` or `>` is illegal characters on windows filesystem.

Fixes #761 