### PR TITLE
Fix import-ordering editorconifg generation

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -40,17 +40,31 @@ public interface UsesEditorConfigProperties {
     }
 
     /**
+     * Write the string representation of [EditorConfigProperty]
+     */
+    public fun <T> EditorConfigProperties.writeEditorConfigProperty(
+        property: EditorConfigProperty<T>,
+        isAndroidCodeStyle: Boolean
+    ): String {
+        return property.propertyWriter(getEditorConfigValue(property, isAndroidCodeStyle))
+    }
+
+    /**
      * Supported `.editorconfig` property.
      *
      * @param type type of property. Could be one of default ones (see [PropertyType.STANDARD_TYPES]) or custom one.
      * @param defaultValue default value for property if it does not exist in loaded properties.
      * @param defaultAndroidValue default value for android codestyle. You should set different value only when it
      * differs from [defaultValue].
+     * @param propertyWriter custom function that represents [T] as String. Defaults to the standard `toString()` call.
+     * You should override the default implementation in case you need a different behavior than the standard `toString()`
+     * (e.g. for collections joinToString() is more applicable).
      */
     public data class EditorConfigProperty<T>(
         public val type: PropertyType<T>,
         public val defaultValue: T,
-        public val defaultAndroidValue: T = defaultValue
+        public val defaultAndroidValue: T = defaultValue,
+        public val propertyWriter: (T) -> String = { it.toString() }
     )
 }
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGenerator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGenerator.kt
@@ -45,10 +45,10 @@ internal class EditorConfigGenerator(
                     rule.editorConfigProperties.forEach { prop ->
                         if (debug) println("Setting '${prop.type.name}' property value")
                         acc[prop.type.name] = with(rule) {
-                            editorConfig.getEditorConfigValue(
+                            editorConfig.writeEditorConfigProperty(
                                 prop,
                                 isAndroidCodeStyle
-                            ).toString()
+                            )
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -114,7 +114,8 @@ public class ImportOrderingRule :
                     editorConfigPropertyParser
                 ),
                 defaultValue = IDEA_PATTERN,
-                defaultAndroidValue = ASCII_PATTERN
+                defaultAndroidValue = ASCII_PATTERN,
+                propertyWriter = { it.joinToString(separator = ",") }
             )
 
         internal val ideaImportsLayoutProperty =
@@ -125,7 +126,8 @@ public class ImportOrderingRule :
                     editorConfigPropertyParser
                 ),
                 defaultValue = IDEA_PATTERN,
-                defaultAndroidValue = ASCII_PATTERN
+                defaultAndroidValue = ASCII_PATTERN,
+                propertyWriter = { it.joinToString(separator = ",") }
             )
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
@@ -8,9 +8,9 @@ import org.jetbrains.kotlin.resolve.ImportPath
  *
  * Adopted from https://github.com/JetBrains/kotlin/blob/a270ee094c4d7b9520e0898a242bb6ce4dfcad7b/idea/src/org/jetbrains/kotlin/idea/util/ImportPathComparator.kt#L15
  */
-internal class ImportSorter(
-    val patterns: List<PatternEntry>
-) : Comparator<KtImportDirective> {
+internal class ImportSorter(importsLayout: String) : Comparator<KtImportDirective> {
+
+    val patterns: List<PatternEntry> = parseImportsLayout(importsLayout)
 
     override fun compare(import1: KtImportDirective, import2: KtImportDirective): Int {
         val importPath1 = import1.importPath!!

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportSorter.kt
@@ -8,9 +8,9 @@ import org.jetbrains.kotlin.resolve.ImportPath
  *
  * Adopted from https://github.com/JetBrains/kotlin/blob/a270ee094c4d7b9520e0898a242bb6ce4dfcad7b/idea/src/org/jetbrains/kotlin/idea/util/ImportPathComparator.kt#L15
  */
-internal class ImportSorter(importsLayout: String) : Comparator<KtImportDirective> {
-
-    val patterns: List<PatternEntry> = parseImportsLayout(importsLayout)
+internal class ImportSorter(
+    val patterns: List<PatternEntry>
+) : Comparator<KtImportDirective> {
 
     override fun compare(import1: KtImportDirective, import2: KtImportDirective): Int {
         val importPath1 = import1.importPath!!

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/PatternEntry.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/PatternEntry.kt
@@ -42,7 +42,11 @@ internal class PatternEntry(
         return entry.packageName.count { it == '.' } < packageName.count { it == '.' }
     }
 
-    override fun toString(): String = packageName
+    override fun toString(): String = when (this) {
+        ALL_OTHER_IMPORTS_ENTRY -> WILDCARD_CHAR
+        ALL_OTHER_ALIAS_IMPORTS_ENTRY -> ALIAS_CHAR
+        else -> "$packageName.$WILDCARD_CHAR" + if (withSubpackages) WILDCARD_CHAR else ""
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -67,6 +71,6 @@ internal class PatternEntry(
     companion object {
         val BLANK_LINE_ENTRY = PatternEntry(BLANK_LINE_CHAR, withSubpackages = true, hasAlias = false)
         val ALL_OTHER_IMPORTS_ENTRY = PatternEntry(WILDCARD_CHAR, withSubpackages = true, hasAlias = false)
-        val ALL_OTHER_ALIAS_IMPORTS_ENTRY = PatternEntry((ALIAS_CHAR + WILDCARD_CHAR), withSubpackages = true, hasAlias = true)
+        val ALL_OTHER_ALIAS_IMPORTS_ENTRY = PatternEntry(ALIAS_CHAR, withSubpackages = true, hasAlias = true)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
@@ -1,0 +1,21 @@
+package com.pinterest.ktlint.ruleset.standard.importordering
+
+import com.pinterest.ktlint.core.api.EditorConfigProperties
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(FeatureInAlphaState::class)
+class ImportOrderingEditorconfigTest {
+
+    @Test
+    fun `import ordering gets written correctly to editorconfig`() {
+        val properties: EditorConfigProperties = emptyMap()
+        val rule = ImportOrderingRule()
+        with(rule) {
+            val raw = properties.getEditorConfigValue(ImportOrderingRule.ideaImportsLayoutProperty).toString()
+            assertThat(raw).isEqualTo("*,java.**,javax.**,kotlin.**,^")
+        }
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
@@ -14,7 +14,7 @@ class ImportOrderingEditorconfigTest {
         val properties: EditorConfigProperties = emptyMap()
         val rule = ImportOrderingRule()
         with(rule) {
-            val raw = properties.getEditorConfigValue(ImportOrderingRule.ideaImportsLayoutProperty).toString()
+            val raw = properties.writeEditorConfigProperty(ImportOrderingRule.ideaImportsLayoutProperty, false)
             assertThat(raw).isEqualTo("*,java.**,javax.**,kotlin.**,^")
         }
     }


### PR DESCRIPTION
@Tapchicoma not sure why you converted the properties to `List<PatternEntry>` but writing to editorconfig didn't work properly, because:

- PatternEntry's `toString` method was messed up
- By default `List<PatternEntry>.toString()` returns something like `[*,kotlin.**,java.**,^]` - mind the braces. This is an incorrect value if we wanna write to the standard `ij_kotlin_imports_layout`, to properly generate it we would need to use `joinToString` but we don't know the type in the `getEditorConfigValue`..

So the easiest path I found is to revert properties to be strings, but not sure if it's the best approach. Maybe we could introduce some interface like `EditorconfigWriteable` which has a `toString` method and put it as an upper bound for generic `EditorConfigProperty<T : EditorconfigWriteable>`