### PR TITLE
Adding new option disable-standard-rules

### DIFF
--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -149,8 +149,10 @@ class KtlintCommandLine {
 
     @Option(
         names = ["--disabled_rules"],
-        description = ["Comma-separated list of rules to globally disable." +
-            " To disable standard ktlint rule-set use --disabled_rules=standard"]
+        description = [
+            "Comma-separated list of rules to globally disable." +
+            " To disable standard ktlint rule-set use --disabled_rules=standard"
+        ]
     )
     var disabledRules: String = ""
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -148,6 +148,12 @@ class KtlintCommandLine {
     var debug: Boolean = false
 
     @Option(
+        names = ["--disable-standard-rules"],
+        description = ["Turn off standard set of rules (default: false). Useful for custom rulesets."]
+    )
+    var isStandardRuleSetDisabled: Boolean = false
+
+    @Option(
         names = ["--disabled_rules"],
         description = ["Comma-separated list of rules to globally disable"]
     )
@@ -234,7 +240,7 @@ class KtlintCommandLine {
         val start = System.currentTimeMillis()
 
         val baselineResults = loadBaseline(baseline)
-        val ruleSetProviders = rulesets.loadRulesets(experimental, debug)
+        val ruleSetProviders = rulesets.loadRulesets(experimental, debug, isStandardRuleSetDisabled)
         var reporter = loadReporter()
         if (baselineResults.baselineGenerationNeeded) {
             val baselineReporter = ReporterTemplate("baseline", null, emptyMap(), baseline)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -151,7 +151,7 @@ class KtlintCommandLine {
         names = ["--disabled_rules"],
         description = [
             "Comma-separated list of rules to globally disable." +
-            " To disable standard ktlint rule-set use --disabled_rules=standard"
+                " To disable standard ktlint rule-set use --disabled_rules=standard"
         ]
     )
     var disabledRules: String = ""

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -148,14 +148,9 @@ class KtlintCommandLine {
     var debug: Boolean = false
 
     @Option(
-        names = ["--disable-standard-rules"],
-        description = ["Turn off standard set of rules (default: false). Useful for custom rulesets."]
-    )
-    var isStandardRuleSetDisabled: Boolean = false
-
-    @Option(
         names = ["--disabled_rules"],
-        description = ["Comma-separated list of rules to globally disable"]
+        description = ["Comma-separated list of rules to globally disable." +
+            " To disable standard ktlint rule-set use --disabled_rules=standard"]
     )
     var disabledRules: String = ""
 
@@ -240,7 +235,7 @@ class KtlintCommandLine {
         val start = System.currentTimeMillis()
 
         val baselineResults = loadBaseline(baseline)
-        val ruleSetProviders = rulesets.loadRulesets(experimental, debug, isStandardRuleSetDisabled)
+        val ruleSetProviders = rulesets.loadRulesets(experimental, debug, disabledRules)
         var reporter = loadReporter()
         if (baselineResults.baselineGenerationNeeded) {
             val baselineReporter = ReporterTemplate("baseline", null, emptyMap(), baseline)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -32,7 +32,8 @@ class GenerateEditorConfigSubCommand : Runnable {
                 ruleSets = ktlintCommand.rulesets
                     .loadRulesets(
                         ktlintCommand.experimental,
-                        ktlintCommand.debug
+                        ktlintCommand.debug,
+                        ktlintCommand.isStandardRuleSetDisabled
                     )
                     .map { it.value.get() },
                 userData = mapOf(

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -33,7 +33,7 @@ class GenerateEditorConfigSubCommand : Runnable {
                     .loadRulesets(
                         ktlintCommand.experimental,
                         ktlintCommand.debug,
-                        ktlintCommand.isStandardRuleSetDisabled
+                        ktlintCommand.disabledRules
                     )
                     .map { it.value.get() },
                 userData = mapOf(

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -11,7 +11,8 @@ import java.util.ServiceLoader
  */
 internal fun JarFiles.loadRulesets(
     loadExperimental: Boolean,
-    debug: Boolean
+    debug: Boolean,
+    isStandardRuleSetDisabled: Boolean
 ) = ServiceLoader
     .load(
         RuleSetProvider::class.java,
@@ -23,6 +24,7 @@ internal fun JarFiles.loadRulesets(
         if (key == "standard") "\u0000$key" else key
     }
     .filterKeys { loadExperimental || it != "experimental" }
+    .filterKeys { !(isStandardRuleSetDisabled && it == "\u0000standard") }
     .toSortedMap()
     .also {
         if (debug) {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -34,6 +34,5 @@ internal fun JarFiles.loadRulesets(
         }
     }
 
-
-private fun String.isStandardRuleSetDisabled()  =
+private fun String.isStandardRuleSetDisabled() =
     this.split(",").map { it.trim() }.toSet().contains("standard")

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -12,7 +12,7 @@ import java.util.ServiceLoader
 internal fun JarFiles.loadRulesets(
     loadExperimental: Boolean,
     debug: Boolean,
-    isStandardRuleSetDisabled: Boolean
+    disabledRules: String
 ) = ServiceLoader
     .load(
         RuleSetProvider::class.java,
@@ -24,7 +24,7 @@ internal fun JarFiles.loadRulesets(
         if (key == "standard") "\u0000$key" else key
     }
     .filterKeys { loadExperimental || it != "experimental" }
-    .filterKeys { !(isStandardRuleSetDisabled && it == "\u0000standard") }
+    .filterKeys { !(disabledRules.isStandardRuleSetDisabled() && it == "\u0000standard") }
     .toSortedMap()
     .also {
         if (debug) {
@@ -33,3 +33,7 @@ internal fun JarFiles.loadRulesets(
             }
         }
     }
+
+
+private fun String.isStandardRuleSetDisabled()  =
+    this.split(",").map { it.trim() }.toSet().contains("standard")


### PR DESCRIPTION
### What's done:
Adding special option `disable-standard-rules` that is extremely useful and needed when `ktlint` is used as a framework for static analysis. In some cases when `custom ruleset` is used - there is no need to use `standard ruleset` as it can lead to conflicts.

In this case we need a mechanism to disable standard rules. This change will not break any API and the default behavior will remain the same.