### PR TITLE
Opening class RuleSet so it can be inherited.

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSet.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSet.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.core.internal.IdNamingPolicy
  * A group of [Rule]s discoverable through [RuleSetProvider].
  * @see RuleSetProvider
  */
-class RuleSet(
+open class RuleSet(
     val id: String,
     vararg val rules: Rule
 ) : Iterable<Rule> {


### PR DESCRIPTION
### What's done:
In some cases some custom rule sets need to have different implementation of RuleSet. For example in the diktat (https://github.com/cqfn/diKTat) project it is used to pass ruleset specific configuration in the rules (config files). This should not affect anything and simply gives developers a chance to customise rule sets more.