### PR TITLE
ArgumentListWrappingRule: fix wrong indentation in `if` condition

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -20,7 +20,9 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtContainerNode
+import org.jetbrains.kotlin.psi.KtDoWhileExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtWhileExpression
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
@@ -214,7 +216,10 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
 
     private fun ASTNode.isOnSameLineAsIfKeyword(): Boolean {
         val containerNode = psi.getStrictParentOfType<KtContainerNode>() ?: return false
-        val ifExpression = containerNode.parent as? KtIfExpression ?: return false
-        return ifExpression.node.lineNumber() == lineNumber()
+        return when (val parent = containerNode.parent) {
+            is KtIfExpression, is KtWhileExpression -> parent.node
+            is KtDoWhileExpression -> parent.whileKeyword?.node
+            else -> null
+        }?.lineNumber() == lineNumber()
     }
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
+import com.pinterest.ktlint.core.ast.lineNumber
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.visit
 import kotlin.math.max
@@ -18,6 +19,9 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.psi.KtContainerNode
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * https://kotlinlang.org/docs/reference/coding-conventions.html#method-call-formatting
@@ -86,7 +90,8 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
                 // <line indent + indentSize> VALUE_ARGUMENT...
                 // <line indent> RPAR
                 val lineIndent = node.lineIndent()
-                val indent = "\n" + lineIndent.substring(0, (lineIndent.length - adjustedIndent).coerceAtLeast(0))
+                val indent = ("\n" + lineIndent.substring(0, (lineIndent.length - adjustedIndent).coerceAtLeast(0)))
+                    .let { if (node.isOnSameLineAsIfKeyword()) it + " ".repeat(indentSize) else it }
                 val paramIndent = indent + " ".repeat(indentSize)
                 nextChild@ for (child in node.children()) {
                     when (child.elementType) {
@@ -205,5 +210,11 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
             prev = prev.prevLeaf()
         }
         return null
+    }
+
+    private fun ASTNode.isOnSameLineAsIfKeyword(): Boolean {
+        val containerNode = psi.getStrictParentOfType<KtContainerNode>() ?: return false
+        val ifExpression = containerNode.parent as? KtIfExpression ?: return false
+        return ifExpression.node.lineNumber() == lineNumber()
     }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -314,4 +314,52 @@ class ArgumentListWrappingRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun testLintInIfCondition() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                 fun test(param1: Int, param2: Int) {
+                     if (listOfNotNull(
+                             param1
+                         ).isEmpty()
+                     ) {
+                         println(1)
+                     } else if (listOfNotNull(
+                             param2
+                         ).isEmpty()
+                     ) {
+                         println(2)
+                     }
+                 }
+                 """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintInIfCondition2() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                 fun test(param1: Int, param2: Int) {
+                     if (
+                         listOfNotNull(
+                             param1
+                         ).isEmpty()
+                     ) {
+                         println(1)
+                     } else if (
+                         listOfNotNull(
+                             param2
+                         ).isEmpty()
+                     ) {
+                         println(2)
+                     }
+                 }
+                 """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -320,20 +320,20 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().lint(
                 """
-                 fun test(param1: Int, param2: Int) {
-                     if (listOfNotNull(
-                             param1
-                         ).isEmpty()
-                     ) {
-                         println(1)
-                     } else if (listOfNotNull(
-                             param2
-                         ).isEmpty()
-                     ) {
-                         println(2)
-                     }
-                 }
-                 """.trimIndent()
+                fun test(param1: Int, param2: Int) {
+                    if (listOfNotNull(
+                            param1
+                        ).isEmpty()
+                    ) {
+                        println(1)
+                    } else if (listOfNotNull(
+                            param2
+                        ).isEmpty()
+                    ) {
+                        println(2)
+                    }
+                }
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -343,22 +343,82 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().lint(
                 """
-                 fun test(param1: Int, param2: Int) {
-                     if (
-                         listOfNotNull(
-                             param1
-                         ).isEmpty()
-                     ) {
-                         println(1)
-                     } else if (
-                         listOfNotNull(
-                             param2
-                         ).isEmpty()
-                     ) {
-                         println(2)
-                     }
-                 }
-                 """.trimIndent()
+                fun test(param1: Int, param2: Int) {
+                    if (
+                        listOfNotNull(
+                            param1
+                        ).isEmpty()
+                    ) {
+                        println(1)
+                    } else if (
+                        listOfNotNull(
+                            param2
+                        ).isEmpty()
+                    ) {
+                        println(2)
+                    }
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintInWhenCondition() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                fun foo(i: Int) = true
+
+                fun test(i: Int) {
+                    when (foo(
+                        i
+                    )) {
+                        true -> println(1)
+                        false -> println(2)
+                    }
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintInWhileCondition() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                fun foo(i: Int) = true
+
+                fun test(i: Int) {
+                    while (foo(
+                            i
+                        )
+                    ) {
+                        println()
+                    }
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintInDoWhileCondition() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                fun foo(i: Int) = true
+
+                fun test(i: Int) {
+                    do {
+                        println()
+                    } while (foo(
+                            i
+                        )
+                    )
+                }
+                """.trimIndent()
             )
         ).isEmpty()
     }


### PR DESCRIPTION
Fixes #864
Fixes #854