### PR TITLE
ImportOrderingRule: update how alias pattern is represented

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ disabled_rules=no-wildcard-imports,experimental:annotation,my-custom-ruleset:my-
 # The custom layout can be composed by the following symbols:
 # "*" - wildcard. There must be at least one entry of a single wildcard to match all other imports. Matches anything after a specified symbol/import as well.
 # "|" - blank line. Supports only single blank lines between imports. No blank line is allowed in the beginning or end of the layout.
-# "^" - alias import, e.g. "^android.*" will match all android alias imports, "^*" will match all other alias imports.
+# "^" - alias import, e.g. "^android.*" will match all android alias imports, "^" will match all other alias imports.
 # import paths - these can be full paths, e.g. "java.util.List" as well as wildcard paths, e.g. "kotlin.*"
 # Examples:
 kotlin_imports_layout=ascii # alphabetical with capital letters before lower case letters (e.g. Z before a), no blank lines
 kotlin_imports_layout=idea # default IntelliJ IDEA style, same as "ascii", but with "java", "javax", "kotlin" and alias imports in the end of the imports list
-kotlin_imports_layout=android.*,|,^org.junit.*,kotlin.io.Closeable,|,*,^* # custom imports layout
+kotlin_imports_layout=android.*,|,^org.junit.*,kotlin.io.Closeable,|,*,^ # custom imports layout
 # Alternatively ij_kotlin_imports_layout name can be used, in order to set an imports layout for both ktlint and IDEA via a single property
 # Note: this is not yet implemented on IDEA side, so it only takes effect for ktlint
 ij_kotlin_imports_layout=*

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -26,11 +26,10 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *  * "*" - wildcard symbol, can be used as follows:
  *      1. Single, meaning matching any import (<all other imports> in IDEA)
  *      2. After an import path, e.g. "java.*" or "kotlin.io.*"
- *      3. In conjunction with "^" operator, meaning matching any alias import - "^*" (<all other alias imports> in IDEA)
  *  * "|" - blank line symbol. Only supported single blank lines between imports. Multiple blank lines will be ignored. Blank lines are not allowed outside of import list.
  *  * "^" - alias symbol, can be used as follows:
  *      1. In front of an import path, meaning matching all alias imports from this path, e.g. "^android.*"
- *      2. In conjunction with "*" operator, meaning matching any alias import - "^*" (<all other alias imports> in IDEA)
+ *      2. Alone, meaning matching any alias import - "^" (<all other alias imports> in IDEA)
  *  * import paths - these can be full paths, e.g. "java.util.List" as well as wildcard paths, e.g. "kotlin.*"
  *
  * In case the custom property is not provided, the rule defaults to "ascii" style in case of "android" flag supplied, or to "idea" otherwise.
@@ -65,7 +64,7 @@ public class ImportOrderingRule :
          *
          * https://github.com/JetBrains/kotlin/blob/ffdab473e28d0d872136b910eb2e0f4beea2e19c/idea/formatter/src/org/jetbrains/kotlin/idea/core/formatter/KotlinCodeStyleSettings.java#L87-L91
          */
-        private val IDEA_PATTERN = parseImportsLayout("*,java.*,javax.*,kotlin.*,^*")
+        private val IDEA_PATTERN = parseImportsLayout("*,java.*,javax.*,kotlin.*,^")
 
         private const val IDEA_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between " +
             "with \"java\", \"javax\", \"kotlin\" and aliases in the end"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportLayoutParser.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportLayoutParser.kt
@@ -2,7 +2,7 @@ package com.pinterest.ktlint.ruleset.standard.internal.importordering
 
 internal const val BLANK_LINE_CHAR = "|"
 internal const val WILDCARD_CHAR = "*"
