### PR TITLE
Fix snapshot publishing

### DIFF
--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -19,10 +19,6 @@ shadowJar {
   mergeServiceFiles()
 }
 
-publishing.publications.named("maven").configure {
-  artifact(shadowJar)
-}
-
 dependencies {
   implementation project(':ktlint-core')
   implementation project(':ktlint-reporter-baseline')


### PR DESCRIPTION
According to https://github.com/johnrengelman/shadow/issues/586 the fat jar is now automatically published, so we do not need to specify it explicitly (this was causing the issue of multiple artifacts with the same classifier). Tested locally with publishToMavenLocal task.