### PR TITLE
ArgumentListWrappingRule: don't report it when line breaks is inside a lambda

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -52,14 +52,14 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
             // skip lambda arguments
             node.treeParent?.elementType != ElementType.FUNCTION_LITERAL &&
             // skip if number of arguments is big (we assume it with a magic number of 8)
-            node.children().filter { it.elementType == ElementType.VALUE_ARGUMENT }.toList().size <= 8
+            node.children().count { it.elementType == ElementType.VALUE_ARGUMENT } <= 8
         ) {
             // each argument should be on a separate line if
             // - at least one of the arguments is
             // - maxLineLength exceeded (and separating arguments with \n would actually help)
             // in addition, "(" and ")" must be on separates line if any of the arguments are (otherwise on the same)
             val putArgumentsOnSeparateLines =
-                node.textContainsIgnoringLambda('\n') ||
+                node.children().any { it.isWhiteSpaceWithNewline() } ||
                     // max_line_length exceeded
                     maxLineLength > -1 && (node.column - 1 + node.textLength) > maxLineLength
             if (putArgumentsOnSeparateLines) {
@@ -180,13 +180,6 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
             ElementType.RPAR -> """Missing newline before ")""""
             else -> throw UnsupportedOperationException()
         }
-
-    private fun ASTNode.textContainsIgnoringLambda(char: Char): Boolean {
-        return children()
-            .flatMap { if (it.elementType == ElementType.VALUE_ARGUMENT) it.children() else sequenceOf(it) }
-            .filter { it.elementType != ElementType.LAMBDA_EXPRESSION }
-            .any { it.textContains(char) }
-    }
 
     private fun ASTNode.hasTypeParameterListInFront(): Boolean =
         treeParent.children()

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -136,6 +136,37 @@ class ArgumentListWrappingRuleTest {
     }
 
     @Test
+    fun testLambdaArgumentsAreIgnored2() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                fun main() {
+                    foo(bar.apply {
+                        // stuff
+                    })
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLambdaArgumentsAreIgnored3() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                fun main() {
+                    println(Runnable {
+                        println("hello")
+                        println("world")
+                    })
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
     fun testFormatWithLambdaArguments() {
         assertThat(
             ArgumentListWrappingRule().format(
@@ -254,9 +285,9 @@ class ArgumentListWrappingRuleTest {
     }
 
     @Test
-    fun testFormatPreservesIndentWithAnnotationsOnMultiLine() {
+    fun testLintPreservesIndentWithAnnotationsOnMultiLine() {
         assertThat(
-            ArgumentListWrappingRule().format(
+            ArgumentListWrappingRule().lint(
                 """
                 class A {
                     fun f(@Annotation
@@ -275,26 +306,6 @@ class ArgumentListWrappingRuleTest {
                 }
                 """.trimIndent()
             )
-        ).isEqualTo(
-            """
-            class A {
-                fun f(@Annotation
-                    a: Any,
-                    @Annotation(
-                        [
-                            "v1",
-                            "v2"
-                        ]
-                    )
-                    b: Any,
-                    c: Any =
-                        false,
-                    @Annotation d: Any,
-                    @SingleLineAnnotation([1, 2])
-                    e: Any) {
-                }
-            }
-            """.trimIndent()
-        )
+        ).isEmpty()
     }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -285,9 +285,9 @@ class ArgumentListWrappingRuleTest {
     }
 
     @Test
-    fun testLintPreservesIndentWithAnnotationsOnMultiLine() {
+    fun testFormatPreservesIndentWithAnnotationsOnMultiLine() {
         assertThat(
-            ArgumentListWrappingRule().lint(
+            ArgumentListWrappingRule().format(
                 """
                 class A {
                     fun f(@Annotation
@@ -306,6 +306,26 @@ class ArgumentListWrappingRuleTest {
                 }
                 """.trimIndent()
             )
-        ).isEmpty()
+        ).isEqualTo(
+            """
+            class A {
+                fun f(@Annotation
+                    a: Any,
+                    @Annotation(
+                        [
+                            "v1",
+                            "v2"
+                        ]
+                    )
+                    b: Any,
+                    c: Any =
+                        false,
+                    @Annotation d: Any,
+                    @SingleLineAnnotation([1, 2])
+                    e: Any) {
+                }
+            }
+            """.trimIndent()
+        )
     }
 }


### PR DESCRIPTION
Fixes #861
Fixes #870