### PR TITLE
Add 'generateEditorConfig' CLI subcommand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Initial implementation IDE integration via '.editorconfig' based on rules default values ([#701](https://github.com/pinterest/ktlint/issues/701))
+- CLI subcommand `generateEditorConfig` to generate '.editorconfig' content for Kotlin files ([#701](https://github.com/pinterest/ktlint/issues/701))
 
 ### Fixed
 - ?

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -14,6 +14,7 @@ import com.pinterest.ktlint.internal.ApplyToIDEAProjectSubCommand
 import com.pinterest.ktlint.internal.GenerateEditorConfigSubCommand
 import com.pinterest.ktlint.internal.GitPreCommitHookSubCommand
 import com.pinterest.ktlint.internal.GitPrePushHookSubCommand
+import com.pinterest.ktlint.internal.JarFiles
 import com.pinterest.ktlint.internal.KtlintVersionProvider
 import com.pinterest.ktlint.internal.PrintASTSubCommand
 import com.pinterest.ktlint.internal.fileSequence
@@ -179,13 +180,13 @@ class KtlintCommandLine {
                 "To use a third-party reporter specify a path to a JAR file on the filesystem."
         ]
     )
-    private var reporters = ArrayList<String>()
+    private var reporters: JarFiles = ArrayList<String>()
 
     @Option(
         names = ["--ruleset", "-R"],
         description = ["A path to a JAR file containing additional ruleset(s)"]
     )
-    var rulesets = ArrayList<String>()
+    var rulesets: JarFiles = ArrayList<String>()
 
     @Option(
         names = ["--stdin"],

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -29,7 +29,12 @@ internal fun List<String>.fileSequence(): Sequence<File> {
         .map(Path::toFile)
 }
 
-internal fun List<String>.toFilesURIList() = map {
+/**
+ * List of paths to Java `jar` files.
+ */
+internal typealias JarFiles = List<String>
+
+internal fun JarFiles.toFilesURIList() = map {
     val jarFile = File(expandTilde(it))
     if (!jarFile.exists()) {
         println("Error: $it does not exist")

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.RuleSet
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.system.exitProcess
 
 internal val workDir: String = File(".").canonicalPath
 
@@ -28,9 +29,18 @@ internal fun List<String>.fileSequence(): Sequence<File> {
         .map(Path::toFile)
 }
 
+internal fun List<String>.toFilesURIList() = map {
+    val jarFile = File(expandTilde(it))
+    if (!jarFile.exists()) {
+        println("Error: $it does not exist")
+        exitProcess(1)
+    }
+    jarFile.toURI().toURL()
+}
+
 // a complete solution would be to implement https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
 // this implementation takes care only of the most commonly used case (~/)
-internal fun expandTilde(path: String): String = path.replaceFirst(Regex("^~"), System.getProperty("user.home"))
+private fun expandTilde(path: String): String = path.replaceFirst(Regex("^~"), System.getProperty("user.home"))
 
 internal fun File.location(
     relative: Boolean

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -1,0 +1,58 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.KtlintCommandLine
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import picocli.CommandLine
+
+@CommandLine.Command(
+    description = [
+        "EXPERIMENTAL!!! Generate kotlin style section for '.editorconfig' file.",
+        "Add output content into '.editorconfig' file"
+    ],
+    mixinStandardHelpOptions = true,
+    versionProvider = KtlintVersionProvider::class
+)
+class GenerateEditorConfigSubCommand : Runnable {
+    @CommandLine.ParentCommand
+    private lateinit var ktlintCommand: KtlintCommandLine
+
+    @CommandLine.Spec
+    private lateinit var commandSpec: CommandLine.Model.CommandSpec
+
+    @OptIn(FeatureInAlphaState::class)
+    override fun run() {
+        commandSpec.commandLine().printHelpOrVersionUsage()
+
+        // For now we are using CLI invocation dir as path to load existing '.editorconfig'
+        val generatedEditorConfig = KtLint.generateKotlinEditorConfigSection(
+            KtLint.Params(
+                fileName = "./test.kt",
+                text = "",
+                ruleSets = ktlintCommand.rulesets
+                    .loadRulesets(
+                        ktlintCommand.experimental,
+                        ktlintCommand.debug
+                    )
+                    .map { it.value.get() },
+                debug = ktlintCommand.debug,
+                cb = { _, _ -> Unit }
+            )
+        )
+
+        if (generatedEditorConfig.isNotBlank()) {
+            println(
+                """
+                [*.{kt,kts}]
+                $generatedEditorConfig
+                """.trimIndent()
+            )
+        } else {
+            println("Nothing to add to .editorconfig file")
+        }
+    }
+
+    companion object {
+        internal const val COMMAND_NAME = "generateEditorConfig"
+    }
+}

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -1,0 +1,33 @@
+package com.pinterest.ktlint.internal
+
+import com.pinterest.ktlint.core.RuleSetProvider
+import java.net.URLClassLoader
+import java.util.ServiceLoader
+
+/**
+ * Load given list of paths to rulesets jars into map of ruleset providers.
+ *
+ * @return map of ruleset ids to ruleset providers
+ */
+internal fun List<String>.loadRulesets(
+    loadExperimental: Boolean,
+    debug: Boolean
+) = ServiceLoader
+    .load(
+        RuleSetProvider::class.java,
+        URLClassLoader(this.toFilesURIList().toTypedArray())
+    )
+    .associateBy {
+        val key = it.get().id
+        // standard should go first
+        if (key == "standard") "\u0000$key" else key
+    }
+    .filterKeys { loadExperimental || it != "experimental" }
+    .toSortedMap()
+    .also {
+        if (debug) {
+            it.forEach { entry ->
+                println("[DEBUG] Discovered ruleset with \"${entry.key}\" id.")
+            }
+        }
+    }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -9,13 +9,13 @@ import java.util.ServiceLoader
  *
  * @return map of ruleset ids to ruleset providers
  */
-internal fun List<String>.loadRulesets(
+internal fun JarFiles.loadRulesets(
     loadExperimental: Boolean,
     debug: Boolean
 ) = ServiceLoader
     .load(
         RuleSetProvider::class.java,
-        URLClassLoader(this.toFilesURIList().toTypedArray())
+        URLClassLoader(toFilesURIList().toTypedArray())
     )
     .associateBy {
         val key = it.get().id


### PR DESCRIPTION
Initial implementation of `.editorconfig` Kotlin section generation via CLI subcommand. For now it just outputs generated content to stdout.

Part of #701 issue.