### PR TITLE
NoSemicolonsRule: don't report when semicolon is before annotation/comment/kdoc and lambda

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
@@ -116,4 +116,58 @@ class NoSemicolonsRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun testSemicolonAllowedBeforeAnnotationAndLambda() {
+        assertThat(
+            NoSemicolonsRule().lint(
+                """
+                annotation class Ann
+                val f: () -> String = run {
+                    listOf(1).map {
+                        it + it
+                    };
+                    @Ann
+                    { "" }
+                }
+                """
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testSemicolonAllowedBeforeCommentAndLambda() {
+        assertThat(
+            NoSemicolonsRule().lint(
+                """
+                val f: () -> String = run {
+                    listOf(1).map {
+                        it + it
+                    };
+                    // comment
+                    { "" }
+                }
+                """
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testSemicolonAllowedBeforeKDocAndLambda() {
+        assertThat(
+            NoSemicolonsRule().lint(
+                """
+                val f: () -> String = run {
+                    listOf(1).map {
+                        it + it
+                    };
+                    /**
+                     * kdoc
+                     */
+                    { "" }
+                }
+                """
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes #825