### PR TITLE
Sample PR to test breaking rule

### DIFF
--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -1183,4 +1183,42 @@ class AnnotationRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `lint there should not be an error on multiple lines assertion while additional formatting ongoing`() {
+        val code =
+            """
+            package a.b.c
+
+            class Test {
+                fun bloop() {
+                    asdfadsf(asdfadsf, asdfasdf, asdfasdfasdfads,
+                    asdfasdf, asdfasdf, asdfasdf)
+                }
+
+                @Blah
+                val test: Int
+            }
+
+            """.trimIndent()
+
+        assertThat(
+            AnnotationRule().format(code)
+        ).isEqualTo(
+            """
+            package a.b.c
+
+            class Test {
+                fun bloop() {
+                    asdfadsf(asdfadsf, asdfasdf, asdfasdfasdfads,
+                    asdfasdf, asdfasdf, asdfasdf)
+                }
+
+                @Blah
+                val test: Int
+            }
+
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Add the test case that was breaking defining the bug: formatting does not play well with other rules (in this case parameter wrapping) that change the number of lines in the file