### PR TITLE
Fixed parameter list wrapping when indent style is tab

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.experimental
 
+import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType
@@ -38,6 +39,7 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
 
     private var indentSize = -1
     private var maxLineLength = -1
+    private var indentCharacter = " "
 
     override fun visit(
         node: ASTNode,
@@ -46,7 +48,13 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
+            if (editorConfig.indentStyle == EditorConfig.IndentStyle.TAB) {
+                indentCharacter = "\t"
+                indentSize = 1
+            } else {
+                indentCharacter = " "
+                indentSize = editorConfig.indentSize
+            }
             maxLineLength = editorConfig.maxLineLength
             return
         }
@@ -109,8 +117,8 @@ class ArgumentListWrappingRule : Rule("argument-list-wrapping") {
                 // <line indent> RPAR
                 val lineIndent = node.lineIndent()
                 val indent = ("\n" + lineIndent.substring(0, (lineIndent.length - adjustedIndent).coerceAtLeast(0)))
-                    .let { if (node.isOnSameLineAsControlFlowKeyword()) it + " ".repeat(indentSize) else it }
-                val paramIndent = indent + " ".repeat(indentSize)
+                    .let { if (node.isOnSameLineAsControlFlowKeyword()) it + indentCharacter.repeat(indentSize) else it }
+                val paramIndent = indent + indentCharacter.repeat(indentSize)
                 nextChild@ for (child in node.children()) {
                     when (child.elementType) {
                         ElementType.LPAR -> {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -762,4 +762,57 @@ class ArgumentListWrappingRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun `ling argument list indented with tabs`() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                class MyClass {
+                ${TAB}private fun initCoilOkHttp() {
+                ${TAB}${TAB}foo.biz(
+                ${TAB}${TAB}${TAB}a.x - d,
+                ${TAB}${TAB}${TAB}a.c,
+                ${TAB}${TAB}${TAB}a.x,
+                ${TAB}${TAB}${TAB}a.c,
+                ${TAB}${TAB}${TAB}a.x,
+                ${TAB}${TAB}${TAB}a.c - d
+                ${TAB}${TAB})
+                ${TAB}}
+                }
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `ling argument list indented with tabs wrong indent`() {
+        assertThat(
+            ArgumentListWrappingRule().lint(
+                """
+                class MyClass {
+                ${TAB}private fun initCoilOkHttp() {
+                ${TAB}${TAB}foo.biz(
+                ${TAB}${TAB}a.x - d,
+                ${TAB}${TAB}    a.c,
+                ${TAB}${TAB}${TAB}a.x,
+                ${TAB}${TAB}${TAB}a.c,
+                ${TAB}${TAB}${TAB}a.x,
+                ${TAB}${TAB}${TAB}a.c - d
+                ${TAB}${TAB})
+                ${TAB}}
+                }
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEqualTo(listOf(
+            LintError(4, 3, "argument-list-wrapping", "Unexpected indentation (expected 3, actual 2)"),
+            LintError(5, 7, "argument-list-wrapping", "Unexpected indentation (expected 3, actual 6)"),
+        ))
+    }
+
+    private companion object {
+        const val TAB = "${'\t'}"
+
+        val INDENT_STYLE_TABS = mapOf("indent_style" to "tab")
+    }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
@@ -31,6 +32,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
 
     private var indentSize = -1
     private var maxLineLength = -1
+    private var indentCharacter = " "
 
     override fun visit(
         node: ASTNode,
@@ -39,7 +41,13 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
     ) {
         if (node.isRoot()) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
+            if (editorConfig.indentStyle == EditorConfig.IndentStyle.TAB) {
+                indentCharacter = "\t"
+                indentSize = 1
+            } else {
+                indentCharacter = " "
+                indentSize = editorConfig.indentSize
+            }
             maxLineLength = editorConfig.maxLineLength
             return
         }
@@ -83,7 +91,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                 // <line indent> RPAR
                 val lineIndent = node.lineIndent()
                 val indent = "\n" + lineIndent.substring(0, (lineIndent.length - adjustedIndent).coerceAtLeast(0))
-                val paramIndent = indent + " ".repeat(indentSize)
+                val paramIndent = indent + indentCharacter.repeat(indentSize)
                 nextChild@ for (child in node.children()) {
                     when (child.elementType) {
                         LPAR -> {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -611,4 +611,86 @@ class ParameterListWrappingRuleTest {
             )
         ).isEmpty()
     }
+
+    @Test
+    fun testLintClassParameterListWhenIndentStyleIsTab() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ClassA(
+                ${TAB}paramA: String,
+                ${TAB}paramB: String,
+                ${TAB}paramC: String
+                )
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintClassParameterListWhenIndentStyleIsTabAndWrongIndent() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ClassA(
+                    paramA: String,
+                    paramB: String,
+                    paramC: String
+                )
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(2, 5, "parameter-list-wrapping", "Unexpected indentation (expected 1, actual 4)"),
+                LintError(3, 5, "parameter-list-wrapping", "Unexpected indentation (expected 1, actual 4)"),
+                LintError(4, 5, "parameter-list-wrapping", "Unexpected indentation (expected 1, actual 4)"),
+            )
+        )
+    }
+
+    @Test
+    fun testLintClassParameterListWhenIndentStyleIsTabWithNestedIndent() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ClassA() {
+                ${TAB}fun foo(
+                ${TAB}${TAB}paramA: String,
+                ${TAB}${TAB}paramB: String,
+                ${TAB}${TAB}paramC: String
+                ${TAB})
+                }
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testLintClassParameterListWhenIndentStyleIsTabWithNestedIndentAndWrongIndent() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+                """
+                class ClassA() {
+                ${TAB}fun foo(
+                ${TAB}    paramA: String,
+                ${TAB}    paramB: String,
+                ${TAB}    paramC: String
+                ${TAB})
+                }
+                """.trimIndent(), INDENT_STYLE_TABS
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(3, 6, "parameter-list-wrapping", "Unexpected indentation (expected 2, actual 5)"),
+                LintError(4, 6, "parameter-list-wrapping", "Unexpected indentation (expected 2, actual 5)"),
+                LintError(5, 6, "parameter-list-wrapping", "Unexpected indentation (expected 2, actual 5)"),
+            )
+        )
+    }
+
+    private companion object {
+        const val TAB = "${'\t'}"
+
+        val INDENT_STYLE_TABS = mapOf("indent_style" to "tab")
+    }
 }


### PR DESCRIPTION
## Description
When the `indent_style` is set to be `tab`, parameter wrapping doesn't consider that tab is 1 character and it expects the indention to be higher than just 1 character. 

Sample code in this issue: https://github.com/pinterest/ktlint/issues/1245

In this PR, I've added a new property to the `ParameterListWrappingRule` class named `indentCharacter` which would be a `" "` or `"\t"` based on the settings and also set the `indentSize` to be 1 in case of tabs. 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ x] tests are added
- [ ] `CHANGELOG.md` is updated
