### PR TITLE
IndentationRule: Indent if-condition with multiline call expression inside correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - No-wildcard-imports properly handles custom infix function with asterisk ([#799](https://github.com/pinterest/ktlint/issues/799))
 - Do not require else to be in the same line of a right brace if the right brace is not part of the if statement ([#756](https://github.com/pinterest/ktlint/issues/756))
 - Brace-less if-else bodies starting with parens indented correctly ([#829](https://github.com/pinterest/ktlint/issues/829))
+- If-condition with multiline call expression inside indented correctly ([#796](https://github.com/pinterest/ktlint/issues/796))
 
 ### Changed
 - Update Gradle to 6.5 version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -593,6 +593,14 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                                         // fun fn():
                                         //     Int
                                         adjustExpectedIndentAfterColon(n, ctx)
+                                    prevLeaf?.elementType == LPAR &&
+                                        p.elementType == VALUE_ARGUMENT_LIST &&
+                                        p.isPartOf(CONDITION) ->
+                                        // if (condition(
+                                        //         params
+                                        //     )
+                                        // )
+                                        adjustExpectedIndentAfterLparInsideCondition(n, ctx)
                                 }
                                 visitWhiteSpace(n, autoCorrect, emit, editorConfig)
                                 if (ctx.localAdj != 0) {
@@ -741,6 +749,12 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     private fun adjustExpectedIndentAfterColon(n: ASTNode, ctx: IndentContext) {
         expectedIndent++
         debug { "++after(COLON) -> $expectedIndent" }
+        ctx.exitAdjBy(n.treeParent, -1)
+    }
+
+    private fun adjustExpectedIndentAfterLparInsideCondition(n: ASTNode, ctx: IndentContext) {
+        expectedIndent++
+        debug { "++inside(CONDITION) -> $expectedIndent" }
         ctx.exitAdjBy(n.treeParent, -1)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -485,4 +485,35 @@ internal class IndentationRuleTest {
             """.trimIndent()
         assertThat(IndentationRule().format(code)).isEqualTo(code)
     }
+
+    // https://github.com/pinterest/ktlint/issues/796
+    @Test
+    fun `lint if-condition with multiline call expression is indented properly`() {
+        val code =
+            """
+            private val gpsRegion =
+                if (permissionHandler.isPermissionGranted(
+                        context, Manifest.permission.ACCESS_FINE_LOCATION
+                    )
+                ) {
+                    // stuff
+                }
+            """.trimIndent()
+        assertThat(IndentationRule().lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `format if-condition with multiline call expression is indented properly`() {
+        val code =
+            """
+            private val gpsRegion =
+                if (permissionHandler.isPermissionGranted(
+                        context, Manifest.permission.ACCESS_FINE_LOCATION
+                    )
+                ) {
+                    // stuff
+                }
+            """.trimIndent()
+        assertThat(IndentationRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Fix #796 