### PR TITLE
Fix indentation for function types after a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Incorrect indentation with multiple interfaces ([#1003](https://github.com/pinterest/ktlint/issues/1003))
 - Empty line before primary constructor is not reported and formatted-out ([#1004](https://github.com/pinterest/ktlint/issues/1004))
-- Fix '.editorconfig' generation for "import-ordering" rule ([#1011](https://github.com/pinterest/ktlint/issues/1004))
-- Fix "filename" rule will not work when '.editorconfig' file is not found ([#997](https://github.com/pinterest/ktlint/issues/1004))
-- EditorConfig generation for `import-ordering` ([#1011](https://github.com/pinterest/ktlint/pull/1011))
+- Fix '.editorconfig' generation for "import-ordering" rule ([#1011](https://github.com/pinterest/ktlint/issues/1011))
+- Fix "filename" rule will not work when '.editorconfig' file is not found ([#997](https://github.com/pinterest/ktlint/issues/997))
+- Fix indentation for function types after a newline (`indent`) ([#918](https://github.com/pinterest/ktlint/issues/918))
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.core.ast.ElementType.ELSE
 import com.pinterest.ktlint.core.ast.ElementType.ELVIS
 import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.EQ
+import com.pinterest.ktlint.core.ast.ElementType.FUN
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.core.ast.ElementType.GT
 import com.pinterest.ktlint.core.ast.ElementType.KDOC
@@ -725,7 +726,12 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     private fun adjustExpectedIndentAfterColon(n: ASTNode, ctx: IndentContext) {
         expectedIndent++
         debug { "++after(COLON) -> $expectedIndent" }
-        ctx.exitAdjBy(n.treeParent, -1)
+        if (n.isPartOf(FUN)) {
+            val returnType = n.nextCodeSibling()
+            ctx.exitAdjBy(returnType!!, -1)
+        } else {
+            ctx.exitAdjBy(n.treeParent, -1)
+        }
     }
 
     private fun adjustExpectedIndentAfterLparInsideCondition(n: ASTNode, ctx: IndentContext) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -802,4 +802,25 @@ internal class IndentationRuleTest {
             )
         ).isEmpty()
     }
+
+    // https://github.com/pinterest/ktlint/issues/918
+    @Test
+    fun `lint newline after type reference in functions`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                override fun actionProcessor():
+                    ObservableTransformer<in SomeVeryVeryLongNameOverHereAction, out SomeVeryVeryLongNameOverHereResult> =
+                    ObservableTransformer { actions ->
+                        // ...
+                    }
+
+                fun generateGooooooooooooooooogle():
+                    Gooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogle {
+                    return Gooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooogle()
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
Closes #918 
Other issues reported in the comments were already fixed.