### PR TITLE
When running format mode, the rules are first executed in parallel to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Trailing space should not lead to delete of indent of next line (`no-trailing-spaces`) ([#1334](https://github.com/pinterest/ktlint/pull/1334))
 - Fix false positive indentation (`parameter-list-wrapping`, `argument-list-wrapping`) ([#897](https://github.com/pinterest/ktlint/issues/897), [#1045](https://github.com/pinterest/ktlint/issues/1045), [#1119](https://github.com/pinterest/ktlint/issues/1119), [#1255](https://github.com/pinterest/ktlint/issues/1255), [#1267](https://github.com/pinterest/ktlint/issues/1267), [#1319](https://github.com/pinterest/ktlint/issues/1319), [#1320](https://github.com/pinterest/ktlint/issues/1320), [#1337](https://github.com/pinterest/ktlint/issues/1337)
 - Fix executable jar on Java 16+ ([#1195](https://github.com/pinterest/ktlint/issues/1195)) 
+- Fix false positive unused import after autocorrecting a trailing comma ([#1367](https://github.com/pinterest/ktlint/issues/1367)) 
 
 ### Changed
 - Update Kotlin version to `1.6.0` release


### PR DESCRIPTION
## Description

When running format mode, the rules are first executed in parallel to find linting errors. In this process, no unused import are found because the trailing comma is not yet added to variable "bar3". Then in the next stage the rules are run consecutively. Nof the trailing comma rule is adding a trailing comma after the type of variable "bar3". When the no-unused-import rule runs after the trailing-comma rule, it was incorrectly seen as part of the type of variable "bar3" and a reference "EnumThree," (with the trailing comma was added) which in turn resulted in not recognizing that the import of EnumThree actually was used.

Closes #1367

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [x] `CHANGELOG.md` is updated
