### PR TITLE
Add new experimental rule 'function-return-type-wrapping'

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ by passing the `--experimental` flag to `ktlint`.
 - No spaces around unary operators (id: `experimental:unary-op-spacing`)
 - Declarations with annotations should be separated by a blank line (id: `experimental:spacing-between-declarations-with-annotations`)
 - Declarations with comments should be separated by a blank line (id: `experimental:spacing-between-declarations-with-comments`)
+- In a multiline function signature the return type should be placed on the same line as the closing parenthesis (id: `experimental:function-return-type-wrapping`)
 
 
 ## EditorConfig

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -20,6 +20,7 @@ public class ExperimentalRuleSetProvider : RuleSetProvider {
         SpacingBetweenDeclarationsWithAnnotationsRule(),
         SpacingAroundAngleBracketsRule(),
         SpacingAroundUnaryOperatorRule(),
-        AnnotationSpacingRule()
+        AnnotationSpacingRule(),
+        FunctionReturnTypeWrappingRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeWrappingRule.kt
@@ -1,0 +1,160 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.EditorConfig
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK
+import com.pinterest.ktlint.core.ast.ElementType.COLON
+import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.core.ast.ElementType.FUN
+import com.pinterest.ktlint.core.ast.ElementType.FUN_KEYWORD
+import com.pinterest.ktlint.core.ast.ElementType.LPAR
+import com.pinterest.ktlint.core.ast.ElementType.RPAR
+import com.pinterest.ktlint.core.ast.ElementType.TYPE_REFERENCE
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.isRoot
+import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+
+public class FunctionReturnTypeWrappingRule : Rule("function-return-type-wrapping") {
+    private var indent: String? = null
+    private var maxLineLength = -1
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.isRoot()) {
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            indent = when (editorConfig.indentStyle) {
+                EditorConfig.IndentStyle.SPACE -> " ".repeat(editorConfig.indentSize)
+                EditorConfig.IndentStyle.TAB -> "\t"
+            }
+            maxLineLength = editorConfig.maxLineLength
+            return
+        }
+        if (node.elementType == FUN) {
+            val functionSignature = node.getSignature()
+            if (functionSignature.contains('\n') || functionSignature.exceedsMaxLineLength()) {
+                visitOpeningParenthesis(node, emit, autoCorrect)
+                visitClosingParenthesisAndReturnType(node, emit, autoCorrect)
+            }
+        }
+    }
+
+    private fun ASTNode.getSignature(): String {
+        require(elementType == FUN)
+
+        val iterator = children().iterator()
+        var currentNode: ASTNode? = null
+
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            if (currentNode.elementType == FUN_KEYWORD) {
+                break
+            }
+        }
+        val indentBeforeFunKeyword =
+            currentNode
+                ?.prevLeaf()
+                ?.takeIf { it.elementType == WHITE_SPACE }
+                ?.text
+                ?.substringAfter('\n')
+                ?: ""
+
+        var signature = indentBeforeFunKeyword + currentNode?.text
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            if (currentNode.elementType == BLOCK || currentNode.elementType == DOT_QUALIFIED_EXPRESSION) {
+                signature = signature.trimEnd()
+                break
+            }
+            signature += currentNode.text
+        }
+        return signature
+    }
+
+    private fun String.exceedsMaxLineLength(): Boolean =
+        isMaxLineLengthSet() && length > maxLineLength
+
+    private fun isMaxLineLengthSet() = maxLineLength > -1
+
+    private fun visitOpeningParenthesis(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val openingParentheses =
+            node
+                .findChildByType(VALUE_PARAMETER_LIST)
+                ?.findChildByType(LPAR)
+        if (openingParentheses != null && node.hasNonEmptyValueParameterList()) {
+            emit(openingParentheses.startOffset, ERROR_PARAMETERS_ON_SEPARATE_LINES, true)
+            if (autoCorrect) {
+                (openingParentheses as LeafPsiElement).upsertWhitespaceAfterMe("\n$indent")
+                // Rules 'parameter-list-wrapping' and 'indent' will take care of the individual parameters
+            }
+        }
+    }
+
+    private fun ASTNode.hasNonEmptyValueParameterList(): Boolean =
+        findChildByType(VALUE_PARAMETER_LIST)
+            ?.children()
+            ?.any { it.elementType != LPAR && it.elementType != RPAR }
+            ?: false
+
+    private fun visitClosingParenthesisAndReturnType(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val closingParentheses =
+            node
+                .findChildByType(VALUE_PARAMETER_LIST)
+                ?.findChildByType(RPAR)
+        val typeReferenceNode = node.findChildByType(TYPE_REFERENCE)
+        if (closingParentheses != null && typeReferenceNode != null) {
+            emit(closingParentheses.startOffset, ERROR_RETURN_TYPE_ON_SAME_LINE_AS_CLOSING_PARENTHESES, true)
+            if (autoCorrect) {
+                // Force closing parenthesis on a new line
+                closingParentheses.forceToNewLine()
+                node.removeWhiteSpaceBetweenClosingParenthesisAndColon()
+                typeReferenceNode.fixWhiteSpaceBetweenColonAndReturnType()
+            }
+        }
+    }
+
+    private fun ASTNode.forceToNewLine() {
+        require(elementType == RPAR)
+        (this as LeafPsiElement).upsertWhitespaceBeforeMe("\n")
+    }
+
+    private fun ASTNode.removeWhiteSpaceBetweenClosingParenthesisAndColon() =
+        findChildByType(COLON)
+            ?.prevLeaf()
+            ?.takeIf { it.elementType == WHITE_SPACE }
+            ?.let { whitespaceBeforeColonNode ->
+                whitespaceBeforeColonNode.treeParent?.removeChild(whitespaceBeforeColonNode)
+            }
+
+    private fun ASTNode.fixWhiteSpaceBetweenColonAndReturnType() {
+        require(elementType == TYPE_REFERENCE)
+        prevLeaf()
+            ?.takeIf { it.elementType == WHITE_SPACE && it.text != " " }
+            ?.let {
+                (it as LeafElement).rawReplaceWithText(" ")
+            }
+    }
+
+    private companion object {
+        const val ERROR_PARAMETERS_ON_SEPARATE_LINES = "Parameters should be on a separate line (unless entire function signature fits on a single line)"
+        const val ERROR_RETURN_TYPE_ON_SAME_LINE_AS_CLOSING_PARENTHESES = "Return type should be on separate line with closing parentheses (unless entire function signature fits on a single line)"
+    }
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeWrappingRuleTest.kt
@@ -1,0 +1,188 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class FunctionReturnTypeWrappingRuleTest {
+    @Test
+    fun `Given a single line function signature which is smaller than the max line length, and function is followed by a block, then do no change the signature`() {
+        val code =
+            """
+            // Max line length marker:             $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String {
+                // body
+            }
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().lint(code, code.setMaxLineLength())
+        ).isEmpty()
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code, code.setMaxLineLength())
+        ).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a single line function signature which is smaller than or equal to the max line length, and function is followed by an expression, then do no change the signature`() {
+        val code =
+            """
+            // Max line length marker:    $EOL_CHAR
+            fun f(string: String): String = string.toUpperCase()
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().lint(code, code.setMaxLineLength())
+        ).isEmpty()
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code, code.setMaxLineLength())
+        ).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a single line function signature followed by a block with a length greater than the max line length, and function is followed by a block, then reformat`() {
+        val code =
+            """
+            // Max line length marker:        $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            // Note: parameters will be wrapped to separate lines by the parameter-list-wrapping rule
+            """
+            // Max line length marker:        $EOL_CHAR
+            fun f(
+                a: Any, b: Any, c: Any
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().lint(code, code.setMaxLineLength())
+        ).containsExactly(
+            LintError(2, 6, "function-return-type-wrapping", "Parameters should be on a separate line (unless entire function signature fits on a single line)"),
+            LintError(2, 29, "function-return-type-wrapping", "Return type should be on separate line with closing parentheses (unless entire function signature fits on a single line)")
+        )
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code, code.setMaxLineLength())
+        ).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature which is greater than the max line length, and parameter list contains a block comment, then reformat`() {
+        val code =
+            """
+            // Max line length marker:   $EOL_CHAR
+            fun f(string: String): String = string.toUpperCase()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // Max line length marker:   $EOL_CHAR
+            fun f(
+                string: String
+            ): String = string.toUpperCase()
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(
+                code,
+                userData = code.setMaxLineLength()
+            )
+        ).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature contain a block comment in the parameter list and signature greater than the max line length, then reformat`() {
+        val code =
+            """
+            // Max line length marker:      $EOL_CHAR
+            fun f( /* some comment */ ): String {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // Max line length marker:      $EOL_CHAR
+            fun f(
+                /* some comment */
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code, code.setMaxLineLength())
+        ).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline function signature with newline between closing parentheses and colon then reformat`() {
+        val code =
+            """
+            fun f(a: Any, b: Any, c: Any)
+                : String {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            // Note: parameters will be wrapped to separate lines by the parameter-list-wrapping rule
+            """
+            fun f(
+                a: Any, b: Any, c: Any
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().lint(code)
+        ).containsExactly(
+            LintError(1, 6, "function-return-type-wrapping", "Parameters should be on a separate line (unless entire function signature fits on a single line)"),
+            LintError(1, 29, "function-return-type-wrapping", "Return type should be on separate line with closing parentheses (unless entire function signature fits on a single line)")
+        )
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code)
+        ).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline function signature with newline between colon and the return type then reformat`() {
+        val code =
+            """
+            fun f(a: Any, b: Any, c: Any):
+                String {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            // Note: parameters will be wrapped to separate lines by the parameter-list-wrapping rule
+            """
+            fun f(
+                a: Any, b: Any, c: Any
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        assertThat(
+            FunctionReturnTypeWrappingRule().lint(code)
+        ).containsExactly(
+            LintError(1, 6, "function-return-type-wrapping", "Parameters should be on a separate line (unless entire function signature fits on a single line)"),
+            LintError(1, 29, "function-return-type-wrapping", "Return type should be on separate line with closing parentheses (unless entire function signature fits on a single line)")
+        )
+        assertThat(
+            FunctionReturnTypeWrappingRule().format(code)
+        ).isEqualTo(formattedCode)
+    }
+
+    private fun String.setMaxLineLength(): Map<String, String> =
+        split("\n")
+            .first { it.startsWith("//") && it.contains(EOL_CHAR) }
+            .indexOf(EOL_CHAR)
+            .let { index ->
+                mapOf(
+                    "max_line_length" to (index + 1).toString()
+                )
+            }
+
+    private companion object {
+        const val EOL_CHAR = '#'
+    }
+}


### PR DESCRIPTION
## Description

In case of a multiline function signature (e.g. the signature already contains a newline) or in case of a single line function signature which exceeds the max-line-length, force the return type to be on the same line as the closing parenthesis. This can either be wrapping the closing parenthesis plus return type to a new line, or joining the line containing the closing parenthesis with the return type. See unit tests for examples.

This rule partly overlaps with the parameter-list-wrapping but does not conflict with it.

Closes #941, #188

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
