### PR TITLE
Escape special html symbols in the html reporter (#814)

### DIFF
--- a/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporter.kt
+++ b/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporter.kt
@@ -129,7 +129,7 @@ class HtmlReporter(private val out: PrintStream) : Reporter {
 
     private fun item(value: String) {
         out.print("<li>")
-        text(value)
+        text(value.escapeHTMLAttrValue())
         out.println("</li>")
     }
 
@@ -144,4 +144,8 @@ class HtmlReporter(private val out: PrintStream) : Reporter {
         body()
         out.println("</p>")
     }
+
+    private fun String.escapeHTMLAttrValue() =
+        this.replace("&", "&amp;").replace("\"", "&quot;").replace("'", "&apos;")
+            .replace("<", "&lt;").replace(">", "&gt;")
 }

--- a/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
@@ -148,4 +148,52 @@ h3 {
         val expected = String(out.toByteArray())
         assertEquals(actual, expected)
     }
+
+    @Test
+    fun shouldRenderIssuesAndEscapeSpecialHtmlSymbolsWhen_LintProblemsFound() {
+        val out = ByteArrayOutputStream()
+        val reporter = HtmlReporter(PrintStream(out, true))
+
+        reporter.onLintError(
+            "/file1.kt",
+            LintError(1, 1, "rule-1", "Error message contains a generic type like List<Int> (cannot be auto-corrected)"),
+            false
+        )
+
+        reporter.onLintError(
+            "/file1.kt",
+            LintError(2, 1, "rule-2", "Error message contains special html symbols like a<b>c\"d'e&f (cannot be auto-corrected)"),
+            false
+        )
+
+        reporter.afterAll()
+
+        val actual =
+            """<html>
+<head>
+<link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" />
+<style>
+body {
+    font-family: 'Source Code Pro', monospace;
+}
+h3 {
+    font-size: 12pt;
+}</style>
+</head>
+<body>
+<h1>Overview</h1>
+<p>Issues found: 2</p>
+<p>Issues corrected: 0</p>
+<h3>/file1.kt</h3>
+<ul>
+<li>(1, 1): Error message contains a generic type like List&lt;Int&gt; (cannot be auto-corrected)  (rule-1)</li>
+<li>(2, 1): Error message contains special html symbols like a&lt;b&gt;c&quot;d&apos;e&amp;f (cannot be auto-corrected)  (rule-2)</li>
+</ul>
+</body>
+</html>
+""".trimStart().replace("\n", System.lineSeparator())
+
+        val expected = String(out.toByteArray())
+        assertEquals(actual, expected)
+    }
 }


### PR DESCRIPTION
Hi guys, I've made a fix for https://github.com/pinterest/ktlint/issues/814. Please let me know what you think.

P.S. This is my first PR here, might have forgotten something 😄 