### PR TITLE
Fix internal error on "no-multi-spaces" rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -18,12 +18,21 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
             // allow multiple spaces in KDoc in case of KDOC_TAG for alignment, e.g.
             // @param foo      stuff
             // @param foobar   stuff2
-            !(node.treePrev.elementType == KDOC_MARKDOWN_LINK && node.treeParent.elementType == KDOC_TAG)
+            !isKdocMarkdownNode(node)
         ) {
             emit(node.startOffset + 1, "Unnecessary space(s)", true)
             if (autoCorrect) {
                 (node as LeafPsiElement).rawReplaceWithText(" ")
             }
+        }
+    }
+
+    private fun isKdocMarkdownNode(node: ASTNode): Boolean {
+        return when {
+            node.treePrev != null -> {
+                node.treePrev.elementType == KDOC_MARKDOWN_LINK && node.treeParent.elementType == KDOC_TAG
+            }
+            else -> false
         }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -18,21 +18,12 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
             // allow multiple spaces in KDoc in case of KDOC_TAG for alignment, e.g.
             // @param foo      stuff
             // @param foobar   stuff2
-            !isKdocMarkdownNode(node)
+            !(node.treePrev?.elementType == KDOC_MARKDOWN_LINK && node.treeParent?.elementType == KDOC_TAG)
         ) {
             emit(node.startOffset + 1, "Unnecessary space(s)", true)
             if (autoCorrect) {
                 (node as LeafPsiElement).rawReplaceWithText(" ")
             }
-        }
-    }
-
-    private fun isKdocMarkdownNode(node: ASTNode): Boolean {
-        return when {
-            node.treePrev != null -> {
-                node.treePrev.elementType == KDOC_MARKDOWN_LINK && node.treeParent.elementType == KDOC_TAG
-            }
-            else -> false
         }
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRuleTest.kt
@@ -63,4 +63,14 @@ class NoMultipleSpacesRuleTest {
             """.trimIndent()
         assertThat(NoMultipleSpacesRule().format(code)).isEqualTo(code)
     }
+
+    @Test
+    fun `test multiple spaces in the beginning of the file`() {
+        assertThat(NoMultipleSpacesRule().lint("  package my.company.android"))
+            .isEqualTo(
+                listOf(
+                    LintError(1, 2, "no-multi-spaces", "Unnecessary space(s)")
+                )
+            )
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/803

The following exception was produced in case when a program starts with multiple spaces:
```java
Caused by: java.lang.IllegalStateException: node.treePrev must not be null
	at com.pinterest.ktlint.ruleset.standard.NoMultipleSpacesRule.visit(NoMultipleSpacesRule.kt:17)
```