### PR TITLE
Migrate to junit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,16 @@ repositories {
   mavenCentral()
 }
 
-if (project.hasProperty('isKotlinDev')) {
-  allprojects { p ->
+def isKotlinDev = project.hasProperty('isKotlinDev')
+
+allprojects { p ->
+  if (isKotlinDev) {
     String definedVersion = p.ext."VERSION_NAME".minus("-SNAPSHOT")
     p.ext."VERSION_NAME" = "$definedVersion-kotlin-dev-SNAPSHOT".toString()
+  }
+
+  tasks.withType(Test).configureEach {
+    it.useJUnitPlatform()
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,7 @@ ext.deps = [
   // Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
   'logback'       : 'ch.qos.logback:logback-classic:1.2.9',
   // Testing libraries
-  'junit'         : 'junit:junit:4.13.1',
-  'junit5Api'     : 'org.junit.jupiter:junit-jupiter-api:5.8.2',
-  'junit5Jupiter' : 'org.junit.jupiter:junit-jupiter-engine:5.8.2',
-  'junit5Vintage' : 'org.junit.vintage:junit-vintage-engine:5.8.2',
+  'junit5'        : 'org.junit.jupiter:junit-jupiter:5.8.2',
   'assertj'       : 'org.assertj:assertj-core:3.12.2',
   'sarif4k'       : 'io.github.detekt.sarif4k:sarif4k:0.0.1',
   'jimfs'         : 'com.google.jimfs:jimfs:1.1'

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -9,8 +9,16 @@ dependencies {
   api deps.logging
   api deps.logback
 
-  testImplementation deps.junit
+  // Standard ruleset is required for EditConfigLoaderTest only
+  testImplementation project(":ktlint-ruleset-standard")
+
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
   testImplementation deps.jimfs
-  testImplementation project(":ktlint-ruleset-standard")
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -11,14 +11,7 @@ dependencies {
 
   // Standard ruleset is required for EditConfigLoaderTest only
   testImplementation project(":ktlint-ruleset-standard")
-
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
   testImplementation deps.jimfs
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.ast.ElementType
 import java.util.ArrayList
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DisabledRulesTest {
     @Test

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ErrorSuppressionTest.kt
@@ -6,7 +6,7 @@ import java.util.ArrayList
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ErrorSuppressionTest {
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.core
 import com.pinterest.ktlint.core.ast.isRoot
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class KtLintTest {
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class VisitorProviderTest {
     @Test

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/BaselineSupportTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/BaselineSupportTest.kt
@@ -3,12 +3,10 @@ package com.pinterest.ktlint.core.internal
 import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 class BaselineSupportTest {
-
     @Test
     fun testParseBaselineFile() {
         val filename = "TestBaselineFile.kt"
@@ -36,9 +34,10 @@ class BaselineSupportTest {
 
         val baselineFiles = parseBaseline(baseline)
 
-        assertTrue(baselineFiles.containsKey(filename))
-        assertEquals(2, baselineFiles[filename]?.size)
-        assertTrue(true == baselineFiles[filename]?.containsLintError(errorOne))
-        assertTrue(true == baselineFiles[filename]?.containsLintError(errorTwo))
+        assertThat(baselineFiles).containsKey(filename)
+        val lintErrors = baselineFiles[filename]
+        assertThat(lintErrors).hasSize(2)
+        assertThat(lintErrors?.containsLintError(errorOne))
+        assertThat(lintErrors?.containsLintError(errorTwo))
     }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -11,7 +11,7 @@ import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 internal class EditorConfigGeneratorTest {

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -15,8 +15,8 @@ import org.assertj.core.api.Assertions.entry
 import org.ec4j.core.model.PropertyType
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.junit.After
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 internal class EditorConfigLoaderTest {
@@ -37,7 +37,7 @@ internal class EditorConfigLoaderTest {
         Files.write(normalizedPath("$filePath/.editorconfig"), content.toByteArray())
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         tempFileSystem.close()
     }

--- a/ktlint-reporter-baseline/build.gradle
+++ b/ktlint-reporter-baseline/build.gradle
@@ -6,12 +6,6 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-reporter-baseline/build.gradle
+++ b/ktlint-reporter-baseline/build.gradle
@@ -6,6 +6,12 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation deps.junit
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
+++ b/ktlint-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/reporter/baseline/BaselineReporterTest.kt
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class BaselineReporterTest {
 

--- a/ktlint-reporter-checkstyle/build.gradle
+++ b/ktlint-reporter-checkstyle/build.gradle
@@ -6,12 +6,6 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-reporter-checkstyle/build.gradle
+++ b/ktlint-reporter-checkstyle/build.gradle
@@ -6,6 +6,12 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation deps.junit
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-reporter-checkstyle/src/test/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterTest.kt
+++ b/ktlint-reporter-checkstyle/src/test/kotlin/com/pinterest/ktlint/reporter/checkstyle/CheckStyleReporterTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CheckStyleReporterTest {
 

--- a/ktlint-reporter-html/build.gradle
+++ b/ktlint-reporter-html/build.gradle
@@ -6,12 +6,6 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-reporter-html/build.gradle
+++ b/ktlint-reporter-html/build.gradle
@@ -6,6 +6,12 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation deps.junit
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-reporter-html/src/test/kotlin/com/pinterest/ktlint/reporter/html/HtmlReporterTest.kt
@@ -27,11 +27,10 @@ package com.pinterest.ktlint.reporter.html
 import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 class HtmlReporterTest {
-
     @Test
     fun shouldRenderEmptyReportWhen_NoIssuesFound() {
         val out = ByteArrayOutputStream()
@@ -59,8 +58,7 @@ class HtmlReporterTest {
 
             """.trimIndent().replace("\n", System.lineSeparator())
 
-        val expected = String(out.toByteArray())
-        assertEquals(actual, expected)
+        assertThat(actual).isEqualTo(String(out.toByteArray()))
     }
 
     @Test
@@ -103,8 +101,7 @@ class HtmlReporterTest {
 
             """.trimIndent().replace("\n", System.lineSeparator())
 
-        val expected = String(out.toByteArray())
-        assertEquals(actual, expected)
+        assertThat(actual).isEqualTo(String(out.toByteArray()))
     }
 
     @Test
@@ -153,8 +150,7 @@ class HtmlReporterTest {
 
             """.trimIndent().replace("\n", System.lineSeparator())
 
-        val expected = String(out.toByteArray())
-        assertEquals(actual, expected)
+        assertThat(actual).isEqualTo(String(out.toByteArray()))
     }
 
     @Test
@@ -204,7 +200,6 @@ class HtmlReporterTest {
 
             """.trimIndent().replace("\n", System.lineSeparator())
 
-        val expected = String(out.toByteArray())
-        assertEquals(actual, expected)
+        assertThat(actual).isEqualTo(String(out.toByteArray()))
     }
 }

--- a/ktlint-reporter-json/build.gradle
+++ b/ktlint-reporter-json/build.gradle
@@ -6,12 +6,6 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-reporter-json/build.gradle
+++ b/ktlint-reporter-json/build.gradle
@@ -6,6 +6,12 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation deps.junit
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-reporter-json/src/test/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterTest.kt
+++ b/ktlint-reporter-json/src/test/kotlin/com/pinterest/ktlint/reporter/json/JsonReporterTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JsonReporterTest {
 

--- a/ktlint-reporter-plain/build.gradle
+++ b/ktlint-reporter-plain/build.gradle
@@ -6,12 +6,6 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-reporter-plain/build.gradle
+++ b/ktlint-reporter-plain/build.gradle
@@ -6,6 +6,12 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation deps.junit
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterProviderTest.kt
@@ -4,7 +4,7 @@ import java.io.PrintStream
 import java.lang.System.out
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PlainReporterProviderTest {
     @Test

--- a/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-reporter-plain/src/test/kotlin/com/pinterest/ktlint/reporter/plain/PlainReporterTest.kt
@@ -7,11 +7,9 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PlainReporterTest {
-
     @Test
     fun testReportGeneration() {
         val out = ByteArrayOutputStream()
@@ -97,11 +95,10 @@ class PlainReporterTest {
             ),
             false
         )
-
         val outputString = String(out.toByteArray())
 
-        // We don't expect class name, or first line to be colored
-        val expectedOutput =
+        assertThat(outputString).isEqualTo(
+            // We don't expect class name, or first line to be colored
             File.separator.color(outputColor) +
                 "one-fixed-and-one-not.kt" +
                 ":".color(outputColor) +
@@ -110,8 +107,7 @@ class PlainReporterTest {
                 " <\"&'> " +
                 "(rule-1)".color(outputColor) +
                 System.lineSeparator()
-
-        assertEquals(expectedOutput, outputString)
+        )
     }
 
     @Test

--- a/ktlint-reporter-sarif/build.gradle
+++ b/ktlint-reporter-sarif/build.gradle
@@ -7,14 +7,8 @@ dependencies {
     implementation project(':ktlint-core')
     implementation deps.sarif4k
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
-  testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
+    testImplementation deps.junit5
+    testImplementation deps.assertj
 }
 
 jar {

--- a/ktlint-reporter-sarif/build.gradle
+++ b/ktlint-reporter-sarif/build.gradle
@@ -7,8 +7,14 @@ dependencies {
     implementation project(':ktlint-core')
     implementation deps.sarif4k
 
-    testImplementation deps.junit
-    testImplementation deps.assertj
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
+  testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }
 
 jar {

--- a/ktlint-reporter-sarif/src/test/kotlin/com/pinterest/ktlint/reporter/sarif/SarifReporterTest.kt
+++ b/ktlint-reporter-sarif/src/test/kotlin/com/pinterest/ktlint/reporter/sarif/SarifReporterTest.kt
@@ -4,13 +4,12 @@ import com.pinterest.ktlint.core.LintError
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
-import org.junit.Assert.assertEquals
-import org.junit.Ignore
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 class SarifReporterTest {
-
-    @Ignore("https://github.com/pinterest/ktlint/issues/1191")
+    @Disabled("https://github.com/pinterest/ktlint/issues/1191")
     @Test
     fun testReportGeneration() {
         val workingDirectory = System.getProperty("user.home").sanitize()
@@ -49,6 +48,6 @@ class SarifReporterTest {
             .readText()
             .replace("{WORKINDG_DIR}", workingDirectory)
             .replace("\\s".toRegex(), "")
-        assertEquals("actual = $actual, expected = $expected", expected, actual)
+        assertThat(actual).isEqualTo(expected)
     }
 }

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -6,8 +6,15 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation project(':ktlint-test')
   testImplementation project(':ktlint-ruleset-standard')
-  testImplementation deps.junit
+  testImplementation project(':ktlint-test')
+
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -6,15 +6,8 @@ plugins {
 dependencies {
   implementation project(':ktlint-core')
 
-  testImplementation project(':ktlint-ruleset-standard')
   testImplementation project(':ktlint-test')
-
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation project(':ktlint-ruleset-standard')
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AnnotationRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationSpacingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationSpacingRuleTest.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import java.util.ArrayList
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AnnotationSpacingRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -8,7 +8,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @FeatureInAlphaState
 class ArgumentListWrappingRuleTest {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class EnumEntryNameCaseRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MultiLineIfElseRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoEmptyFirstLineInMethodBlockRuleTest {
 
@@ -146,7 +146,7 @@ class NoEmptyFirstLineInMethodBlockRuleTest {
         val code =
             """
             fun fooBuilder() = object : Foo {
-            
+
                 override fun foo() {
                     TODO()
                 }
@@ -160,7 +160,7 @@ class NoEmptyFirstLineInMethodBlockRuleTest {
         val code =
             """
             fun fooBuilder() = object : Foo {
-            
+
                 override fun foo() {
                     TODO()
                 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/PackageNameRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/PackageNameRuleTest.kt
@@ -5,7 +5,7 @@ import com.pinterest.ktlint.test.lint
 import java.net.URI
 import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PackageNameRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
@@ -5,7 +5,7 @@ import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundAngleBracketRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundDoubleColonRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundDoubleColonRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.experimental
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundDoubleColonRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundUnaryOperatorRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundUnaryOperatorRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.experimental
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundUnaryOperatorRuleTest {
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
@@ -3,97 +3,98 @@ package com.pinterest.ktlint.ruleset.experimental
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
-import org.assertj.core.api.Assertions
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
     @Test
     fun `annotation at top of file should do nothing`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                @Foo
-                fun a()
-                """.trimIndent()
-            )
+        val code =
+            """
+            @Foo
+            fun a()
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `multiple annotations should do nothing`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                @Foo
-                @Bar
-                fun a()
-                """.trimIndent()
-            )
+        val code =
+            """
+            @Foo
+            @Bar
+            fun a()
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `missing space after comment should do nothing`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                // hello
-                @Foo
-                fun a()
-                """.trimIndent()
-            )
+        val code =
+            """
+            // hello
+            @Foo
+            fun a()
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `missing space before declaration with annotation should cause error`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                fun a()
-                @Foo
-                fun b()
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(
-                    2,
-                    1,
-                    "spacing-between-declarations-with-annotations",
-                    "Declarations and declarations with annotations should have an empty space between."
-                )
+        val code =
+            """
+            fun a()
+            @Foo
+            fun b()
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
+        ).containsExactly(
+            LintError(
+                2,
+                1,
+                "spacing-between-declarations-with-annotations",
+                "Declarations and declarations with annotations should have an empty space between."
             )
         )
     }
 
     @Test
     fun `missing space before declaration with multiple annotations should cause error`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                fun a()
-                @Foo
-                @Bar
-                fun b()
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(
-                    2,
-                    1,
-                    "spacing-between-declarations-with-annotations",
-                    "Declarations and declarations with annotations should have an empty space between."
-                )
-            )
+        val code =
+            """
+            fun a()
+            @Foo
+            @Bar
+            fun b()
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
+        ).containsExactly(
+            LintError(2, 1, "spacing-between-declarations-with-annotations", "Declarations and declarations with annotations should have an empty space between.")
         )
     }
 
     @Test
     fun `autoformat should work correctly`() {
-        assertEquals(
+        val code =
+            """
+            @Annotation1
+            fun one() = 1
+            @Annotation1
+            @Annotation2
+            fun two() = 2
+            fun three() = 42
+            @Annotation1
+            fun four() = 44
+            """.trimIndent()
+        val formattedCode =
             """
             @Annotation1
             fun one() = 1
@@ -105,74 +106,74 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
 
             @Annotation1
             fun four() = 44
-            """.trimIndent(),
-            SpacingBetweenDeclarationsWithAnnotationsRule().format(
-                """
-                @Annotation1
-                fun one() = 1
-                @Annotation1
-                @Annotation2
-                fun two() = 2
-                fun three() = 42
-                @Annotation1
-                fun four() = 44
-                """.trimIndent()
-            )
-        )
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().format(code)
+        ).isEqualTo(formattedCode)
     }
 
     @Test
     fun `missing space before primary constructor`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                annotation class E
+        val code =
+            """
+            annotation class E
 
-                private class A
-                @E
-                constructor(a: Int)
-                """.trimIndent()
-            )
+            private class A
+            @E
+            constructor(a: Int)
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `missing space before function parameter`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                annotation class E
+        val code =
+            """
+            annotation class E
 
-                fun foo(
-                    a: String,
-                    @E
-                    b: String
-                ) = 1
-                """.trimIndent()
-            )
+            fun foo(
+                a: String,
+                @E
+                b: String
+            ) = 1
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `missing space before member function`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                annotation class E
+        val code =
+            """
+            annotation class E
 
-                class C {
-                    fun foo() = 1
-                    @E
-                    fun bar() = 2
-                }
-                """.trimIndent()
-            )
+            class C {
+                fun foo() = 1
+                @E
+                fun bar() = 2
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).hasSize(1)
     }
 
     @Test
     fun `format missing space before member function`() {
-        assertEquals(
+        val code =
+            """
+            annotation class E
+
+            class C {
+                fun foo() = 1
+                @E
+                fun bar() = 2
+            }
+            """.trimIndent()
+        val formattedCode =
             """
             annotation class E
 
@@ -182,95 +183,86 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
                 @E
                 fun bar() = 2
             }
-            """.trimIndent(),
-            SpacingBetweenDeclarationsWithAnnotationsRule().format(
-                """
-                annotation class E
-
-                class C {
-                    fun foo() = 1
-                    @E
-                    fun bar() = 2
-                }
-                """.trimIndent()
-            )
-        )
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().format(code)
+        ).isEqualTo(formattedCode)
     }
 
     @Test
     fun `two new lines before member function`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                annotation class E
-                class C {
-                    fun foo() = 1
+        val code =
+            """
+            annotation class E
+            class C {
+                fun foo() = 1
 
 
-                    @E
-                    fun bar() = 2
-                }
-                """.trimIndent()
-            )
+                @E
+                fun bar() = 2
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `missing space after comment with previous member function should do nothing`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                annotation class E
-                class C {
-                    fun foo() = 1
+        val code =
+            """
+            annotation class E
+            class C {
+                fun foo() = 1
 
-                    // Hello
-                    @E
-                    fun bar() = 2
-                }
-                """.trimIndent()
-            )
+                // Hello
+                @E
+                fun bar() = 2
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `No blank line is required between comment and an annotated declaration`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                fun foo() {
+        val code =
+            """
+            fun foo() {
 
-                    val a = 1
+                val a = 1
 
-                    // hello
-                    @Foo
-                    val b = 2
-                }
-                """.trimIndent()
-            )
+                // hello
+                @Foo
+                val b = 2
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `Issue 1281 - No blank line is required between comment and an annotated declaration when previous declaration end with a comment`() {
-        Assertions.assertThat(
-            SpacingBetweenDeclarationsWithAnnotationsRule().lint(
-                """
-                class KotlinPluginTest {
-                    // tag::setUp[]
-                    @BeforeEach
-                    fun setUp() {
-                    }
-                    // end::setUp[]
-
-                    // tag::testQuery[]
-                    @Test
-                        fun testFindById() {
-                    }
-                    // end::testQuery[]
+        val code =
+            """
+            class KotlinPluginTest {
+                // tag::setUp[]
+                @BeforeEach
+                fun setUp() {
                 }
-                """.trimIndent()
-            )
+                // end::setUp[]
+
+                // tag::testQuery[]
+                @Test
+                    fun testFindById() {
+                }
+                // end::testQuery[]
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithAnnotationsRule().lint(code)
         ).isEmpty()
     }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
@@ -4,8 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingBetweenDeclarationsWithCommentsRuleTest {
     @Test
@@ -67,53 +66,53 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
 
     @Test
     fun `missing space before declaration with kdoc should cause error`() {
+        val code =
+            """
+            fun a()
+            /**
+             * foo
+             */
+            fun b()
+            """.trimIndent()
         assertThat(
-            SpacingBetweenDeclarationsWithCommentsRule().lint(
-                """
-                fun a()
-                /**
-                 * foo
-                 */
-                fun b()
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(
-                    2,
-                    1,
-                    "spacing-between-declarations-with-comments",
-                    "Declarations and declarations with comments should have an empty space between."
-                )
-            )
+            SpacingBetweenDeclarationsWithCommentsRule().lint(code)
+        ).containsExactly(
+            LintError(2, 1, "spacing-between-declarations-with-comments", "Declarations and declarations with comments should have an empty space between.")
         )
     }
 
     @Test
     fun `missing space before declaration with eol comment should cause error`() {
+        val code =
+            """
+            fun a()
+            // foo
+            fun b()
+            """.trimIndent()
         assertThat(
-            SpacingBetweenDeclarationsWithCommentsRule().lint(
-                """
-                fun a()
-                // foo
-                fun b()
-                """.trimIndent()
-            )
-        ).isEqualTo(
-            listOf(
-                LintError(
-                    2,
-                    1,
-                    "spacing-between-declarations-with-comments",
-                    "Declarations and declarations with comments should have an empty space between."
-                )
-            )
+            SpacingBetweenDeclarationsWithCommentsRule().lint(code)
+        ).containsExactly(
+            LintError(2, 1, "spacing-between-declarations-with-comments", "Declarations and declarations with comments should have an empty space between.")
         )
     }
 
     @Test
     fun `autoformat should work correctly`() {
-        assertEquals(
+        val code =
+            """
+            /**
+             * Doc 1
+             */
+            fun one() = 1
+            /**
+             * Doc 2
+             */
+            fun two() = 2
+            fun three() = 42
+            // comment
+            fun four() = 44
+            """.trimIndent()
+        val formattedCode =
             """
             /**
              * Doc 1
@@ -128,63 +127,50 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
 
             // comment
             fun four() = 44
-            """.trimIndent(),
-            SpacingBetweenDeclarationsWithCommentsRule().format(
-                """
-                /**
-                 * Doc 1
-                 */
-                fun one() = 1
-                /**
-                 * Doc 2
-                 */
-                fun two() = 2
-                fun three() = 42
-                // comment
-                fun four() = 44
-                """.trimIndent()
-            )
-        )
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithCommentsRule().format(code)
+        ).isEqualTo(formattedCode)
     }
 
     @Test
     fun `not a declaration comment`() {
-        assertThat(
-            SpacingBetweenDeclarationsWithCommentsRule().lint(
-                """
-                fun function() {
-                    with(binding) {
-                        loginButton.setOnClickListener {
-                //            comment
-                            showScreen()
-                        }
+        val code =
+            """
+            fun function() {
+                with(binding) {
+                    loginButton.setOnClickListener {
+            //            comment
+                        showScreen()
                     }
                 }
-                """.trimIndent()
-            )
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithCommentsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `not a comment between declarations`() {
-        assertThat(
-            SpacingBetweenDeclarationsWithCommentsRule().lint(
-                """
-                class C {
-                    fun test() {
-                        println()
-                        // comment1
-                        fun one() = 1
-                    }
+        val code =
+            """
+            class C {
+                fun test() {
+                    println()
+                    // comment1
+                    fun one() = 1
                 }
-                """.trimIndent()
-            )
+            }
+            """.trimIndent()
+        assertThat(
+            SpacingBetweenDeclarationsWithCommentsRule().lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `declarations in class`() {
-        val actual = SpacingBetweenDeclarationsWithCommentsRule().format(
+        val code =
             """
             class C {
                 /**
@@ -200,8 +186,7 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
                 fun four() = 44
             }
             """.trimIndent()
-        )
-        assertThat(actual).isEqualTo(
+        val formattedCode =
             """
             class C {
                 /**
@@ -219,43 +204,45 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
                 fun four() = 44
             }
             """.trimIndent()
-        )
+        assertThat(
+            SpacingBetweenDeclarationsWithCommentsRule().format(code)
+        ).isEqualTo(formattedCode)
     }
 
     // https://github.com/pinterest/ktlint/issues/1053
     @Test
     fun `declaration has tail comments`() {
+        val code =
+            """
+            class SampleClass {
+
+                private val public = "ok" // ok
+                private val private = "not_ok" // false positive
+                private val halfPublicHalfPrivate = "not_ok" // false positive
+
+                /**
+                 * Doc 1
+                 */
+                fun one() = 1
+
+                /**
+                 * Doc 2
+                 */
+                fun two() = 2
+                fun three() {
+                    val public = "ok" // ok
+                    val private = "not_ok" // false positive
+                }
+            }
+
+            enum class SampleEnum {
+                One, // ok
+                Two, // false positive
+                Three, // false positive
+            }
+            """.trimIndent()
         assertThat(
-            SpacingBetweenDeclarationsWithCommentsRule().lint(
-                """
-                class SampleClass {
-
-                    private val public = "ok" // ok
-                    private val private = "not_ok" // false positive
-                    private val halfPublicHalfPrivate = "not_ok" // false positive
-
-                    /**
-                     * Doc 1
-                     */
-                    fun one() = 1
-
-                    /**
-                     * Doc 2
-                     */
-                    fun two() = 2
-                    fun three() {
-                        val public = "ok" // ok
-                        val private = "not_ok" // false positive
-                    }
-                }
-
-                enum class SampleEnum {
-                    One, // ok
-                    Two, // false positive
-                    Three, // false positive
-                }
-                """.trimIndent()
-            )
+            SpacingBetweenDeclarationsWithCommentsRule().lint(code)
         ).isEmpty()
     }
 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
@@ -8,8 +8,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class TrailingCommaRuleTest {
@@ -1032,13 +1031,6 @@ class TrailingCommaRuleTest {
             rules.format(code, ALLOW_TRAILING_COMMA, cb = { e, _ -> afterFormatLintErrors.add(e) })
         assertThat(afterFormatLintErrors).isEmpty()
         assertThat(formatResult).isEqualTo(formattedCode)
-    }
-
-    @Test
-    fun assertTrue() {
-        val ktlintOutput = "Some unused import"
-
-        assertTrue(ktlintOutput.contains("unused import"))
     }
 
     private companion object {

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class UnnecessaryParenthesesBeforeTrailingLambdaRuleTest {
     private val unnecessaryParenthesesRule = UnnecessaryParenthesesBeforeTrailingLambdaRule()

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -8,6 +8,13 @@ dependencies {
   implementation deps.logging
 
   testImplementation project(':ktlint-test')
-  testImplementation deps.junit
+
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -8,13 +8,6 @@ dependencies {
   implementation deps.logging
 
   testImplementation project(':ktlint-test')
-
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRuleTest.kt
@@ -5,10 +5,9 @@ import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ChainWrappingRuleTest {
-
     @Test
     fun testLint() {
         assertThat(ChainWrappingRule().diffFileLint("spec/chain-wrapping/lint.kt.spec")).isEmpty()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CommentSpacingRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -3,10 +3,9 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FilenameRuleTest {
-
     @Test
     fun testMatchingSingleClassName() {
         for (

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRuleTest.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class FinalNewlineRuleTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -11,7 +11,7 @@ import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.model.PropertyType
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @FeatureInAlphaState
 internal class IndentationRuleTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
@@ -8,7 +8,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class MaxLineLengthRuleTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ModifierOrderRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoBlankLineBeforeRbraceRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoConsecutiveBlankLinesRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoEmptyClassBodyRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoLineBreakAfterElseRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 const val ruleId = "no-line-break-before-assignment"
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoMultipleSpacesRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoSemicolonsRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoTrailingSpacesRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoUnitReturnRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoUnusedImportsRuleTest {
     @Test
@@ -688,7 +688,7 @@ class NoUnusedImportsRuleTest {
                 import com.pinterest.ktlint.ruleset.standard.internal.importordering.PatternEntry
                 import com.pinterest.ktlint.ruleset.standard.internal.importordering.parseImportsLayout
                 import org.assertj.core.api.Assertions.assertThat
-                import org.junit.Test
+                import org.junit.jupiter.api.Test
 
                 class ImportLayoutParserTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoWildcardImportsRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class ParameterListWrappingRuleTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundColonRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundCommaRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundCurlyRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundDotRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundKeywordRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundOperatorsRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRuleTest.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundParensRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SpacingAroundRangeOperatorRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetIntegrationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetIntegrationTest.kt
@@ -2,7 +2,7 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.KtLint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class StandardRuleSetIntegrationTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class StringTemplateRuleTest {
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
@@ -3,18 +3,22 @@ package com.pinterest.ktlint.ruleset.standard.importordering
 import com.pinterest.ktlint.ruleset.standard.internal.importordering.PatternEntry
 import com.pinterest.ktlint.ruleset.standard.internal.importordering.parseImportsLayout
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
 
 class ImportLayoutParserTest {
-
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `blank lines in the beginning and end of import list are not allowed`() {
-        parseImportsLayout("|,*,|")
+        assertThatThrownBy {
+            parseImportsLayout("|,*,|")
+        }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `pattern without single wildcard is not allowed`() {
-        parseImportsLayout("java.util.List.*")
+        assertThatThrownBy {
+            parseImportsLayout("java.util.List.*")
+        }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class ImportOrderingEditorconfigTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleAsciiTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleCustomTest {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class ImportOrderingRuleIdeaTest {

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -26,15 +26,17 @@ configurations {
 }
 
 dependencies {
+  ktlint project(':ktlint')
+
   compileOnly project(':ktlint-core')
 
   testImplementation project(':ktlint-core')
   testImplementation project(':ktlint-test')
-  testImplementation deps.assertj
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
 
-  ktlint project(':ktlint')
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
+  testImplementation deps.assertj
 }
 
 test {

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -32,10 +32,7 @@ dependencies {
 
   testImplementation project(':ktlint-core')
   testImplementation project(':ktlint-test')
-
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
 }
 

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -7,12 +7,6 @@ dependencies {
   api project(':ktlint-core')
   api project(':ktlint-ruleset-test')
 
-  implementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  implementation deps.junit5
   implementation deps.assertj
-}
-
-test {
-  useJUnitPlatform()
 }

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -7,6 +7,12 @@ dependencies {
   api project(':ktlint-core')
   api project(':ktlint-ruleset-test')
 
+  implementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   implementation deps.assertj
-  implementation deps.junit
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/EditorConfigTestRule.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/EditorConfigTestRule.kt
@@ -3,39 +3,39 @@ package com.pinterest.ktlint.test
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import java.io.File
 import org.ec4j.core.model.PropertyType
-import org.junit.rules.TemporaryFolder
 
-/**
- * Helper [org.junit.rules.TestRule] allows to write `.editorconfig` file content
- * for test case.
- */
+@Deprecated(
+    message = "Marked for removal in Ktlint 0.46. See KDoc on method call for more information."
+)
 @FeatureInAlphaState
-public class EditorConfigTestRule : TemporaryFolder() {
+public class EditorConfigTestRule {
 
+    @Deprecated(
+        message = "Implementation has been removed as it depended on a JUnit 4 implementation which no longer is " +
+            "being used by Ktlint.",
+        replaceWith = ReplaceWith(""),
+        level = DeprecationLevel.ERROR
+    )
     /**
-     * Write new `.editorconfig` file.
-     *
-     * @param content map of `.editorconfig` [PropertyType] to expected value `String` representation
-     * to write under `[*.{kt,kts}] block
-     * @param lintedFileExtension linted file extension, default is `.kt`
-     * @return pass returned fake lint file path to `KtLint`,
-     * so written `.editorconfig` will be picked up for linting
+     * Unit tests should not use the filesystem if that can be avoided. Unit tests that depend on an `.editorconfig`
+     * property should now be written as follows:
+     * ```
+     * MaxLineLengthRule().lint(
+     *     "some-code",
+     *     EditorConfigOverride.from(
+     *         maxLineLengthProperty to 40,
+     *         ignoreBackTickedIdentifierProperty to true
+     *     )
+     * )
+     * ```
+     * All helper methods in [com.pinterest.ktlint.test.RuleExtensionKt] class now support the EditorConfigOverride
+     * values. Please, be aware that this class also contains a lot of deprecated methods which you should not use
+     * either.
      */
     public fun writeToEditorConfig(
         content: Map<PropertyType<*>, String>,
         lintedFileExtension: String = ".kt"
     ): File {
-        val editorConfigFile = File(root, ".editorconfig")
-        editorConfigFile.writeText(
-            "[*.{kt,kts}]${System.lineSeparator()}"
-                .plus(
-                    content
-                        .map { entry ->
-                            "${entry.key.name} = ${entry.value}"
-                        }
-                        .joinToString(System.lineSeparator())
-                )
-        )
-        return File(editorConfigFile.parent, "test$lintedFileExtension")
+        throw UnsupportedOperationException("This functionality has been removed. See deprecation notice and KDoc.")
     }
 }

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
@@ -3,13 +3,12 @@ package com.pinterest.ktlint.test
 import com.pinterest.ktlint.core.RuleSetProvider
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 open class RuleSetProviderTest(
     private val rulesetClass: Class<out RuleSetProvider>,
     private val packageName: String
 ) {
-
     @Test
     fun checkAllRulesProvided() {
         val srcLocation = rulesetClass.protectionDomain.codeSource.location.path

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -34,13 +34,12 @@ dependencies {
   implementation deps.klob
   implementation deps.picocli
 
-  testImplementation deps.junit
-  testImplementation deps.junit5Api
+
+  testImplementation(deps.junit5) {
+    because 'allows to write and run Jupiter tests'
+  }
   testImplementation deps.assertj
   testImplementation deps.jimfs
-
-  testRuntimeOnly deps.junit5Jupiter
-  testRuntimeOnly deps.junit5Vintage
 }
 
 // Implements https://github.com/brianm/really-executable-jars-maven-plugin maven plugin behaviour.

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -35,9 +35,7 @@ dependencies {
   implementation deps.picocli
 
 
-  testImplementation(deps.junit5) {
-    because 'allows to write and run Jupiter tests'
-  }
+  testImplementation deps.junit5
   testImplementation deps.assertj
   testImplementation deps.jimfs
 }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/BaselineTests.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/BaselineTests.kt
@@ -3,15 +3,13 @@ package com.pinterest.ktlint
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.security.Permission
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class BaselineTests {
-
-    @Before
-    fun setup() {
+    @BeforeEach
+    internal fun setUp() {
         System.setSecurityManager(object : SecurityManager() {
             override fun checkPermission(perm: Permission?) { // allow anything.
             }
@@ -39,8 +37,8 @@ class BaselineTests {
         }
 
         val output = String(stream.toByteArray())
-        assertTrue(output.contains(".*:1:24: Unnecessary block".toRegex()))
-        assertTrue(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+        assertThat(output).contains(":1:24: Unnecessary block")
+        assertThat(output).contains(":2:1: Unexpected blank line(s) before \"}\"")
     }
 
     @Test
@@ -56,8 +54,8 @@ class BaselineTests {
         }
 
         val output = String(stream.toByteArray())
-        assertFalse(output.contains(".*:1:24: Unnecessary block".toRegex()))
-        assertFalse(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+        assertThat(output).doesNotContain(":1:24: Unnecessary block")
+        assertThat(output).doesNotContain(":2:1: Unexpected blank line(s) before \"}\"")
     }
 
     @Test
@@ -73,8 +71,8 @@ class BaselineTests {
         }
 
         val output = String(stream.toByteArray())
-        assertFalse(output.contains(".*:1:34: Unnecessary block".toRegex()))
-        assertTrue(output.contains(".*:2:1: Unexpected blank line\\(s\\) before \"}\"".toRegex()))
+        assertThat(output).doesNotContain(":1:34: Unnecessary block")
+        assertThat(output).contains(":2:1: Unexpected blank line(s) before \"}\"")
     }
 
     private class ExitException : SecurityException("Should not exit in tests")

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsFileSequenceTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsFileSequenceTest.kt
@@ -6,11 +6,10 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.CoreMatchers
-import org.junit.After
-import org.junit.Assume
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [fileSequence] method.
@@ -32,13 +31,13 @@ internal class FileUtilsFileSequenceTest {
         "${rootDir}project2/src/main/java/Three.kt"
     ).map { it.normalizePath() }
 
-    @Before
-    fun setUp() {
+    @BeforeEach
+    internal fun setUp() {
         project1Files.createFiles()
     }
 
-    @After
-    fun tearDown() {
+    @AfterEach
+    internal fun tearDown() {
         tempFileSystem.close()
     }
 
@@ -125,7 +124,7 @@ internal class FileUtilsFileSequenceTest {
 
     @Test
     fun `Should support unescaped slashes for Windows`() {
-        Assume.assumeThat(System.getProperty("os.name").toLowerCase(), CoreMatchers.startsWith("windows"))
+        assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("windows"))
 
         val foundFiles = getFiles(
             listOf(
@@ -171,7 +170,7 @@ internal class FileUtilsFileSequenceTest {
 
     @Test
     fun `transforming globs with leading tilde`() {
-        Assume.assumeThat(System.getProperty("os.name").toLowerCase(), CoreMatchers.startsWith("linux"))
+        assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("linux"))
 
         val glob = tempFileSystem.toGlob(
             "~/project/src/main/kotlin/One.kt",


### PR DESCRIPTION
## Description

Replace JUnit4 with JUnit5. I am confident about the changes in de unit tests themselves. But I have doubts about my changes to `build.gradle` files.

1. I had to define the test task below in (almost) each `build.gradle`:
```
test {
  useJUnitPlatform()
}
```

2. In the old implementation the unit tests for jdk8 *and* jdk11 were executed when triggering task `check`. Now only one of them runs, and I am even not sure which of them. I am fine with this (even prefer it) as long as all unit tests run with botj jdk8 and jdk11 when pushing changes.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated
