### PR TITLE
Add CI & Mega-Linter link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ See [w0rp/ale](https://github.com/w0rp/ale).
 
 > Integrated with something else? Send a PR.
 
+#### ... with Continuous Integration (Github Actions, Circle CI...)
+
+See [Mega-Linter](https://nvuillam.github.io/mega-linter/): 70+ linters aggregated in a single tool for CI, including **ktlint** activated out of the box
+
 ## Creating a ruleset
 
 > See also [Writing your first ktlint rule](https://medium.com/@vanniktech/writing-your-first-ktlint-rule-5a1707f4ca5b) by [Niklas Baudy](https://github.com/vanniktech). 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's also [easy to create your own](#creating-a-reporter).
 - **A single executable jar with all dependencies included.**
 
 <p align="center">
-<a href="#installation">Installation</a> | <a href="#usage">Usage</a> | <a href="#integration">Integration</a> with <a href="#-with-maven">Maven</a> / <a href="#-with-gradle">Gradle</a> / <a href="#-with-intellij-idea">IntelliJ IDEA</a> / <a href="#-with-emacs">Emacs</a> | Creating <a href="#creating-a-ruleset">a ruleset</a> | <a href="#creating-a-reporter">a reporter</a> | <a href="#badge">Badge</a> | <a href="#faq">FAQ</a>
+<a href="#installation">Installation</a> | <a href="#usage">Usage</a> | <a href="#integration">Integration</a> with <a href="#-with-maven">Maven</a> / <a href="#-with-gradle">Gradle</a> / <a href="#-with-intellij-idea">IntelliJ IDEA</a> / <a href="#-with-emacs">Emacs</a> / <a href="#-with-continuous-integration">Continuous Integration</a> | Creating <a href="#creating-a-ruleset">a ruleset</a> | <a href="#creating-a-reporter">a reporter</a> | <a href="#badge">Badge</a> | <a href="#faq">FAQ</a>
 </p>
 
 ## Standard rules
@@ -406,7 +406,7 @@ See [w0rp/ale](https://github.com/w0rp/ale).
 
 > Integrated with something else? Send a PR.
 
-#### ... with Continuous Integration (Github Actions, Circle CI...)
+#### ... with Continuous Integration
 
 See [Mega-Linter](https://nvuillam.github.io/mega-linter/): 70+ linters aggregated in a single tool for CI, including **ktlint** activated out of the box
 


### PR DESCRIPTION
New PR to replace #948  :) 

ktlint page in Mega-Linter documentation is the following: https://nvuillam.github.io/mega-linter/descriptors/kotlin_ktlint/

Please notify me if you have any suggestion to improve it :)