-internal const val ALIAS_CHAR = "^" // TODO: replace with a proper char, once implemented on IDEA's side
+internal const val ALIAS_CHAR = "^"
 
 /**
  * Adopted from https://github.com/JetBrains/intellij-community/blob/70fd799e94246f2c0fe924763ed892765c0dff9a/java/java-impl/src/com/intellij/psi/codeStyle/JavaPackageEntryTableAccessor.java#L25
@@ -32,8 +32,10 @@ internal fun parseImportsLayout(importsLayout: String): List<PatternEntry> {
             if (import.endsWith(WILDCARD_CHAR)) {
                 withSubpackages = true
             }
-            return@map if (import == WILDCARD_CHAR) {
-                if (hasAlias) PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY else PatternEntry.ALL_OTHER_IMPORTS_ENTRY
+            return@map if (import == WILDCARD_CHAR) { // *
+                PatternEntry.ALL_OTHER_IMPORTS_ENTRY
+            } else if (import.isEmpty() && hasAlias) { // ^
+                PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY
             } else {
                 PatternEntry(import, withSubpackages, hasAlias)
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
@@ -28,7 +28,7 @@ class ImportLayoutParserTest {
             PatternEntry.ALL_OTHER_IMPORTS_ENTRY,
             PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY
         )
-        val actual = parseImportsLayout("android.*,|,org.junit.*,|,^android.*,*,^*")
+        val actual = parseImportsLayout("android.*,|,org.junit.*,|,^android.*,*,^")
 
         assertThat(actual).isEqualTo(expected)
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
@@ -33,17 +33,17 @@ class ImportOrderingRuleCustomTest {
     fun `empty line between imports and aliases - ok`() {
         val formattedImports =
             """
+            import android.content.Context as Ctx
+            import androidx.fragment.app.Fragment as F
+
             import android.app.Activity
             import android.view.View
             import android.view.ViewGroup
             import java.util.List
             import kotlin.concurrent.Thread
-
-            import android.content.Context as Ctx
-            import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+        val testFile = writeCustomImportsOrderingConfig("^,|,*")
 
         assertThat(
             rule.lint(testFile, formattedImports)
@@ -78,7 +78,7 @@ class ImportOrderingRuleCustomTest {
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+        val testFile = writeCustomImportsOrderingConfig("*,|,^")
 
         assertThat(
             rule.lint(testFile, imports)
@@ -106,17 +106,17 @@ class ImportOrderingRuleCustomTest {
 
         val formattedImports =
             """
+            import android.content.Context as Ctx
+            import androidx.fragment.app.Fragment as F
+
             import android.app.Activity
             import android.view.View
             import android.view.ViewGroup
             import java.util.List
             import kotlin.concurrent.Thread
-
-            import android.content.Context as Ctx
-            import androidx.fragment.app.Fragment as F
             """.trimIndent()
 
-        val testFile = writeCustomImportsOrderingConfig("*,|,^*")
+        val testFile = writeCustomImportsOrderingConfig("^,|,*")
 
         assertThat(
             rule.lint(testFile, imports)
@@ -282,7 +282,7 @@ class ImportOrderingRuleCustomTest {
             """.trimIndent()
 
         val testFile = writeCustomImportsOrderingConfig(
-            "^kotlin.*,^android.*,android.*,|,*,^*"
+            "^kotlin.*,^android.*,android.*,|,*,^"
         )
 
         assertThat(
@@ -311,12 +311,12 @@ class ImportOrderingRuleCustomTest {
             import android.view.View as V
             import android.app.Activity
 
-            import kotlin.concurrent.Thread
             import java.util.List as L
+            import kotlin.concurrent.Thread
             """.trimIndent()
 
         val testFile = writeCustomImportsOrderingConfig(
-            "^kotlin.*,^android.*,android.*,|,*,^*"
+            "^kotlin.*,^android.*,android.*,|,^,*"
         )
 
         assertThat(


### PR DESCRIPTION
Part of #753 - also updated documentation and tests that were no failing apparently, even when I changed the pattern 🤷 Now they are properly testing it :) 

Source of truth - https://github.com/JetBrains/intellij-kotlin/blob/master/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPackageEntryTableAccessor.kt