### PR TITLE
Empty space after package name

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
@@ -65,7 +65,6 @@ class NoConsecutiveBlankLinesRuleTest {
         )
     }
 
-
     @Test
     fun testLintAfterPackageName() {
         assertThat(
@@ -79,7 +78,7 @@ class NoConsecutiveBlankLinesRuleTest {
             )
         ).isEmpty()
     }
-    
+
     @Test
     fun testLintInString() {
         assertThat(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
@@ -65,6 +65,21 @@ class NoConsecutiveBlankLinesRuleTest {
         )
     }
 
+
+    @Test
+    fun testLintAfterPackageName() {
+        assertThat(
+            NoConsecutiveBlankLinesRule().lint(
+                """
+                package com.test
+                
+                fun main() {
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+    
     @Test
     fun testLintInString() {
         assertThat(


### PR DESCRIPTION
We are getting reports of `no-consecutive-blank-lines` just because we have an empty line after package declaration. According to the code style guidelines, there should be 1 space after package name. 

I'm opening this PR just to have the conversation with ktlin team + verify this behavior with tests.