### PR TITLE
Fix negated globs passed to CLI are no longer worked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix IndexOutOfBoundsException in `argument-list-wrapping-rule` formatting file with many corrections ([#1081](https://github.com/pinterest/ktlint/issues/1081))
 - Fix formatting in arguments (`multiline-if-else`) ([#1079](https://github.com/pinterest/ktlint/issues/1079))
 - Fix experimental:annotation-spacing-rule autocorrection with comments
+- Migrate from klob dependency and fix negated globs passed to CLI are no longer worked ([#999](https://github.com/pinterest/ktlint/issues/999))
+  **Breaking**: absolute paths globs will no longer work, check updated README
 
 ### Changed
 - Update Gradle shadow plugin to `6.1.0` version

--- a/README.md
+++ b/README.md
@@ -150,32 +150,42 @@ On macOS ([or Linux](http://linuxbrew.sh/)) you can also use [brew](https://brew
 [wget](https://www.gnu.org/software/wget/manual/wget.html#Proxies) manpage. 
 Usually simple `http_proxy=http://proxy-server:port https_proxy=http://proxy-server:port curl -sL ...` is enough. 
 
-## Usage
+## Command line usage
 
 ```bash
-# check the style of all Kotlin files inside the current dir (recursively)
-# (hidden folders will be skipped)
-$ ktlint --color [--color-name="RED"]
-  src/main/kotlin/Main.kt:10:10: Unused import
-  
-# check only certain locations (prepend ! to negate the pattern,
-# Ktlint uses .gitignore pattern style syntax)
-$ ktlint "src/**/*.kt" "!src/**/*Test.kt"
+# Get help about all available commands
+$ ktlint --help
 
-# auto-correct style violations
-# (if some errors cannot be fixed automatically they will be printed to stderr) 
+# Check the style of all Kotlin files (ending with '.kt' or '.kts') inside the current dir (recursively).
+# Hidden folders will be skipped.
+$ ktlint
+  
+# Check only certain locations starting from the current directory.
+#
+# Prepend ! to negate the pattern, KtLint uses .gitignore pattern style syntax.
+# Globs are applied starting from the last one.
+#
+# Hidden folders will be skipped.
+# Check all '.kt' files in 'src/' directory, but ignore files ending with 'Test.kt':
+ktlint "src/**/*.kt" "!src/**/*Test.kt"
+# Check all '.kt' files in 'src/' directory, but ignore 'generated' directory and its subdirectories:
+ktlint "src/**/*.kt" "!src/**/generated/**"
+
+# Auto-correct style violations.
+# If some errors cannot be fixed automatically they will be printed to stderr. 
 $ ktlint -F "src/**/*.kt"
 
-# print style violations grouped by file
+# Print style violations grouped by file.
 $ ktlint --reporter=plain?group_by_file
-# print style violations as usual + create report in checkstyle format 
+
+# Print style violations as usual + create report in checkstyle format, specifying report location. 
 $ ktlint --reporter=plain --reporter=checkstyle,output=ktlint-report-in-checkstyle-format.xml
 
-# check against a baseline file
+# Check against a baseline file.
 $ ktlint --baseline=ktlint-baseline.xml
 
-# install git hook to automatically check files for style violations on commit
-# Run "ktlint installGitPrePushHook" if you wish to run ktlint on push instead
+# Install git hook to automatically check files for style violations on commit.
+# Run "ktlint installGitPrePushHook" if you wish to run ktlint on push instead.
 $ ktlint installGitPreCommitHook
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ task ktlint(type: JavaExec, group: LifecycleBasePlugin.VERIFICATION_GROUP) {
   description = "Check Kotlin code style."
   classpath = configurations.ktlint
   main = 'com.pinterest.ktlint.Main'
-  args '*/src/**/*.kt', '--baseline=ktlint-baseline.xml'
+  args '**/src/**/*.kt', '--baseline=ktlint-baseline.xml'
 }
 
 allprojects {

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
   testImplementation deps.junit
   testImplementation deps.assertj
+  testImplementation deps.jimfs
 }
 
 // Implements https://github.com/brianm/really-executable-jars-maven-plugin maven plugin behaviour.

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.ParseException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ruleset.test.DumpASTRule
 import java.io.File
+import java.nio.file.FileSystems
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -47,9 +48,12 @@ internal class PrintASTSubCommand : Runnable {
         if (stdin) {
             printAST(KtLint.STDIN_FILE, String(System.`in`.readBytes()))
         } else {
-            for (file in patterns.fileSequence()) {
-                printAST(file.path, file.readText())
-            }
+            FileSystems.getDefault()
+                .fileSequence(patterns)
+                .map { it.toFile() }
+                .forEach {
+                    printAST(it.path, it.readText())
+                }
         }
     }
 

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsFileSequenceTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsFileSequenceTest.kt
@@ -1,0 +1,161 @@
+package com.pinterest.ktlint.internal
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [fileSequence] method.
+ */
+internal class FileUtilsFileSequenceTest {
+    private val tempFileSystem = Jimfs.newFileSystem(Configuration.forCurrentPlatform())
+
+    private val rootDir = tempFileSystem.rootDirectories.first().toString()
+    private val project1Files = listOf(
+        "${rootDir}project1/.git/ignored.kts",
+        "${rootDir}project1/build.gradle.kts",
+        "${rootDir}project1/src/scripts/someScript.kts",
+        "${rootDir}project1/src/main/kotlin/One.kt",
+        "${rootDir}project1/src/main/kotlin/example/Two.kt",
+    ).map { it.normalizePath() }
+
+    private val project2Files = listOf(
+        "${rootDir}project2/build.gradle.kts",
+        "${rootDir}project2/src/main/java/Three.kt"
+    ).map { it.normalizePath() }
+
+    @Before
+    fun setUp() {
+        project1Files.createFiles()
+    }
+
+    @After
+    fun tearDown() {
+        tempFileSystem.close()
+    }
+
+    @Test
+    fun `On empty patterns should include all kt and kts files`() {
+        val foundFiles = getFiles()
+
+        assertThat(foundFiles).hasSize(project1Files.size - 1)
+        assertThat(foundFiles).containsAll(project1Files.drop(1))
+    }
+
+    @Test
+    fun `Should ignore hidden dirs on empty patterns`() {
+        val foundFiles = getFiles()
+
+        assertThat(foundFiles).doesNotContain(project1Files.first())
+    }
+
+    @Test
+    fun `Should return only files matching passed pattern`() {
+        val expectedResult = project1Files.drop(1).filter { it.endsWith(".kt") }
+        val foundFiles = getFiles(
+            listOf(
+                "**/src/**/*.kt".normalizeGlob()
+            )
+        )
+
+        assertThat(foundFiles).hasSize(expectedResult.size)
+        assertThat(foundFiles).containsAll(expectedResult)
+    }
+
+    @Test
+    fun `Should ignore hidden folders when some pattern is passed`() {
+        val expectedResult = project1Files.drop(1).filter { it.endsWith(".kts") }
+        val foundFiles = getFiles(
+            listOf(
+                "project1/**/*.kts".normalizeGlob(),
+                "project1/*.kts".normalizeGlob()
+            )
+        )
+
+        assertThat(foundFiles).hasSize(expectedResult.size)
+        assertThat(foundFiles).containsAll(expectedResult)
+    }
+
+    @Test
+    fun `Should ignore files in negated pattern`() {
+        val foundFiles = getFiles(
+            listOf(
+                "project1/src/**/*.kt".normalizeGlob(),
+                "!project1/src/**/example/*.kt".normalizeGlob()
+            )
+        )
+
+        assertThat(foundFiles).hasSize(1)
+        assertThat(foundFiles).containsAll(project1Files.subList(3, 4))
+    }
+
+    @Test
+    fun `Should return only files for the the current rootDir matching passed patterns`() {
+        project2Files.createFiles()
+
+        val foundFiles = getFiles(
+            listOf(
+                "**/main/**/*.kt".normalizeGlob()
+            ),
+            tempFileSystem.getPath("${rootDir}project2".normalizePath())
+        )
+
+        assertThat(foundFiles).hasSize(1)
+        assertThat(foundFiles).containsAll(project2Files.subList(1, 1))
+    }
+
+    @Test
+    fun `Should treat correctly root path without separator in the end`() {
+        val foundFiles = getFiles(
+            patterns = listOf("src/main/kotlin/One.kt".normalizeGlob()),
+            rootDir = tempFileSystem.getPath("${rootDir}project1".normalizePath())
+        )
+
+        assertThat(foundFiles).hasSize(1)
+        assertThat(foundFiles.first()).isEqualTo(project1Files[3])
+    }
+
+    @Test
+    fun `Should fail the search when glob contain absolute path`() {
+        val globs = listOf(
+            "src/main/kotlin/One.kt".normalizeGlob(),
+            "!${rootDir}project1/src/main/kotlin/example/Two.kt".normalizeGlob()
+        )
+
+        try {
+            getFiles(
+                patterns = globs
+            )
+            fail("No exception was thrown!")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).contains(
+                globs.last().removePrefix("!")
+            )
+        }
+    }
+
+    private fun String.normalizePath() = replace('/', File.separatorChar)
+    private fun String.normalizeGlob(): String = replace("/", globSeparator)
+
+    private fun List<String>.createFiles() = forEach {
+        val filePath = tempFileSystem.getPath(it)
+        val fileDir = filePath.parent
+        if (!Files.exists(fileDir)) Files.createDirectories(fileDir)
+        Files.createFile(filePath)
+    }
+
+    private fun getFiles(
+        patterns: List<String> = emptyList(),
+        rootDir: Path = tempFileSystem.rootDirectories.first()
+    ): List<String> = tempFileSystem
+        .fileSequence(patterns, rootDir)
+        .map { it.toString() }
+        .toList()
+}


### PR DESCRIPTION
## Description

Migrate method to get all mathing globs files to use internally `PathMatcher` and `FileVisitor` instead of using klob dependency.

Fixes #999 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
