### PR TITLE
Fix false positive with lambda argument and call chain (`indent`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- Fix false positive with lambda argument and call chain (`indent`) ([#1202](https://github.com/pinterest/ktlint/issues/1202))
 
 ### Changed
 - Support absolute paths for globs ([#1131](https://github.com/pinterest/ktlint/issues/1131))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -1130,8 +1130,9 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     }
 
     private fun ASTNode?.isAfterLambdaArgumentOnSameLine(): Boolean {
-        val prevComma = this?.prevLeafOnSameLine(RBRACE)?.nextCodeLeaf()?.takeIf { it.elementType == COMMA }
-        return prevComma?.treeParent?.elementType == VALUE_ARGUMENT_LIST
+        if (this == null) return false
+        val prevComma = prevLeafOnSameLine(RBRACE)?.nextCodeLeaf()?.takeIf { it.elementType == COMMA } ?: return false
+        return prevComma.parent(VALUE_ARGUMENT_LIST) == parent(VALUE_ARGUMENT_LIST)
     }
 
     private fun ASTNode.hasLineBreak(vararg ignoreElementTypes: IElementType): Boolean {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1032,6 +1032,22 @@ internal class IndentationRuleTest {
         ).isEmpty()
     }
 
+    // https://github.com/pinterest/ktlint/issues/1202
+    @Test
+    fun `lint lambda argument and call chain`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                class Foo {
+                    fun bar() {
+                        val foo = bar.associateBy({ item -> item.toString() }, ::someFunction).toMap()
+                    }
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
     // https://github.com/pinterest/ktlint/issues/1165
     @Test
     fun `lint multiline expression with elvis operator in assignment`() {


### PR DESCRIPTION
## Description

<!--Describe what was done or link related issue -->
Fixes #1202

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
