### PR TITLE
Always pass file path via user data properties.

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -29,6 +29,7 @@ public object KtLint {
     public val EDITOR_CONFIG_USER_DATA_KEY: Key<EditorConfig> = Key<EditorConfig>("EDITOR_CONFIG")
     public val ANDROID_USER_DATA_KEY: Key<Boolean> = Key<Boolean>("ANDROID")
     public val FILE_PATH_USER_DATA_KEY: Key<String> = Key<String>("FILE_PATH")
+    private const val FILE_PATH_PROPERTY = "file_path"
     public val EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY: Key<EditorConfigProperties> =
         Key<EditorConfigProperties>("EDITOR_CONFIG_PROPERTIES")
     public val DISABLED_RULES: Key<Set<String>> = Key<Set<String>>("DISABLED_RULES")
@@ -145,10 +146,15 @@ public object KtLint {
         )
 
         // Passed-in userData overrides .editorconfig
-        val mergedUserData = editorConfigProperties.convertToRawValues(
-            params.normalizedFilePath,
-            params.isStdIn
-        ) + params.userData
+        val mergedUserData = editorConfigProperties
+            .convertToRawValues() + params.userData
+            .run {
+                if (!params.isStdIn) {
+                    plus(FILE_PATH_PROPERTY to params.normalizedFilePath.toString())
+                } else {
+                    this
+                }
+            }
 
         injectUserData(rootNode, editorConfigProperties, mergedUserData)
 
@@ -188,7 +194,7 @@ public object KtLint {
             } else {
                 userData
             }
-        node.putUserData(FILE_PATH_USER_DATA_KEY, userData["file_path"])
+        node.putUserData(FILE_PATH_USER_DATA_KEY, userData[FILE_PATH_PROPERTY])
         node.putUserData(EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(editorConfigMap - "android" - "file_path"))
         node.putUserData(EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY, editorConfigProperties)
         node.putUserData(ANDROID_USER_DATA_KEY, android)

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoader.kt
@@ -121,7 +121,6 @@ class EditorConfigLoader(
     }
 
     companion object {
-        internal const val FILE_PATH_PROPERTY = "file_path"
         /**
          * List of file extensions, editorconfig lookup will be performed.
          */
@@ -131,31 +130,17 @@ class EditorConfigLoader(
         )
 
         /**
-         * Converts loaded [editorConfigProperties] values to string representation.
+         * Converts loaded [EditorConfigProperties] values into string representation.
          *
-         * @param filePath added under [FILE_PATH_PROPERTY] key
-         * @param isStdIn indicate that input is from std-in and [filePath] should not be added to the map
-         *
-         * @return converted [editorConfigProperties]
+         * @return map of key as string and value as string property representation
          */
-        fun EditorConfigProperties.convertToRawValues(
-            filePath: Path?,
-            isStdIn: Boolean = false
-        ): Map<String, String> {
+        fun EditorConfigProperties.convertToRawValues(): Map<String, String> {
             return if (isEmpty()) {
                 emptyMap()
             } else {
-                this
-                    .mapValues {
-                        if (it.value.isUnset) "unset" else it.value.sourceValue
-                    }
-                    .run {
-                        if (!isStdIn) {
-                            plus(FILE_PATH_PROPERTY to filePath.toString())
-                        } else {
-                            this
-                        }
-                    }
+                mapValues {
+                    if (it.value.isUnset) "unset" else it.value.sourceValue
+                }
             }
         }
     }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -74,7 +74,7 @@ internal class EditorConfigLoaderTest {
 
             val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.kt")
             val editorConfig = editorConfigLoader.loadPropertiesForFile(lintFile, rules = rules)
-            val parsedEditorConfig = editorConfig.convertToRawValues(lintFile)
+            val parsedEditorConfig = editorConfig.convertToRawValues()
 
             assertThat(parsedEditorConfig).isNotEmpty
             assertThat(parsedEditorConfig)
@@ -86,7 +86,6 @@ internal class EditorConfigLoaderTest {
                     mapOf(
                         "indent_size" to "2",
                         "tab_width" to "2",
-                        EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
                     )
                 )
         }
@@ -130,38 +129,35 @@ internal class EditorConfigLoaderTest {
 
         val lintFileSubdirectory = tempFileSystem.normalizedPath(project1Subdirectory).resolve("test.kt")
         var editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFileSubdirectory, rules = rules)
-        var parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFileSubdirectory)
+        var parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "indent_size" to "2",
                 "tab_width" to "2",
                 "indent_style" to "space",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFileSubdirectory.toString()
             )
         )
 
         val lintFileMainDir = tempFileSystem.normalizedPath(project1Dir).resolve("test.kts")
         editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFileMainDir, rules = rules)
-        parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFileMainDir)
+        parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "indent_size" to "4",
                 "tab_width" to "4",
                 "indent_style" to "space",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFileMainDir.toString()
             )
         )
 
         val lintFileRoot = tempFileSystem.normalizedPath(rootDir).resolve("test.kt")
         editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFileRoot, rules = rules)
-        parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFileRoot)
+        parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "end_of_line" to "lf",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFileRoot.toString()
             )
         )
     }
@@ -179,14 +175,13 @@ internal class EditorConfigLoaderTest {
 
         val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.kt")
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFile, rules = rules)
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "insert_final_newline" to "true",
                 "disabled_rules" to "import-ordering",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
     }
@@ -203,14 +198,13 @@ internal class EditorConfigLoaderTest {
 
         val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.kt")
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFile, rules = rules)
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "indent_size" to "unset",
                 "tab_width" to "unset",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
     }
