### PR TITLE
Adding links to ktlint demo to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ disabled_rules=import-ordering
 disabled_rules=indent
 ```
 
+## Online demo
+In case you would like to see how `ktlint` works and you are not able (or do not want) to install it -
+ try it's [**online demo**](https://ktlint-demo.herokuapp.com/) first.
+With this demo you are able to see how powerful `ktlint` is with standard or custom rule sets.
+ In case you will need help or would like to see sources you can visit [it's repository](https://github.com/akuleshov7/diKTat-demo)
+
 ## Installation
 
 > Skip all the way to the "Integration" section if you don't plan to use `ktlint`'s command line interface.

--- a/README.md
+++ b/README.md
@@ -118,10 +118,9 @@ disabled_rules=indent
 ```
 
 ## Online demo
-In case you would like to see how `ktlint` works and you are not able (or do not want) to install it -
- try it's [**online demo**](https://ktlint-demo.herokuapp.com/) first.
-With this demo you are able to see how powerful `ktlint` is with standard or custom rule sets.
- In case you will need help or would like to see sources you can visit [it's repository](https://github.com/akuleshov7/diKTat-demo)
+You can try `ktlint` online [here](https://ktlint-demo.herokuapp.com/) using the standard or a custom ruleset without installing it to your PC. \
+To contribute or get more info, please visit the [GitHub repository](https://github.com/akuleshov7/diKTat-demo).
+
 
 ## Installation
 


### PR DESCRIPTION
### What's done:
Continuation from https://github.com/pinterest/ktlint/issues/912. Added a section with ktlint online demo. This can attract more users to ktlint. As now they can see how powerful ktlint is without installing it to your PC.