### PR TITLE
ReporterProvider, LintError and RuleSetProvider now implement Serializable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `ktlint_ignore_back_ticked_identifier` EditorConfig option for `max-line-length` rule to ignore long method names inside backticks 
   (primarily used in tests) ([#1007](https://github.com/pinterest/ktlint/issues/1007))
 - Allow to add/replace loaded `.editorconfig` values via `ExperimentalParams#editorConfigOverride` ([#1016](https://github.com/pinterest/ktlint/issues/1003))
-- `ReporterProvider` now implements `Serializable` interface
+- `ReporterProvider` and `LintError` now implement `Serializable` interface
 ### Fixed
 - Incorrect indentation with multiple interfaces ([#1003](https://github.com/pinterest/ktlint/issues/1003))
 - Empty line before primary constructor is not reported and formatted-out ([#1004](https://github.com/pinterest/ktlint/issues/1004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `ktlint_ignore_back_ticked_identifier` EditorConfig option for `max-line-length` rule to ignore long method names inside backticks 
   (primarily used in tests) ([#1007](https://github.com/pinterest/ktlint/issues/1007))
 - Allow to add/replace loaded `.editorconfig` values via `ExperimentalParams#editorConfigOverride` ([#1016](https://github.com/pinterest/ktlint/issues/1003))
-- `ReporterProvider` and `LintError` now implement `Serializable` interface
+- `ReporterProvider`, `LintError`, `RuleSetProvider` now implement `Serializable` interface
 ### Fixed
 - Incorrect indentation with multiple interfaces ([#1003](https://github.com/pinterest/ktlint/issues/1003))
 - Empty line before primary constructor is not reported and formatted-out ([#1004](https://github.com/pinterest/ktlint/issues/1004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `ktlint_ignore_back_ticked_identifier` EditorConfig option for `max-line-length` rule to ignore long method names inside backticks 
   (primarily used in tests) ([#1007](https://github.com/pinterest/ktlint/issues/1007))
 - Allow to add/replace loaded `.editorconfig` values via `ExperimentalParams#editorConfigOverride` ([#1016](https://github.com/pinterest/ktlint/issues/1003))
-
+- `ReporterProvider` now implements `Serializable` interface
 ### Fixed
 - Incorrect indentation with multiple interfaces ([#1003](https://github.com/pinterest/ktlint/issues/1003))
 - Empty line before primary constructor is not reported and formatted-out ([#1004](https://github.com/pinterest/ktlint/issues/1004))

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintError.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/LintError.kt
@@ -1,5 +1,7 @@
 package com.pinterest.ktlint.core
 
+import java.io.Serializable
+
 /**
  * Lint error.
  *
@@ -8,7 +10,12 @@ package com.pinterest.ktlint.core
  * @param ruleId rule id (prepended with "&lt;ruleSetId&gt;:" in case of non-standard ruleset)
  * @param detail error message
  */
-data class LintError(val line: Int, val col: Int, val ruleId: String, val detail: String) {
+public data class LintError(
+    val line: Int,
+    val col: Int,
+    val ruleId: String,
+    val detail: String
+) : Serializable {
 
     // fixme:
     // not included in equals/hashCode for backward-compatibility with ktlint < 0.25.0
@@ -18,7 +25,7 @@ data class LintError(val line: Int, val col: Int, val ruleId: String, val detail
             field = value
         }
 
-    constructor(
+    public constructor(
         line: Int,
         col: Int,
         ruleId: String,

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.core
 
 import java.io.PrintStream
+import java.io.Serializable
 
 /**
  * `ktlint` uses [ServiceLoader](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html) to
@@ -8,7 +9,7 @@ import java.io.PrintStream
  * `META-INF/services/com.pinterest.ktlint.core.ReporterProvider`
  * (see `ktlint-reporter-plain/src/main/resources` for an example).
  */
-interface ReporterProvider {
-    val id: String
-    fun get(out: PrintStream, opt: Map<String, String>): Reporter
+public interface ReporterProvider : Serializable {
+    public val id: String
+    public fun get(out: PrintStream, opt: Map<String, String>): Reporter
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProvider.kt
@@ -1,16 +1,18 @@
 package com.pinterest.ktlint.core
 
+import java.io.Serializable
+
 /**
  * `ktlint` uses [ServiceLoader](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html) to
  * discover all available `RuleSetProvider`s on the classpath and so each `RuleSetProvider` must be registered using
  * `META-INF/services/com.pinterest.ktlint.core.RuleSetProvider`
  * (see `ktlint-ruleset-standard/src/main/resources` for an example).
  */
-interface RuleSetProvider {
+public interface RuleSetProvider : Serializable {
 
     /**
      * This method is going to be called once for each file (which means if any of the rules have state or
      * are not thread-safe - a new RuleSet must be created).
      */
-    fun get(): RuleSet
+    public fun get(): RuleSet
 }

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-class BaselineReporterProvider : ReporterProvider {
+public class BaselineReporterProvider : ReporterProvider {
     override val id: String = "baseline"
     override fun get(out: PrintStream, opt: Map<String, String>): Reporter = BaselineReporter(out)
 }

--- a/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterProvider.kt
+++ b/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterProvider.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-class CheckStyleReporterProvider : ReporterProvider {
+public class CheckStyleReporterProvider : ReporterProvider {
     override val id: String = "checkstyle"
     override fun get(out: PrintStream, opt: Map<String, String>): Reporter = CheckStyleReporter(out)
 }

--- a/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterProvider.kt
+++ b/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterProvider.kt
@@ -28,7 +28,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-class HtmlReporterProvider : ReporterProvider {
+public class HtmlReporterProvider : ReporterProvider {
     override val id: String = "html"
     override fun get(out: PrintStream, opt: Map<String, String>): Reporter = HtmlReporter(out)
 }

--- a/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterProvider.kt
+++ b/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterProvider.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-class JsonReporterProvider : ReporterProvider {
+public class JsonReporterProvider : ReporterProvider {
     override val id: String = "json"
     override fun get(out: PrintStream, opt: Map<String, String>): Reporter = JsonReporter(out)
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
@@ -5,7 +5,7 @@ import com.pinterest.ktlint.core.ReporterProvider
 import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.PrintStream
 
-class PlainReporterProvider : ReporterProvider {
+public class PlainReporterProvider : ReporterProvider {
 
     override val id: String = "plain"
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 
-class StandardRuleSetProvider : RuleSetProvider {
+public class StandardRuleSetProvider : RuleSetProvider {
 
     // Note: some of these rules may be disabled by default. See the default .editorconfig.
     override fun get(): RuleSet = RuleSet(

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
@@ -3,7 +3,7 @@ package yourpkgname
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 
-class CustomRuleSetProvider : RuleSetProvider {
+public class CustomRuleSetProvider : RuleSetProvider {
 
     override fun get(): RuleSet = RuleSet("custom", NoVarRule())
 }


### PR DESCRIPTION
## Description

Required for better Gradle plugin support.


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] tests are added
- [x] `CHANGELOG.md` is updated
