### PR TITLE
Deploy snapshots built against Kotlin EAP version

### DIFF
--- a/.deploy_snapshot
+++ b/.deploy_snapshot
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# publish usual snapshot
+./gradlew clean uploadArchives --no-daemon --no-parallel
+
+# kotlin eap version
+KOTLIN_EAP_VERSION=$(grep "^KOTLIN_EAP_VERSION" gradle.properties | cut -d'=' -f2-)
+
+if [ -z "$KOTLIN_EAP_VERSION" ]; then
+  echo "KOTLIN_EAP_VERSION is not set or empty"
+  exit 0
+fi
+
+# capture old version name to write it back after the snapshot is published
+VERSION_NAME=$(grep "^VERSION_NAME" gradle.properties | cut -d'=' -f2-)
+VERSION_NUMBER=$(echo $VERSION_NAME | cut -f1 -d-)
+
+# define a new version name for the snapshot by adding "kotlin-EAP_VERSION"
+EAP_VERSION_NAME="$VERSION_NUMBER-kotlin-$KOTLIN_EAP_VERSION-SNAPSHOT"
+
+# overwrite actual version name in gradle.properties, so uploadArchives task uses it
+sed -i -e "/^VERSION_NAME/s/=.*$/=$EAP_VERSION_NAME/" gradle.properties
+
+# publish a snapshot compiled against latest kotlin eap version and with respective version name
+./gradlew -PKOTLIN_VERSION=${KOTLIN_EAP_VERSION} clean uploadArchives --no-daemon --no-parallel
+
+# rewrite back the original version name
+sed -i -e "/^VERSION_NAME/s/=.*$/=$VERSION_NAME/" gradle.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - |
     if [[ $TRAVIS_REPO_SLUG == "pinterest/ktlint" && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" ]]; then
       # Gradle
-      ./gradlew clean uploadArchives --no-daemon --no-parallel
+      ./.deploy_snapshot
     else
       # Gradle
       ./gradlew clean build ktlint

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.3.70' apply false
+  id 'org.jetbrains.kotlin.jvm' version "$KOTLIN_VERSION" apply false
   id 'com.vanniktech.maven.publish' version '0.8.0' apply false
   id 'com.github.breadmoirai.github-release' version '2.2.12'
 }
 
 ext.versions = [
-  'kotlin': '1.3.70',
+  'kotlin': "$KOTLIN_VERSION",
   'gradle': '5.6.2'
 ]
 
@@ -41,6 +41,7 @@ task ktlint(type: JavaExec, group: LifecycleBasePlugin.VERIFICATION_GROUP) {
 allprojects {
   repositories {
     gradlePluginPortal()
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
   }
 
   tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+KOTLIN_VERSION=1.3.70
+KOTLIN_EAP_VERSION=1.4-M2
 VERSION_NAME=0.38.0-SNAPSHOT
 
 POM_DESCRIPTION=An anti-bikeshedding Kotlin linter with built-in formatter.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
+  }
+}
 rootProject.name = 'ktlint'
 
 include ':ktlint'


### PR DESCRIPTION
This will enable us auto-publish snapshots on `master` built against the latest available Kotlin EAP version. Unfortunately there's no way in the maven-publish-plugin to customize VERSION_NAME from gradle script, so I had to do a bit of shell scripts magic (overwrite VERSION_NAME in gradle.properties -> deploy the snapshots -> revert VERSION_NAME)