### PR TITLE
Wrapping block and kdoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This section is applicable when providing rules that depend on one or more value
 ### Added
 - New experimental rule for aligning the initial stars in a block comment when present (`experimental:block-comment-initial-star-alignment` ([#297](https://github.com/pinterest/ktlint/issues/297))
 - Respect `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand` (`no-wildcard-imports`) ([#1272](https://github.com/pinterest/ktlint/pull/1272))
+- Add new experimental rules for wrapping of block comment (`comment-wrapping`) ([#todo](https://github.com/pinterest/ktlint/pull/todo))
+- Add new experimental rules for wrapping of KDoc comment (`kdoc-wrapping`) ([#todo](https://github.com/pinterest/ktlint/pull/todo))
 
 ### Fixed
 - Fix lint message to "Unnecessary long whitespace" (`no-multi-spaces`) ([#1394](https://github.com/pinterest/ktlint/issues/1394))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ This section is applicable when providing rules that depend on one or more value
 ### Added
 - New experimental rule for aligning the initial stars in a block comment when present (`experimental:block-comment-initial-star-alignment` ([#297](https://github.com/pinterest/ktlint/issues/297))
 - Respect `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand` (`no-wildcard-imports`) ([#1272](https://github.com/pinterest/ktlint/pull/1272))
-- Add new experimental rules for wrapping of block comment (`comment-wrapping`) ([#todo](https://github.com/pinterest/ktlint/pull/todo))
-- Add new experimental rules for wrapping of KDoc comment (`kdoc-wrapping`) ([#todo](https://github.com/pinterest/ktlint/pull/todo))
+- Add new experimental rules for wrapping of block comment (`comment-wrapping`) ([#1403](https://github.com/pinterest/ktlint/pull/1403))
+- Add new experimental rules for wrapping of KDoc comment (`kdoc-wrapping`) ([#1403](https://github.com/pinterest/ktlint/pull/1403))
 
 ### Fixed
 - Fix lint message to "Unnecessary long whitespace" (`no-multi-spaces`) ([#1394](https://github.com/pinterest/ktlint/issues/1394))

--- a/README.md
+++ b/README.md
@@ -76,14 +76,12 @@ New rules will be added into the [experimental ruleset](https://github.com/pinte
 by passing the `--experimental` flag to `ktlint`.
 
 - `experimental:annotation`: Annotation formatting - multiple annotations should be on a separate line than the annotated declaration; annotations with parameters should each be on separate lines; annotations should be followed by a space
-- `experimental:argument-list-wrapping`: Argument list wrapping
 - `experimental:block-comment-initial-star-alignment`: Lines in a block comment which (exclusive the indentation) start with a `*` should have this `*` aligned with the `*` in the opening of the block comment.
 - `experimental:discouraged-comment-location`: Detect discouraged comment locations (no autocorrect)
 - `experimental:enum-entry-name-case`: Enum entry names should be uppercase underscore-separated names
 - `experimental:multiline-if-else`: Braces required for multiline if/else statements
 - `experimental:no-empty-first-line-in-method-block`: No leading empty lines in method blocks
 - `experimental:package-name`: No underscores in package names
-- `experimental:unary-op-spacing`: No spaces around unary operators
 - `experimental:unnecessary-parentheses-before-trailing-lambda`: An empty parentheses block before a lambda is redundant. For example `some-string".count() { it == '-' }`
 
 ### Spacing
@@ -95,6 +93,12 @@ by passing the `--experimental` flag to `ktlint`.
 - `experimental:spacing-around-angle-brackets`: No spaces around angle brackets
 - `experimental:spacing-between-declarations-with-annotations`: Declarations with annotations should be separated by a blank line
 - `experimental:spacing-between-declarations-with-comments`: Declarations with comments should be separated by a blank line
+- `experimental:unary-op-spacing`: No spaces around unary operators
+
+### Wrapping
+- `experimental:argument-list-wrapping`: Argument list wrapping
+- `experimental:comment-wrapping`: A block comment should start and end on a line that does not contain any other element. A block comment should not be used as end of line comment.
+- `experimental:kdoc-wrapping`: A KDoc comment should start and end on a line that does not contain any other element.
 
 ## EditorConfig
 

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
@@ -1,0 +1,133 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.lineIndent
+import com.pinterest.ktlint.core.ast.lineNumber
+import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
+
+/**
+ * Checks external wrapping of block comments. Wrapping inside the comment is not altered. A block comment following
+ * another element on the same line is replaced with an EOL comment, if possible.
+ */
+@OptIn(FeatureInAlphaState::class)
+public class CommentWrappingRule :
+    Rule("comment-wrapping"),
+    UsesEditorConfigProperties {
+    override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
+        listOf(
+            DefaultEditorConfigProperties.indentSizeProperty,
+            DefaultEditorConfigProperties.indentStyleProperty
+        )
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == BLOCK_COMMENT) {
+            val nonIndentLeafOnSameLinePrecedingBlockComment =
+                node
+                    .prevLeaf()
+                    ?.takeIf { isNonIndentLeafOnSameLine(it) }
+            val nonIndentLeafOnSameLineFollowingBlockComment =
+                node
+                    .nextLeaf()
+                    ?.takeIf { isNonIndentLeafOnSameLine(it) }
+
+            if (nonIndentLeafOnSameLinePrecedingBlockComment != null &&
+                nonIndentLeafOnSameLineFollowingBlockComment != null
+            ) {
+                if (nonIndentLeafOnSameLinePrecedingBlockComment.lineNumber() == nonIndentLeafOnSameLineFollowingBlockComment.lineNumber()) {
+                    // Do not try to fix constructs like below:
+                    //    val foo /* some comment */ = "foo"
+                    emit(
+                        node.startOffset,
+                        "A block comment in between other elements on the same line is disallowed",
+                        false
+                    )
+                } else {
+                    // Do not try to fix constructs like below:
+                    //    val foo = "foo" /*
+                    //    some comment
+                    //    */ val bar = "bar"
+                    emit(
+                        node.startOffset,
+                        "A block comment starting on same line as another element and ending on another line before another element is disallowed",
+                        false
+                    )
+                }
+                return
+            }
+
+            nonIndentLeafOnSameLinePrecedingBlockComment
+                ?.precedesBlockCommentOnSameLine(node, emit, autoCorrect)
+
+            nonIndentLeafOnSameLineFollowingBlockComment
+                ?.followsBlockCommentOnSameLine(node, emit, autoCorrect)
+        }
+    }
+
+    private fun ASTNode.precedesBlockCommentOnSameLine(
+        blockCommentNode: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val leafAfterBlockComment = blockCommentNode.nextLeaf()
+        if (!blockCommentNode.textContains('\n') && leafAfterBlockComment.isLastElementOnLine()) {
+            emit(
+                startOffset,
+                "A single line block comment after a code element on the same line must be replaced with an EOL comment",
+                true
+            )
+            if (autoCorrect) {
+                blockCommentNode.replaceWithEndOfLineComment()
+            }
+        } else {
+            // It can not be autocorrected as it might depend on the situation and code style what is preferred.
+            emit(
+                blockCommentNode.startOffset,
+                "A block comment after any other element on the same line must be separated by a new line",
+                false
+            )
+        }
+    }
+
+    private fun ASTNode.replaceWithEndOfLineComment() {
+        val content = text.removeSurrounding("/*", "*/").trim()
+        val eolComment = PsiCommentImpl(EOL_COMMENT, "// $content")
+        (this as LeafPsiElement).rawInsertBeforeMe(eolComment)
+        rawRemove()
+    }
+
+    private fun ASTNode.followsBlockCommentOnSameLine(
+        blockCommentNode: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        emit(startOffset, "A block comment may not be followed by any other element on that same line", true)
+        if (autoCorrect) {
+            if (elementType == WHITE_SPACE) {
+                (this as LeafPsiElement).rawReplaceWithText("\n${blockCommentNode.lineIndent()}")
+            } else {
+                (this as LeafPsiElement).upsertWhitespaceBeforeMe("\n${blockCommentNode.lineIndent()}")
+            }
+        }
+    }
+
+    private fun isNonIndentLeafOnSameLine(it: ASTNode) =
+        it.elementType != WHITE_SPACE || !it.textContains('\n')
+
+    private fun ASTNode?.isLastElementOnLine() =
+        this == null || (elementType == WHITE_SPACE && textContains('\n'))
+}

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -26,6 +26,8 @@ public class ExperimentalRuleSetProvider : RuleSetProvider {
         DiscouragedCommentLocationRule(),
         FunKeywordSpacingRule(),
         FunctionTypeReferenceSpacingRule(),
-        ModifierListSpacingRule()
+        ModifierListSpacingRule(),
+        CommentWrappingRule(),
+        KdocWrappingRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
@@ -1,0 +1,106 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.ElementType.KDOC
+import com.pinterest.ktlint.core.ast.ElementType.KDOC_END
+import com.pinterest.ktlint.core.ast.ElementType.KDOC_START
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.lineIndent
+import com.pinterest.ktlint.core.ast.lineNumber
+import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+
+/**
+ * Checks external wrapping of KDoc comment. Wrapping inside the KDoc comment is not altered.
+ */
+@OptIn(FeatureInAlphaState::class)
+public class KdocWrappingRule :
+    Rule("kdoc-wrapping"),
+    UsesEditorConfigProperties {
+    override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
+        listOf(
+            DefaultEditorConfigProperties.indentSizeProperty,
+            DefaultEditorConfigProperties.indentStyleProperty
+        )
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == KDOC) {
+            val nonIndentLeafOnSameLinePrecedingKdocComment =
+                node
+                    .findChildByType(KDOC_START)
+                    ?.prevLeaf()
+                    ?.takeIf { isNonIndentLeafOnSameLine(it) }
+            val nonIndentLeafOnSameLineFollowingKdocComment =
+                node
+                    .findChildByType(KDOC_END)
+                    ?.nextLeaf()
+                    ?.takeIf { isNonIndentLeafOnSameLine(it) }
+
+            if (nonIndentLeafOnSameLinePrecedingKdocComment != null &&
+                nonIndentLeafOnSameLineFollowingKdocComment != null
+            ) {
+                if (nonIndentLeafOnSameLinePrecedingKdocComment.lineNumber() == nonIndentLeafOnSameLineFollowingKdocComment.lineNumber()) {
+                    // Do not try to fix constructs like below:
+                    //    val foo /** some comment */ = "foo"
+                    emit(
+                        node.startOffset,
+                        "A KDoc comment in between other elements on the same line is disallowed",
+                        false
+                    )
+                } else {
+                    // Do not try to fix constructs like below:
+                    //    val foo = "foo" /*
+                    //    some comment*
+                    //    */ val bar = "bar"
+                    emit(
+                        node.startOffset,
+                        "A KDoc comment starting on same line as another element and ending on another line before another element is disallowed",
+                        false
+                    )
+                }
+                return
+            }
+
+            if (nonIndentLeafOnSameLinePrecedingKdocComment != null) {
+                // It can not be autocorrected as it might depend on the situation and code style what is
+                // preferred.
+                emit(
+                    node.startOffset,
+                    "A KDoc comment after any other element on the same line must be separated by a new line",
+                    false
+                )
+            }
+
+            nonIndentLeafOnSameLineFollowingKdocComment
+                ?.followsKdocCommentOnSameLine(node, emit, autoCorrect)
+        }
+    }
+
+    private fun ASTNode.followsKdocCommentOnSameLine(
+        kdocCommentNode: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        emit(startOffset, "A KDoc comment may not be followed by any other element on that same line", true)
+        if (autoCorrect) {
+            if (elementType == WHITE_SPACE) {
+                (this as LeafPsiElement).rawReplaceWithText("\n${kdocCommentNode.lineIndent()}")
+            } else {
+                (this as LeafPsiElement).upsertWhitespaceBeforeMe("\n${kdocCommentNode.lineIndent()}")
+            }
+        }
+    }
+
+    private fun isNonIndentLeafOnSameLine(it: ASTNode) =
+        it.elementType != WHITE_SPACE || !it.textContains('\n')
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRuleTest.kt
@@ -1,0 +1,137 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CommentWrappingRuleTest {
+    @Test
+    fun `Given a single line block comment that start starts and end on a separate line then do not reformat`() {
+        val code =
+            """
+            /* Some comment */
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).isEmpty()
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a multi line block comment that start starts and end on a separate line then do not reformat`() {
+        val code =
+            """
+            /*
+             * Some comment
+             */
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).isEmpty()
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a block comment followed by a code element on the same line as the block comment ended then split the elements with a new line`() {
+        val code =
+            """
+            /* Some comment 1 */ val foo1 = "foo1"
+            /* Some comment 2 */val foo2 = "foo2"
+            /* Some comment 3 */ fun foo3() = "foo3"
+            /* Some comment 4 */fun foo4() = "foo4"
+            """.trimIndent()
+        val formattedCode =
+            """
+             /* Some comment 1 */
+             val foo1 = "foo1"
+             /* Some comment 2 */
+             val foo2 = "foo2"
+             /* Some comment 3 */
+             fun foo3() = "foo3"
+             /* Some comment 4 */
+             fun foo4() = "foo4"
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(1, 21, "comment-wrapping", "A block comment may not be followed by any other element on that same line"),
+            LintError(2, 21, "comment-wrapping", "A block comment may not be followed by any other element on that same line"),
+            LintError(3, 21, "comment-wrapping", "A block comment may not be followed by any other element on that same line"),
+            LintError(4, 21, "comment-wrapping", "A block comment may not be followed by any other element on that same line")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a block comment containing a newline which is preceded by another element on the same line then raise lint error but do not autocorrect`() {
+        val code =
+            """
+            val foo = "foo" /* Some comment
+                             * with a newline
+                             */
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(1, 17, "comment-wrapping", "A block comment after any other element on the same line must be separated by a new line")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a block comment that does not contain a newline and which is after some code om the same line is changed to an EOL comment`() {
+        val code =
+            """
+            val foo = "foo" /* Some comment */
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = "foo" // Some comment
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(1, 16, "comment-wrapping", "A single line block comment after a code element on the same line must be replaced with an EOL comment")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Given a block comment in between code elements on the same line then raise lint error but do not autocorrect`() {
+        val code =
+            """
+            val foo /* some comment */ = "foo"
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(1, 9, "comment-wrapping", "A block comment in between other elements on the same line is disallowed")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a block comment containing a new line and the block is preceded and followed by other code elements then raise lint errors but do not autocorrect`() {
+        val code =
+            """
+            val foo /*
+            some comment
+            */ = "foo"
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(1, 9, "comment-wrapping", "A block comment starting on same line as another element and ending on another line before another element is disallowed")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a block comment which is indented then keep that indent when wrapping the line`() {
+        val code =
+            """
+            fun bar() {
+                /* Some comment */ val foo = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun bar() {
+                /* Some comment */
+                val foo = "foo"
+            }
+            """.trimIndent()
+        assertThat(CommentWrappingRule().lint(code)).containsExactly(
+            LintError(2, 23, "comment-wrapping", "A block comment may not be followed by any other element on that same line")
+        )
+        assertThat(CommentWrappingRule().format(code)).isEqualTo(formattedCode)
+    }
+}

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRuleTest.kt
@@ -1,0 +1,121 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class KdocWrappingRuleTest {
+    @Test
+    fun `Given a single line KDoc comment that start starts and end on a separate line then do not reformat`() {
+        val code =
+            """
+            /** Some KDoc comment */
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).isEmpty()
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a multi line KDoc comment that start starts and end on a separate line then do not reformat`() {
+        val code =
+            """
+            /**
+             * Some KDoc comment
+             */
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).isEmpty()
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a KDoc comment followed by a code element on the same line as the KDoc comment ended then split the elements with a new line`() {
+        val code =
+            """
+            /** Some KDoc comment 1 */ val foo1 = "foo1"
+            /** Some KDoc comment 2 */val foo2 = "foo2"
+            /** Some KDoc comment 3 */ fun foo3() = "foo3"
+            /** Some KDoc comment 4 */fun foo4() = "foo4"
+            """.trimIndent()
+        val formattedCode =
+            """
+             /** Some KDoc comment 1 */
+             val foo1 = "foo1"
+             /** Some KDoc comment 2 */
+             val foo2 = "foo2"
+             /** Some KDoc comment 3 */
+             fun foo3() = "foo3"
+             /** Some KDoc comment 4 */
+             fun foo4() = "foo4"
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).containsExactly(
+            LintError(1, 27, "kdoc-wrapping", "A KDoc comment may not be followed by any other element on that same line"),
+            LintError(2, 27, "kdoc-wrapping", "A KDoc comment may not be followed by any other element on that same line"),
+            LintError(3, 27, "kdoc-wrapping", "A KDoc comment may not be followed by any other element on that same line"),
+            LintError(4, 27, "kdoc-wrapping", "A KDoc comment may not be followed by any other element on that same line")
+        )
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `A KDoc comment containing a newline should start on a new line but is not autocorrected`() {
+        val code =
+            """
+            val foo = "foo" /** Some KDoc comment
+                             * with a newline
+                             */
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).containsExactly(
+            LintError(1, 17, "kdoc-wrapping", "A KDoc comment after any other element on the same line must be separated by a new line")
+        )
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `A KDoc comment in between code elements on the same line should start and end on a new line but is only partially autocorrected`() {
+        val code =
+            """
+            val foo /** Some KDoc comment */ = "foo"
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).containsExactly(
+            LintError(1, 9, "kdoc-wrapping", "A KDoc comment in between other elements on the same line is disallowed")
+        )
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a KDoc comment containing a new line and the block is preceded and followed by other code elements then raise lint errors but do not autocorrect`() {
+        val code =
+            """
+            val foo /**
+            some KDoc comment
+            */ = "foo"
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).containsExactly(
+            LintError(1, 9, "kdoc-wrapping", "A KDoc comment starting on same line as another element and ending on another line before another element is disallowed")
+        )
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(code)
+    }
+
+    @Test
+    fun `Given a KDoc comment which is indented then keep that indent when wrapping the line`() {
+        val code =
+            """
+            fun bar() {
+                /** Some KDoc comment */ val foo = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun bar() {
+                /** Some KDoc comment */
+                val foo = "foo"
+            }
+            """.trimIndent()
+        assertThat(KdocWrappingRule().lint(code)).containsExactly(
+            LintError(2, 29, "kdoc-wrapping", "A KDoc comment may not be followed by any other element on that same line")
+        )
+        assertThat(KdocWrappingRule().format(code)).isEqualTo(formattedCode)
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -110,11 +110,10 @@ class MaxLineLengthRule :
         public val ignoreBackTickedIdentifierProperty: UsesEditorConfigProperties.EditorConfigProperty<Boolean> =
             UsesEditorConfigProperties.EditorConfigProperty(
                 type = PropertyType.LowerCasingPropertyType(
-                    /* name = */ KTLINT_IGNORE_BACKTICKED_IDENTIFIER_NAME,
-                    /* description = */ PROPERTY_DESCRIPTION,
-                    /* parser = */ PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                    /* possibleValues = */ true.toString(),
-                    false.toString()
+                    KTLINT_IGNORE_BACKTICKED_IDENTIFIER_NAME,
+                    PROPERTY_DESCRIPTION,
+                    PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                    setOf(true.toString(), false.toString())
                 ),
                 defaultValue = false
             )

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -75,7 +75,7 @@ class NoSemicolonsRule : Rule("no-semi") {
                     nextLeaf.textContains('\n') && nextNextLeaf.elementType != KtTokens.LBRACE
                 )
         }
-        return nextLeaf == null /* eof */
+        return nextLeaf == null // eof
     }
 
     private fun doesNotRequirePostSemi(prevLeaf: ASTNode?): Boolean {


### PR DESCRIPTION
## Description

Add new experimental rules for wrapping of block comments and KDoc comments. Both block comments as well as KDoc comments should always start and end on a line which does not contain any other element (except the whitespace for indentation). Block comments at the end of a line and which are preceded by another element, are automatically converted to an EOL comment.

Closes #1329 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] tests are added
- [X] `CHANGELOG.md` is updated
- [X] `README.md` is updated