### PR TITLE
Print loaded .editorconfig content when debug flag is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add new applyToIDEA location for IDEA 2020.1.x and above on MacOs
+- Debug output: print loaded .editorconfig content
 
 ### Fixed
 - Do not enforce raw strings opening quote to be on a separate line ([#711](https://github.com/pinterest/ktlint/issues/711))

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
@@ -73,6 +73,18 @@ class EditorConfigLoader(
             .mapValues {
                 if (it.value.isUnset) "unset" else it.value.sourceValue
             }
+            .also {
+                if (debug) {
+                    val editorConfigValues = it
+                        .map { entry ->
+                            "${entry.key}: ${entry.value}"
+                        }
+                        .joinToString(
+                            separator = ", "
+                        )
+                    println("Loaded .editorconfig: [$editorConfigValues]")
+                }
+            }
             .run {
                 if (!isStdIn) {
                     plus(FILE_PATH_PROPERTY to filePath.toString())


### PR DESCRIPTION
Only when debug flag is enabled.
Should simplify debugging issues.