### PR TITLE
Unit test to enforce issue #680

### DIFF
--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
@@ -57,4 +57,42 @@ class SpacingAroundAngleBracketRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test multiline type parameter list no change`() {
+        assertThat(
+            SpacingAroundAngleBracketsRule().format(
+                """
+                object TestCase {
+                  inline fun <
+                    T1,
+                    T2,
+                    T3> create(
+                      t1: T1,
+                      t2: T2,
+                      t3: T3
+                  ) {
+                    // do things
+                  }
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+                object TestCase {
+                  inline fun <
+                    T1,
+                    T2,
+                    T3> create(
+                      t1: T1,
+                      t2: T2,
+                      t3: T3
+                  ) {
+                    // do things
+                  }
+                }
+                """.trimIndent()
+        )
+    }
+
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
@@ -79,20 +79,19 @@ class SpacingAroundAngleBracketRuleTest {
             )
         ).isEqualTo(
             """
-                object TestCase {
-                  inline fun <
-                    T1,
-                    T2,
-                    T3> create(
-                      t1: T1,
-                      t2: T2,
-                      t3: T3
-                  ) {
-                    // do things
-                  }
-                }
-                """.trimIndent()
+            object TestCase {
+              inline fun <
+                T1,
+                T2,
+                T3> create(
+                  t1: T1,
+                  t2: T2,
+                  t3: T3
+              ) {
+                // do things
+              }
+            }
+            """.trimIndent()
         )
     }
-
 }


### PR DESCRIPTION
Adding a test to enforce the rule so that the spacing of a subset of multi-line type parameter list is not flattened when an indentation seems appropriate #680 