### PR TITLE
Do not remove trailing comma in value argument list in annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Fix false positive in rule spacing-between-declarations-with-annotations ([#1281](https://github.com/pinterest/ktlint/issues/1281))
+- Do not remove trailing comma in annotation ([#1297](https://github.com/pinterest/ktlint/issues/1297))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
@@ -235,11 +235,11 @@ public class TrailingCommaRule :
         element is KtFunctionLiteral -> containsLineBreakInRange(element.valueParameterList!!, element.arrow!!)
         element is KtWhenEntry -> containsLineBreakInRange(element.firstChild, element.arrow!!)
         element is KtDestructuringDeclaration -> containsLineBreakInRange(element.lPar!!, element.rPar!!)
-        element is KtValueArgumentList && element.anyDescendantOfType<KtCollectionLiteralExpression>() -> {
+        element is KtValueArgumentList && element.children.size == 1 && element.anyDescendantOfType<KtCollectionLiteralExpression>() -> {
             // special handling for collection literal
             // @Annotation([
             //    "something",
-            // )]
+            // ])
             val lastChild = element.collectDescendantsOfType<KtCollectionLiteralExpression>().last()
             containsLineBreakInRange(element.rightParenthesis!!, lastChild.rightBracket!!)
         }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
@@ -875,6 +875,18 @@ class TrailingCommaRuleTest {
                 2 /* The comma should be inserted before the comment */
             ])
             val foo3: Int = 0
+
+            @Annotation(
+                [
+                    1,
+                    2 /* The comma should be inserted before the comment */
+                ],
+                [
+                    3,
+                    4 /* The comma should be inserted before the comment */
+                ]
+            )
+            val foo4: Int = 0
             """.trimIndent()
         val autoCorrectedCode =
             """
@@ -894,6 +906,18 @@ class TrailingCommaRuleTest {
                 2, /* The comma should be inserted before the comment */
             ])
             val foo3: Int = 0
+
+            @Annotation(
+                [
+                    1,
+                    2, /* The comma should be inserted before the comment */
+                ],
+                [
+                    3,
+                    4, /* The comma should be inserted before the comment */
+                ],
+            )
+            val foo4: Int = 0
             """.trimIndent()
 
         val editorConfigFilePath = writeEditorConfigFile(ALLOW_TRAILING_COMMA_ON_CALL_SITE).absolutePath
@@ -901,11 +925,62 @@ class TrailingCommaRuleTest {
         assertThat(TrailingCommaRule().lint(editorConfigFilePath, code)).isEqualTo(
             listOf(
                 LintError(line = 8, col = 6, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\""),
-                LintError(line = 14, col = 6, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\"")
+                LintError(line = 14, col = 6, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\""),
+                LintError(line = 21, col = 10, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\""),
+                LintError(line = 25, col = 10, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\""),
+                LintError(line = 26, col = 6, ruleId = "trailing-comma", detail = "Missing trailing comma before \")\""),
             )
         )
         assertThat(TrailingCommaRule().format(editorConfigFilePath, code))
             .isEqualTo(autoCorrectedCode)
+    }
+
+    @Test
+    fun `1297 - trailing comma required for collection literal`() {
+        val code =
+            """
+            annotation class FooBar(
+                val foo1: Array<String> = [],
+                val foo2: Array<String> = [],
+                val bar1: String = ""
+            )
+
+            @FooBar(
+                foo1 = [
+                    "foo-1" // Add trailing comma as the argument value list foo1 is a multiline statement
+                ],
+                foo2 = ["foo-2"], // Do not add trailing comma in the array as the argument value list foo2 is a single line statement
+                bar1 = "bar-1" // Add trailing comma as the outer argument value list of the annotation is a multiline statement
+            )
+            val fooBar = null
+            """.trimIndent()
+        val formattedCode =
+            """
+            annotation class FooBar(
+                val foo1: Array<String> = [],
+                val foo2: Array<String> = [],
+                val bar1: String = ""
+            )
+
+            @FooBar(
+                foo1 = [
+                    "foo-1", // Add trailing comma as the argument value list foo1 is a multiline statement
+                ],
+                foo2 = ["foo-2"], // Do not add trailing comma in the array as the argument value list foo2 is a single line statement
+                bar1 = "bar-1", // Add trailing comma as the outer argument value list of the annotation is a multiline statement
+            )
+            val fooBar = null
+            """.trimIndent()
+        val editorConfigFilePath = writeEditorConfigFile(ALLOW_TRAILING_COMMA_ON_CALL_SITE).absolutePath
+
+        assertThat(TrailingCommaRule().lint(editorConfigFilePath, code)).isEqualTo(
+            listOf(
+                LintError(line = 9, col = 16, ruleId = "trailing-comma", detail = "Missing trailing comma before \"]\""),
+                LintError(line = 12, col = 19, ruleId = "trailing-comma", detail = "Missing trailing comma before \")\"")
+            )
+        )
+        assertThat(TrailingCommaRule().format(editorConfigFilePath, code))
+            .isEqualTo(formattedCode)
     }
 
     private fun writeEditorConfigFile(vararg editorConfigProperties: Pair<PropertyType<Boolean>, String>) = editorConfigTestRule


### PR DESCRIPTION
## Description

The code previously contained special handling for case below:
```
    @Annotation([
        "something",
    ])
```

This special case however was also triggered in case of:
```
    @Annotation(
       foo = [
        "something"
       ],
       bar = "some-bar"
   )
```

In this case the normal handling of value argument lists should be used once for the outer value argument list (containing elements foo and bar) and once for the inner value argument list of parameter foo (containing element "something"). So in example above, a trailing comma has to be added to both the outer and the inner value argument list.

Closes #1297

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
