### PR TITLE
ParameterListWrappingRule: correctly indent primary constructor parameters when class has multiline type parameter

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
+import com.pinterest.ktlint.core.ast.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
@@ -15,6 +16,7 @@ import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
 import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.ast.prevSibling
 import com.pinterest.ktlint.core.ast.visit
 import kotlin.math.max
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -161,9 +163,13 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
             else -> throw UnsupportedOperationException()
         }
 
-    private fun ASTNode.hasTypeParameterListInFront(): Boolean =
-        treeParent.children()
-            .firstOrNull { it.elementType == TYPE_PARAMETER_LIST }
-            ?.children()
-            ?.any { it.isWhiteSpaceWithNewline() } == true
+    private fun ASTNode.hasTypeParameterListInFront(): Boolean {
+        val parent = this.treeParent
+        val typeParameterList = if (parent.elementType == PRIMARY_CONSTRUCTOR) {
+            parent.prevSibling { it.elementType == TYPE_PARAMETER_LIST }
+        } else {
+            parent.children().firstOrNull { it.elementType == TYPE_PARAMETER_LIST }
+        } ?: return false
+        return typeParameterList.children().any { it.isWhiteSpaceWithNewline() }
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -577,8 +577,6 @@ class ParameterListWrappingRuleTest {
                     private val tracked: Boolean,
                     private val sourceInformation: String?
                 )
-                // https://github.com/pinterest/ktlint/issues/938
-
                 """.trimIndent()
             )
         ).isEmpty()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -563,4 +563,24 @@ class ParameterListWrappingRuleTest {
         assertThat(ParameterListWrappingRule().lint(code)).isEmpty()
         assertThat(ParameterListWrappingRule().format(code)).isEqualTo(code)
     }
+
+    // https://github.com/pinterest/ktlint/issues/921
+    @Test
+    fun `correctly indent primary constructor parameters when class has multiline type parameter`() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ComposableLambda<
+                    P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16,
+                    P17, P18, R>(
+                    val key: Int,
+                    private val tracked: Boolean,
+                    private val sourceInformation: String?
+                )
+                // https://github.com/pinterest/ktlint/issues/938
+
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes #921