### PR TITLE
SpacingAroundCommaRule: Add more cases 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix ParseException when an assigment contains comments (`no-line-break-before-assignment`) ([#956](https://github.com/pinterest/ktlint/issues/956))
 - Fix false positive when right brace is after a try-catch block (`spacing-around-keyword`) ([#978](https://github.com/pinterest/ktlint/issues/978))
 - Fix false positive for control flow with empty body (`no-semicolons`) ([#955](https://github.com/pinterest/ktlint/issues/955))
+- Fix false positive for trailing comma before right parentheses|bracket|angle (`spacing-around-comma`) ([#975](https://github.com/pinterest/ktlint/issues/975))
 
 ### Changed
 - 'import-ordering' now supports `.editorconfig' default value generation ([#701](https://github.com/pinterest/ktlint/issues/701))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -1,6 +1,8 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.GT
+import com.pinterest.ktlint.core.ast.ElementType.RBRACKET
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.isPartOfString
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
@@ -13,8 +15,11 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 
 class SpacingAroundCommaRule : Rule("comma-spacing") {
+
+    private val rTokenSet = TokenSet.create(RPAR, RBRACKET, GT)
 
     override fun visit(
         node: ASTNode,
@@ -43,7 +48,7 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
                 }
             }
             val nextLeaf = node.nextLeaf()
-            if (nextLeaf !is PsiWhiteSpace && nextLeaf?.elementType != RPAR) {
+            if (nextLeaf !is PsiWhiteSpace && nextLeaf?.elementType !in rTokenSet) {
                 emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)
                 if (autoCorrect) {
                     node.upsertWhitespaceAfterMe(" ")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
@@ -106,4 +106,30 @@ class SpacingAroundCommaRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun testCommaBeforeRightBracket() {
+        assertThat(
+            SpacingAroundCommaRule().lint(
+                """
+                @file:Suppress(["unused", "UNUSED_PARAMETER", "UNUSED_VARIABLE",])
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testCommaBeforeRightAngle() {
+        assertThat(
+            SpacingAroundCommaRule().lint(
+                """
+                fun <T, R,> test() = Unit
+
+                fun foo() {
+                    test<Int, Double,>()
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
A follow-up for #982 - figured out [here](https://kotlinlang.org/docs/reference/grammar.html) that there might be more cases, when trailing comma can have no spaces on the right (in particular before RBRACKET and GT), also added a changelog entry for #982.