### PR TITLE
Re-apply #1129 with fixes for regressions

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -70,6 +70,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private val ref = mutableSetOf<Reference>()
     private val parentExpressions = mutableSetOf<String>()
     private val imports = mutableSetOf<String>()
+    private val usedImportPaths = mutableSetOf<ImportPath>()
     private var packageName = ""
     private var rootNode: ASTNode? = null
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.resolve.ImportPath
 
 class NoUnusedImportsRule : Rule("no-unused-imports") {
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -86,6 +86,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
             ref.add(Reference("*", false))
             parentExpressions.clear()
             imports.clear()
+            usedImportPaths.clear()
             node.visit { vnode ->
                 val psi = vnode.psi
                 val type = vnode.elementType
@@ -103,9 +104,13 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
                 } else if (type == IMPORT_DIRECTIVE) {
                     val importPath = (vnode.psi as KtImportDirective).importPath!!
                     if (!usedImportPaths.add(importPath)) {
-                        emit(vnode.startOffset, "Unused import", false)
+                        emit(vnode.startOffset, "Unused import", true)
+                        if (autoCorrect) {
+                            vnode.psi.delete()
+                        }
+                    } else {
+                        imports += importPath.pathStr.removeBackticks().trim()
                     }
-                    imports += importPath.pathStr.removeBackticks().trim()
                 }
             }
             val directCalls = ref.filter { !it.inDotQualifiedExpression }.map { it.text }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -197,8 +197,6 @@ class NoUnusedImportsRuleTest {
         assertThat(
             NoUnusedImportsRule().lint(
                 """
-
-
                 import org.repository.RepositoryPolicy
                 import org.repository.any
                 import org.repository.all
@@ -212,8 +210,35 @@ class NoUnusedImportsRuleTest {
             )
         ).isEqualTo(
             listOf(
-                LintError(6, 1, "no-unused-imports", "Unused import")
+                LintError(4, 1, "no-unused-imports", "Unused import")
             )
+        )
+
+        assertThat(
+            NoUnusedImportsRule().format(
+                """
+                import org.repository.RepositoryPolicy
+                import org.repository.any
+                import org.repository.all
+                import org.repository.any
+                fun main() {
+                        RepositoryPolicy(
+                        any(false), all("trial")
+                    )
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            import org.repository.RepositoryPolicy
+            import org.repository.any
+            import org.repository.all
+            fun main() {
+                    RepositoryPolicy(
+                    any(false), all("trial")
+                )
+            }
+            """.trimIndent()
         )
     }
 
@@ -222,8 +247,6 @@ class NoUnusedImportsRuleTest {
         assertThat(
             NoUnusedImportsRule().lint(
                 """
-
-
                 import org.repository.RepositoryPolicy
                 import org.repository.any
                 import org.repository.all
@@ -238,10 +261,37 @@ class NoUnusedImportsRuleTest {
             )
         ).isEqualTo(
             listOf(
-                LintError(6, 1, "no-unused-imports", "Unused import"),
-                LintError(7, 1, "no-unused-imports", "Unused import")
-
+                LintError(4, 1, "no-unused-imports", "Unused import"),
+                LintError(5, 1, "no-unused-imports", "Unused import")
             )
+        )
+
+        assertThat(
+            NoUnusedImportsRule().format(
+                """
+                import org.repository.RepositoryPolicy
+                import org.repository.any
+                import org.repository.all
+                import org.repository.any
+                import org.repository.any
+                fun main() {
+                        RepositoryPolicy(
+                        any(false), all("trial")
+                                            )
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+                import org.repository.RepositoryPolicy
+                import org.repository.any
+                import org.repository.all
+                fun main() {
+                        RepositoryPolicy(
+                        any(false), all("trial")
+                                            )
+                }
+                """.trimIndent()
         )
     }
 
@@ -250,8 +300,6 @@ class NoUnusedImportsRuleTest {
         assertThat(
             NoUnusedImportsRule().lint(
                 """
-
-
                 import org.repository.RepositoryPolicy
                 import org.repository.any
                 import org.repository.all
@@ -268,9 +316,41 @@ class NoUnusedImportsRuleTest {
             )
         ).isEqualTo(
             listOf(
-                LintError(7, 1, "no-unused-imports", "Unused import"),
-                LintError(9, 1, "no-unused-imports", "Unused import")
+                LintError(5, 1, "no-unused-imports", "Unused import"),
+                LintError(7, 1, "no-unused-imports", "Unused import")
             )
+        )
+
+        assertThat(
+            NoUnusedImportsRule().format(
+                """
+                import org.repository.RepositoryPolicy
+                import org.repository.any
+                import org.repository.all
+                import org.repository.many
+                import org.repository.any
+                import org.repository.none
+                import org.repository.all
+                fun main() {
+                        RepositoryPolicy(
+                        any(false), all("trial"), many("hello"), none("goodbye")
+                    )
+                }
+                """.trimIndent()
+            )
+        ).isEqualTo(
+                """
+                import org.repository.RepositoryPolicy
+                import org.repository.any
+                import org.repository.all
+                import org.repository.many
+                import org.repository.none
+                fun main() {
+                        RepositoryPolicy(
+                        any(false), all("trial"), many("hello"), none("goodbye")
+                    )
+                }
+                """.trimIndent()
         )
     }
 
@@ -724,6 +804,36 @@ class NoUnusedImportsRuleTest {
 
                 class Consumer(producer1: Producer1<String>) {
                     val x = 1
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `repeated invocations on the same rule instance should work`() {
+        val rule = NoUnusedImportsRule()
+        assertThat(
+            rule.lint(
+                """
+                import foo.bar
+
+                fun main() {
+                    bar()
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+
+        assertThat(
+            rule.lint(
+                """
+                import foo.bar
+                import foo.baz
+
+                fun main() {
+                    bar()
+                    baz()
                 }
                 """.trimIndent()
             )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -283,15 +283,15 @@ class NoUnusedImportsRuleTest {
             )
         ).isEqualTo(
             """
-                import org.repository.RepositoryPolicy
-                import org.repository.any
-                import org.repository.all
-                fun main() {
-                        RepositoryPolicy(
-                        any(false), all("trial")
-                                            )
-                }
-                """.trimIndent()
+            import org.repository.RepositoryPolicy
+            import org.repository.any
+            import org.repository.all
+            fun main() {
+                    RepositoryPolicy(
+                    any(false), all("trial")
+                                        )
+            }
+            """.trimIndent()
         )
     }
 
@@ -339,18 +339,18 @@ class NoUnusedImportsRuleTest {
                 """.trimIndent()
             )
         ).isEqualTo(
-                """
-                import org.repository.RepositoryPolicy
-                import org.repository.any
-                import org.repository.all
-                import org.repository.many
-                import org.repository.none
-                fun main() {
-                        RepositoryPolicy(
-                        any(false), all("trial"), many("hello"), none("goodbye")
-                    )
-                }
-                """.trimIndent()
+            """
+            import org.repository.RepositoryPolicy
+            import org.repository.any
+            import org.repository.all
+            import org.repository.many
+            import org.repository.none
+            fun main() {
+                    RepositoryPolicy(
+                    any(false), all("trial"), many("hello"), none("goodbye")
+                )
+            }
+            """.trimIndent()
         )
     }
 


### PR DESCRIPTION
- Used imports state has to be reset per-file

## Description

- A regression was introduced to the `no-unused-imports` rule where it would report false positives 
- Add auto-correction to the case of repeated imports

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
