### PR TITLE
Move baseline utils into 'ktlint-core' package.

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/BaselineSupport.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/BaselineSupport.kt
@@ -1,4 +1,4 @@
-package com.pinterest.ktlint.internal
+package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.LintError
 import java.io.File
@@ -16,7 +16,9 @@ import org.xml.sax.SAXException
  * @param baselineFilePath the path to the xml baseline file
  * @return a [CurrentBaseline] with the file details
  */
-internal fun loadBaseline(baselineFilePath: String): CurrentBaseline {
+public fun loadBaseline(
+    baselineFilePath: String
+): CurrentBaseline {
     if (baselineFilePath.isBlank()) {
         return CurrentBaseline(null, false)
     }
@@ -92,9 +94,9 @@ private fun parseBaselineErrorsByFile(element: Element): MutableList<LintError> 
     return errors
 }
 
-internal class CurrentBaseline(
-    val baselineRules: Map<String, List<LintError>>?,
-    val baselineGenerationNeeded: Boolean
+public class CurrentBaseline(
+    public val baselineRules: Map<String, List<LintError>>?,
+    public val baselineGenerationNeeded: Boolean
 )
 
 /**
@@ -102,7 +104,7 @@ internal class CurrentBaseline(
  * as the `checkstyle` reporter formats the details string and hence the comparison
  * normally fails
  */
-internal fun List<LintError>.containsLintError(error: LintError): Boolean {
+public fun List<LintError>.containsLintError(error: LintError): Boolean {
     return firstOrNull { lintError ->
         lintError.col == error.col &&
             lintError.line == error.line &&
@@ -114,7 +116,7 @@ internal fun List<LintError>.containsLintError(error: LintError): Boolean {
  * Gets the relative route of the file for baselines
  * Also adjusts the slashes for uniformity between file systems
  */
-internal val File.relativeRoute: String
+public val File.relativeRoute: String
     get() {
         val rootPath = Paths.get("").toAbsolutePath()
         val filePath = this.toPath()

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/BaselineSupportTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/BaselineSupportTest.kt
@@ -1,4 +1,4 @@
-package com.pinterest.ktlint.internal
+package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayInputStream
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class BaselineUtilsKtTest {
+class BaselineSupportTest {
 
     @Test
     fun testParseBaselineFile() {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -9,6 +9,9 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import com.pinterest.ktlint.core.RuleExecutionException
 import com.pinterest.ktlint.core.RuleSetProvider
+import com.pinterest.ktlint.core.internal.containsLintError
+import com.pinterest.ktlint.core.internal.loadBaseline
+import com.pinterest.ktlint.core.internal.relativeRoute
 import com.pinterest.ktlint.internal.ApplyToIDEAGloballySubCommand
 import com.pinterest.ktlint.internal.ApplyToIDEAProjectSubCommand
 import com.pinterest.ktlint.internal.GenerateEditorConfigSubCommand
@@ -17,15 +20,12 @@ import com.pinterest.ktlint.internal.GitPrePushHookSubCommand
 import com.pinterest.ktlint.internal.JarFiles
 import com.pinterest.ktlint.internal.KtlintVersionProvider
 import com.pinterest.ktlint.internal.PrintASTSubCommand
-import com.pinterest.ktlint.internal.containsLintError
 import com.pinterest.ktlint.internal.fileSequence
 import com.pinterest.ktlint.internal.formatFile
 import com.pinterest.ktlint.internal.lintFile
-import com.pinterest.ktlint.internal.loadBaseline
 import com.pinterest.ktlint.internal.loadRulesets
 import com.pinterest.ktlint.internal.location
 import com.pinterest.ktlint.internal.printHelpOrVersionUsage
-import com.pinterest.ktlint.internal.relativeRoute
 import com.pinterest.ktlint.internal.toFilesURIList
 import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.File


### PR DESCRIPTION
## Description

Makes it easier to add baseline support for 3rd party tools ([for example](https://github.com/JLLeitschuh/ktlint-gradle/issues/414))

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated
