### PR TITLE
Lint and format trailing spaces inside block comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New `trailing-comma` rule ([#709](https://github.com/pinterest/ktlint/issues/709)) (prior art by [paul-dingemans](https://github.com/paul-dingemans))
 ### Fixed
 - Fix false positive with lambda argument and call chain (`indent`) ([#1202](https://github.com/pinterest/ktlint/issues/1202))
+- Fix trailing spaces not formatted inside block comments (`no-trailing-spaces`) ([#1197](https://github.com/pinterest/ktlint/issues/1197))
 
 ### Changed
 - Support absolute paths for globs ([#1131](https://github.com/pinterest/ktlint/issues/1131))

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRuleTest.kt
@@ -24,4 +24,45 @@ class NoTrailingSpacesRuleTest {
         assertThat(NoTrailingSpacesRule().format("fun main() {\n    val a = 1 \n  \n \n} "))
             .isEqualTo("fun main() {\n    val a = 1\n\n\n}")
     }
+
+    @Test
+    fun `lint trailing spaces inside block comments`() {
+        val code =
+            """
+            /*${" "}
+             * Some comment${" "}
+             */
+            """.trimIndent()
+
+        val actual = NoTrailingSpacesRule().lint(code)
+
+        assertThat(actual)
+            .isEqualTo(
+                listOf(
+                    LintError(1, 1, "no-trailing-spaces", "Trailing space(s)"),
+                    LintError(2, 1, "no-trailing-spaces", "Trailing space(s)")
+                )
+            )
+    }
+
+    @Test
+    fun `format trailing spaces inside block comments`() {
+        val code =
+            """
+            /*${" "}
+             * Some comment${" "}
+             */
+            """.trimIndent()
+
+        val actual = NoTrailingSpacesRule().format(code)
+
+        assertThat(actual)
+            .isEqualTo(
+                """
+                /*
+                 * Some comment
+                 */
+                """.trimIndent()
+            )
+    }
 }


### PR DESCRIPTION
Closes #1197

## Description

The trailing spaces rules only looked as PsiWhiteSpace elements. Now also the PsiComment element is inspected and fixed if needed. Rule has been refactored entirely to make it more readable and to explain why the last line of a PsiWhiteSpace element is ignored.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [x] `CHANGELOG.md` is updated
