### PR TITLE
Report unexpected indentation characters in margin of multiline string

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -798,6 +798,18 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     ) {
         val psi = node.psi as KtStringTemplateExpression
         if (psi.isMultiLine() && psi.isFollowedByTrimIndent()) {
+            if (node.containsMixedIndentationCharacters()) {
+                // It can not be determined with certainty how mixed indentation characters should be interpreted.
+                // The trimIndent function handles tabs and spaces equally (one tabs equals one space) while the user
+                // might expect that the tab size in the indentation is more than one space.
+                emit(
+                    node.startOffset,
+                    "Indentation of multiline string should not contain both tab(s) and space(s)",
+                    false
+                )
+                return
+            }
+
             val prefixLength = node.children()
                 .filterNot { it.elementType == OPEN_QUOTE }
                 .filterNot { it.elementType == CLOSING_QUOTE }
@@ -1091,6 +1103,27 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
             elementType !in ignoreElementTypes &&
                 children().any { c -> c.textContains('\n') && c.elementType !in ignoreElementTypes }
         }
+    }
+
+    private fun ASTNode.containsMixedIndentationCharacters(): Boolean {
+        assert((this.psi as KtStringTemplateExpression).isMultiLine())
+        val nonBlankLines = this
+            .text
+            .split("\n")
+            .filterNot { it.startsWith("\"\"\"") }
+            .filterNot { it.endsWith("\"\"\"") }
+            .filterNot { it.isBlank() }
+        val prefixLength = nonBlankLines
+            .map { it.indentLength() }
+            .min() ?: 0
+        val distinctIndentCharacters = nonBlankLines
+            .joinToString(separator = "") {
+                it.splitIndentAt(prefixLength).first
+            }
+            .toCharArray()
+            .distinct()
+            .count()
+        return distinctIndentCharacters > 1
     }
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1271,6 +1271,31 @@ internal class IndentationRuleTest {
         ).isEmpty()
     }
 
+    @Test
+    fun `multiline string with mixed indentation characters, can not be autocorrected`() {
+        val code =
+            """
+                val foo = $MULTILINE_STRING_QUOTE
+                      line1
+                ${TAB}line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """
+                .trimIndent()
+        assertThat(
+            IndentationRule().lint(code)
+        ).isEqualTo(
+            listOf(
+                LintError(
+                    line = 1,
+                    col = 11,
+                    ruleId = "indent",
+                    detail = "Indentation of multiline string should not contain both tab(s) and space(s)"
+                ),
+            )
+        )
+        assertThat(IndentationRule().format(code)).isEqualTo(code)
+    }
+
     private companion object {
         const val MULTILINE_STRING_QUOTE = "${'"'}${'"'}${'"'}"
         const val TAB = "${'\t'}"


### PR DESCRIPTION
It can not be determined with certainty how mixed indentation characters should be interpreted.
The trimIndent function handles tabs and spaces equally (one tabs equals one space) while the
user might expect that the tab size in the indentation is more than one space.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [ ] `CHANGELOG.md` is updated
