### PR TITLE
Retain the UTF8 BOM (Byte Order Mark) in case present in original code

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -357,11 +357,15 @@ public object KtLint {
             return params.text
         }
 
-        return if (hasUTF8BOM) UTF8_BOM else "" + // Restore UTF8 BOM if it was present
-            preparedCode
-                .rootNode
-                .text
-                .replace("\n", determineLineSeparator(params.text, params.userData))
+        val code = preparedCode
+            .rootNode
+            .text
+            .replace("\n", determineLineSeparator(params.text, params.userData))
+        return if (hasUTF8BOM) {
+            UTF8_BOM + code
+        } else {
+            code
+        }
     }
 
     /**

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -42,4 +42,37 @@ class KtLintTest {
         )
         assertThat(bus).isEqualTo(listOf("file:a", "file:b", "file:c", "b", "c", "file:d"))
     }
+
+    @Test
+    fun testFormatUnicodeBom() {
+        val code = getResourceAsText("spec/format-unicode-bom.kt.spec")
+
+        val actual = KtLint.format(
+            KtLint.Params(
+                text = code,
+                ruleSets = listOf(
+                    RuleSet("standard", DummyRule())
+                ),
+                cb = { _, _ -> }
+            )
+        )
+
+        assertThat(actual).isEqualTo(code)
+    }
 }
+
+class DummyRule : Rule("dummy-rule") {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        // The rule does not need to do anything except emit
+        emit(node.startOffset, "Dummy rule", true)
+    }
+}
+
+private fun getResourceAsText(path: String) =
+    (ClassLoader.getSystemClassLoader().getResourceAsStream(path) ?: throw RuntimeException("$path not found"))
+        .bufferedReader()
+        .readText()

--- a/ktlint-core/src/test/resources/spec/format-unicode-bom.kt.spec
+++ b/ktlint-core/src/test/resources/spec/format-unicode-bom.kt.spec
@@ -1,0 +1,1 @@
+﻿// Although probably not visible in your editor, this file starts with a UTF8 BOM unicode character


### PR DESCRIPTION
Resolves #1013