### PR TITLE
Fix alternative .editorconfig path is ignored on stdin input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Do not enforce raw strings opening quote to be on a separate line ([#711](https://github.com/pinterest/ktlint/issues/711))
 - False negative with multiline type parameter list in function signature for `parameter-list-wrapping`([#680](https://github.com/pinterest/ktlint/issues/680))
+- Alternative `.editorconfig` path is ignored on stdin input ([#869](https://github.com/pinterest/ktlint/issues/869))
 
 ### Changed
 - `Ktlint` object internal code cleanup

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
@@ -51,15 +51,17 @@ class EditorConfigLoader(
         }
 
         val normalizedFilePath = when {
+            alternativeEditorConfig != null -> {
+                val editorconfigFilePath = if (isStdIn) "stdin${SUPPORTED_FILES.first()}" else filePath!!.last()
+                alternativeEditorConfig
+                    .toAbsolutePath()
+                    .resolve("$editorconfigFilePath")
+            }
             isStdIn ->
                 fs
                     .getPath(".")
                     .toAbsolutePath()
                     .resolve("stdin${SUPPORTED_FILES.first()}")
-            alternativeEditorConfig != null ->
-                alternativeEditorConfig
-                    .toAbsolutePath()
-                    .resolve("${filePath!!.last()}")
             else -> filePath
         }
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -317,6 +317,46 @@ internal class EditorConfigLoaderTest {
     }
 
     @Test
+    fun `Should load properties from alternative editorconfig on stdin input`() {
+        val rootDir = "/projects"
+        val anotherDir = "$rootDir/project-2-dir"
+
+        //language=EditorConfig
+        tempFileSystem.writeEditorConfigFile(
+            rootDir,
+            """
+            root = true
+            [*]
+            end_of_line = lf
+            """.trimIndent()
+        )
+
+        //language=EditorConfig
+        tempFileSystem.writeEditorConfigFile(
+            anotherDir,
+            """
+            [*]
+            indent_size = 2
+            """.trimIndent()
+        )
+
+        val parsedEditorConfig = editorConfigLoader.loadPropertiesForFile(
+            filePath = null,
+            alternativeEditorConfig = tempFileSystem.normalizedPath(anotherDir).resolve(".editorconfig"),
+            isStdIn = true
+        )
+
+        assertThat(parsedEditorConfig).isNotEmpty
+        assertThat(parsedEditorConfig).isEqualTo(
+            mapOf(
+                "end_of_line" to "lf",
+                "indent_size" to "2",
+                "tab_width" to "2"
+            )
+        )
+    }
+
+    @Test
     fun `Should support editorconfig globs when loading properties for file specified under such glob`() {
         val projectDir = "/project"
         @Language("EditorConfig") val editorconfigFile =


### PR DESCRIPTION
Fixes #869 