### PR TITLE
Multiline string indent

### DIFF
--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -938,11 +938,12 @@ class AnnotationRuleTest {
 
     @Test
     fun `lint file annotations should be separated with a blank line in script 1`() {
-        val code = """
+        val code =
+            """
             @file:Suppress("UnstableApiUsage")
             pluginManagement {
             }
-        """.trimIndent()
+            """.trimIndent()
         assertThat(AnnotationRule().lint(code, script = true)).isEqualTo(
             listOf(
                 LintError(1, 34, "annotation", AnnotationRule.fileAnnotationsShouldBeSeparated)
@@ -952,12 +953,13 @@ class AnnotationRuleTest {
 
     @Test
     fun `lint file annotations should be separated with a blank line in script 2`() {
-        val code = """
+        val code =
+            """
             @file:Suppress("UnstableApiUsage")
 
             pluginManagement {
             }
-        """.trimIndent()
+            """.trimIndent()
         assertThat(AnnotationRule().lint(code, script = true)).isEmpty()
     }
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -13,10 +13,10 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().lint(
                 """
-                    val x = f(
-                        a,
-                        b, c
-                    )
+                val x = f(
+                    a,
+                    b, c
+                )
                 """.trimIndent()
             )
         ).isEqualTo(
@@ -36,19 +36,19 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().format(
                 """
-                    val x = f(
-                        a,
-                        b, c
-                    )
+                val x = f(
+                    a,
+                    b, c
+                )
                 """.trimIndent()
             )
         ).isEqualTo(
             """
-                val x = f(
-                    a,
-                    b,
-                    c
-                )
+            val x = f(
+                a,
+                b,
+                c
+            )
             """.trimIndent()
         )
     }
@@ -58,25 +58,25 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().format(
                 """
-                    val x = test(
-                        one("a", "b",
-                        "c"),
-                        "Two", "Three", "Four"
-                    )
+                val x = test(
+                    one("a", "b",
+                    "c"),
+                    "Two", "Three", "Four"
+                )
                 """.trimIndent()
             )
         ).isEqualTo(
             """
-                val x = test(
-                    one(
-                        "a",
-                        "b",
-                        "c"
-                    ),
-                    "Two",
-                    "Three",
-                    "Four"
-                )
+            val x = test(
+                one(
+                    "a",
+                    "b",
+                    "c"
+                ),
+                "Two",
+                "Three",
+                "Four"
+            )
             """.trimIndent()
         )
     }
@@ -86,7 +86,7 @@ class ArgumentListWrappingRuleTest {
         assertThat(
             ArgumentListWrappingRule().lint(
                 """
-                    val x = f(a, b, c)
+                val x = f(a, b, c)
                 """.trimIndent(),
                 userData = mapOf("max_line_length" to "10")
             )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 
 internal class IndentationRuleTest {
@@ -16,7 +17,7 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun testFormat() {
+    fun `format unindented input`() {
         assertThat(
             IndentationRule().diffFileFormat(
                 "spec/indent/format.kt.spec",
@@ -26,12 +27,12 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun testFormatTabs() {
+    fun `format unindented input with tabs`() {
         assertThat(
             IndentationRule().diffFileFormat(
                 "spec/indent/format.kt.spec",
                 "spec/indent/format-expected-tabs.kt.spec",
-                mapOf("indent_style" to "tab")
+                INDENT_STYLE_TABS
             )
         ).isEmpty()
     }
@@ -66,7 +67,7 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun testLintIndentTab() {
+    fun `lint IndentTab with tabs`() {
         assertThat(
             IndentationRule().lint(
                 """
@@ -84,7 +85,7 @@ internal class IndentationRuleTest {
                 |		set(v: String) { x = v }
                 |}
                 |""".trimMargin(),
-                mapOf("indent_style" to "tab")
+                INDENT_STYLE_TABS
             )
         ).isEqualTo(
             listOf(
@@ -181,10 +182,30 @@ internal class IndentationRuleTest {
 
     @Test
     fun testLintFirstLine() {
-        assertThat(IndentationRule().lint("  // comment")).hasSize(1)
-        assertThat(IndentationRule().lint("  // comment", script = true)).hasSize(1)
-        assertThat(IndentationRule().lint("  \n  // comment")).hasSize(1)
-        assertThat(IndentationRule().lint("  \n  // comment", script = true)).hasSize(1)
+        assertThat(IndentationRule().lint("  // comment"))
+            .isEqualTo(
+                listOf(
+                    LintError(line = 1, col = 1, ruleId = "indent", detail = "Unexpected indentation (2) (should be 0)"),
+                )
+            )
+        assertThat(IndentationRule().lint("  // comment", script = true))
+            .isEqualTo(
+                listOf(
+                    LintError(line = 1, col = 1, ruleId = "indent", detail = "Unexpected indentation (2) (should be 0)"),
+                )
+            )
+        assertThat(IndentationRule().lint("  \n  // comment"))
+            .isEqualTo(
+                listOf(
+                    LintError(line = 2, col = 1, ruleId = "indent", detail = "Unexpected indentation (2) (should be 0)"),
+                )
+            )
+        assertThat(IndentationRule().lint("  \n  // comment", script = true))
+            .isEqualTo(
+                listOf(
+                    LintError(line = 2, col = 1, ruleId = "indent", detail = "Unexpected indentation (2) (should be 0)"),
+                )
+            )
     }
 
     @Test
@@ -403,23 +424,21 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun `no indentation after lambda arrow`() {
+    fun `incorrect indentation after lambda arrow`() {
         assertThat(
             IndentationRule().lint(
                 """
                 fun bar() {
-                    foo.func {
-                        param1, param2 ->
-                            doSomething()
-                            doSomething2()
-                    }
+                    Pair("val1", "val2")
+                        .let { (first, second) ->
+                                first + second
+                        }
                 }
                 """.trimIndent()
             )
         ).isEqualTo(
             listOf(
-                LintError(line = 4, col = 1, ruleId = "indent", detail = "Unexpected indentation (12) (should be 8)"),
-                LintError(line = 5, col = 1, ruleId = "indent", detail = "Unexpected indentation (12) (should be 8)")
+                LintError(line = 4, col = 1, ruleId = "indent", detail = "Unexpected indentation (16) (should be 12)"),
             )
         )
     }
@@ -593,6 +612,240 @@ internal class IndentationRuleTest {
                     // stuff
                 }
             """.trimIndent()
+        assertThat(IndentationRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `format new line before opening quotes multiline string as parameter`() {
+        val code =
+            """
+            fun foo() {
+              println($MULTILINE_STRING_QUOTE
+                line1
+                    line2
+                    $MULTILINE_STRING_QUOTE.trimIndent())
+            }
+            """.trimIndent()
+        val expectedCode =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                    line1
+                        line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        @Suppress("RemoveCurlyBracesFromTemplate") val expectedCodeTabs =
+            """
+            fun foo() {
+            ${TAB}println(
+            ${TAB}${TAB}$MULTILINE_STRING_QUOTE
+            ${TAB}${TAB}line1
+            ${TAB}${TAB}    line2
+            ${TAB}${TAB}$MULTILINE_STRING_QUOTE.trimIndent()
+            ${TAB})
+            }
+            """.trimIndent()
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(2, 1, "indent", "Unexpected indentation (2) (should be 4)"),
+                LintError(2, 11, "indent", "Missing newline after \"(\""),
+                LintError(3, 1, "indent", "Unexpected indent of multiline string"),
+                LintError(4, 1, "indent", "Unexpected indent of multiline string"),
+                LintError(5, 24, "indent", "Missing newline before \")\""),
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(expectedCode)
+        assertThat(IndentationRule().format(code, INDENT_STYLE_TABS)).isEqualTo(expectedCodeTabs)
+    }
+
+    @Test
+    fun `format new line before closing quotes multiline string when not blank`() {
+        val code =
+            """
+            fun foo() {
+                println($MULTILINE_STRING_QUOTE
+                    line1
+                line2$MULTILINE_STRING_QUOTE.trimIndent())
+            }
+            """.trimIndent()
+        val expectedCode =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                        line1
+                    line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(line = 2, col = 13, ruleId = "indent", detail = "Missing newline after \"(\""),
+                LintError(line = 3, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+                LintError(line = 4, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+                LintError(line = 4, col = 10, ruleId = "indent", detail = "Missing newline before \"\"\""),
+                LintError(line = 4, col = 25, ruleId = "indent", detail = "Missing newline before \")\""),
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(expectedCode)
+    }
+
+    @Test
+    fun `format multiline string containing quotation marks`() {
+        val code =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                text ""
+
+                     text
+                     ""
+                $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        val expectedCode =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                    text ""
+
+                         text
+                         ""
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(line = 4, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+                LintError(line = 6, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+                LintError(line = 7, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+                LintError(line = 8, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string"),
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(expectedCode)
+    }
+
+    @Test
+    fun `format multiline string containing a template string as the first non blank element on the line`() {
+        // Escape '${true}' as '${"$"}{true}' to prevent evaluation before actually processing the multiline sting
+        val code =
+            """
+            fun foo() {
+            println($MULTILINE_STRING_QUOTE
+            ${"$"}{true}
+
+                ${"$"}{true}
+            $MULTILINE_STRING_QUOTE.trimIndent())
+            }
+            """.trimIndent()
+        val expectedCode =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                    ${"$"}{true}
+
+                        ${"$"}{true}
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(2, 1, "indent", "Unexpected indentation (0) (should be 4)"),
+                LintError(2, 9, "indent", "Missing newline after \"(\""),
+                LintError(3, 1, "indent", "Unexpected indent of multiline string"),
+                LintError(5, 1, "indent", "Unexpected indent of multiline string"),
+                LintError(6, 1, "indent", "Unexpected indent of multiline string"),
+                LintError(6, 16, "indent", "Missing newline before \")\"")
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(expectedCode)
+    }
+
+    @Test
+    fun `issue 575 - format multiline string with tabs only in indentation margin`() {
+        val code =
+            """
+            val str =
+                $MULTILINE_STRING_QUOTE
+            ${TAB}line1
+            ${TAB}${TAB}line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val expectedCode =
+            """
+            val str =
+                $MULTILINE_STRING_QUOTE
+                line1
+                ${TAB}line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        assertThat(IndentationRule().lint(code)).isEqualTo(
+            listOf(
+                LintError(3, 1, "indent", "Unexpected 'tab' character(s) in margin of multiline string"),
+                LintError(4, 1, "indent", "Unexpected 'tab' character(s) in margin of multiline string"),
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(expectedCode)
+    }
+
+    @Test
+    fun `issue 575 - format multiline string with tabs after the margin is indented properly`() {
+        val code =
+            """
+            val str =
+                $MULTILINE_STRING_QUOTE
+                ${TAB}Tab at the beginning of this line but after the indentation margin
+                Tab${TAB}in the middle of this string
+                Tab at the end of this line.$TAB
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        assertThat(IndentationRule().lint(code)).isEmpty()
+        assertThat(IndentationRule().format(code)).isEqualTo(code)
+    }
+
+    @Ignore
+    @Test
+    fun `issue 575 - lint multiline string with mixed indentation characters, can not be autocorrected`() {
+        val code =
+            """
+                val foo = $MULTILINE_STRING_QUOTE
+                      line1
+                {TAB} line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """
+                .trimIndent()
+                .replace("{TAB}", "\t")
+                .replace("{SPACE}", " ")
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(
+                    line = 1,
+                    col = 11,
+                    ruleId = "indent",
+                    detail = "Indentation of multiline string should not contain both tab(s) and space(s)"
+                ),
+            )
+        )
         assertThat(IndentationRule().format(code)).isEqualTo(code)
     }
 
@@ -874,5 +1127,12 @@ internal class IndentationRuleTest {
                 """.trimIndent()
             )
         ).isEmpty()
+    }
+
+    private companion object {
+        const val MULTILINE_STRING_QUOTE = "${'"'}${'"'}${'"'}"
+        const val TAB = "${'\t'}"
+
+        val INDENT_STYLE_TABS = mapOf("indent_style" to "tab")
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTrimIndentTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTrimIndentTest.kt
@@ -1,0 +1,264 @@
+package com.pinterest.ktlint.ruleset.standard // ktlint-disable
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for trimIndent are added to explain and validate changes in the behavior of trimIndent as the logic for
+ * the indentation rule relies on this.
+ */
+internal class IndentationRuleTrimIndentTest {
+    @Test
+    fun `Text is indented with equal amount of spaces which are all removed -1-`() {
+        val foo = """
+            line 1
+            line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with equal amount of spaces which are all removed -2-`() {
+        val foo = """
+            line 1
+            line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with different amount of spaces -1-`() {
+        val foo = """
+            line 1
+              line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "  line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with different amount of spaces -2-`() {
+        val foo = """
+              line 1
+            line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "  line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with spaces but not well formatted -1-`() {
+        // Next multiline string is formatted improperly on purpose
+        val foo = """
+      line 1
+        line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "  line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with spaces but not well formatted -2-`() {
+        // Next multiline string is formatted improperly on purpose
+        val foo = """line 1
+          line 2""".trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "          line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with spaces but not well formatted -3-`() {
+        // Next multiline string is formatted improperly on purpose
+        val foo =
+"""
+      line 1
+        line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "  line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with equal amount of tabs which are all removed -1-`() {
+        val foo = """
+            ${TAB}line 1
+            ${TAB}line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with equal amount of tabs which are all removed -2-`() {
+        val foo = """
+            ${TAB}line 1
+            ${TAB}line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with different amount of tabs -1-`() {
+        val foo = """
+            line 1
+            ${TAB}line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "\tline 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with different amount of tabs -2-`() {
+        val foo = """
+            ${TAB}line 1
+            line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "\tline 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with tabs but not well formatted -1-`() {
+        // Next multiline string is formatted improperly on purpose
+        val foo = """
+${TAB}line 1
+${TAB}${TAB}line 2
+            """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "\tline 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with tabs but not well formatted -2-`() {
+        // Next multiline string is formatted improperly on purpose
+        val foo = """line 1
+${TAB}${TAB}line 2""".trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "\t\tline 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with tabs but not well formatted -3-`() {
+        val foo =
+            // Next multiline string is formatted improperly on purpose
+            """
+${TAB}${TAB}line 1
+${TAB}${TAB}${TAB}line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "\tline 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with same amount of spaces and tabs which are all removed (one space equals one tab) -1-`() {
+        val foo = """
+            ${TAB}${SPACE}line 1
+            ${SPACE}${TAB}line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with same amount of spaces and tabs which are all removed (one space equals one tab) -2-`() {
+        val foo = """
+            ${TAB}${TAB}line 1
+            ${SPACE}${SPACE}line 2
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "line 1\n" +
+                "line 2"
+        )
+    }
+
+    @Test
+    fun `Text is indented with different amount of spaces and tabs (one space equals one tab)`() {
+        val foo = """
+            ${TAB}line 1
+            ${SPACE}${SPACE}line 2
+            line 3
+        """.trimIndent()
+
+        assertThat(foo).isEqualTo(
+            "" +
+                "\tline 1\n" +
+                "  line 2\n" +
+                "line 3"
+        )
+    }
+
+    private companion object {
+        /**
+         * Replace the ${TAB} and ${SPACE} tokens before trimming the indent. Tabs can used in multiline string as ${'\t'}
+         * but it tends to read a lot hard than the token. The space token is helpful for emphasising  when mixing tabs and
+         * spaces.
+         */
+        const val TAB = "${'\t'}"
+        const val SPACE = " "
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -168,10 +168,10 @@ class ParameterListWrappingRuleTest {
         assertThat(
             ParameterListWrappingRule().lint(
                 """
-                    fun f(
-                        a: Any,
-                        b: Any, c: Any
-                    )
+                fun f(
+                    a: Any,
+                    b: Any, c: Any
+                )
                 """.trimIndent()
             )
         ).isEqualTo(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
@@ -110,24 +110,24 @@ class SpacingAroundKeywordRuleTest {
         assertThat(
             SpacingAroundKeywordRule().format(
                 """
-            var x: String
-			    get () {
-				    return ""
-			    }
-			    private set (value) {
-				    x = value
-			    }
-            """.trimIndent()
+                var x: String
+                    get () {
+                        return ""
+                    }
+                    private set (value) {
+                        x = value
+                    }
+                """.trimIndent()
             )
         ).isEqualTo(
             """
             var x: String
-			    get() {
-				    return ""
-			    }
-			    private set(value) {
-				    x = value
-			    }
+                get() {
+                    return ""
+                }
+                private set(value) {
+                    x = value
+                }
             """.trimIndent()
         )
     }

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected-tabs.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected-tabs.kt.spec
@@ -1,0 +1,126 @@
+fun f() {
+	val y = 5
+	val x =
+		"""
+		$y
+		""".trimIndent()
+	println("""${true}""".trimIndent())
+	println(
+		"""
+		""".trimIndent()
+	)
+	println(
+		"""
+		${true}
+
+		    ${true}
+		""".trimIndent()
+	)
+	println(
+		"""
+		${true}
+
+		    ${true}
+		""".trimIndent()
+	)
+	println(
+		"""
+		text
+
+		    text
+		""".trimIndent().toByteArray()
+	)
+	println(
+		"""
+		text
+
+		    text
+		""".trimIndent()
+	)
+	println(
+		"""
+		    text
+
+		        text
+		_
+		""".trimIndent()
+	)
+	println(
+		"""
+		text ""
+
+		    text
+		    ""
+		""".trimIndent()
+	)
+	format(
+		"""
+		class A {
+		    fun f(@Annotation
+		          a: Any,
+		          @Annotation([
+		              "v1",
+		              "v2"
+		          ])
+		          b: Any,
+		          c: Any =
+		              false,
+		          @Annotation d: Any) {
+		    }
+		}
+		""".trimIndent()
+	)
+	write(
+		fs.getPath("/projects/.editorconfig"),
+		"""
+		root = true
+		[*]
+		end_of_line = lf
+		""".trimIndent().toByteArray()
+	)
+	SpacingAroundKeywordRule().format( // string below is indented with tabs and spaces and will not be changed
+		"""
+            var x: String
+			    get () {
+				    return ""
+			    }
+			    private set (value) {
+				    x = value
+			    }
+            """.trimIndent()
+	)
+}
+
+class C {
+	val CONFIG_COMPACT = """
+		{
+		}
+		""".trimIndent()
+	val CONFIG_COMPACT = // comment
+		"""
+		{
+		}
+		""".trimIndent()
+
+	fun getBazelWorkspaceContent(blueprint: BazelWorkspaceBlueprint) =
+		"""${Target(
+			"android_sdk_repository",
+			listOf(StringAttribute("name", "androidsdk"))
+		)}
+
+${Comment("Google Maven Repository")}
+${LoadStatement("@bazel_tools//tools/build_defs/repo:http.bzl", listOf("http_archive"))}
+${AssignmentStatement("GMAVEN_TAG", "\"${blueprint.gmavenRulesTag}\"")}
+${Target(
+			"http_archive",
+			listOf(
+				StringAttribute("name", "gmaven_rules"),
+				RawAttribute("strip_prefix", "\"gmaven_rules-%s\" % GMAVEN_TAG"),
+				RawAttribute("urls", "[\"https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz\" % GMAVEN_TAG]")
+			)
+		)}
+${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules"))}
+${Target("gmaven_rules", listOf())}
+"""
+
+}

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -2,7 +2,7 @@ fun f() {
     val y = 5
     val x =
         """
-            $y
+        $y
         """.trimIndent()
     println("""${true}""".trimIndent())
     println(
@@ -11,63 +11,63 @@ fun f() {
     )
     println(
         """
-    ${true}
-
         ${true}
+
+            ${true}
         """.trimIndent()
     )
     println(
         """
-${true}
+        ${true}
 
-    ${true}
+            ${true}
         """.trimIndent()
     )
     println(
         """
-    text
-
         text
+
+            text
         """.trimIndent().toByteArray()
     )
     println(
         """
-    text
-
         text
+
+            text
         """.trimIndent()
     )
     println(
         """
-    text
+            text
 
-        text
-_
+                text
+        _
         """.trimIndent()
     )
     println(
         """
-    text ""
+        text ""
 
-        text
-        """.trimIndent(),
-        ""
+            text
+            ""
+        """.trimIndent()
     )
     format(
         """
-            class A {
-                fun f(@Annotation
-                      a: Any,
-                      @Annotation([
-                          "v1",
-                          "v2"
-                      ])
-                      b: Any,
-                      c: Any =
-                          false,
-                      @Annotation d: Any) {
-                }
+        class A {
+            fun f(@Annotation
+                  a: Any,
+                  @Annotation([
+                      "v1",
+                      "v2"
+                  ])
+                  b: Any,
+                  c: Any =
+                      false,
+                  @Annotation d: Any) {
             }
+        }
         """.trimIndent()
     )
     write(
@@ -78,23 +78,25 @@ _
         end_of_line = lf
         """.trimIndent().toByteArray()
     )
-    SpacingAroundKeywordRule().format( // string below is tab-indented
+    SpacingAroundKeywordRule().format(
+        // string below is indented with tabs and spaces should and should therefore not be autocorrected as this can
+        // not been done reliable. This will be fixed in a separate PR.
         """
-            var x: String
-			    get () {
-				    return ""
-			    }
-			    private set (value) {
-				    x = value
-			    }
-            """.trimIndent()
+             var x: String
+        get () {
+         return ""
+        }
+        private set (value) {
+         x = value
+        }
+        """.trimIndent()
     )
 }
 
 class C {
     val CONFIG_COMPACT = """
-        {
-        }
+    {
+    }
     """.trimIndent()
     val CONFIG_COMPACT = // comment
         """

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent.kt.spec
@@ -37,8 +37,8 @@ _""".trimIndent())
     text ""
 
         text
-    """.trimIndent(),
         ""
+    """.trimIndent()
     )
     format(
                 """
@@ -62,7 +62,9 @@ _""".trimIndent())
         [*]
         end_of_line = lf
     """.trimIndent().toByteArray())
-            SpacingAroundKeywordRule().format( // string below is tab-indented
+            SpacingAroundKeywordRule().format(
+                // string below is indented with tabs and spaces should and should therefore not be autocorrected as this can
+                // not been done reliable. This will be fixed in a separate PR.
                 """
             var x: String
 			    get () {

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.RuleSet
 import java.util.ArrayList
+import org.assertj.core.api.Assertions
 import org.assertj.core.util.diff.DiffUtils.diff
 import org.assertj.core.util.diff.DiffUtils.generateUnifiedDiff
 
@@ -119,6 +120,30 @@ public fun Rule.diffFileFormat(
         generateUnifiedDiff(expectedPath, "output", expected, diff(expected, actual), expected.size + actual.size)
             .joinToString("\n")
     return if (diff.isEmpty()) "" else diff
+}
+
+/**
+ * Alternative to [diffFileFormat]. Depending on your personal favor it might be more insightful whenever a test is
+ * failing. Currently it is offered as utility so it can be used during development.
+ *
+ * To be used as:
+ *
+ *     @Test
+ *     fun testFormatRawStringTrimIndent() {
+ *         IndentationRule().assertThatFileFormat(
+ *             "spec/indent/format-raw-string-trim-indent.kt.spec",
+ *             "spec/indent/format-raw-string-trim-indent-expected.kt.spec"
+ *         )
+ *     }
+ */
+public fun Rule.assertThatFileFormat(
+    srcPath: String,
+    expectedPath: String,
+    userData: Map<String, String> = emptyMap()
+) {
+    val actual = format(getResourceAsText(srcPath), userData, script = true).split('\n')
+    val expected = getResourceAsText(expectedPath).split('\n')
+    Assertions.assertThat(actual).isEqualTo(expected)
 }
 
 private fun getResourceAsText(path: String) =


### PR DESCRIPTION
The indenting margin is determined analog to the trimIndent function. Spaces and tabs are both handled as single indent characters. The indentation of the closing quotes is not relevant unless the opening and closing quotes are on different lines but does not contain any content which is weird but still valid Kotlin code. The 'IndentationRuleTrimIndentTest' is added to clarify and validate the behavior of the trimIndent function.
Note: build currently breaks until [PR ktlint-disable](https://github.com/pinterest/ktlint/pull/1038) is merged.

Content of a multiline string should not be indented with respect to the closing quotes (note that the opening quotes can be on a previous line, for example after an assignment).

File 'format-raw-string-trim-indent.kt.spec' is changed for following reasons:
* Example code was not valid Kotlin code
* Changed a comment in an example to explain why the autocorrected code actually looks worse than the original. This will be fixed in a next PR.