### PR TITLE
Allow to have different default value for android code style.

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -172,12 +172,14 @@ public object KtLint {
             .replaceFirst(UTF8_BOM, "")
     }
 
+    private val Map<String, String>.isAndroidCodeStyle get() = get("android")?.toBoolean() ?: false
+
     private fun injectUserData(
         node: ASTNode,
         editorConfigProperties: EditorConfigProperties,
         userData: Map<String, String>
     ) {
-        val android = userData["android"]?.toBoolean() ?: false
+        val android = userData.isAndroidCodeStyle
         val editorConfigMap =
             if (android &&
                 userData["max_line_length"].let { it?.toLowerCase() != "off" && it?.toIntOrNull() == null }
@@ -389,6 +391,7 @@ public object KtLint {
         return editorConfigGenerator.generateEditorconfig(
             filePath,
             params.rules,
+            params.userData.isAndroidCodeStyle,
             params.debug
         )
     }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -30,8 +30,13 @@ public interface UsesEditorConfigProperties {
     /**
      * Get the value of [EditorConfigProperty] based on loaded [EditorConfigProperties] content.
      */
-    public fun <T> EditorConfigProperties.getEditorConfigValue(property: EditorConfigProperty<T>): T {
-        return get(property.type.name)?.getValueAs() ?: property.defaultValue
+    public fun <T> EditorConfigProperties.getEditorConfigValue(
+        property: EditorConfigProperty<T>,
+        isAndroidCodeStyle: Boolean = false
+    ): T {
+        return get(property.type.name)
+            ?.getValueAs()
+            ?: if (isAndroidCodeStyle) property.defaultAndroidValue else property.defaultValue
     }
 
     /**
@@ -39,10 +44,13 @@ public interface UsesEditorConfigProperties {
      *
      * @param type type of property. Could be one of default ones (see [PropertyType.STANDARD_TYPES]) or custom one.
      * @param defaultValue default value for property if it does not exist in loaded properties.
+     * @param defaultAndroidValue default value for android codestyle. You should set different value only when it
+     * differs from [defaultValue].
      */
     public data class EditorConfigProperty<T>(
         public val type: PropertyType<T>,
-        public val defaultValue: T
+        public val defaultValue: T,
+        public val defaultAndroidValue: T = defaultValue
     )
 }
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGenerator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGenerator.kt
@@ -29,6 +29,7 @@ internal class EditorConfigGenerator(
     fun generateEditorconfig(
         filePath: Path,
         rules: Set<Rule>,
+        isAndroidCodeStyle: Boolean = false,
         debug: Boolean = false
     ): String {
         val editorConfig: Map<String, Property> = editorConfigLoader.loadPropertiesForFile(
@@ -43,7 +44,12 @@ internal class EditorConfigGenerator(
                     if (debug) println("Checking properties for '${rule.id}' rule")
                     rule.editorConfigProperties.forEach { prop ->
                         if (debug) println("Setting '${prop.type.name}' property value")
-                        acc[prop.type.name] = with(rule) { editorConfig.getEditorConfigValue(prop).toString() }
+                        acc[prop.type.name] = with(rule) {
+                            editorConfig.getEditorConfigValue(
+                                prop,
+                                isAndroidCodeStyle
+                            ).toString()
+                        }
                     }
                 }
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -44,6 +44,20 @@ internal class EditorConfigGeneratorTest {
     }
 
     @Test
+    fun `Should use default Android code style value if value is missing and android code style is active`() {
+        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
+            filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
+            rules = rules,
+            isAndroidCodeStyle = true
+        )
+
+        assertThat(generatedEditorConfig.lines()).contains(
+            "${TestRule.PROP_1_NUM} = ${TestRule.PROP_1_DEFAULT_ANDROID}",
+            "${TestRule.PROP_2_BOOL} = ${TestRule.PROP_2_DEFAULT_ANDROID}"
+        )
+    }
+
+    @Test
     fun `Should not modify existing editorconfig property`() {
         tempFileSystem.writeEditorConfigFile(
             rootDir,
@@ -115,7 +129,8 @@ internal class EditorConfigGeneratorTest {
                     PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
                     setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
                 ),
-                defaultValue = PROP_1_DEFAULT
+                defaultValue = PROP_1_DEFAULT,
+                defaultAndroidValue = PROP_1_DEFAULT_ANDROID
             ),
             UsesEditorConfigProperties.EditorConfigProperty(
                 type = PropertyType(
@@ -124,7 +139,8 @@ internal class EditorConfigGeneratorTest {
                     PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
                     setOf("true", "false")
                 ),
-                defaultValue = PROP_2_DEFAULT
+                defaultValue = PROP_2_DEFAULT,
+                defaultAndroidValue = PROP_2_DEFAULT_ANDROID
             )
         )
 
@@ -139,8 +155,10 @@ internal class EditorConfigGeneratorTest {
         companion object {
             const val PROP_1_NUM = "kotlin_test_if_else_num"
             const val PROP_1_DEFAULT = 10
+            const val PROP_1_DEFAULT_ANDROID = 11
             const val PROP_2_BOOL = "insert_final_newline"
             const val PROP_2_DEFAULT = true
+            const val PROP_2_DEFAULT_ANDROID = false
         }
     }
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -35,6 +35,9 @@ class GenerateEditorConfigSubCommand : Runnable {
                         ktlintCommand.debug
                     )
                     .map { it.value.get() },
+                userData = mapOf(
+                    "android" to ktlintCommand.android.toString()
+                ),
                 debug = ktlintCommand.debug,
                 cb = { _, _ -> Unit }
             )


### PR DESCRIPTION
Allow on '.editorconfig' file generation to use different default values for android code style.

Part of #701 