### PR TITLE
Fix false positive with 'by lazy {}' (`indent`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix false positives for SpacingBetweenDeclarationsWithAnnotationsRule ([#1125](https://github.com/pinterest/ktlint/issues/1125))
 - Fix false positive with eol comment (`annotation-spacing`) ([#1124](https://github.com/pinterest/ktlint/issues/1124))
 - Fix KtLint dependency variant selection ([#1114](https://github.com/pinterest/ktlint/issues/1114))
+- Fix false positive with 'by lazy {}' (`indent`) ([#1162](https://github.com/pinterest/ktlint/issues/1162))
 ### Changed
 - Updated to dokka 1.4.32 ([#1148](https://github.com/pinterest/ktlint/pull/1148))
 ### Removed

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -647,6 +647,45 @@ internal class IndentationRuleTest {
                 """
                 val i: Int
                     by lazy { 1 }
+
+                val j = 0
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `lint property delegate is indented properly 2`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                val i: Int
+                    by lazy {
+                        "".let {
+                            println(it)
+                        }
+                        1
+                    }
+
+                val j = 0
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `lint property delegate is indented properly 3`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                val i: Int by lazy {
+                    "".let {
+                        println(it)
+                    }
+                    1
+                }
+
+                val j = 0
                 """.trimIndent()
             )
         ).isEmpty()


### PR DESCRIPTION
## Description

<!--Describe what was done or link related issue -->
Fixes #1162


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
