### PR TITLE
Add ignoreSingleLineRawStringProperty

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
@@ -91,6 +91,41 @@ class MaxLineLengthRuleTest {
     }
 
     @Test
+    fun testErrorSuppressionOnSingleLineRawString() {
+        val testFile = ignoreSingleLineRawString()
+
+        assertThat(
+            MaxLineLengthRule().lint(
+                testFile.absolutePath,
+                """
+                fun main() {
+                    val longRawString = ${"\"\"\""}this is a very very very very long long raw string on a single line${"\"\"\""}
+                }
+                """.trimIndent(),
+                userData = mapOf("max_line_length" to "40")
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testReportLongLinesAfterExcludingSingleLineRawString() {
+        assertThat(
+            MaxLineLengthRule().lint(
+                """
+                fun main() {
+                    val longRawString = ${"\"\"\""}this is a very very very very long long raw string on a single line${"\"\"\""}
+                }
+                """.trimIndent(),
+                userData = mapOf("max_line_length" to "40")
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(2, 1, "max-line-length", "Exceeded max line length (40)")
+            )
+        )
+    }
+
+    @Test
     fun testLintOff() {
         assertThat(
             MaxLineLengthRule().diffFileLint(
@@ -117,5 +152,10 @@ class MaxLineLengthRuleTest {
     private fun ignoreBacktickedIdentifier(): File = editorConfigTestRule
         .writeToEditorConfig(
             mapOf(MaxLineLengthRule.ignoreBackTickedIdentifierProperty.type to true.toString())
+        )
+
+    private fun ignoreSingleLineRawString(): File = editorConfigTestRule
+        .writeToEditorConfig(
+            mapOf(MaxLineLengthRule.ignoreSingleLineRawStringProperty.type to true.toString())
         )
 }


### PR DESCRIPTION
## Description

Allow single line raw strings to be ignored during MaxLineLengthRule execution.

Since multi-line raw strings are already ignored by default and that it is common to have long string literals, this may be a good compromise between disabling the rule and using multi-line raw strings.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [ ] `CHANGELOG.md` is updated
