### PR TITLE
IndentationRule: Fix incorrect indentation for multi-line call expressions in conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix ParseException when an assigment contains comments (`no-line-break-before-assignment`) ([#956](https://github.com/pinterest/ktlint/issues/956))
 - Fix false positive when right brace is after a try-catch block (`spacing-around-keyword`) ([#978](https://github.com/pinterest/ktlint/issues/978))
 - Fix false positive for control flow with empty body (`no-semicolons`) ([#955](https://github.com/pinterest/ktlint/issues/955))
+- Fix incorrect indentation for multi-line call expressions in conditions (`indent`) ([#959](https://github.com/pinterest/ktlint/issues/959))
 
 ### Changed
 - 'import-ordering' now supports `.editorconfig' default value generation ([#701](https://github.com/pinterest/ktlint/issues/701))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -634,7 +634,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             if (
                 nextSibling?.elementType.let {
                     it == BINARY_EXPRESSION || it == BINARY_WITH_TYPE
-                }
+                } && nextSibling.firstChildNode.elementType != CALL_EXPRESSION
             ) {
                 ctx.localAdj = -1
                 debug { "--inside(${nextSibling.elementType}) -> $expectedIndent" }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -762,4 +762,22 @@ internal class IndentationRuleTest {
             )
         ).isEmpty()
     }
+
+    // https://github.com/pinterest/ktlint/issues/959
+    @Test
+    fun `lint conditions with multi-line call expressions indented properly`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                fun test() {
+                    val result = true &&
+                        minOf(
+                            1, 2
+                        ) == 2
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }
+

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -780,4 +780,3 @@ internal class IndentationRuleTest {
         ).isEmpty()
     }
 }
-


### PR DESCRIPTION
Close #959 