### PR TITLE
Add a generic type to ReporterProvider

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
  * `META-INF/services/com.pinterest.ktlint.core.ReporterProvider`
  * (see `ktlint-reporter-plain/src/main/resources` for an example).
  */
-public interface ReporterProvider : Serializable {
+public interface ReporterProvider<T : Reporter> : Serializable {
     public val id: String
-    public fun get(out: PrintStream, opt: Map<String, String>): Reporter
+    public fun get(out: PrintStream, opt: Map<String, String>): T
 }

--- a/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
+++ b/ktlint-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterProvider.kt
@@ -1,10 +1,9 @@
 package com.pinterest.ktlint.reporter.baseline
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-public class BaselineReporterProvider : ReporterProvider {
+public class BaselineReporterProvider : ReporterProvider<BaselineReporter> {
     override val id: String = "baseline"
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = BaselineReporter(out)
+    override fun get(out: PrintStream, opt: Map<String, String>): BaselineReporter = BaselineReporter(out)
 }

--- a/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterProvider.kt
+++ b/ktlint-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterProvider.kt
@@ -1,10 +1,9 @@
 package com.pinterest.ktlint.reporter.checkstyle
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-public class CheckStyleReporterProvider : ReporterProvider {
+public class CheckStyleReporterProvider : ReporterProvider<CheckStyleReporter> {
     override val id: String = "checkstyle"
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = CheckStyleReporter(out)
+    override fun get(out: PrintStream, opt: Map<String, String>): CheckStyleReporter = CheckStyleReporter(out)
 }

--- a/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterProvider.kt
+++ b/ktlint-reporter-html/src/main/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterProvider.kt
@@ -24,11 +24,10 @@
 
 package com.pinterest.ktlint.reporter.html
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-public class HtmlReporterProvider : ReporterProvider {
+public class HtmlReporterProvider : ReporterProvider<HtmlReporter> {
     override val id: String = "html"
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = HtmlReporter(out)
+    override fun get(out: PrintStream, opt: Map<String, String>): HtmlReporter = HtmlReporter(out)
 }

--- a/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterProvider.kt
+++ b/ktlint-reporter-json/src/main/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterProvider.kt
@@ -1,10 +1,9 @@
 package com.pinterest.ktlint.reporter.json
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-public class JsonReporterProvider : ReporterProvider {
+public class JsonReporterProvider : ReporterProvider<JsonReporter> {
     override val id: String = "json"
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = JsonReporter(out)
+    override fun get(out: PrintStream, opt: Map<String, String>): JsonReporter = JsonReporter(out)
 }

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProvider.kt
@@ -1,15 +1,14 @@
 package com.pinterest.ktlint.reporter.plain
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import com.pinterest.ktlint.reporter.plain.internal.Color
 import java.io.PrintStream
 
-public class PlainReporterProvider : ReporterProvider {
+public class PlainReporterProvider : ReporterProvider<PlainReporter> {
 
     override val id: String = "plain"
 
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter =
+    override fun get(out: PrintStream, opt: Map<String, String>): PlainReporter =
         PlainReporter(
             out,
             verbose = opt["verbose"]?.emptyOrTrue() ?: false,

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -14,7 +14,7 @@ class PlainReporterProviderTest {
             PlainReporterProvider().get(
                 out = PrintStream(out, true),
                 opt = mapOf()
-            ) as PlainReporter
+            )
 
             fail("Expected IllegalArgumentException.")
         } catch (iae: IllegalArgumentException) {
@@ -30,7 +30,7 @@ class PlainReporterProviderTest {
             PlainReporterProvider().get(
                 out = PrintStream(out, true),
                 opt = mapOf("color_name" to "")
-            ) as PlainReporter
+            )
 
             fail("Expected IllegalArgumentException.")
         } catch (iae: IllegalArgumentException) {
@@ -45,7 +45,7 @@ class PlainReporterProviderTest {
         val plainReporter = PlainReporterProvider().get(
             out = PrintStream(out, true),
             opt = mapOf("color_name" to "RED")
-        ) as PlainReporter
+        )
 
         assertEquals(Color.RED, plainReporter.outputColor)
     }
@@ -56,7 +56,7 @@ class PlainReporterProviderTest {
             PlainReporterProvider().get(
                 out = PrintStream(out, true),
                 opt = mapOf("colo_namer" to "GARBAGE_INPUT")
-            ) as PlainReporter
+            )
 
             fail("Expected IllegalArgumentException.")
         } catch (iae: IllegalArgumentException) {

--- a/ktlint-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/reporter/sarif/SarifReporterProvider.kt
+++ b/ktlint-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/reporter/sarif/SarifReporterProvider.kt
@@ -1,12 +1,11 @@
 package com.pinterest.ktlint.reporter.sarif
 
-import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-public class SarifReporterProvider : ReporterProvider {
+public class SarifReporterProvider : ReporterProvider<SarifReporter> {
 
     override val id: String = "sarif"
 
-    override fun get(out: PrintStream, opt: Map<String, String>): Reporter = SarifReporter(out)
+    override fun get(out: PrintStream, opt: Map<String, String>): SarifReporter = SarifReporter(out)
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -466,7 +466,7 @@ class KtlintCommandLine {
     }
 
     private fun ReporterTemplate.toReporter(
-        reporterProviderById: Map<String, ReporterProvider>
+        reporterProviderById: Map<String, ReporterProvider<*>>
     ): Reporter {
         val reporterProvider = reporterProviderById[id]
         if (reporterProvider == null) {


### PR DESCRIPTION
## Description

Return subtypes when invoking `get()`


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated
