### PR TITLE
Allow to add/replace loaded values from '.editorconfig' files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - New `ktlint_ignore_back_ticked_identifier` EditorConfig option for `max-line-length` rule to ignore long method names inside backticks 
   (primarily used in tests) ([#1007](https://github.com/pinterest/ktlint/issues/1007))
+- Allow to add/replace loaded `.editorconfig` values via `ExperimentalParams#editorConfigOverride` ([#1016](https://github.com/pinterest/ktlint/issues/1003))
 
 ### Fixed
 - Incorrect indentation with multiple interfaces ([#1003](https://github.com/pinterest/ktlint/issues/1003))

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -10,4 +10,5 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
   testImplementation deps.jimfs
+  testImplementation project(":ktlint-ruleset-standard")
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/OptInFeatures.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/OptInFeatures.kt
@@ -5,7 +5,11 @@ package com.pinterest.ktlint.core.api
     level = RequiresOptIn.Level.ERROR
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS,
+)
 public annotation class FeatureInAlphaState
 
 @RequiresOptIn(
@@ -13,5 +17,9 @@ public annotation class FeatureInAlphaState
     level = RequiresOptIn.Level.WARNING
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS,
+)
 public annotation class FeatureInBetaState

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -52,6 +52,9 @@ public interface UsesEditorConfigProperties {
     /**
      * Supported `.editorconfig` property.
      *
+     * [Rule] preferably should expose it with `public` visibility in `companion object`,
+     * so it will be possible to add/replace via [com.pinterest.ktlint.core.KtLint.Params].
+     *
      * @param type type of property. Could be one of default ones (see [PropertyType.STANDARD_TYPES]) or custom one.
      * @param defaultValue default value for property if it does not exist in loaded properties.
      * @param defaultAndroidValue default value for android codestyle. You should set different value only when it

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
@@ -53,10 +53,11 @@ public class FinalNewlineRule :
     private tailrec fun lastChildNodeOf(node: ASTNode): ASTNode? =
         if (node.lastChildNode == null) node else lastChildNodeOf(node.lastChildNode)
 
-    internal companion object {
-        internal val insertNewLineProperty = UsesEditorConfigProperties.EditorConfigProperty(
-            type = PropertyType.insert_final_newline,
-            defaultValue = true
-        )
+    public companion object {
+        public val insertNewLineProperty: UsesEditorConfigProperties.EditorConfigProperty<Boolean> =
+            UsesEditorConfigProperties.EditorConfigProperty(
+                type = PropertyType.insert_final_newline,
+                defaultValue = true
+            )
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -131,7 +131,7 @@ public class ImportOrderingRule :
                 propertyWriter = { it.joinToString(separator = ",") }
             )
 
-        internal val ideaImportsLayoutProperty =
+        public val ideaImportsLayoutProperty: UsesEditorConfigProperties.EditorConfigProperty<List<PatternEntry>> =
             UsesEditorConfigProperties.EditorConfigProperty<List<PatternEntry>>(
                 type = PropertyType(
                     IDEA_IMPORTS_LAYOUT_PROPERTY_NAME,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/PatternEntry.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/PatternEntry.kt
@@ -7,10 +7,10 @@ import org.jetbrains.kotlin.resolve.ImportPath
  *
  * Adopted from https://github.com/JetBrains/kotlin/blob/ffdab473e28d0d872136b910eb2e0f4beea2e19c/idea/formatter/src/org/jetbrains/kotlin/idea/core/formatter/KotlinPackageEntry.kt#L10
  */
-internal class PatternEntry(
+public class PatternEntry(
     packageName: String,
-    val withSubpackages: Boolean,
-    val hasAlias: Boolean
+    public val withSubpackages: Boolean,
+    public val hasAlias: Boolean
 ) {
 
     private val packageName = packageName.removeSuffix(".*")
@@ -28,7 +28,7 @@ internal class PatternEntry(
         return false
     }
 
-    fun isBetterMatchForPackageThan(entry: PatternEntry?, import: ImportPath): Boolean {
+    internal fun isBetterMatchForPackageThan(entry: PatternEntry?, import: ImportPath): Boolean {
         if (hasAlias != import.hasAlias() || !matchesPackageName(import.pathStr)) return false
         if (entry == null) return true
 
@@ -68,9 +68,26 @@ internal class PatternEntry(
         return result
     }
 
-    companion object {
-        val BLANK_LINE_ENTRY = PatternEntry(BLANK_LINE_CHAR, withSubpackages = true, hasAlias = false)
-        val ALL_OTHER_IMPORTS_ENTRY = PatternEntry(WILDCARD_CHAR, withSubpackages = true, hasAlias = false)
-        val ALL_OTHER_ALIAS_IMPORTS_ENTRY = PatternEntry(ALIAS_CHAR, withSubpackages = true, hasAlias = true)
+    public companion object {
+        public val BLANK_LINE_ENTRY: PatternEntry =
+            PatternEntry(
+                BLANK_LINE_CHAR,
+                withSubpackages = true,
+                hasAlias = false
+            )
+
+        public val ALL_OTHER_IMPORTS_ENTRY: PatternEntry =
+            PatternEntry(
+                WILDCARD_CHAR,
+                withSubpackages = true,
+                hasAlias = false
+            )
+
+        public val ALL_OTHER_ALIAS_IMPORTS_ENTRY: PatternEntry =
+            PatternEntry(
+                ALIAS_CHAR,
+                withSubpackages = true,
+                hasAlias = true
+            )
     }
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.internal
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import java.io.File
 import java.nio.file.FileSystem
 import java.nio.file.FileVisitResult
@@ -138,6 +139,7 @@ internal fun File.location(
 /**
  * Run lint over common kotlin file or kotlin script file.
  */
+@OptIn(FeatureInAlphaState::class)
 internal fun lintFile(
     fileName: String,
     fileContents: String,
@@ -148,7 +150,7 @@ internal fun lintFile(
     lintErrorCallback: (LintError) -> Unit = {}
 ) {
     KtLint.lint(
-        KtLint.Params(
+        KtLint.ExperimentalParams(
             fileName = fileName,
             text = fileContents,
             ruleSets = ruleSets,
@@ -167,6 +169,7 @@ internal fun lintFile(
 /**
  * Format a kotlin file or script file
  */
+@OptIn(FeatureInAlphaState::class)
 internal fun formatFile(
     fileName: String,
     fileContents: String,
@@ -177,7 +180,7 @@ internal fun formatFile(
     cb: (e: LintError, corrected: Boolean) -> Unit
 ): String =
     KtLint.format(
-        KtLint.Params(
+        KtLint.ExperimentalParams(
             fileName = fileName,
             text = fileContents,
             ruleSets = ruleSets,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -26,7 +26,7 @@ class GenerateEditorConfigSubCommand : Runnable {
 
         // For now we are using CLI invocation dir as path to load existing '.editorconfig'
         val generatedEditorConfig = KtLint.generateKotlinEditorConfigSection(
-            KtLint.Params(
+            KtLint.ExperimentalParams(
                 fileName = "./test.kt",
                 text = "",
                 ruleSets = ktlintCommand.rulesets


### PR DESCRIPTION
## Description

Add new parameter to add/replace loaded values from `.editorconfig` files.

Fixes #1016 


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
