### PR TITLE
Fixing false-positive Unused Import with extension function

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -146,6 +146,12 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
 
     // Contains list of all imports and checks if given import is present
     private fun checkIfParentImportExists(text: String): Boolean {
+        // Only check static imports; identified if they start with a capital letter indicating a
+        // class name rather than a sub-package
+        if (text.isNotEmpty() && text[0] !in 'A'..'Z') {
+            return false
+        }
+
         val staticImports = imports.filter { it.endsWith(text) }
         staticImports.forEach { import ->
             var count = 0

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -553,6 +553,24 @@ class NoUnusedImportsRuleTest {
 
                         assertThat(actual).isEqualTo(expected)
                     }
+                    }
+                """.trimIndent()
+            ).isEmpty()
+        )
+    }
+
+    @Test
+    fun `only redundant static imports should be removed`() {
+        assertThat(
+            NoUnusedImportsRule().lint(
+                """
+                import com.foo.psi.abc
+                import com.foo.psi.findAnnotation
+
+                fun main() {
+                    val psi = getPsi()
+                    psi.abc()
+                    val bar = psi.findAnnotation(SOME_CONSTANT)
                 }
                 """.trimIndent()
             )


### PR DESCRIPTION
Fixes #836 

Some code that was meant to handle redundant static imports was removing an import for an extension function because the name of the variable we were calling the extension function on happened to match a sub-package name.