### PR TITLE
Fix false positive with multiline expression with elvis operator in assignment (`indent`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix false positive with 'by lazy {}' (`indent`) ([#1162](https://github.com/pinterest/ktlint/issues/1162))
 - Fix false positive with value argument list has lambda (`indent`) ([#764](https://github.com/pinterest/ktlint/issues/764))
 - Fix false positive in lambda in dot qualified expression (`argument-list-wrapping`) ([#1112](https://github.com/pinterest/ktlint/issues/1112))
+- Fix false positive with multiline expression with elvis operator in assignment (`indent`) ([#1165](https://github.com/pinterest/ktlint/issues/1165))
 ### Changed
 - Updated to dokka 1.4.32 ([#1148](https://github.com/pinterest/ktlint/pull/1148))
 - Updated Kotlin to 1.5.20 version

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -666,9 +666,10 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             }
             val nextSibling = n.treeNext
             if (
-                nextSibling?.elementType.let {
-                    it == BINARY_EXPRESSION || it == BINARY_WITH_TYPE
-                } && nextSibling.firstChildNode.elementType != CALL_EXPRESSION
+                nextSibling?.elementType.let { it == BINARY_EXPRESSION || it == BINARY_WITH_TYPE } &&
+                nextSibling.children().firstOrNull { it.elementType == OPERATION_REFERENCE }
+                    ?.firstChildNode?.elementType != ELVIS &&
+                nextSibling.firstChildNode.elementType != CALL_EXPRESSION
             ) {
                 ctx.localAdj = -1
                 debug { "--inside(${nextSibling.elementType}) -> $expectedIndent" }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -975,4 +975,25 @@ internal class IndentationRuleTest {
             )
         ).isEmpty()
     }
+
+    // https://github.com/pinterest/ktlint/issues/1165
+    @Test
+    fun `lint multiline expression with elvis operator in assignment`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                fun test() {
+                    val a: String = ""
+
+                    val someTest: Int?
+
+                    someTest =
+                        a
+                            .toIntOrNull()
+                            ?: 1
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
## Description

<!--Describe what was done or link related issue -->
Fixes #1165

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
