### PR TITLE
IndentationRule: Indent brace-less if-else bodies starting with parens correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - No false empty lines inserted in multiline if-else block ([#793](https://github.com/pinterest/ktlint/issues/793))
 - No-wildcard-imports properly handles custom infix function with asterisk ([#799](https://github.com/pinterest/ktlint/issues/799))
 - Do not require else to be in the same line of a right brace if the right brace is not part of the if statement ([#756](https://github.com/pinterest/ktlint/issues/756))
+- Brace-less if-else bodies starting with parens indented correctly ([#829](https://github.com/pinterest/ktlint/issues/829))
 
 ### Changed
 - Update Gradle to 6.5 version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -676,11 +676,9 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
 
     private fun adjustExpectedIndentInFrontOfControlBlock(n: ASTNode, ctx: IndentContext) {
         val nextSibling = n.treeNext
-        if (nextSibling.nextCodeLeaf()?.elementType !in lTokenSet) {
-            expectedIndent++
-            debug { "++in_front(${nextSibling.elementType}) -> $expectedIndent" }
-            ctx.exitAdjBy(nextSibling, -1)
-        }
+        expectedIndent++
+        debug { "++in_front(${nextSibling.elementType}) -> $expectedIndent" }
+        ctx.exitAdjBy(nextSibling, -1)
     }
 
     private fun adjustExpectedIndentInFrontOfPropertyAccessor(n: ASTNode, ctx: IndentContext) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -457,4 +457,32 @@ internal class IndentationRuleTest {
             """.trimIndent()
         assertThat(IndentationRule().format(code)).isEqualTo(code)
     }
+
+    @Test
+    fun `lint block started with parens after if is allowed`() {
+        val code =
+            """
+            fun test() {
+                if (true)
+                    (1).toString()
+                else
+                    2.toString()
+            }
+            """.trimIndent()
+        assertThat(IndentationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format block started with parens after if is allowed`() {
+        val code =
+            """
+            fun test() {
+                if (true)
+                    (1).toString()
+                else
+                    2.toString()
+            }
+            """.trimIndent()
+        assertThat(IndentationRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Fix #829 