### PR TITLE
Fix alignment of arrow when trailing comma is missing in when entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Do not remove trailing comma in annotation ([#1297](https://github.com/pinterest/ktlint/issues/1297))
 - Do not remove import which is used as markdown link in KDoc only (`no-unused-imports`) ([#1282](https://github.com/pinterest/ktlint/issues/1282))
 - Fix indentation of secondary constructor (`indent`) ([#1222](https://github.com/pinterest/ktlint/issues/1222))
+- Fix alignment of arrow when trailing comma is missing in when entry (`trailing-comma`) ([#1312](https://github.com/pinterest/ktlint/issues/1312))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
@@ -15,6 +15,7 @@ import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
@@ -25,6 +26,7 @@ import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 
 @OptIn(FeatureInAlphaState::class)
@@ -195,13 +197,33 @@ public class TrailingCommaRule :
                 }
             }
             TrailingCommaState.MISSING -> if (isTrailingCommaAllowed) {
+                val addNewLineBeforeArrowInWhenEntry = addNewLineBeforeArrowInWhen()
                 val prevNode = inspectNode.prevCodeLeaf()!!
-                emit(
-                    prevNode.startOffset + prevNode.textLength,
-                    "Missing trailing comma before \"${inspectNode.text}\"",
-                    true
-                )
+                if (addNewLineBeforeArrowInWhenEntry) {
+                    emit(
+                        prevNode.startOffset + prevNode.textLength,
+                        "Missing trailing comma and newline before \"${inspectNode.text}\"",
+                        true
+                    )
+                } else {
+                    emit(
+                        prevNode.startOffset + prevNode.textLength,
+                        "Missing trailing comma before \"${inspectNode.text}\"",
+                        true
+                    )
+                }
                 if (autoCorrect) {
+                    if (addNewLineBeforeArrowInWhenEntry) {
+                        val parentIndent = (prevNode.psi.parent.prevLeaf() as? PsiWhiteSpace)?.text ?: "\n"
+                        val leafBeforeArrow = (psi as KtWhenEntry).arrow?.prevLeaf()
+                        if (leafBeforeArrow != null && leafBeforeArrow is PsiWhiteSpace) {
+                            val newLine = KtPsiFactory(prevNode.psi).createWhiteSpace(parentIndent)
+                            leafBeforeArrow.replace(newLine)
+                        } else {
+                            val newLine = KtPsiFactory(prevNode.psi).createWhiteSpace(parentIndent)
+                            prevNode.psi.parent.addAfter(newLine, prevNode.psi)
+                        }
+                    }
                     val comma = KtPsiFactory(prevNode.psi).createComma()
                     prevNode.psi.parent.addAfter(comma, prevNode.psi)
                 }
@@ -219,6 +241,14 @@ public class TrailingCommaRule :
             TrailingCommaState.NOT_EXISTS -> Unit
         }
     }
+
+    private fun ASTNode.addNewLineBeforeArrowInWhen() =
+        if (psi is KtWhenEntry) {
+            val leafBeforeArrow = (psi as KtWhenEntry).arrow?.prevLeaf()
+            !(leafBeforeArrow is PsiWhiteSpace && leafBeforeArrow.textContains('\n'))
+        } else {
+            false
+        }
 
     private fun ASTNode?.findPreviousTrailingCommaNodeOrNull(): ASTNode? {
         var node = this


### PR DESCRIPTION
## Description

Fix alignment of arrow when trailing comma is missing in when entry.

Closes #1312

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
