### PR TITLE
Fix false positive for delegated properties with a lambda argument (`indent`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix trailing spaces not formatted inside block comments (`no-trailing-spaces`) ([#1197](https://github.com/pinterest/ktlint/issues/1197))
 - Do not check for `.idea` folder presence when using `applyToIDEA` globally ([#1186](https://github.com/pinterest/ktlint/issues/1186))
 - Remove spaces before primary constructor (`paren-spacing`) ([#1207](https://github.com/pinterest/ktlint/issues/1207))
+- Fix false positive for delegated properties with a lambda argument (`indent`) ([#1210](https://github.com/pinterest/ktlint/issues/1210))
 
 ### Changed
 - Support absolute paths for globs ([#1131](https://github.com/pinterest/ktlint/issues/1131))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -65,6 +65,7 @@ import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.isPartOfComment
+import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithoutNewline
 import com.pinterest.ktlint.core.ast.nextCodeLeaf
@@ -482,7 +483,7 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
                             val byKeywordOnSameLine = pairedLeft?.prevLeafOnSameLine(BY_KEYWORD)
                             if (byKeywordOnSameLine != null &&
                                 byKeywordOnSameLine.prevLeaf()?.isWhiteSpaceWithNewline() == true &&
-                                !byKeywordOnSameLine.isPartOf(DELEGATED_SUPER_TYPE_ENTRY)
+                                n.leavesOnSameLine(forward = true).all { it.isWhiteSpace() || it.isPartOfComment() }
                             ) expectedIndent--
                             debug { "--${n.text} -> $expectedIndent" }
                         }
@@ -1123,11 +1124,11 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
         return null
     }
 
-    private fun ASTNode.prevLeafOnSameLine(prevLeafType: IElementType): ASTNode? {
-        return leaves(forward = false)
-            .takeWhile { !it.isWhiteSpaceWithNewline() }
-            .firstOrNull { it.elementType == prevLeafType }
-    }
+    private fun ASTNode.leavesOnSameLine(forward: Boolean): Sequence<ASTNode> =
+        leaves(forward = forward).takeWhile { !it.isWhiteSpaceWithNewline() }
+
+    private fun ASTNode.prevLeafOnSameLine(prevLeafType: IElementType): ASTNode? =
+        leavesOnSameLine(forward = false).firstOrNull { it.elementType == prevLeafType }
 
     private fun ASTNode?.isAfterLambdaArgumentOnSameLine(): Boolean {
         if (this == null) return false

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -730,6 +730,25 @@ internal class IndentationRuleTest {
         ).isEmpty()
     }
 
+    // https://github.com/pinterest/ktlint/issues/1210
+    @Test
+    fun `lint delegated properties with a lambda argument`() {
+        assertThat(
+            IndentationRule().lint(
+                """
+                import kotlin.properties.Delegates
+
+                class Test {
+                    private var test
+                        by Delegates.vetoable("") { _, old, new ->
+                            true
+                        }
+                }
+                """.trimIndent()
+            )
+        ).isEmpty()
+    }
+
     @Test
     fun `lint delegation 1`() {
         assertThat(


### PR DESCRIPTION
## Description

<!--Describe what was done or link related issue -->
https://github.com/pinterest/ktlint/issues/1210#issuecomment-898650141

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] tests are added
- [x] `CHANGELOG.md` is updated
