### PR TITLE
Fix ktlint-disable directive on package statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,22 +511,38 @@ See [Creating A Ruleset](#creating-a-ruleset).
 to produce the correct result (please report any such instances using [GitHub Issues](https://github.com/pinterest/ktlint/issues)).
 
 To disable a specific rule you'll need to turn on the verbose mode (`ktlint --verbose ...`). At the end of each line
-you'll see an error code. Use it as an argument for `ktlint-disable` directive (shown below).  
+you'll see the id of the rule. This id can be used as an argument for `ktlint-disable` directive (shown below).  
 
+A specific rule can be disabled for one specific line by adding the `ktlint-disable` directive, and the rule id as 
+follows:
 ```kotlin
-import package.* // ktlint-disable no-wildcard-imports
+import com.example.mypackage.* // ktlint-disable no-wildcard-imports
+```
 
+A rule can be disabled for a block of statements by adding the `ktlint-disable` directive, and the rule id as follows:
+```
 /* ktlint-disable no-wildcard-imports */
-import package.a.*
-import package.b.*
+import com.example.mypackage1.*
+import com.example.mypackage2.*
 /* ktlint-enable no-wildcard-imports */
 ```
+Note: the `ktlint-enable` directive above can be omitted in case the rule should be disabled for the remainder of the 
+file.
 
-To disable all checks:
+
+It is also possible to disable all checks for one single line, or a block of lines by not specifying the rule id after 
+the `ktlint-disable` directive:
 
 ```kotlin
-import package.* // ktlint-disable
+import com.example.mypackage.* // ktlint-disable
+
+/* ktlint-disable */
+import com.example.mypackage1.*
+import com.example.mypackage2.*
+/* ktlint-enable */
 ```
+Note: the `ktlint-enable` directive above can be omitted in case all rules should be disabled for the remainder of the 
+file.
 
 ### How do I globally disable a rule?
 See the [EditorConfig section](https://github.com/pinterest/ktlint#editorconfig) for details on how to use the `disabled_rules` property.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -98,13 +98,13 @@ public object KtLint {
             // fixme: enforcing suppression based on node.startOffset is wrong
             // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
             if (
-                !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)
+                !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId)
             ) {
                 try {
                     rule.visit(node, false) { offset, errorMessage, canBeAutoCorrected ->
                         // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
                         if (node.startOffset != offset &&
-                            preparedCode.suppressedRegionLocator(offset, fqRuleId, node === preparedCode.rootNode)
+                            preparedCode.suppressedRegionLocator(offset, fqRuleId)
                         ) {
                             return@visit
                         }
@@ -313,7 +313,7 @@ public object KtLint {
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (
-                    !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)
+                    !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId)
                 ) {
                     try {
                         rule.visit(node, true) { _, _, canBeAutoCorrected ->
@@ -346,14 +346,14 @@ public object KtLint {
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (
-                    !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)
+                    !preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId)
                 ) {
                     try {
                         rule.visit(node, false) { offset, errorMessage, canBeAutoCorrected ->
                             // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
                             if (
                                 node.startOffset != offset &&
-                                preparedCode.suppressedRegionLocator(offset, fqRuleId, node === preparedCode.rootNode)
+                                preparedCode.suppressedRegionLocator(offset, fqRuleId)
                             ) {
                                 return@visit
                             }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.core
 
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.visit
 import com.pinterest.ktlint.core.internal.EditorConfigGenerator
 import com.pinterest.ktlint.core.internal.EditorConfigLoader
@@ -88,6 +89,12 @@ public object KtLint {
         val errors = mutableListOf<LintError>()
 
         visitor(preparedCode.rootNode, params.ruleSets).invoke { node, rule, fqRuleId ->
+            if (node.isRoot() && rule is Rule.Modifier.InitializeRoot) {
+                // In case the rule has a root initializer then it should always be called regardless whether offset 0
+                // of the file is suppressed by a ktlint-disable directive.
+                rule.initializeRoot(node)
+            }
+
             // fixme: enforcing suppression based on node.startOffset is wrong
             // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
             if (
@@ -297,6 +304,12 @@ public object KtLint {
         var mutated = false
         visitor(preparedCode.rootNode, params.ruleSets, concurrent = false)
             .invoke { node, rule, fqRuleId ->
+                if (node.isRoot() && rule is Rule.Modifier.InitializeRoot) {
+                    // In case the rule has a root initializer then it should always be called regardless whether offset
+                    // 0 of the file is suppressed by a ktlint-disable directive.
+                    rule.initializeRoot(node)
+                }
+
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (
@@ -324,6 +337,12 @@ public object KtLint {
         if (tripped) {
             val errors = mutableListOf<Pair<LintError, Boolean>>()
             visitor(preparedCode.rootNode, params.ruleSets).invoke { node, rule, fqRuleId ->
+                if (node.isRoot() && rule is Rule.Modifier.InitializeRoot) {
+                    // In case the rule has a root initializer then it should always be called regardless whether offset 0
+                    // of the file is suppressed by a ktlint-disable directive.
+                    rule.initializeRoot(node)
+                }
+
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -47,5 +47,13 @@ abstract class Rule(val id: String) {
          */
         interface RestrictToRootLast : RestrictToRoot
         interface Last
+        /**
+         * Any rule implementing this interface will be given the root ([FileASTNode]) node so that the rule is
+         * guaranteed to be initialized even in case the first line of the file contains a ktlint-disable directive
+         * for the rule.
+         */
+        interface InitializeRoot {
+            fun initializeRoot(node: ASTNode)
+        }
     }
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
@@ -39,20 +39,12 @@ internal fun buildSuppressedRegionsLocator(
     return if (hintsList.isEmpty()) {
         noSuppression
     } else { offset, ruleId, isRoot ->
-        if (isRoot) {
-            val h = hintsList[0]
-            h.range.last == 0 && (
-                h.disabledRules.isEmpty() ||
-                    h.disabledRules.contains(ruleId)
-                )
-        } else {
-            hintsList.any { hint ->
-                (
-                    hint.disabledRules.isEmpty() ||
-                        hint.disabledRules.contains(ruleId)
-                    ) &&
-                    hint.range.contains(offset)
-            }
+        hintsList.any { hint ->
+            (
+                hint.disabledRules.isEmpty() ||
+                    hint.disabledRules.contains(ruleId)
+                ) &&
+                hint.range.contains(offset)
         }
     }
 }
@@ -77,7 +69,8 @@ private fun collect(
             if (text.startsWith("//")) {
                 val commentText = text.removePrefix("//").trim()
                 if (node.isDisabledOnPackageStatement()) {
-                    node.createBlockDisableSuppressionHint(commentText)
+                    parseHintArgs(commentText, "ktlint-disable")
+                        ?.let { hints -> SuppressionHint(IntRange(0, Int.MAX_VALUE), hints) }
                         ?.let { suppressionHint -> open.add(suppressionHint) }
                 } else {
                     node.createLineDisableSupressionHint(commentText)
@@ -124,7 +117,7 @@ private fun PsiElement.createLineDisableSupressionHint(commentText: String): Sup
 
 private fun PsiElement.createBlockDisableSuppressionHint(commentText: String): SuppressionHint? {
     return parseHintArgs(commentText, "ktlint-disable")
-        ?.let { hints -> SuppressionHint(IntRange(node.startOffset, node.startOffset), hints) }
+        ?.let { hints -> SuppressionHint(IntRange(node.startOffset, Int.MAX_VALUE), hints) }
 }
 
 private fun PsiElement.createBlockEnableSuppressionHint(commentText: String, open: java.util.ArrayList<SuppressionHint>): SuppressionHint? {

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
@@ -68,14 +68,8 @@ private fun collect(
             val text = node.getText()
             if (text.startsWith("//")) {
                 val commentText = text.removePrefix("//").trim()
-                if (node.isDisabledOnPackageStatement()) {
-                    parseHintArgs(commentText, "ktlint-disable")
-                        ?.let { hints -> SuppressionHint(IntRange(0, Int.MAX_VALUE), hints) }
-                        ?.let { suppressionHint -> open.add(suppressionHint) }
-                } else {
-                    node.createLineDisableSupressionHint(commentText)
-                        ?.let { suppressionHint -> result.add(suppressionHint) }
-                }
+                node.createLineDisableSupressionHint(commentText)
+                    ?.let { suppressionHint -> result.add(suppressionHint) }
             } else {
                 val commentText = text.removePrefix("/*").removeSuffix("*/").trim()
                 node.createBlockDisableSuppressionHint(commentText)

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
@@ -16,12 +16,12 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 /**
  * Detects if given `ruleId` at given `offset` is suppressed.
  */
-internal typealias SuppressionLocator = (offset: Int, ruleId: String, isRoot: Boolean) -> Boolean
+internal typealias SuppressionLocator = (offset: Int, ruleId: String) -> Boolean
 
 /**
  * No suppression is detected. Always returns `false`.
  */
-internal val noSuppression: SuppressionLocator = { _, _, _ -> false }
+internal val noSuppression: SuppressionLocator = { _, _ -> false }
 
 private val suppressAnnotationRuleMap = mapOf(
     "RemoveCurlyBracesFromTemplate" to "string-template"
@@ -38,7 +38,7 @@ internal fun buildSuppressedRegionsLocator(
     val hintsList = collect(rootNode)
     return if (hintsList.isEmpty()) {
         noSuppression
-    } else { offset, ruleId, isRoot ->
+    } else { offset: Int, ruleId: String ->
         hintsList.any { hint ->
             (
                 hint.disabledRules.isEmpty() ||

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SupressedRegionLocator.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.ast.ElementType
-import com.pinterest.ktlint.core.ast.logStructure
 import com.pinterest.ktlint.core.ast.visit
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
@@ -34,46 +34,6 @@ class ErrorSuppressionTest {
         }
 
     @Test
-    fun testErrorSuppressionDisableAllOnPackage() {
-        assertThat(
-            lint(
-                """
-                package com.pinterest.ktlint // ktlint-disable
-
-                import a.* // Should not trigger an error due to ktlin-disable directive on package
-
-                /* ktlint-enable */
-                import b.* // will trigger an error
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(6, 10, "no-wildcard-imports", "Wildcard import")
-            )
-        )
-    }
-
-    @Test
-    fun testErrorSuppressionDisableRuleOnPackage() {
-        assertThat(
-            lint(
-                """
-                package com.pinterest.ktlint // ktlint-disable no-wildcard-imports
-
-                import a.* // Should not trigger an error due to ktlin-disable directive on package
-
-                /* ktlint-enable no-wildcard-imports */
-                import b.* // will trigger an error
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(6, 10, "no-wildcard-imports", "Wildcard import")
-            )
-        )
-    }
-
-    @Test
     fun testErrorSuppressionDisableAllOnImport() {
         assertThat(
             lint(

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -37,10 +37,18 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * - maxLineLength exceeded (and separating arguments with \n would actually help)
  * in addition, "(" and ")" must be on separates line if any of the arguments are (otherwise on the same)
  */
-class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
+class ArgumentListWrappingRule :
+    Rule("argument-list-wrapping"),
+    Rule.Modifier.InitializeRoot {
 
     private var indentSize = -1
     private var maxLineLength = -1
+
+    override fun initializeRoot(node: ASTNode) {
+        val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+        indentSize = editorConfig.indentSize
+        maxLineLength = editorConfig.maxLineLength
+    }
 
     override fun visit(
         node: ASTNode,
@@ -48,9 +56,6 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
-            maxLineLength = editorConfig.maxLineLength
             return
         }
         if (indentSize <= 0) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -20,7 +20,9 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
-class NoUnusedImportsRule : Rule("no-unused-imports") {
+class NoUnusedImportsRule :
+    Rule("no-unused-imports"),
+    Rule.Modifier.InitializeRoot {
 
     private val componentNRegex = Regex("^component\\d+$")
 
@@ -73,17 +75,20 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private var packageName = ""
     private var rootNode: ASTNode? = null
 
+    override fun initializeRoot(node: ASTNode) {
+        rootNode = node
+        ref.clear() // rule can potentially be executed more than once (when formatting)
+        ref.add(Reference("*", false))
+        parentExpressions.clear()
+        imports.clear()
+    }
+
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            rootNode = node
-            ref.clear() // rule can potentially be executed more than once (when formatting)
-            ref.add(Reference("*", false))
-            parentExpressions.clear()
-            imports.clear()
             node.visit { vnode ->
                 val psi = vnode.psi
                 val type = vnode.elementType

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -27,10 +27,18 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
-class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
+class ParameterListWrappingRule :
+    Rule("parameter-list-wrapping"),
+    Rule.Modifier.InitializeRoot {
 
     private var indentSize = -1
     private var maxLineLength = -1
+
+    override fun initializeRoot(node: ASTNode) {
+        val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+        indentSize = editorConfig.indentSize
+        maxLineLength = editorConfig.maxLineLength
+    }
 
     override fun visit(
         node: ASTNode,
@@ -38,9 +46,6 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
-            maxLineLength = editorConfig.maxLineLength
             return
         }
         if (indentSize <= 0) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -849,4 +849,30 @@ internal class IndentationRuleTest {
             )
         ).isEmpty()
     }
+
+    // Explicitly test disabling this rule as the code hierarchy is changed when new elements need to be inserted for
+    // certain indentation fixes.
+    @Test
+    fun `lint can be suppressed on incorrectly indented lines`() {
+        val code =
+            """
+            class Foo {
+            // Next lines should not fail due to EOL comment containing suppression
+            val bar1 = "bar" // ktlint-disable
+            val bar2 = "bar" // ktlint-disable indent
+
+            /* ktlint-disable */
+            val bar3 = "bar" // Should not fail due to block comment above
+
+            /* ktlint-enable */
+            val bar5 = "bar" // Should fail
+            }
+            """.trimIndent()
+
+        assertThat(IndentationRule().lint(code)).isEqualTo(
+            listOf(
+                LintError(line = 10, col = 1, ruleId = "indent", detail = "Unexpected indentation (0) (should be 4)"),
+            )
+        )
+    }
 }


### PR DESCRIPTION
* Split unit tests for error suppression into multiple tests
* Extract the creation of the SuppressionHints to extension
  methods for readability and reuseability

## Description

According to the documentation the `ktlint-disable` can be appended as an EOL comment to indicate that all rules for this file should be disabled. However that didn't work
```
                package com.pinterest.ktlint // ktlint-disable

                import something.*
```
Adding it as block comment before the package statement resulted in an internal error on the import rule. I have not tried to fix that.

Now it is possible to:
* Disable all rules for this file by adding `// ktlint-disable` after the package statement
* Disable specific rules for this file by adding `// ktlint-disable rule-id` after the package statement
* After disabling a or all rules via the package statement, the rules can be enabled again.