### PR TITLE
Fix indentation of the closing quotes of a multiline string literal in a variable assignment

### DIFF
--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -84,7 +84,7 @@ class C {
     val CONFIG_COMPACT = """
         {
         }
-    """.trimIndent()
+        """.trimIndent()
     val CONFIG_COMPACT = // comment
         """
         {


### PR DESCRIPTION
## Description

Fix indentation below:
```
val bar = """
    some text
         some more text
"""
```
to
```
val bar = """
    some text
         some more text
    """
```

However, above might be a debatable choice. Therefore I left following TODO in a test:
```
        // TODO: What is the proper way to place the opening and closing quotes of a multi line string value? Note that
        //  the actual content of the multi line string is never been changed as required by ktlint maintainers
        //     val foo =
        //        """
        //        line1
        //        line2
        //        """
        //  or
        //     val foo = """
        //        line1
        //        line2
        //        """
        //  or
        //     val foo = """
        //     line1
        //     line2
        //     """
        //  or
        //     val foo = """
        //        line1
        //        line2
        //     """
        // First option would be most in line with function parameter. Second option is also acceptable. Third option
        // (previous behavior) is not logical as there is no continuation kind of indent visible. Last option is not in
        // sync with function parameter.
```
I would like your opinion about it, so that I can finalize this PR.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [ ] `CHANGELOG.md` is updated
