### PR TITLE
Fix false positive `Missing newline after "->"` when `when` entry has if/else block

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -347,8 +347,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
         if (lToken != null && lToken.elementType in lTokenSet) {
             val rElementType = matchingRToken[lToken.elementType]
             val rToken = lToken.nextSibling { it.elementType == rElementType }
-            val lf = rToken?.nextLeaf { it.isWhiteSpaceWithNewline() }
-            return lf?.parent({ it == p }) == null
+            return rToken?.treeParent == lToken.treeParent
         }
         if (nextCodeSibling?.textContains('\n') == false) {
             return true

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/lint-when-expression.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/lint-when-expression.kt.spec
@@ -19,6 +19,23 @@ fun main() {
             else -> 2 + 3
         }
     }
+    val v3 = when (1) {
+        1 -> if (true) {
+            2
+        } else {
+            3
+        }
+        else -> 0
+    }
+
+    val v4 = when (1) {
+        1 -> 1.let {
+            it + 1
+        }.let {
+            it + 1
+        }
+        else -> 0
+    }
 }
 
 // expect


### PR DESCRIPTION
Fixes #901