### PR TITLE
Don't remove the equals sign for a default argument (`no-line-break-before-assignment`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Internal error (`no-unused-imports`) ([#996](https://github.com/pinterest/ktlint/issues/996))
 - Fix false positive when argument list is after multiline dot-qualified expression (`argument-list-wrapping`) ([#893](https://github.com/pinterest/ktlint/issues/893))
 - Fix indentation for function types after a newline (`indent`) ([#918](https://github.com/pinterest/ktlint/issues/918))
+- Don't remove the equals sign for a default argument (`no-line-break-before-assignment`) ([#1039](https://github.com/pinterest/ktlint/issues/1039))
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
@@ -9,6 +9,7 @@ import com.pinterest.ktlint.core.ast.prevCodeSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class NoLineBreakBeforeAssignmentRule : Rule("no-line-break-before-assignment") {
@@ -23,13 +24,14 @@ class NoLineBreakBeforeAssignmentRule : Rule("no-line-break-before-assignment") 
             if (hasLineBreakBeforeAssignment == true) {
                 emit(node.startOffset, "Line break before assignment is not allowed", true)
                 if (autoCorrect) {
-                    val next = prevCodeSibling.treeNext
-                    val newText = buildString {
-                        append(" =")
-                        if (next !is PsiWhiteSpace) append(" ")
-                        append(next.text)
+                    val prevPsi = prevCodeSibling.psi
+                    val parentPsi = prevPsi.parent
+                    val psiFactory = KtPsiFactory(prevPsi)
+                    if (prevPsi.nextSibling !is PsiWhiteSpace) {
+                        parentPsi.addAfter(psiFactory.createWhiteSpace(), prevPsi)
                     }
-                    (next as? LeafPsiElement)?.rawReplaceWithText(newText)
+                    parentPsi.addAfter(psiFactory.createEQ(), prevPsi)
+                    parentPsi.addAfter(psiFactory.createWhiteSpace(), prevPsi)
                     (node as? LeafPsiElement)?.delete()
                 }
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
@@ -166,6 +167,52 @@ class NoLineBreakBeforeAssignmentRuleTest {
             """
             fun sum(a: Int, b: Int): Int = // comment
                 a + b
+            """.trimIndent()
+        )
+    }
+
+    // https://github.com/pinterest/ktlint/issues/1039
+    @Test
+    fun `test default arguments`() {
+        assertThat(
+            NoLineBreakBeforeAssignmentRule().format(
+                """
+                fun test(b: Boolean?
+                = null): Int = 3
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            fun test(b: Boolean? =
+            null): Int = 3
+            """.trimIndent()
+        )
+    }
+
+    // https://github.com/pinterest/ktlint/issues/1039
+    @Test
+    fun `test default arguments with standard rule set`() {
+        val code = """
+            fun test(b: Boolean?
+            = null): Int = 3
+
+        """.trimIndent()
+
+        val actual = KtLint.format(
+            KtLint.Params(
+                text = code,
+                ruleSets = listOf(StandardRuleSetProvider().get()),
+                cb = { _, _ -> }
+            )
+        )
+
+        assertThat(actual).isEqualTo(
+            """
+            fun test(
+                b: Boolean? =
+                    null
+            ): Int = 3
+
             """.trimIndent()
         )
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
@@ -188,32 +188,4 @@ class NoLineBreakBeforeAssignmentRuleTest {
             """.trimIndent()
         )
     }
-
-    // https://github.com/pinterest/ktlint/issues/1039
-    @Test
-    fun `test default arguments with standard rule set`() {
-        val code = """
-            fun test(b: Boolean?
-            = null): Int = 3
-
-        """.trimIndent()
-
-        val actual = KtLint.format(
-            KtLint.Params(
-                text = code,
-                ruleSets = listOf(StandardRuleSetProvider().get()),
-                cb = { _, _ -> }
-            )
-        )
-
-        assertThat(actual).isEqualTo(
-            """
-            fun test(
-                b: Boolean? =
-                    null
-            ): Int = 3
-
-            """.trimIndent()
-        )
-    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
@@ -1,6 +1,5 @@
 package com.pinterest.ktlint.ruleset.standard
 
-import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint


### PR DESCRIPTION
## Description
Fixes #1039

## Checklist
- [x] tests are added
- [x] `CHANGELOG.md` is updated
