### PR TITLE
Add check whether a custom rule set provider has been loaded for each specified jar

### DIFF
--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/RuleSetsLoader.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.internal
 import com.pinterest.ktlint.core.RuleSetProvider
 import java.net.URLClassLoader
 import java.util.ServiceLoader
+import kotlin.system.exitProcess
 
 /**
  * Load given list of paths to rulesets jars into map of ruleset providers.
@@ -26,11 +27,34 @@ internal fun JarFiles.loadRulesets(
     .filterKeys { loadExperimental || it != "experimental" }
     .filterKeys { !(disabledRules.isStandardRuleSetDisabled() && it == "\u0000standard") }
     .toSortedMap()
-    .also {
+    .also { ruleSetMap ->
         if (debug) {
-            it.forEach { entry ->
+            ruleSetMap.forEach { entry ->
                 println("[DEBUG] Discovered ruleset with \"${entry.key}\" id.")
             }
+        }
+
+        val expectedNumberOfCustomRuleSetsToBeLoaded = this.distinct().count()
+        val customRuleSetsLoaded =
+            ruleSetMap
+                .filterKeys { it != "experimental" && it != "\u0000standard" }
+                .values
+                .map { it.javaClass.canonicalName }
+        val actualNumberOfCustomRuleSetsLoaded = customRuleSetsLoaded.count()
+        if (expectedNumberOfCustomRuleSetsToBeLoaded != actualNumberOfCustomRuleSetsLoaded) {
+            System.err.println(
+                """
+                [ERROR] Number of custom rule sets loaded does not match the expected number of rule sets to be loaded.
+                        Expected to load $expectedNumberOfCustomRuleSetsToBeLoaded custom rule set(s) for rules: ${this.joinToString()}
+                        Actually loaded $actualNumberOfCustomRuleSetsLoaded custom rule set(s) with names: ${customRuleSetsLoaded.joinToString() }
+                        One or more of the specified jars does not provide the custom rule set correctly. Check following:
+                          - Does the jar contain an implementation of the RuleSetProvider interface?
+                          - Does the jar contain a resource file with name "com.pinterest.ktlint.core.RuleSetProvider"?
+                          - Is the resource file located in directory "src/main/resources/META-INF/services"?
+                          - Does the resource file contain the fully qualified class name of the class implementing the RuleSetProvider interface?
+                """.trimIndent() // ktlint-disable string-template
+            )
+            exitProcess(2)
         }
     }
 


### PR DESCRIPTION
Closes #1225

## Description

This changes provides, in case of an incorrectly configured jar, the following output:
```
$ ktlint -R /tmp/some-incorrectly-configured-ruleset.jar [ERROR] Number of custom rule sets loaded does not match the expected number of rule sets to be loaded.
        Expected to load 1 custom rule set(s) for rules: /tmp/some-incorrectly-configured-ruleset.jar
        Actually loaded 0 custom rule set(s) with names: 
        One or more of the specified jars does not provide the custom rule set correctly. Check following:
          - Does the jar contain an implementation of the RuleSetProvider interface?
          - Does the jar contain a resource file with name "com.pinterest.ktlint.core.RuleSetProvider"?
          - Is the resource file located in directory "src/main/resources/META-INF/services"?
          - Does the resource file contain the fully qualified class name of the class implementing the RuleSetProvider interface?
```
