### PR TITLE
Wrapping of function type inside nullable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fix indent of delegated super type entry (`indent`) ([#1210](https://github.com/pinterest/ktlint/issues/1210))
 - Improve indentation of closing quotes of a multiline raw string literal (`indent`) ([#1262](https://github.com/pinterest/ktlint/pull/1262))
 - Fix false positive indentation (`parameter-list-wrapping`, `argument-list-wrapping`) ([#897](https://github.com/pinterest/ktlint/issues/897), [#1045](https://github.com/pinterest/ktlint/issues/1045), [#1119](https://github.com/pinterest/ktlint/issues/1119), [#1255](https://github.com/pinterest/ktlint/issues/1255), [#1267](https://github.com/pinterest/ktlint/issues/1267), [#1319](https://github.com/pinterest/ktlint/issues/1319), [#1320](https://github.com/pinterest/ktlint/issues/1320), [#1337](https://github.com/pinterest/ktlint/issues/1337)
+- Force a single line function type inside a nullable type to a separate line when the max line length is exceeded (`parameter-list-wrapping`) ([#1255](https://github.com/pinterest/ktlint/issues/1255))
 
 ### Changed
 - Update Kotlin version to `1.6.0` release

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/EditorConfig.kt
@@ -1,17 +1,27 @@
 package com.pinterest.ktlint.core
 
+import com.pinterest.ktlint.core.EditorConfig.IndentStyle.SPACE
+import com.pinterest.ktlint.core.EditorConfig.IndentStyle.TAB
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
 /**
  * @see [EditorConfig](https://editorconfig.org/)
  *
  * This class is injected into the user data, so it is available to rules via [KtLint.EDITOR_CONFIG_USER_DATA_KEY]
  */
 interface EditorConfig {
-
+    @Deprecated("Replace with IndentConfig.IndentStyle")
     enum class IndentStyle { SPACE, TAB }
 
-    val indentStyle: IndentStyle
+    @Deprecated("Prefer to use IndentConfig.indent only or IndentConfig.indentStyle otherwise")
+    public val indentStyle: IndentStyle
+
+    @Deprecated("Prefer to use IndentConfig.indent.length")
     val indentSize: Int
+
+    @Deprecated("Prefer to use IndentConfig.indent.length")
     val tabWidth: Int
+
     val maxLineLength: Int
 
     @Deprecated(
@@ -24,12 +34,18 @@ interface EditorConfig {
     companion object {
         fun fromMap(map: Map<String, String>): EditorConfig {
             val indentStyle = when {
-                map["indent_style"]?.toLowerCase() == "tab" -> IndentStyle.TAB
-                else -> IndentStyle.SPACE
+                map["indent_style"]?.toLowerCase() == "tab" -> TAB
+                else -> SPACE
             }
-            val indentSize = map["indent_size"].let { v ->
-                if (v?.toLowerCase() == "unset") -1 else v?.toIntOrNull() ?: 4
-            }
+            val indentSize =
+                map["indent_size"]
+                    .let { value ->
+                        if (value?.toLowerCase() == "unset") {
+                            -1
+                        } else {
+                            value?.toIntOrNull() ?: IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
+                        }
+                    }
             val tabWidth = map["indent_size"]?.toIntOrNull()
             val maxLineLength = map["max_line_length"]?.toIntOrNull() ?: -1
             val insertFinalNewline = map["insert_final_newline"]?.toBoolean() ?: true
@@ -41,6 +57,40 @@ interface EditorConfig {
                 override val insertFinalNewline = insertFinalNewline
                 override fun get(key: String): String? = map[key]
             }
+        }
+
+        public fun ASTNode.loadEditorConfig(): EditorConfig = getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+
+        public fun EditorConfig.loadIndentConfig(): IndentConfig =
+            IndentConfig(
+                indentStyle = when (indentStyle) {
+                    TAB -> IndentConfig.IndentStyle.TAB
+                    SPACE -> IndentConfig.IndentStyle.SPACE
+                },
+                tabWidth = tabWidth,
+                disabled = indentSize <= 0 || tabWidth <= 0
+            )
+
+        /**
+         * Use this value to define a non-nullable class variable of type EditorConfig. When loading the root node in
+         * rule visitor, the value should be replaced with the real value.
+         */
+        public val UNINITIALIZED: EditorConfig = object : EditorConfig {
+            override val indentStyle: IndentStyle
+                get() = throw EditorConfigNotInitializedException()
+            override val indentSize: Int
+                get() = throw EditorConfigNotInitializedException()
+            override val tabWidth: Int
+                get() = throw EditorConfigNotInitializedException()
+            override val maxLineLength: Int
+                get() = throw EditorConfigNotInitializedException()
+            override val insertFinalNewline: Boolean
+                get() = throw EditorConfigNotInitializedException()
+            override fun get(key: String): String? {
+                throw EditorConfigNotInitializedException()
+            }
+
+            inner class EditorConfigNotInitializedException : RuntimeException("EditorConfig is not yet initialized")
         }
     }
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/IndentConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/IndentConfig.kt
@@ -1,0 +1,117 @@
+package com.pinterest.ktlint.core
+
+import com.pinterest.ktlint.core.IndentConfig.IndentStyle.SPACE
+import com.pinterest.ktlint.core.IndentConfig.IndentStyle.TAB
+
+public data class IndentConfig(
+    val indentStyle: IndentStyle,
+
+    /**
+     * The number of spaces that is equivalent to one tab
+     */
+    val tabWidth: Int,
+
+    /**
+     * When disabled, rules may not enforce any indentation related changes regardless of other settings in this
+     * configuration.
+     */
+    val disabled: Boolean = false
+) {
+    public enum class IndentStyle { SPACE, TAB }
+
+    private val indentChar =
+        when (indentStyle) {
+            TAB -> '\t'
+            SPACE -> ' '
+        }
+
+    private val unexpectedIndentChar =
+        when (indentStyle) {
+            TAB -> ' '
+            SPACE -> '\t'
+        }
+
+    /**
+     * Normalized indent of 1 level deep. Representation is either in spaces or a single tab depending on the
+     * configuration.
+     */
+    public val indent: String =
+        if (disabled) {
+            ""
+        } else {
+            when (indentStyle) {
+                TAB -> indentChar.toString()
+                SPACE -> indentChar.toString().repeat(tabWidth)
+            }
+        }
+
+    /**
+     * Converts [text] to a normalized indent. If [text] contains a new line, then only text after the last new line
+     * is converted. This text may only contain spaces and tabs.
+     *
+     * Tabs in the given text are converted to spaces depending on the tab size of the indent style.
+     *
+     * When converting a text (possibly contains both tabs and spaces) to tabs, all tabs are first converted to
+     * spaces. Each consecutive set of spaces is converted to tabs. Sapces which are left, e.g. not enough space to
+     * complete a full tab, are ignored silently.
+     */
+    public fun toNormalizedIndent(text: String): String {
+        val indent = getTextAfterLastNewLine(text)
+        require(indent.matches(TABS_AND_SPACES))
+        return when (indentStyle) {
+            SPACE -> indent.replaceTabWithSpaces()
+            TAB -> {
+                "\t".repeat(indentLevelFrom(indent))
+                // Silently swallow spaces if not enough spaces present to convert to a tab
+                // val spaceCount = asSpaces.length - (tabCount * tabWidth)
+                // "\t".repeat(tabCount) + " ".repeat(spaceCount)
+            }
+        }
+    }
+
+    private fun getTextAfterLastNewLine(text: String): String {
+        val index = text.indexOfLast { it == '\n' }
+        val indent = if (index == -1) {
+            text
+        } else {
+            text.substring(index + 1, text.length)
+        }
+        return indent
+    }
+
+    private fun String.replaceTabWithSpaces() = replace("\t", " ".repeat(tabWidth))
+
+    /**
+     * Gets the indent level for given [text]. If [text] contains a new line, then only text after the last new line
+     * is considered. This text may only contain spaces and tabs.
+     *
+     * Tabs in the [text] are first converted to spaces depending on the tab size of the indent style. For each set
+     * of spaces that is equivalent to one tab is counted as indentation level. Space that are remaining because
+     * they do not fill up an entire tab, are ignored silently.
+     */
+    public fun indentLevelFrom(text: String): Int {
+        val indent = getTextAfterLastNewLine(text)
+        require(indent.matches(TABS_AND_SPACES))
+        return indent.replaceTabWithSpaces().length / tabWidth
+    }
+
+    public fun containsUnexpectedIndentChar(indentText: String): Boolean = indentText.contains(unexpectedIndentChar)
+
+    public fun indexOfFirstUnexpectedIndentChar(indentText: String): Int = indentText.indexOfFirst { it == unexpectedIndentChar }
+
+    public val unexpectedIndentCharDescription: String =
+        when (indentStyle) {
+            SPACE -> "tab"
+            TAB -> "space"
+        }
+
+    public companion object {
+        private val TABS_AND_SPACES = Regex("[ \t]*")
+
+        public val DEFAULT_INDENT_CONFIG: IndentConfig = IndentConfig(
+            indentStyle = SPACE,
+            tabWidth = 4,
+            disabled = false
+        )
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -1,8 +1,11 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.EditorConfig
-import com.pinterest.ktlint.core.EditorConfig.IndentStyle
-import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.EditorConfig.Companion.loadEditorConfig
+import com.pinterest.ktlint.core.EditorConfig.Companion.loadIndentConfig
+import com.pinterest.ktlint.core.IndentConfig
+import com.pinterest.ktlint.core.IndentConfig.IndentStyle.SPACE
+import com.pinterest.ktlint.core.IndentConfig.IndentStyle.TAB
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
@@ -132,13 +135,17 @@ class IndentationRule : Rule(
         expectedIndent = 0
     }
 
+    private var editorConfig = EditorConfig.UNINITIALIZED
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
+
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-        if (editorConfig.indentSize <= 1) {
+        editorConfig = node.loadEditorConfig()
+        indentConfig = editorConfig.loadIndentConfig()
+        if (indentConfig.disabled) {
             return
         }
         reset()
@@ -162,7 +169,7 @@ class IndentationRule : Rule(
         reset()
         logger.trace { "phase: indentation" }
         // step 2: correct indentation
-        indent(node, autoCorrect, emit, editorConfig)
+        indent(node, autoCorrect, emit)
 
         // The expectedIndent should never be negative. If so, it is very likely that ktlint crashes at runtime when
         // autocorrecting is executed while no error occurs with linting only. Such errors often are not found in unit
@@ -492,8 +499,7 @@ class IndentationRule : Rule(
     private fun indent(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        editorConfig: EditorConfig
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val firstNotEmptyLeaf = node.nextLeaf()
         if (firstNotEmptyLeaf?.let { it.elementType == WHITE_SPACE && !it.textContains('\n') } == true) {
@@ -887,8 +893,8 @@ class IndentationRule : Rule(
             } else {
                 expectedIndent
             }
-            val expectedIndentation = editorConfig.repeatIndent(correctedExpectedIndent)
-            val expectedPrefixLength = correctedExpectedIndent * editorConfig.indentSize
+            val expectedIndentation = indentConfig.indent.repeat(correctedExpectedIndent)
+            val expectedPrefixLength = correctedExpectedIndent * indentConfig.indent.length
             node.children()
                 .forEach {
                     if (it.prevLeaf()?.text == "\n" &&
@@ -906,12 +912,11 @@ class IndentationRule : Rule(
                             } else {
                                 it.text.splitIndentAt(prefixLength)
                             }
-                        val (wrongIndentChar, wrongIndentDescription) = editorConfig.wrongIndentChar()
-                        if (actualIndent.contains(wrongIndentChar)) {
-                            val offsetFirstWrongIndentChar = actualIndent.indexOfFirst(wrongIndentChar)
+                        if (indentConfig.containsUnexpectedIndentChar(actualIndent)) {
+                            val offsetFirstWrongIndentChar = indentConfig.indexOfFirstUnexpectedIndentChar(actualIndent)
                             emit(
                                 it.startOffset + offsetFirstWrongIndentChar,
-                                "Unexpected '$wrongIndentDescription' character(s) in margin of multiline string",
+                                "Unexpected '${indentConfig.unexpectedIndentCharDescription}' character(s) in margin of multiline string",
                                 true
                             )
                             if (autoCorrect) {
@@ -1049,23 +1054,23 @@ class IndentationRule : Rule(
         }
         // indentation with incorrect characters replaced
         val normalizedNodeIndent =
-            when (editorConfig.indentStyle) {
-                IndentStyle.SPACE -> {
+            when (indentConfig.indentStyle) {
+                SPACE -> {
                     if ('\t' in nodeIndent) {
                         emit(
                             node.startOffset + text.length - nodeIndent.length,
                             "Unexpected tab character(s)",
                             true
                         )
-                        nodeIndent.replace("\t", " ".repeat(editorConfig.tabWidth))
+                        indentConfig.toNormalizedIndent(nodeIndent)
                     } else {
                         nodeIndent
                     }
                 }
-                IndentStyle.TAB -> {
+                TAB -> {
                     val isKdocIndent = node.isKDocIndent()
                     val indentWithoutKdocIndent =
-                        if (isKdocIndent) {
+                        if (node.isKDocIndent()) {
                             nodeIndent.removeSuffix(" ")
                         } else {
                             nodeIndent
@@ -1076,10 +1081,7 @@ class IndentationRule : Rule(
                             "Unexpected space character(s)",
                             true
                         )
-                        // First normalize the indent to spaces using the tab width.
-                        val asSpaces = nodeIndent.replace("\t", " ".repeat(editorConfig.tabWidth))
-                        // Then divide that space-based indent into tabs.
-                        "\t".repeat(asSpaces.length / editorConfig.tabWidth) +
+                        indentConfig.toNormalizedIndent(indentWithoutKdocIndent) +
                             // Re-add the kdoc indent when it was present before
                             if (isKdocIndent) {
                                 " "
@@ -1091,34 +1093,23 @@ class IndentationRule : Rule(
                     }
                 }
             }
-        val indentLength =
-            when (editorConfig.indentStyle) {
-                IndentStyle.SPACE -> editorConfig.indentSize
-                IndentStyle.TAB -> 1
-            }
-        val expectedIndentLength =
-            adjustedExpectedIndent * indentLength +
-                // +1 space before * in `/**\n *\n */`
-                if (comment?.elementType == KDOC && nextLeafElementType != KDOC_START) 1 else 0
-        if (normalizedNodeIndent.length != expectedIndentLength) {
+        val expectedIndent = indentConfig.indent.repeat(adjustedExpectedIndent) +
+            // +1 space before * in `/**\n *\n */`
+            if (comment?.elementType == KDOC && nextLeafElementType != KDOC_START) " " else ""
+        if (normalizedNodeIndent != expectedIndent) {
             emit(
                 node.startOffset + text.length - nodeIndent.length,
-                "Unexpected indentation (${normalizedNodeIndent.length}) (should be $expectedIndentLength)",
+                "Unexpected indentation (${normalizedNodeIndent.length}) (should be ${expectedIndent.length})",
                 true
             )
             logger.trace {
-                "$line: " + (if (!autoCorrect) "would have " else "") + "changed indentation to $expectedIndentLength (from ${normalizedNodeIndent.length})"
+                "$line: " + (if (!autoCorrect) "would have " else "") + "changed indentation to ${expectedIndent.length} (from ${normalizedNodeIndent.length})"
             }
         }
         if (autoCorrect) {
-            if (nodeIndent != normalizedNodeIndent || normalizedNodeIndent.length != expectedIndentLength) {
-                val indent = when (editorConfig.indentStyle) {
-                    IndentStyle.SPACE -> " "
-                    IndentStyle.TAB -> "\t"
-                }
+            if (nodeIndent != normalizedNodeIndent || normalizedNodeIndent != expectedIndent) {
                 (node as LeafPsiElement).rawReplaceWithText(
-                    text.substringBeforeLast("\n") + "\n" +
-                        indent.repeat(expectedIndentLength)
+                    text.substringBeforeLast("\n") + "\n" + expectedIndent
                 )
             }
         }
@@ -1215,18 +1206,6 @@ private fun ASTNode.isKDocIndent() =
 private fun ASTNode.isIndentBeforeClosingQuote() =
     elementType == CLOSING_QUOTE || (text.isBlank() && nextCodeSibling()?.elementType == CLOSING_QUOTE)
 
-private fun EditorConfig.repeatIndent(indentLevel: Int) =
-    when (indentStyle) {
-        IndentStyle.SPACE -> " ".repeat(indentLevel * indentSize)
-        IndentStyle.TAB -> "\t".repeat(indentLevel)
-    }
-
-private fun EditorConfig.wrongIndentChar(): Pair<Char, String> =
-    when (indentStyle) {
-        IndentStyle.SPACE -> Pair('\t', "tab")
-        IndentStyle.TAB -> Pair(' ', "space")
-    }
-
 private fun ASTNode.isLiteralStringTemplateEntry() =
     elementType == LITERAL_STRING_TEMPLATE_ENTRY && text != "\n"
 
@@ -1277,6 +1256,3 @@ private fun String.splitIndentAt(index: Int): Pair<String, String> {
         second = this.substring(safeIndex)
     )
 }
-
-private fun String.indexOfFirst(char: Char) =
-    indexOfFirst { it == char }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
+import com.pinterest.ktlint.core.EditorConfig.Companion.loadEditorConfig
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.EditorConfigProperties
@@ -51,11 +52,11 @@ class MaxLineLengthRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
             val editorConfigProperties: EditorConfigProperties =
                 node.getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY)!!
-            val ignoreBackTickedIdentifier = editorConfigProperties.getEditorConfigValue(ignoreBackTickedIdentifierProperty)
-            maxLineLength = editorConfig.maxLineLength
+            val ignoreBackTickedIdentifier =
+                editorConfigProperties.getEditorConfigValue(ignoreBackTickedIdentifierProperty)
+            maxLineLength = node.loadEditorConfig().maxLineLength
             if (maxLineLength <= 0) {
                 return
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -1,9 +1,13 @@
 package com.pinterest.ktlint.ruleset.standard
 
-import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.EditorConfig.Companion.loadEditorConfig
+import com.pinterest.ktlint.core.EditorConfig.Companion.loadIndentConfig
+import com.pinterest.ktlint.core.IndentConfig
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_TYPE
 import com.pinterest.ktlint.core.ast.ElementType.LPAR
+import com.pinterest.ktlint.core.ast.ElementType.NULLABLE_TYPE
 import com.pinterest.ktlint.core.ast.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_PARAMETER_LIST
@@ -17,6 +21,8 @@ import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.prevSibling
+import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.core.ast.visit
 import kotlin.math.max
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -28,8 +34,7 @@ import org.jetbrains.kotlin.psi.KtTypeArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
-
-    private var indentSize = -1
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
     private var maxLineLength = -1
 
     override fun visit(
@@ -38,12 +43,12 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
-            indentSize = editorConfig.indentSize
+            val editorConfig = node.loadEditorConfig()
+            indentConfig = editorConfig.loadIndentConfig()
             maxLineLength = editorConfig.maxLineLength
             return
         }
-        if (indentSize <= 0) {
+        if (indentConfig.disabled) {
             return
         }
         if (node.elementType == VALUE_PARAMETER_LIST &&
@@ -59,31 +64,31 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
             val putParametersOnSeparateLines =
                 node.textContains('\n') ||
                     // max_line_length exceeded
-                    maxLineLength > -1 && (node.column - 1 + node.textLength) > maxLineLength
+                    maxLineLength > -1 && (node.column - 1 + node.textLength) > maxLineLength && !node.textContains('\n')
             if (putParametersOnSeparateLines) {
-                // IDEA quirk:
-                // fun <
-                //     T,
-                //     R> test(
-                //     param1: T
-                //     param2: R
-                // )
-                // instead of
-                // fun <
-                //     T,
-                //     R> test(
-                //         param1: T
-                //         param2: R
-                //     )
-                val adjustedIndent = if (node.hasTypeParameterListInFront()) indentSize else 0
+                val currentIndentLevel = indentConfig.indentLevelFrom(node.lineIndent())
+                val newIndentLevel =
+                    when {
+                        // IDEA quirk:
+                        // fun <
+                        //     T,
+                        //     R> test(
+                        //     param1: T
+                        //     param2: R
+                        // )
+                        // instead of
+                        // fun <
+                        //     T,
+                        //     R> test(
+                        //         param1: T
+                        //         param2: R
+                        //     )
+                        currentIndentLevel > 0 && node.hasTypeParameterListInFront() -> currentIndentLevel - 1
 
-                // aiming for
-                // ... LPAR
-                // <line indent + indentSize> VALUE_PARAMETER...
-                // <line indent> RPAR
-                val lineIndent = node.lineIndent()
-                val indent = "\n" + lineIndent.substring(0, (lineIndent.length - adjustedIndent).coerceAtLeast(0))
-                val paramIndent = indent + " ".repeat(indentSize)
+                        else -> currentIndentLevel
+                    }
+                val indent = "\n" + indentConfig.indent.repeat(newIndentLevel)
+
                 nextChild@ for (child in node.children()) {
                     when (child.elementType) {
                         LPAR -> {
@@ -98,12 +103,18 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
                         VALUE_PARAMETER,
                         RPAR -> {
                             var paramInnerIndentAdjustment = 0
-                            val prevLeaf = child.prevLeaf()
+
+                            // aiming for
+                            // ... LPAR
+                            // <line indent + indentSize> VALUE_PARAMETER...
+                            // <line indent> RPAR
                             val intendedIndent = if (child.elementType == VALUE_PARAMETER) {
-                                paramIndent
+                                indent + indentConfig.indent
                             } else {
                                 indent
                             }
+
+                            val prevLeaf = child.prevLeaf()
                             if (prevLeaf is PsiWhiteSpace) {
                                 if (prevLeaf.getText().contains("\n")) {
                                     // The current child is already wrapped to a new line. Checking and fixing the

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -476,4 +476,28 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         assertThat(ParameterListWrappingRule().lint(code)).isEmpty()
     }
+
+    @Test
+    fun `Issue 1255 - Given a variable declaration for nullable function type which exceeds the max-line-length then wrap the function type to a new line`() {
+        val code =
+            """
+            var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
+            """.trimIndent()
+        val formattedCode =
+            """
+            var changesListener: (
+                (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
+            )? = null
+            """.trimIndent()
+        assertThat(
+            ParameterListWrappingRule().lint(
+                code,
+                userData = mapOf("max_line_length" to "80")
+            )
+        ).containsExactly(
+            LintError(1, 22, "parameter-list-wrapping", "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
+            LintError(1, 95, "parameter-list-wrapping", """Missing newline before ")"""")
+        )
+        assertThat(ParameterListWrappingRule().format(code, userData = mapOf("max_line_length" to "80"))).isEqualTo(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

As described in #1255, the code below execeeds the max line length:
```
var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
```
and got formatted as:
```
var changesListener: (
        (
            width: Double?,
            depth: Double?,
            length: Double?,
            area: Double?
        ) -> Unit
    )? = null
```

When the nullable type is removed from the original example:
```
var changesListener: (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
```
it gets formatted as:
```
var changesListener: (
    width: Double?,
    depth: Double?,
    length: Double?,
    area: Double?
) -> Unit
```

So, it turned out that the nullable type around function type `(width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit` was the real cause of the problem. Both the nullable type as well as the function type have a value parameter list element. By definition, the nullable type does not have a label/or name. The opening parenthesis therefore looks to be dangling.

For now there is no good way to format a nullable type nicely without causing a conflict with the default IntelliJ IDEA code formatting. In this PR, the function type inside a nullable type is forced to a separate line in case the original declaration was a single line which exceeds the max line length.

NOTE: The first commit of this PR (Extract indent related editorconfig settings to Indent data class) is only loosely related to the PR. Reviewing is therefore best be done per commit.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
