### PR TITLE
Add editorconfig value generation support to 'import-ordering' rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Initial implementation IDE integration via '.editorconfig' based on rules default values ([#701](https://github.com/pinterest/ktlint/issues/701))
-- CLI subcommand `generateEditorConfig` to generate '.editorconfig' content for Kotlin files ([#701](https://github.com/pinterest/ktlint/issues/701))
+- CLI subcommand `generateEditorConfig` to generate '.editorconfig' content for Kotlin files ([#701](https://github.com/pinterest/ktlint/issues/701)) 
 
 ### Fixed
 - Do not report when semicolon is before annotation/comment/kdoc and lambda ([#825](https://github.com/pinterest/ktlint/issues/825))
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix wrong indentation inside an if-condition in `argument-list-wrapping` ([#854](https://github.com/pinterest/ktlint/issues/854)) ([#864](https://github.com/pinterest/ktlint/issues/864))
 
 ### Changed
-- ?
+- 'import-ordering' now supports `.editorconfig' default value generation ([#701](https://github.com/pinterest/ktlint/issues/701))
 
 ### Removed
 - ?

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
@@ -8,9 +8,9 @@ import org.jetbrains.kotlin.resolve.ImportPath
  *
  * Adopted from https://github.com/JetBrains/kotlin/blob/a270ee094c4d7b9520e0898a242bb6ce4dfcad7b/idea/src/org/jetbrains/kotlin/idea/util/ImportPathComparator.kt#L15
  */
-internal class ImportSorter(importsLayout: String) : Comparator<KtImportDirective> {
-
-    val patterns: List<PatternEntry> = parseImportsLayout(importsLayout)
+internal class ImportSorter(
+    val patterns: List<PatternEntry>
+) : Comparator<KtImportDirective> {
 
     override fun compare(import1: KtImportDirective, import2: KtImportDirective): Int {
         val importPath1 = import1.importPath!!

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
@@ -1,17 +1,19 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
+import com.pinterest.ktlint.test.EditorConfigTestRule
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 
+@OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleAsciiTest {
 
     companion object {
-        private val userData = mapOf("kotlin_imports_layout" to "ascii")
-
         private fun expectedErrors(additionalMessage: String = "") = listOf(
             LintError(
                 1,
@@ -21,6 +23,11 @@ class ImportOrderingRuleAsciiTest {
             )
         )
     }
+
+    @get:Rule
+    val editorConfigTestRule = EditorConfigTestRule()
+
+    private val rule = ImportOrderingRule()
 
     @Test
     fun testFormat() {
@@ -38,8 +45,14 @@ class ImportOrderingRuleAsciiTest {
             import b.C
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -53,8 +66,14 @@ class ImportOrderingRuleAsciiTest {
             import kotlin.concurrent.Thread
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, userData)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -77,8 +96,14 @@ class ImportOrderingRuleAsciiTest {
             import kotlin.concurrent.Thread
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -96,8 +121,14 @@ class ImportOrderingRuleAsciiTest {
             import android.view.ViewGroup
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -124,8 +155,14 @@ class ImportOrderingRuleAsciiTest {
             import kotlin.concurrent.Thread
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -151,8 +188,14 @@ class ImportOrderingRuleAsciiTest {
             import kotlin.concurrent.Thread
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -171,8 +214,14 @@ class ImportOrderingRuleAsciiTest {
             import android.view.ViewGroup
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -185,8 +234,14 @@ class ImportOrderingRuleAsciiTest {
             import android.view.ViewGroup
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors(" -- no autocorrection due to comments in the import list"))
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(imports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors(" -- no autocorrection due to comments in the import list"))
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(imports)
     }
 
     @Test
@@ -199,8 +254,14 @@ class ImportOrderingRuleAsciiTest {
             import android.view.ViewGroup
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors(" -- no autocorrection due to comments in the import list"))
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(imports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors(" -- no autocorrection due to comments in the import list"))
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(imports)
     }
 
     @Test
@@ -223,7 +284,21 @@ class ImportOrderingRuleAsciiTest {
             import kotlin.concurrent.Thread
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors())
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeAsciiImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors())
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
+
+    private fun writeAsciiImportsOrderingConfig() = editorConfigTestRule
+        .writeToEditorConfig(
+            mapOf(
+                ImportOrderingRule.ideaImportsLayoutProperty.type to "ascii"
+            )
+        )
+        .absolutePath
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
@@ -1,12 +1,16 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
+import com.pinterest.ktlint.test.EditorConfigTestRule
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 
+@OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleCustomTest {
 
     companion object {
@@ -20,10 +24,13 @@ class ImportOrderingRuleCustomTest {
         )
     }
 
+    @get:Rule
+    val editorConfigTestRule = EditorConfigTestRule()
+
+    private val rule = ImportOrderingRule()
+
     @Test
     fun `empty line between imports and aliases - ok`() {
-        val emptyLineBeforeAliasPattern = mapOf("kotlin_imports_layout" to "*,|,^*")
-
         val formattedImports =
             """
             import android.app.Activity
@@ -36,14 +43,18 @@ class ImportOrderingRuleCustomTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, emptyLineBeforeAliasPattern)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, emptyLineBeforeAliasPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `empty line between imports and aliases - no empty line`() {
-        val emptyLineBeforeAliasPattern = mapOf("kotlin_imports_layout" to "*,|,^*")
-
         val imports =
             """
             import android.app.Activity
@@ -67,14 +78,18 @@ class ImportOrderingRuleCustomTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, emptyLineBeforeAliasPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, emptyLineBeforeAliasPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `empty line between imports and aliases - wrong order`() {
-        val emptyLineBeforeAliasPattern = mapOf("kotlin_imports_layout" to "*,|,^*")
-
         val imports =
             """
             import android.app.Activity
@@ -101,14 +116,18 @@ class ImportOrderingRuleCustomTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, emptyLineBeforeAliasPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, emptyLineBeforeAliasPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `default idea java pattern - ok`() {
-        val defaultIdeaJavaPattern = mapOf("kotlin_imports_layout" to "android.*,|,org.junit.*,|,net.*,|,org.*,|,java.*,|,com.*,|,javax.*,|,*")
-
         val formattedImports =
             """
             import android.app.Activity
@@ -126,13 +145,20 @@ class ImportOrderingRuleCustomTest {
             import kotlin.io.Closeable
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, defaultIdeaJavaPattern)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, defaultIdeaJavaPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "android.*,|,org.junit.*,|,net.*,|,org.*,|,java.*,|,com.*,|,javax.*,|,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `default idea java pattern - wrong order`() {
-        val defaultIdeaJavaPattern = mapOf("kotlin_imports_layout" to "android.*,|,org.junit.*,|,net.*,|,org.*,|,java.*,|,com.*,|,javax.*,|,*")
 
         val imports =
             """
@@ -168,13 +194,20 @@ class ImportOrderingRuleCustomTest {
             import kotlin.io.Closeable
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, defaultIdeaJavaPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, defaultIdeaJavaPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "android.*,|,org.junit.*,|,net.*,|,org.*,|,java.*,|,com.*,|,javax.*,|,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `multiple empty lines - ignored`() {
-        val multipleEmptyLinesPattern = mapOf("kotlin_imports_layout" to "java.*,|,|,|,kotlin.*,*")
 
         val formattedImports =
             """
@@ -186,13 +219,20 @@ class ImportOrderingRuleCustomTest {
             import android.view.View
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, multipleEmptyLinesPattern)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, multipleEmptyLinesPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "java.*,|,|,|,kotlin.*,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `multiple empty lines - transformed into one`() {
-        val multipleEmptyLinesPattern = mapOf("kotlin_imports_layout" to "java.*,|,|,|,kotlin.*,*")
 
         val imports =
             """
@@ -216,13 +256,20 @@ class ImportOrderingRuleCustomTest {
             import android.view.View
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, multipleEmptyLinesPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, multipleEmptyLinesPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "java.*,|,|,|,kotlin.*,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `alias pattern - ok`() {
-        val aliasPattern = mapOf("kotlin_imports_layout" to "^kotlin.*,^android.*,android.*,|,*,^*")
 
         val formattedImports =
             """
@@ -234,13 +281,20 @@ class ImportOrderingRuleCustomTest {
             import java.util.List as L
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, aliasPattern)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, aliasPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "^kotlin.*,^android.*,android.*,|,*,^*"
+        )
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `alias pattern - wrong order`() {
-        val aliasPattern = mapOf("kotlin_imports_layout" to "^kotlin.*,^android.*,android.*,|,*,^*")
 
         val imports =
             """
@@ -261,13 +315,20 @@ class ImportOrderingRuleCustomTest {
             import java.util.List as L
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, aliasPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, aliasPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "^kotlin.*,^android.*,android.*,|,*,^*"
+        )
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `full path pattern - ok`() {
-        val fullPathPattern = mapOf("kotlin_imports_layout" to "kotlin.io.Closeable,kotlin.*,*")
 
         val formattedImports =
             """
@@ -278,13 +339,20 @@ class ImportOrderingRuleCustomTest {
             import java.util.List
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, fullPathPattern)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, fullPathPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "kotlin.io.Closeable,kotlin.*,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
     fun `full path pattern - wrong order`() {
-        val fullPathPattern = mapOf("kotlin_imports_layout" to "kotlin.io.Closeable,kotlin.*,*")
 
         val imports =
             """
@@ -305,7 +373,25 @@ class ImportOrderingRuleCustomTest {
             import java.util.List
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, fullPathPattern)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, fullPathPattern)).isEqualTo(formattedImports)
+        val testFile = writeCustomImportsOrderingConfig(
+            "kotlin.io.Closeable,kotlin.*,*"
+        )
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
+
+    private fun writeCustomImportsOrderingConfig(
+        importsLayout: String
+    ) = editorConfigTestRule
+        .writeToEditorConfig(
+            mapOf(
+                ImportOrderingRule.ideaImportsLayoutProperty.type to importsLayout
+            )
+        )
+        .absolutePath
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
@@ -1,17 +1,19 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
+import com.pinterest.ktlint.test.EditorConfigTestRule
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 
+@OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleIdeaTest {
 
     companion object {
-        private val userData = mapOf("kotlin_imports_layout" to "idea")
-
         private val expectedErrors = listOf(
             LintError(
                 1,
@@ -21,6 +23,11 @@ class ImportOrderingRuleIdeaTest {
             )
         )
     }
+
+    @get:Rule
+    val editorConfigTestRule = EditorConfigTestRule()
+
+    private val rule = ImportOrderingRule()
 
     @Test
     fun testFormat() {
@@ -38,8 +45,14 @@ class ImportOrderingRuleIdeaTest {
             import b.C
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -59,8 +72,14 @@ class ImportOrderingRuleIdeaTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, userData)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -95,8 +114,14 @@ class ImportOrderingRuleIdeaTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -117,8 +142,14 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx1
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -160,8 +191,14 @@ class ImportOrderingRuleIdeaTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -202,8 +239,14 @@ class ImportOrderingRuleIdeaTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -238,8 +281,14 @@ class ImportOrderingRuleIdeaTest {
             import androidx.fragment.app.Fragment as F // comment 3
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(imports, userData)).isEqualTo(expectedErrors)
-        assertThat(ImportOrderingRule().format(imports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -273,8 +322,14 @@ class ImportOrderingRuleIdeaTest {
             import kotlin.reflect.KClass
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, userData)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
 
     @Test
@@ -285,7 +340,21 @@ class ImportOrderingRuleIdeaTest {
             import android.view.ViewGroup.LayoutParams.WRAP_CONTENT as WRAP
             """.trimIndent()
 
-        assertThat(ImportOrderingRule().lint(formattedImports, userData)).isEmpty()
-        assertThat(ImportOrderingRule().format(formattedImports, userData)).isEqualTo(formattedImports)
+        val testFile = writeIdeaImportsOrderingConfig()
+
+        assertThat(
+            rule.lint(testFile, formattedImports)
+        ).isEmpty()
+        assertThat(
+            rule.format(testFile, formattedImports)
+        ).isEqualTo(formattedImports)
     }
+
+    private fun writeIdeaImportsOrderingConfig() = editorConfigTestRule
+        .writeToEditorConfig(
+            mapOf(
+                ImportOrderingRule.ideaImportsLayoutProperty.type to "idea"
+            )
+        )
+        .absolutePath
 }


### PR DESCRIPTION
Part of #701 