### PR TITLE
Correctly indent parameters when having multiline type parameter list in function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Do not enforce raw strings opening quote to be on a separate line ([#711](https://github.com/pinterest/ktlint/issues/711))
+- False negative with multiline type parameter list in function signature for `parameter-list-wrapping`([#680](https://github.com/pinterest/ktlint/issues/680))
 
 ## [0.38.1] - 2020-08-24
 Minor release to support projects using mixed 1.3/1.4 Kotlin versions (e.g. Gradle plugins)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -803,4 +803,26 @@ class ParameterListWrappingRuleTest {
             )
         ).isEmpty()
     }
+
+    // https://github.com/pinterest/ktlint/issues/680
+    @Test
+    fun `multiline type parameter list in function signature - indented correctly`() {
+        val code =
+            """
+            object TestCase {
+                inline fun <
+                    T1,
+                    T2,
+                    T3> create(
+                    t1: T1,
+                    t2: T2,
+                    t3: T3
+                ) {
+                    // do things
+                }
+            }
+            """.trimIndent()
+        assertThat(ParameterListWrappingRule().lint(code)).isEmpty()
+        assertThat(ParameterListWrappingRule().format(code)).isEqualTo(code)
+    }
 }


### PR DESCRIPTION
Fixes #680 