### PR TITLE
Fix false positives when declaration has tail comments (`spacing-between-declarations-with-comments`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix indentation for function types after a newline (`indent`) ([#918](https://github.com/pinterest/ktlint/issues/918))
 - Don't remove the equals sign for a default argument (`no-line-break-before-assignment`) ([#1039](https://github.com/pinterest/ktlint/issues/1039))
 - Fix internal error in `no-unused-imports` ([#1040](https://github.com/pinterest/ktlint/issues/1040))
+- Fix false positives when declaration has tail comments (`spacing-between-declarations-with-comments`) ([#1053](https://github.com/pinterest/ktlint/issues/1053))
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35088
@@ -24,7 +25,8 @@ class SpacingBetweenDeclarationsWithCommentsRule : Rule("spacing-between-declara
     ) {
         if (node is PsiComment) {
             val declaration = node.parent as? KtDeclaration ?: return
-            if (declaration.getPrevSiblingIgnoringWhitespaceAndComments() !is KtDeclaration) return
+            val isTailComment = node.startOffset > declaration.startOffset
+            if (isTailComment || declaration.getPrevSiblingIgnoringWhitespaceAndComments() !is KtDeclaration) return
 
             val prevSibling = declaration.node.prevSibling { it.elementType != WHITE_SPACE }
             if (prevSibling != null &&

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
@@ -221,4 +221,41 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
             """.trimIndent()
         )
     }
+
+    // https://github.com/pinterest/ktlint/issues/1053
+    @Test
+    fun `declaration has tail comments`() {
+        assertThat(
+            SpacingBetweenDeclarationsWithCommentsRule().lint(
+                """
+                class SampleClass {
+
+                    private val public = "ok" // ok
+                    private val private = "not_ok" // false positive
+                    private val halfPublicHalfPrivate = "not_ok" // false positive
+
+                    /**
+                     * Doc 1
+                     */
+                    fun one() = 1
+
+                    /**
+                     * Doc 2
+                     */
+                    fun two() = 2
+                    fun three() {
+                        val public = "ok" // ok
+                        val private = "not_ok" // false positive
+                    }
+                }
+
+                enum class SampleEnum {
+                    One, // ok
+                    Two, // false positive
+                    Three, // false positive
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
## Description
Fixes #1053


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
