### PR TITLE
Do not indent raw string literals that are not followed by either trimIndent() or trimMargin()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Fixed
+- Do not indent raw string literals that are not followed by either trimIndent() or trimMargin() (`indent`) ([#1375](https://github.com/pinterest/ktlint/issues/1375))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string-expected.kt.spec
@@ -8,7 +8,11 @@ fun f0() {
     println("""${true}""")
     println(
         """
+"""
+    )
+    println(
         """
+        """.trimIndent()
     )
     f(
         """${
@@ -18,7 +22,7 @@ fun f0() {
 _${
         true
         }
-        """,
+        """.trimIndent(),
         """text"""
     )
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string.kt.spec
@@ -6,11 +6,13 @@ fun f0() {
 println("""${true}""")
 println("""
 """)
+println("""
+""".trimIndent())
     f("""${
 true
     }
     text
 _${
 true
-    }""", """text""")
+    }""".trimIndent(), """text""")
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -110,6 +110,6 @@ ${Target(
         )}
 ${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules"))}
 ${Target("gmaven_rules", listOf())}
-        """
+"""
 
 }


### PR DESCRIPTION
## Description

Closes #1375

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
