### PR TITLE
Fix NoSuchElementException in trailing-comma rule in property accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Fix false positive in rule spacing-between-declarations-with-annotations ([#1281](https://github.com/pinterest/ktlint/issues/1281))
+- Fix NoSuchElementException for property accessor (`trailing-comma`) ([#1280](https://github.com/pinterest/ktlint/issues/1280))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
@@ -129,10 +129,12 @@ public class TrailingCommaRule :
         autoCorrect: Boolean
     ) {
         if (node.treeParent.elementType != ElementType.FUNCTION_LITERAL) {
-            val inspectNode = node
+            node
                 .children()
-                .last { it.elementType == ElementType.RPAR }
-            node.reportAndCorrectTrailingCommaNodeBefore(inspectNode, emit, autoCorrect)
+                .lastOrNull { it.elementType == ElementType.RPAR }
+                ?.let {
+                    node.reportAndCorrectTrailingCommaNodeBefore(it, emit, autoCorrect)
+                }
         }
     }
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
@@ -908,6 +908,26 @@ class TrailingCommaRuleTest {
             .isEqualTo(autoCorrectedCode)
     }
 
+    @Test
+    fun `Trailing comma is not added for property setter`() {
+        val code =
+            """
+            class Test {
+              var foo = Bar()
+                set(value) {
+                }
+            }
+            """.trimIndent()
+
+        val editorConfigFilePath = writeEditorConfigFile(
+            ALLOW_TRAILING_COMMA_ON_DECLARATION_SITE, ALLOW_TRAILING_COMMA_ON_CALL_SITE
+        ).absolutePath
+
+        assertThat(TrailingCommaRule().lint(editorConfigFilePath, code)).isEmpty()
+        assertThat(TrailingCommaRule().format(editorConfigFilePath, code))
+            .isEqualTo(code)
+    }
+
     private fun writeEditorConfigFile(vararg editorConfigProperties: Pair<PropertyType<Boolean>, String>) = editorConfigTestRule
         .writeToEditorConfig(
             mapOf(*editorConfigProperties)


### PR DESCRIPTION
Closes #1280

## Description

The property setter has exactly 1 argument. As a result a special kind of parameter list is provided, which resulted in a NoSuchElementException.  The same construct which caused this exception is used in other cases in this rule as well. However, I as not able to construct any tests in which that would lead to an error as well.


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
