### PR TITLE
Fix (custom) import rule in case no imports are found for the first group

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.isRoot
+import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule.Companion.ASCII_PATTERN
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule.Companion.IDEA_PATTERN
 import com.pinterest.ktlint.ruleset.standard.internal.importordering.ImportSorter
@@ -193,7 +194,7 @@ public class ImportOrderingRule :
                             break
                         }
                     }
-                    if (hasBlankLines) {
+                    if (hasBlankLines && sortedImportsWithSpaces.isNotEmpty()) {
                         sortedImportsWithSpaces += PsiWhiteSpaceImpl("\n\n")
                     }
                     sortedImportsWithSpaces += current
@@ -216,7 +217,9 @@ public class ImportOrderingRule :
                     if (autoCorrect && canAutoCorrect) {
                         node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
                         sortedImportsWithSpaces.reduce { current, next ->
-                            node.addChild(current, null)
+                            if (!(current.isWhiteSpace() && node.firstChildNode == null)) {
+                                node.addChild(current, null)
+                            }
                             if (current !is PsiWhiteSpace && next !is PsiWhiteSpace) {
                                 node.addChild(PsiWhiteSpaceImpl("\n"), null)
                             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
@@ -385,6 +385,38 @@ class ImportOrderingRuleCustomTest {
         ).isEqualTo(formattedImports)
     }
 
+    @Test
+    fun `Empty import groups before the wildcard group should not result in consecutive empty lines`() {
+
+        val imports =
+            """
+            import com.group2.b
+            import com.group2.a
+            import com.group1.b
+            import com.group1.a
+            """.trimIndent()
+
+        val formattedImports =
+            """
+            import com.group1.a
+            import com.group1.b
+
+            import com.group2.a
+            import com.group2.b
+            """.trimIndent()
+
+        val testFile = writeCustomImportsOrderingConfig(
+            "empty.group1.**,|,empty.group2.**,|,*,|,com.group1.**,|,com.group2.**"
+        )
+
+        assertThat(
+            rule.lint(testFile, imports)
+        ).isEqualTo(expectedErrors)
+        assertThat(
+            rule.format(testFile, imports)
+        ).isEqualTo(formattedImports)
+    }
+
     private fun writeCustomImportsOrderingConfig(
         importsLayout: String
     ) = editorConfigTestRule


### PR DESCRIPTION
In my .editorconfig file I have defined a custom import order as follows:
```
kotlin_imports_layout = empty.group1.**,|,empty.group2.**,|,*,|,com.group1.**,|,com.group2.**
```

All files in which no imports are found for `empty.group1` fail on the `no-consecutive-blank-lines` rule. For example:
```
            import com.group2.b
            import com.group2.a
            import com.group1.b
            import com.group1.a
```

In the `import-ordering` rule should not add blank lines for groups until at least one import has been processed.