### PR TITLE
IndentationRule: Do not enforce raw strings opening quote to be on a separate line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- 
+### Fixed
+- Do not enforce raw strings opening quote to be on a separate line ([#711](https://github.com/pinterest/ktlint/issues/711))
 
 ## [0.38.0] - 2020-08-21
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -167,7 +167,6 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                 LPAR, LBRACE, LBRACKET -> rearrangeBlock(n, autoCorrect, emit) // TODO: LT
                 SUPER_TYPE_LIST -> rearrangeSuperTypeList(n, autoCorrect, emit)
                 VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(n, autoCorrect, emit)
-                EQ -> rearrangeEq(n, autoCorrect, emit)
                 ARROW -> rearrangeArrow(n, autoCorrect, emit)
                 WHITE_SPACE -> line += n.text.count { it == '\n' }
             }
@@ -326,25 +325,6 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                 }
             }
         }
-    }
-
-    private fun rearrangeEq(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-    ) {
-        // force """ to be on a separate line
-        if (!node.nextCodeLeaf().isRawString()) {
-            return
-        }
-        val nextCodeLeaf = node.nextCodeLeaf()!!
-        if (!nextCodeLeaf.prevLeaf().isWhiteSpaceWithNewline()) {
-            requireNewlineAfterLeaf(node, autoCorrect, emit)
-        }
-    }
-
-    private fun ASTNode?.isRawString(): Boolean {
-        return this?.elementType == OPEN_QUOTE && this.text == "\"\"\""
     }
 
     private fun mustBeFollowedByNewline(node: ASTNode): Boolean {

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -92,11 +92,10 @@ _
 }
 
 class C {
-    val CONFIG_COMPACT =
-        """
+    val CONFIG_COMPACT = """
         {
         }
-        """.trimIndent()
+    """.trimIndent()
     val CONFIG_COMPACT = // comment
         """
         {


### PR DESCRIPTION
Fixes #711 

@shashachu I saw you've introduced this change in https://github.com/pinterest/ktlint/pull/387/commits/b54ea782bc5ee776efc69830e7c903523fc89178 but I think we should just leave raw strings alone because IDEA also does nothing about them (at least I haven't found any pattern) neither there are any mentions about it in the style guides