### PR TITLE
Do not indent raw string literals that are not followed by either trimIndent() or trimMargin()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fix lint message to "Unnecessary long whitespace" (`no-multi-spaces`) ([#1394](https://github.com/pinterest/ktlint/issues/1394))
 - Do not remove trailing comma after a parameter of type array in an annotation (experimental:trailing-comma) ([#1379](https://github.com/pinterest/ktlint/issues/1379))
 - Do not delete blank lines in KDoc (no-trailing-spaces) ([#1376](https://github.com/pinterest/ktlint/issues/1376))
+- Do not indent raw string literals that are not followed by either trimIndent() or trimMargin() (`indent`) ([#1375](https://github.com/pinterest/ktlint/issues/1375))
 
 ### Changed
 - Print the rule id always in the PlainReporter ([#1121](https://github.com/pinterest/ktlint/issues/1121))

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1271,7 +1271,7 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun `Issue 1127 - multiline string in parameter list`() {
+    fun `Issue 1127 - multiline string followed by trimIndent in parameter list`() {
         val code =
             """
             interface UserRepository : JpaRepository<User, UUID> {
@@ -1279,7 +1279,7 @@ internal class IndentationRuleTest {
                     select u from User u
                     inner join Organization o on u.organization = o
                     where o = :organization
-                $MULTILINE_STRING_QUOTE)
+                $MULTILINE_STRING_QUOTE.trimIndent())
                 fun findByOrganization(organization: Organization, pageable: Pageable): Page<User>
             }
             """.trimIndent()
@@ -1291,7 +1291,7 @@ internal class IndentationRuleTest {
                     select u from User u
                     inner join Organization o on u.organization = o
                     where o = :organization
-                    $MULTILINE_STRING_QUOTE
+                    $MULTILINE_STRING_QUOTE.trimIndent()
                 )
                 fun findByOrganization(organization: Organization, pageable: Pageable): Page<User>
             }
@@ -1302,7 +1302,7 @@ internal class IndentationRuleTest {
             listOf(
                 LintError(line = 2, col = 12, ruleId = "wrapping", detail = "Missing newline after \"(\""),
                 LintError(line = 6, col = 1, ruleId = "indent", detail = "Unexpected indent of multiline string closing quotes"),
-                LintError(line = 6, col = 7, ruleId = "wrapping", detail = "Missing newline before \")\"")
+                LintError(line = 6, col = 20, ruleId = "wrapping", detail = "Missing newline before \")\"")
             )
         )
         assertThat(wrappingAndIndentRule.format(code)).isEqualTo(formattedCode)

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string-expected.kt.spec
@@ -8,7 +8,11 @@ fun f0() {
     println("""${true}""")
     println(
         """
+"""
+    )
+    println(
         """
+        """.trimIndent()
     )
     f(
         """${
@@ -18,7 +22,7 @@ fun f0() {
 _${
         true
         }
-        """,
+        """.trimIndent(),
         """text"""
     )
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-multiline-string.kt.spec
@@ -6,11 +6,13 @@ fun f0() {
 println("""${true}""")
 println("""
 """)
+println("""
+""".trimIndent())
     f("""${
 true
     }
     text
 _${
 true
-    }""", """text""")
+    }""".trimIndent(), """text""")
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -102,6 +102,6 @@ ${Target(
         )}
 ${LoadStatement("@gmaven_rules//:gmaven.bzl", listOf("gmaven_rules"))}
 ${Target("gmaven_rules", listOf())}
-        """
+"""
 
 }


### PR DESCRIPTION
## Description

Closes #1375

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
