### PR TITLE
Memory leak in initPsiFileFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This section is applicable when providing rules that depend on one or more value
 - Do not delete blank lines in KDoc (no-trailing-spaces) ([#1376](https://github.com/pinterest/ktlint/issues/1376))
 - Do not indent raw string literals that are not followed by either trimIndent() or trimMargin() (`indent`) ([#1375](https://github.com/pinterest/ktlint/issues/1375))
 - Revert remove unnecessary wildcard imports as introduced in Ktlint 0.43.0 (`no-unused-imports`) ([#1277](https://github.com/pinterest/ktlint/issues/1277)), ([#1393](https://github.com/pinterest/ktlint/issues/1393)), ([#1256](https://github.com/pinterest/ktlint/issues/1256))
+- (Possibly) resolve memory leak ([#1216](https://github.com/pinterest/ktlint/issues/1216))
 
 ### Changed
 - Print the rule id always in the PlainReporter ([#1121](https://github.com/pinterest/ktlint/issues/1121))

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/KotlinPsiFileFactory.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/KotlinPsiFileFactory.kt
@@ -55,16 +55,22 @@ internal fun initPsiFileFactory(isFromCli: Boolean): PsiFileFactory {
     }
 
     val disposable = Disposer.newDisposable()
+    try {
+        val project = KotlinCoreEnvironment.createForProduction(
+            disposable,
+            compilerConfiguration,
+            EnvironmentConfigFiles.JVM_CONFIG_FILES
+        ).project as MockProject
 
-    val project = KotlinCoreEnvironment.createForProduction(
-        disposable,
-        compilerConfiguration,
-        EnvironmentConfigFiles.JVM_CONFIG_FILES
-    ).project as MockProject
+        project.enableASTMutations()
 
-    project.enableASTMutations()
-
-    return PsiFileFactory.getInstance(project)
+        return PsiFileFactory.getInstance(project)
+    } finally {
+        // Dispose explicitly to (possibly) prevent memory leak
+        // https://discuss.kotlinlang.org/t/memory-leak-in-kotlincoreenvironment-and-kotlintojvmbytecodecompiler/21950
+        // https://youtrack.jetbrains.com/issue/KT-47044
+        disposable.dispose()
+    }
 }
 
 /**


### PR DESCRIPTION
## Description

Explicitly dispose the disposable which is created in initPsiFileFactory to prevent leakage of memory. I do not claim to understand or be 100% sure that this resolves #1216 but results on the local machine looked promising. For this I temporarily modified the lint-method so that it continuously kept on scanning the same file. 
```
@OptIn(FeatureInAlphaState::class)
internal fun lintFile(
    fileName: String,
    fileContents: String,
    ruleSets: Iterable<RuleSet>,
    visitorProvider: VisitorProvider,
    userData: Map<String, String> = emptyMap(),
    editorConfigPath: String? = null,
    debug: Boolean = false,
    lintErrorCallback: (LintError) -> Unit = {}
) {
    repeat(1_000_000) {
        KtLint.lint(
            KtLint.ExperimentalParams(
                fileName = fileName,
                text = fileContents,
                ruleSets = ruleSets,
                userData = userData,
                script = !fileName.endsWith(".kt", ignoreCase = true),
                editorConfigPath = editorConfigPath,
                cb = { e, _ ->
                    lintErrorCallback(e)
                },
                debug = debug,
                isInvokedFromCli = true
            ),
            visitorProvider
        )
    }
}
```

The heap memory kept stable during a 10 minute interval as is shown below:
![Screenshot 2022-03-13 at 13 50 17](https://user-images.githubusercontent.com/5195292/158060206-fb440cda-ade3-47a9-afa3-16f6a8ea5011.png)

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [x] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
