### PR TITLE
Fix string-template for dot-expression from which the  toString() is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix '.editorconfig' generation for "import-ordering" rule ([#1011](https://github.com/pinterest/ktlint/issues/1004))
 - Fix "filename" rule will not work when '.editorconfig' file is not found ([#997](https://github.com/pinterest/ktlint/issues/1004))
 - EditorConfig generation for `import-ordering` ([#1011](https://github.com/pinterest/ktlint/pull/1011))
+- Internal error (`no-unused-imports`) ([#996](https://github.com/pinterest/ktlint/issues/996))
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
@@ -6,7 +6,11 @@ import com.pinterest.ktlint.core.ast.ElementType.DOT
 import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.LITERAL_STRING_TEMPLATE_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.LONG_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.core.ast.ElementType.LONG_TEMPLATE_ENTRY_END
+import com.pinterest.ktlint.core.ast.ElementType.LONG_TEMPLATE_ENTRY_START
+import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_EXPRESSION
+import com.pinterest.ktlint.core.ast.children
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
@@ -65,9 +69,19 @@ class StringTemplateRule : Rule("string-template") {
             ) {
                 emit(node.treePrev.startOffset + 2, "Redundant curly braces", true)
                 if (autoCorrect) {
-                    // fixme: a proper way would be to downcast to SHORT_STRING_TEMPLATE_ENTRY
-                    (node.firstChildNode as LeafPsiElement).rawReplaceWithText("$") // entry start
-                    (node.lastChildNode as LeafPsiElement).rawReplaceWithText("") // entry end
+                    val leftCurlyBraceNode = node.findChildByType(LONG_TEMPLATE_ENTRY_START)
+                    val rightCurlyBraceNode = node.findChildByType(LONG_TEMPLATE_ENTRY_END)
+                    if (node.children().count() == 3 && leftCurlyBraceNode != null && rightCurlyBraceNode != null) {
+                        node.removeChild(leftCurlyBraceNode)
+                        node.removeChild(rightCurlyBraceNode)
+                        val remainingNode = node.firstChildNode
+                        val newNode = if (remainingNode.elementType == DOT_QUALIFIED_EXPRESSION) {
+                            LeafPsiElement(REGULAR_STRING_PART, "\$${remainingNode.text}")
+                        } else {
+                            LeafPsiElement(remainingNode.elementType, "\$${remainingNode.text}")
+                        }
+                        node.replaceChild(node.firstChildNode, newNode)
+                    }
                 }
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
@@ -71,7 +71,7 @@ class StringTemplateRule : Rule("string-template") {
                 if (autoCorrect) {
                     val leftCurlyBraceNode = node.findChildByType(LONG_TEMPLATE_ENTRY_START)
                     val rightCurlyBraceNode = node.findChildByType(LONG_TEMPLATE_ENTRY_END)
-                    if (node.children().count() == 3 && leftCurlyBraceNode != null && rightCurlyBraceNode != null) {
+                    if (leftCurlyBraceNode != null && rightCurlyBraceNode != null) {
                         node.removeChild(leftCurlyBraceNode)
                         node.removeChild(rightCurlyBraceNode)
                         val remainingNode = node.firstChildNode

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
@@ -10,7 +10,6 @@ import com.pinterest.ktlint.core.ast.ElementType.LONG_TEMPLATE_ENTRY_END
 import com.pinterest.ktlint.core.ast.ElementType.LONG_TEMPLATE_ENTRY_START
 import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_EXPRESSION
-import com.pinterest.ktlint.core.ast.children
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
+import com.pinterest.ktlint.test.format
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -20,5 +21,24 @@ class StringTemplateRuleTest {
                 "spec/string-template/format-expected.kt.spec"
             )
         ).isEmpty()
+    }
+
+    @Test
+    fun testFormatIssue996() {
+        assertThat(
+            StringTemplateRule().format(
+                """
+                fun getDrafts(val draftsIds: List<Long>) {
+                    println("draftIds=[${'$'}{draftsIds.toString()}]")
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            fun getDrafts(val draftsIds: List<Long>) {
+                println("draftIds=[${'$'}draftsIds]")
+            }
+            """.trimIndent()
+        )
     }
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/string-template/format-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/string-template/format-expected.kt.spec
@@ -2,6 +2,7 @@ fun main() {
     val x = "${String::class}"
     println("$x.hello")
     println("$x.hello")
+    println("$x")
     println("${x}hello")
     println("${x.length}.hello")
     println("$x.hello")

--- a/ktlint-ruleset-standard/src/test/resources/spec/string-template/format.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/string-template/format.kt.spec
@@ -2,6 +2,7 @@ fun main() {
     val x = "${String::class.toString()}"
     println("${x}.hello")
     println("${x.toString()}.hello")
+    println("${x.toString()}")
     println("${x}hello")
     println("${x.length}.hello")
     println("$x.hello")

--- a/ktlint-ruleset-standard/src/test/resources/spec/string-template/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/string-template/lint.kt.spec
@@ -1,5 +1,6 @@
 fun main() {
     println("${String::class.toString()}")
+    println("${hello.toString()}")
     println("""${Int::class.toString()}""")
     println("$s0")
     println("""$s1""")
@@ -62,9 +63,10 @@ class F {
 
 // expect
 // 2:29:Redundant "toString()" call in string template
-// 3:28:Redundant "toString()" call in string template
-// 6:15:Redundant curly braces
+// 3:21:Redundant "toString()" call in string template
+// 4:28:Redundant "toString()" call in string template
 // 7:15:Redundant curly braces
-// 28:79:Redundant "toString()" call in string template
-// 45:20:Redundant curly braces
-// 55:19:Redundant curly braces
+// 8:15:Redundant curly braces
+// 29:79:Redundant "toString()" call in string template
+// 46:20:Redundant curly braces
+// 56:19:Redundant curly braces


### PR DESCRIPTION
Given code example below:
```
                fun getDrafts(val draftsIds: List<Long>) {
                    println("draftIds=[${'$'}{draftsIds.toString()}]")
                }
```
Formatting with autocorrect of this code fails on the no-unused-imports rule as the dot-expression node still exists but the toString invocation was already removed.

Resolves #996 