### PR TITLE
Update ec4j to 0.2.2 version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Update Gradle to 6.5 version
+- Update ec4j to 0.2.2 version. Now it should report path to `.editorconfig` file on failed parsing 
+and allow empty `.editorconfig` files.
 
 
 ## [0.37.2] - 2020-06-16

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext.deps = [
     'compiler': "org.jetbrains.kotlin:kotlin-compiler-embeddable:${versions.kotlin}"
   ],
   'klob'          : 'com.github.shyiko.klob:klob:0.2.1',
-  ec4j            : 'org.ec4j.core:ec4j-core:0.2.0',
+  ec4j            : 'org.ec4j.core:ec4j-core:0.2.2',
   'picocli'       : 'info.picocli:picocli:3.9.6',
   // Testing libraries
   'junit'         : 'junit:junit:4.12',

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,10 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>true</verify-signatures>
+      <trusted-artifacts>
+          <trust file=".*-javadoc[.]jar" regex="true" />
+          <trust file=".*-sources[.]jar" regex="true" />
+      </trusted-artifacts>
       <trusted-keys>
          <trusted-key id="160a7a9cf46221a56b06ad64461a804f2609fd89" group="com.github.shyiko.klob" name="klob" version="0.2.1"/>
          <trusted-key id="184454fad8697760f3e00d2e4a51a45b944ffd51" group="org.apache.tika"/>


### PR DESCRIPTION
This update resolves few issues reported in #790:
- allow empty `.editorconfig` file in the path
- print path to failed `.editorconfig` on parsing