### PR TITLE
Upgrade ec4j to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext.deps = [
     'compiler': "org.jetbrains.kotlin:kotlin-compiler-embeddable:${versions.kotlin}"
   ],
   'klob'          : 'com.github.shyiko.klob:klob:0.2.1',
-  ec4j            : 'org.ec4j.core:ec4j-core:0.2.2',
+  ec4j            : 'org.ec4j.core:ec4j-core:0.3.0',
   'picocli'       : 'info.picocli:picocli:3.9.6',
   // Testing libraries
   'junit'         : 'junit:junit:4.13.1',


### PR DESCRIPTION
ec4j 0.3.0 removes the length limit of key, value and section name in editor config files.

Fixes #739.
