### PR TITLE
Compile ktlint with backwards compatibility to kotlin 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ allprojects {
 
     kotlinOptions {
       jvmTarget = '1.8'
+      apiVersion = '1.3'
     }
   }
 }


### PR DESCRIPTION
This is needed to run any ktlint code within gradle since it bundles kotlin 1.3.72 at the moment.
It should not have negative consequences since the compiled code will be forward compatible with kotlin 1.4.

First off, thank you for your heroic efforts @shashachu and @Tapchicoma getting the 0.38.0 updates out to the community.

I ended up still running into a wrinkle using this in kotlinter-gradle since we execute ktlint code inside the gradle runtime.
See discussion here: https://github.com/jeremymailen/kotlinter-gradle/issues/144#issuecomment-678582319

At the moment, gradle still bundles kotlin 1.3.72 and there doesn't seem to be a way to push that forward and it probably wouldn't be safe given gradle dsl kotlin.

So, in that context we'll need ktlint compiled for 1.3 compatibility. As far as I know this shouldn't cause any issues unless the ktlint project was planning to use some language features or optimizations only available in 1.4 without a backwards compatible form (are there any?).

Thanks again.