### PR TITLE
Print the rule id in the PlainReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 ### Changed
+- Print the rule id always in the PlainReporter ([#1121](https://github.com/pinterest/ktlint/issues/1121))
+
 
 ### Removed
 

--- a/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
+++ b/ktlint-reporter-plain/src/main/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporter.kt
@@ -28,7 +28,7 @@ class PlainReporter(
                 out.println(
                     "${colorFileName(file)}${":".colored()}${err.line}${
                     ":${"${err.col}:".let { if (pad) String.format("%-4s", it) else it}}".colored()
-                    } ${err.detail}${if (verbose) " (${err.ruleId})".colored() else ""}"
+                    } ${err.detail} ${"(${err.ruleId})".colored()}"
                 )
             }
         }

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -70,9 +70,9 @@ class PlainReporterTest {
         )
         assertThat(String(out.toByteArray())).isEqualTo(
             """
-            /one-fixed-and-one-not.kt:1:1: <"&'>
-            /two-not-fixed.kt:1:10: I thought I would again
-            /two-not-fixed.kt:2:20: A single thin straight line
+            /one-fixed-and-one-not.kt:1:1: <"&'> (rule-1)
+            /two-not-fixed.kt:1:10: I thought I would again (rule-1)
+            /two-not-fixed.kt:2:20: A single thin straight line (rule-2)
 
             """.trimIndent().replace("\n", System.lineSeparator())
         )
@@ -107,7 +107,8 @@ class PlainReporterTest {
                 ":".color(outputColor) +
                 "1" +
                 ":1:".color(outputColor) +
-                " <\"&'>" +
+                " <\"&'> " +
+                "(rule-1)".color(outputColor) +
                 System.lineSeparator()
 
         assertEquals(expectedOutput, outputString)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -532,7 +532,7 @@ class IndentationRule : Rule(
     ) {
         val firstNotEmptyLeaf = node.nextLeaf()
         if (firstNotEmptyLeaf?.let { it.elementType == WHITE_SPACE && !it.textContains('\n') } == true) {
-            visitWhiteSpace(firstNotEmptyLeaf, autoCorrect, emit, editorConfig)
+            visitWhiteSpace(firstNotEmptyLeaf, autoCorrect, emit)
         }
         val ctx = IndentContext()
         node.visit(
@@ -652,7 +652,7 @@ class IndentationRule : Rule(
                         adjustExpectedIndentInsideSuperTypeCall(n, ctx)
                     }
                     STRING_TEMPLATE ->
-                        indentStringTemplate(n, autoCorrect, emit, editorConfig)
+                        indentStringTemplate(n, autoCorrect, emit)
                     DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION, BINARY_EXPRESSION, BINARY_WITH_TYPE -> {
                         val prevBlock = ctx.blockStack.peek()
                         if (prevBlock != null && prevBlock.line == line) {
@@ -727,14 +727,14 @@ class IndentationRule : Rule(
                                         // )
                                         adjustExpectedIndentAfterLparInsideCondition(n, ctx)
                                 }
-                                visitWhiteSpace(n, autoCorrect, emit, editorConfig)
+                                visitWhiteSpace(n, autoCorrect, emit)
                                 if (ctx.localAdj != 0) {
                                     expectedIndent += ctx.localAdj
                                     logger.trace { "$line: ++${ctx.localAdj} on whitespace containing new line (${n.elementType}) -> $expectedIndent" }
                                     ctx.localAdj = 0
                                 }
                             } else if (n.isPartOf(KDOC)) {
-                                visitWhiteSpace(n, autoCorrect, emit, editorConfig)
+                                visitWhiteSpace(n, autoCorrect, emit)
                             }
                             line += n.text.count { it == '\n' }
                         }
@@ -929,8 +929,7 @@ class IndentationRule : Rule(
     private fun indentStringTemplate(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        editorConfig: EditorConfig
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val psi = node.psi as KtStringTemplateExpression
         if (psi.isMultiLine()) {
@@ -1044,8 +1043,7 @@ class IndentationRule : Rule(
     private fun visitWhiteSpace(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        editorConfig: EditorConfig
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         val text = node.text
         val nodeIndent = text.substringAfterLast("\n")


### PR DESCRIPTION
## Description

The rule id was printed in by the PlainReporter only when the verbose mode was enabled. Now it will also be printed in case the verbose mode is not enabled. In this way it is easier to discover the correct rule id which is to be used to suppress a lint violation.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