@@ -227,13 +221,12 @@ internal class EditorConfigLoaderTest {
         val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.kts")
 
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFile, rules = rules)
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "disabled_rules" to "import-ordering, no-wildcard-imports",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
     }
@@ -251,7 +244,7 @@ internal class EditorConfigLoaderTest {
         val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.txt")
 
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFile, rules = rules)
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isEmpty()
     }
@@ -272,13 +265,9 @@ internal class EditorConfigLoaderTest {
             rules = rules,
             debug = true,
         )
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(
-            null,
-            true
-        )
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
-        assertThat(parsedEditorConfig).doesNotContainKey(EditorConfigLoader.FILE_PATH_PROPERTY)
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "insert_final_newline" to "true",
@@ -329,13 +318,12 @@ internal class EditorConfigLoaderTest {
             alternativeEditorConfig = tempFileSystem.normalizedPath(anotherDir).resolve(".editorconfig"),
             rules = rules
         )
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "end_of_line" to "lf",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString(),
                 "indent_size" to "2",
                 "tab_width" to "2"
             )
@@ -372,7 +360,7 @@ internal class EditorConfigLoaderTest {
             isStdIn = true,
             rules = rules
         )
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(null, true)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
@@ -402,14 +390,13 @@ internal class EditorConfigLoaderTest {
         Files.createDirectories(lintFile)
 
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(lintFile, debug = true, rules = rules)
-        val parsedEditorConfig = editorConfigProperties.convertToRawValues(lintFile)
+        val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
         assertThat(parsedEditorConfig).isNotEmpty
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "insert_final_newline" to "true",
                 "disabled_rules" to "class-must-be-internal",
-                EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
     }
@@ -421,6 +408,8 @@ internal class EditorConfigLoaderTest {
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-        ) = TODO("Not yet implemented")
+        ) {
+            throw NotImplementedError()
+        }
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -25,6 +25,7 @@ class FilenameRuleTest {
         ) {
             assertThat(
                 FilenameRule().lint(
+                    "/some/path/A.kt",
                     """
                     /*
                      * license
@@ -35,7 +36,6 @@ class FilenameRuleTest {
                     $src
                     //
                     """.trimIndent(),
-                    fileName("/some/path/A.kt")
                 )
             ).isEmpty()
         }
@@ -56,6 +56,7 @@ class FilenameRuleTest {
         ) {
             assertThat(
                 FilenameRule().lint(
+                    "/some/path/B.kt",
                     """
                     /*
                      * license
@@ -66,7 +67,6 @@ class FilenameRuleTest {
                     ${src.key}
                     //
                     """.trimIndent(),
-                    fileName("/some/path/B.kt")
                 )
             ).isEqualTo(
                 listOf(
@@ -80,12 +80,12 @@ class FilenameRuleTest {
     fun testFileWithoutTopLevelDeclarations() {
         assertThat(
             FilenameRule().lint(
+                "A.kt",
                 """
                 /*
                  * copyright
                  */
                 """.trimIndent(),
-                fileName("A.kt")
             )
         ).isEmpty()
     }
@@ -94,11 +94,11 @@ class FilenameRuleTest {
     fun testMultipleTopLevelClasses() {
         assertThat(
             FilenameRule().lint(
+                "A.kt",
                 """
                 class B
                 class C
                 """.trimIndent(),
-                fileName("A.kt")
             )
         ).isEmpty()
     }
@@ -107,13 +107,13 @@ class FilenameRuleTest {
     fun testMultipleNonTopLevelClasses() {
         assertThat(
             FilenameRule().lint(
+                "A.kt",
                 """
                 class B {
                     class C
                     class D
                 }
                 """.trimIndent(),
-                fileName("A.kt")
             )
         ).isEqualTo(
             listOf(
@@ -126,10 +126,10 @@ class FilenameRuleTest {
     fun testCaseSensitiveMatching() {
         assertThat(
             FilenameRule().lint(
+                "woohoo.kt",
                 """
                 interface Woohoo
                 """.trimIndent(),
-                fileName("woohoo.kt")
             )
         ).isEqualTo(
             listOf(
@@ -142,10 +142,10 @@ class FilenameRuleTest {
     fun testCaseEscapedClassNames() {
         assertThat(
             FilenameRule().lint(
+                "B.kt",
                 """
                 class `A`
                 """.trimIndent(),
-                fileName("B.kt")
             )
         ).isEqualTo(
             listOf(
@@ -158,13 +158,11 @@ class FilenameRuleTest {
     fun testIgnoreKotlinScriptFiles() {
         assertThat(
             FilenameRule().lint(
+                "A.kts",
                 """
                 class B
                 """.trimIndent(),
-                fileName("A.kts")
             )
         ).isEmpty()
     }
-
-    private fun fileName(fileName: String) = mapOf("file_path" to fileName)
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/IntellijIDEAIntegration.kt
@@ -31,10 +31,7 @@ object IntellijIDEAIntegration {
         }
         val editorConfigProperties = EditorConfigLoader(FileSystems.getDefault())
             .loadPropertiesForFile(null, isStdIn = true, rules = emptySet())
-        val editorConfig: Map<String, String> = editorConfigProperties.convertToRawValues(
-            null,
-            isStdIn = true
-        )
+        val editorConfig: Map<String, String> = editorConfigProperties.convertToRawValues()
         val indentSize = editorConfig["indent_size"]?.toIntOrNull() ?: 4
         val continuationIndentSize = editorConfig["continuation_indent_size"]?.toIntOrNull() ?: 4
         val updates = if (local) {


### PR DESCRIPTION
Previously, when ktlint failed to find '.editorconfig', file path was not passed to the rules. This lead for wrong "filename" rule behaviour.

Fixes #997 