### PR TITLE
Fix internal error in `no-unused-imports`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix false positive when argument list is after multiline dot-qualified expression (`argument-list-wrapping`) ([#893](https://github.com/pinterest/ktlint/issues/893))
 - Fix indentation for function types after a newline (`indent`) ([#918](https://github.com/pinterest/ktlint/issues/918))
 - Don't remove the equals sign for a default argument (`no-line-break-before-assignment`) ([#1039](https://github.com/pinterest/ktlint/issues/1039))
+- Fix internal error in `no-unused-imports` ([#1040](https://github.com/pinterest/ktlint/issues/1040))
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetIntegrationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetIntegrationTest.kt
@@ -1,0 +1,33 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.core.KtLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class StandardRuleSetIntegrationTest {
+
+    @Test
+    fun `test string-template wit unused-imports integration`() {
+        val actual = KtLint.format(
+            KtLint.Params(
+                text = """
+                fun foo() = 1
+                fun test() {
+                    println("${'$'}{foo().toString()}")
+                }
+                """.trimIndent(),
+                ruleSets = listOf(StandardRuleSetProvider().get()),
+                cb = { _, _ -> }
+            )
+        )
+        assertThat(actual).isEqualTo(
+            """
+            fun foo() = 1
+            fun test() {
+                println("${'$'}{foo()}")
+            }
+
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
## Description
Fixes #1040

Test code to reproduce in master (780d11a2c1539f8011a6271b2cc97806d0c90aa8):
```kotlin
@Test
fun test() {
    val actual = KtLint.format(
        KtLint.Params(
            text = """
                fun foo() = 1
                fun test() {
                    println("${'$'}{foo().toString()}")
                }

            """.trimIndent(),
            ruleSets = listOf(StandardRuleSetProvider().get()),
            cb = { _, _ -> }
        )
    )
    assertThat(actual).isEqualTo(
        """
        fun foo() = 1
        fun test() {
            println("${'$'}{foo()}")
        }

        """.trimIndent()
    )
}
```



## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
