### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,6 @@ $ ktlint installGitPreCommitHook
                 <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true"
                     classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
                     <arg value="src/**/*.kt"/>
-                    <!-- to generate report in checkstyle format prepend following args: -->
-                    <!-- 
-                    <arg value="--reporter=plain"/>
-                    <arg value="--reporter=checkstyle,output=${project.build.directory}/ktlint.xml"/>
-                    -->
                     <!-- see https://github.com/pinterest/ktlint#usage for more -->                    
                 </java>
             </target>


### PR DESCRIPTION
When pasting this to `pom.xml` it corrupts it. Because, it's not allowed to have `--` inside of comments.
You can paste it, for example, here: https://www.xmlvalidation.com/ to check.

After pasting the suggested snippet Maven stops working, I don't see another way to cure it, let's just remove it then.