### PR TITLE
Add option to enable specific experimental rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Support for globally enabling experimental rules via `--experimental_rules` command line flag.
+- Support for globally enabling experimental rules via custom `experimental_rules` property in `.editorconfig`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ max_line_length=off
 # Note that rules in any ruleset other than the standard ruleset will need to be prefixed 
 # by the ruleset identifier.
 disabled_rules=no-wildcard-imports,experimental:annotation,my-custom-ruleset:my-custom-rule
+experimental_rules=multiline-if-else,annotation
 
 # Defines the imports layout. There are predefined layouts like "ascii" or "idea", as well as a custom layout.
 # The predefined layouts are temporary and will be deprecated in the future, once Kotlin plugin supports EditorConfig property for imports layout.
@@ -531,6 +532,13 @@ import package.* // ktlint-disable
 See the [EditorConfig section](https://github.com/pinterest/ktlint#editorconfig) for details on how to use the `disabled_rules` property.
 
 You may also pass a list of disabled rules via the `--disabled_rules` command line flag. It has the same syntax as the EditorConfig property.
+
+### How do I globally enable an experimental rule?
+Experimental rules are not enabled by default.
+
+See the [EditorConfig section](https://github.com/pinterest/ktlint#editorconfig) for details on how to use the `experimental_rules` property.
+
+You may also pass a list of enabled experimental rules via the `--experimental_rules` command line flag. It has the same syntax as the EditorConfig property.
 
 ## Development
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -174,6 +174,7 @@ internal class EditorConfigLoaderTest {
             [*.{kt,kts}]
             insert_final_newline = true
             disabled_rules = import-ordering
+            experimental_rules = annotation
             """.trimIndent()
         tempFileSystem.writeEditorConfigFile(projectDir, editorconfigFile)
 
@@ -186,6 +187,7 @@ internal class EditorConfigLoaderTest {
             mapOf(
                 "insert_final_newline" to "true",
                 "disabled_rules" to "import-ordering",
+                "experimental_rules" to "annotation",
                 EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
@@ -222,6 +224,7 @@ internal class EditorConfigLoaderTest {
             """
             [*.{kt,kts}]
             disabled_rules=import-ordering, no-wildcard-imports
+            experimental_rules=annotation, multiline-if-else
             """.trimIndent()
         tempFileSystem.writeEditorConfigFile(projectDir, editorconfigFile)
         val lintFile = tempFileSystem.normalizedPath(projectDir).resolve("test.kts")
@@ -233,6 +236,7 @@ internal class EditorConfigLoaderTest {
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "disabled_rules" to "import-ordering, no-wildcard-imports",
+                "experimental_rules" to "annotation, multiline-if-else",
                 EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )
@@ -263,6 +267,7 @@ internal class EditorConfigLoaderTest {
             [*.{kt,kts}]
             insert_final_newline = true
             disabled_rules = import-ordering
+            experimental_rules = annotation
             """.trimIndent()
         tempFileSystem.writeEditorConfigFile(".", editorconfigFile)
 
@@ -282,7 +287,8 @@ internal class EditorConfigLoaderTest {
         assertThat(parsedEditorConfig).isEqualTo(
             mapOf(
                 "insert_final_newline" to "true",
-                "disabled_rules" to "import-ordering"
+                "disabled_rules" to "import-ordering",
+                "experimental_rules" to "annotation"
             )
         )
     }
@@ -392,9 +398,11 @@ internal class EditorConfigLoaderTest {
             [*.{kt,kts}]
             insert_final_newline = true
             disabled_rules = import-ordering
+            experimental_rules = annotation
 
             [api/*.{kt,kts}]
             disabled_rules = class-must-be-internal
+            experimental_rules = multiline-if-else
             """.trimIndent()
         tempFileSystem.writeEditorConfigFile(projectDir, editorconfigFile)
 
@@ -409,6 +417,7 @@ internal class EditorConfigLoaderTest {
             mapOf(
                 "insert_final_newline" to "true",
                 "disabled_rules" to "class-must-be-internal",
+                "experimental_rules" to "multiline-if-else",
                 EditorConfigLoader.FILE_PATH_PROPERTY to lintFile.toString()
             )
         )

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -219,6 +219,15 @@ class KtlintCommandLine {
     var experimental: Boolean = false
 
     @Option(
+        names = ["--experimental_rules"],
+        description = [
+            "Comma-separated list of experimental rules to globally enable." +
+                " To enable all experimental rules use --experimental"
+        ]
+    )
+    var experimentalRules: String = ""
+
+    @Option(
         names = ["--baseline"],
         description = ["Defines a baseline file to check against"]
     )
@@ -237,7 +246,10 @@ class KtlintCommandLine {
         val start = System.currentTimeMillis()
 
         val baselineResults = loadBaseline(baseline)
-        val ruleSetProviders = rulesets.loadRulesets(experimental, debug, disabledRules)
+        if (experimental) {
+            experimentalRules = "all"
+        }
+        val ruleSetProviders = rulesets.loadRulesets(debug, disabledRules, experimentalRules)
         var reporter = loadReporter()
         if (baselineResults.baselineGenerationNeeded) {
             val baselineReporter = ReporterTemplate("baseline", null, emptyMap(), baseline)
@@ -246,7 +258,8 @@ class KtlintCommandLine {
         }
         val userData = listOfNotNull(
             "android" to android.toString(),
-            if (disabledRules.isNotBlank()) "disabled_rules" to disabledRules else null
+            if (disabledRules.isNotBlank()) "disabled_rules" to disabledRules else null,
+            if (experimentalRules.isNotBlank()) "experimental_rules" to experimentalRules else null
         ).toMap()
 
         reporter.beforeAll()

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -31,9 +31,9 @@ class GenerateEditorConfigSubCommand : Runnable {
                 text = "",
                 ruleSets = ktlintCommand.rulesets
                     .loadRulesets(
-                        ktlintCommand.experimental,
                         ktlintCommand.debug,
-                        ktlintCommand.disabledRules
+                        ktlintCommand.disabledRules,
+                        ktlintCommand.experimentalRules
                     )
                     .map { it.value.get() },
                 userData = mapOf(

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -23,7 +23,7 @@ internal fun JarFiles.loadRulesets(
         // standard should go first
         if (key == "standard") "\u0000$key" else key
     }
-    .filterKeys { it != "experimental" || !enabledExperimentalRules.isNullOrEmpty()}
+    .filterKeys { it != "experimental" || !enabledExperimentalRules.isNullOrEmpty() }
     .filterKeys { !(disabledRules.isStandardRuleSetDisabled() && it == "\u0000standard") }
     .toSortedMap()
     .also {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -10,9 +10,9 @@ import java.util.ServiceLoader
  * @return map of ruleset ids to ruleset providers
  */
 internal fun JarFiles.loadRulesets(
-    loadExperimental: Boolean,
     debug: Boolean,
-    disabledRules: String
+    disabledRules: String,
+    enabledExperimentalRules: String
 ) = ServiceLoader
     .load(
         RuleSetProvider::class.java,
@@ -23,7 +23,7 @@ internal fun JarFiles.loadRulesets(
         // standard should go first
         if (key == "standard") "\u0000$key" else key
     }
-    .filterKeys { loadExperimental || it != "experimental" }
+    .filterKeys { it != "experimental" || !enabledExperimentalRules.isNullOrEmpty()}
     .filterKeys { !(disabledRules.isStandardRuleSetDisabled() && it == "\u0000standard") }
     .toSortedMap()
     .also {


### PR DESCRIPTION
With command line flag "--experimental" it is possible to enable all experimental rules. I want to be able to enable specific experimental rules which work well for a repository from the .editorconfig in that repository.