### PR TITLE
Fix The Html reporter Chinese garbled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ignore backticks in imports for ordering purposes (`import-ordering`) ([#1106](https://github.com/pinterest/ktlint/issues/1106))
 - Fix false positive with elvis operator and comment (`chain-wrapping`) ([#1055](https://github.com/pinterest/ktlint/issues/1055))
 - Fix false negative in when conditions (`chain-wrapping`) ([#1130](https://github.com/pinterest/ktlint/issues/1130))
+- Fix the Html reporter Chinese garbled ([#1140](https://github.com/pinterest/ktlint/issues/1140))
 ### Changed
 - Updated to dokka 1.4.32 ([#1148](https://github.com/pinterest/ktlint/pull/1148))
 - Updated Kotlin to 1.5.20 version

--- a/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporter.kt
+++ b/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporter.kt
@@ -48,6 +48,7 @@ class HtmlReporter(private val out: PrintStream) : Reporter {
         html {
             head {
                 cssLink("https://fonts.googleapis.com/css?family=Source+Code+Pro")
+                text("<meta http-equiv=\"Content-Type\" Content=\"text/html; Charset=UTF-8\">${System.lineSeparator()}")
                 text("<style>${System.lineSeparator()}")
                 text("body {${System.lineSeparator()}")
                 text("    font-family: 'Source Code Pro', monospace;${System.lineSeparator()}")

--- a/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
@@ -43,6 +43,7 @@ class HtmlReporterTest {
 <html>
 <head>
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" />
+<meta http-equiv="Content-Type" Content="text/html; Charset=UTF-8">
 <style>
 body {
     font-family: 'Source Code Pro', monospace;
@@ -78,6 +79,7 @@ h3 {
             """<html>
 <head>
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" />
+<meta http-equiv="Content-Type" Content="text/html; Charset=UTF-8">
 <style>
 body {
     font-family: 'Source Code Pro', monospace;
@@ -125,6 +127,7 @@ h3 {
             """<html>
 <head>
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" />
+<meta http-equiv="Content-Type" Content="text/html; Charset=UTF-8">
 <style>
 body {
     font-family: 'Source Code Pro', monospace;
@@ -172,6 +175,7 @@ h3 {
             """<html>
 <head>
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" />
+<meta http-equiv="Content-Type" Content="text/html; Charset=UTF-8">
 <style>
 body {
     font-family: 'Source Code Pro', monospace;


### PR DESCRIPTION
## Description
Fixes #1140 .
Insert
```
<meta http-equiv="Content-Type" Content="text/html; Charset=UTF-8">
```
to ktlint.html head.
And update HtmlReporterTest.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
