### PR TITLE
NoUnusedImportsRule: fix false positive with imported sub classes are used in DOT_QUALIFIED_EXPRESSION

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -595,6 +595,28 @@ class NoUnusedImportsRuleTest {
     }
 
     @Test
+    fun `only redundant sealed sub class imports should be removed 2`() {
+        assertThat(
+            NoUnusedImportsRule().lint(
+                """
+                import com.zak.result.Result.Expected
+                import com.zak.result.Result.Unexpected
+                import org.assertj.core.api.Assertions.assertThat
+
+                fun test() {
+                    assertThat(Result.just(1)).isEqualTo(Expected(1))
+                    assertThat(Result.just(1)).isEqualTo(Result.Expected(1))
+
+                    val ex = Exception()
+                    assertThat(Result.raise(exception)).isEqualTo(Unexpected(ex))
+                    assertThat(Result.raise(exception)).isEqualTo(Result.Unexpected(exception))
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
     fun `only redundant static java function imports should be removed`() {
         assertThat(
             NoUnusedImportsRule().lint(


### PR DESCRIPTION
Fixes #902