### PR TITLE
Remove spaces before primary constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix false positive with lambda argument and call chain (`indent`) ([#1202](https://github.com/pinterest/ktlint/issues/1202))
 - Fix trailing spaces not formatted inside block comments (`no-trailing-spaces`) ([#1197](https://github.com/pinterest/ktlint/issues/1197))
 - Do not check for `.idea` folder presence when using `applyToIDEA` globally ([#1186](https://github.com/pinterest/ktlint/issues/1186))
+- Remove spaces before primary constructor (`paren-spacing`) ([#1207](https://github.com/pinterest/ktlint/issues/1207))
 
 ### Changed
 - Support absolute paths for globs ([#1131](https://github.com/pinterest/ktlint/issues/1131))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_TYPE
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.KDOC_START
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
+import com.pinterest.ktlint.core.ast.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT_LIST
@@ -38,7 +39,8 @@ class SpacingAroundParensRule : Rule("paren-spacing") {
                             // val foo: @Composable () -> Unit
                             node.treeParent?.treeParent?.elementType != FUNCTION_TYPE ||
                             // Super keyword needs special-casing
-                            prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD
+                            prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD ||
+                            prevLeaf.prevLeaf()?.treeParent?.elementType == PRIMARY_CONSTRUCTOR
                         ) &&
                     (
                         node.treeParent?.elementType == VALUE_PARAMETER_LIST ||

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
@@ -88,5 +89,40 @@ class SpacingAroundParensRuleTest {
             val typeParameter2: (@Foo() () -> Unit) -> Unit = { { } }
             """.trimIndent()
         assertThat(SpacingAroundParensRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `lint trailing spaces after constructor`() {
+        val code =
+            """
+            class SomeClass constructor ()
+
+            """.trimIndent()
+
+        val actual = SpacingAroundParensRule().lint(code)
+
+        assertThat(actual)
+            .isEqualTo(
+                listOf(
+                    LintError(1, 28, "paren-spacing", """Unexpected spacing before "(""""),
+                )
+            )
+    }
+
+    @Test
+    fun `format trailing spaces after constructor`() {
+        val code =
+            """
+            class SomeClass constructor ()
+            """.trimIndent()
+
+        val actual = SpacingAroundParensRule().format(code)
+
+        assertThat(actual)
+            .isEqualTo(
+                """
+                class SomeClass constructor()
+                """.trimIndent()
+            )
     }
 }


### PR DESCRIPTION
Closes #1207

## Description

Add condition for primary constructor in oarrn-soacing rule


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
