### PR TITLE
Display explanatory note about path after installing a git hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fix indentation of secondary constructor (`indent`) ([#1222](https://github.com/pinterest/ktlint/issues/1222))
 - Fix alignment of arrow when trailing comma is missing in when entry (`trailing-comma`) ([#1312](https://github.com/pinterest/ktlint/issues/1312))
 - Fix indent of delegated super type entry (`indent`) ([#1210](https://github.com/pinterest/ktlint/issues/1210))
-- Display explanatory note about path after installing a git hook ([#634](https://github.com/pinterest/ktlint/issues/634))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fix indentation of secondary constructor (`indent`) ([#1222](https://github.com/pinterest/ktlint/issues/1222))
 - Fix alignment of arrow when trailing comma is missing in when entry (`trailing-comma`) ([#1312](https://github.com/pinterest/ktlint/issues/1312))
 - Fix indent of delegated super type entry (`indent`) ([#1210](https://github.com/pinterest/ktlint/issues/1210))
+- Display explanatory note about path after installing a git hook ([#634](https://github.com/pinterest/ktlint/issues/634))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
@@ -25,7 +25,12 @@ object GitHookInstaller {
 
         gitHookFile.writeBytes(hookContent)
         gitHookFile.setExecutable(true)
-        println(".git/hooks/$gitHookName installed")
+        println(
+            """
+            .git/hooks/$gitHookName is installed. Be aware that this hook assumes to find ktlint on the PATH. Either
+            ensure that ktlint is actually added to the path or expand the ktlint command in the hook with the path.
+            """.trimIndent()
+        )
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
## Description

It is not worth it to ensure that the git hook installation is completely fool proof. I have just added a small note which is displayed on successful install of the git hook:
```
Be aware that this hook assumes to find ktlint on the PATH. Either
ensure that ktlint is actually added to the path or expand the ktlint command in the hook with the path.
```

It is reasonable to expect from a developer that (s)he knows how to fix the path.

Closes #634

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] tests are added
- [X] `CHANGELOG.md` is updated
