### PR TITLE
Set continuation indent to 4 in codestyle for IDE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Safe-called wrapped trailing lambdas indented correctly ([#776](https://github.com/pinterest/ktlint/issues/776))
 - `provideDelegate` imports are not marked as unused anymore ([#669](https://github.com/pinterest/ktlint/issues/669))
+- Set continuation indent to 4 in IDE integration codestyle ([#775](https://github.com/pinterest/ktlint/issues/775)) 
 
 ### Changed
 - Update Gradle to 6.5 version

--- a/ktlint/src/main/resources/config/codestyles/ktlint.xml
+++ b/ktlint/src/main/resources/config/codestyles/ktlint.xml
@@ -24,7 +24,7 @@
     <option name="LINE_COMMENT_ADD_SPACE" value="true" />
     <indentOptions>
       <option name="INDENT_SIZE" value="4" />
-      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>

--- a/ktlint/src/main/resources/project-config/.idea/codeStyles/Project.xml
+++ b/ktlint/src/main/resources/project-config/.idea/codeStyles/Project.xml
@@ -25,7 +25,7 @@
       <option name="LINE_COMMENT_ADD_SPACE" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="4" />
-        <option name="CONTINUATION_INDENT_SIZE" value="8" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>
     </codeStyleSettings>
   </code_scheme>


### PR DESCRIPTION
Fixes #775 