### PR TITLE
Enable type-safe project accessors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configurations {
 }
 
 dependencies {
-  ktlint project(':ktlint')
+  ktlint projects.ktlint
 }
 
 task ktlint(type: JavaExec, group: LifecycleBasePlugin.VERIFICATION_GROUP) {
@@ -74,7 +74,7 @@ String getGithubToken() {
 
 // Explicitly adding dependency on "shadowJarExecutable" as Gradle does not it set via "releaseAssets" property
 tasks.named("githubRelease") {
-  dependsOn { project(":ktlint").tasks.named("shadowJarExecutable") }
+  dependsOn { projects.ktlint.dependencyProject.tasks.named("shadowJarExecutable") }
 }
 
 githubRelease {
@@ -87,7 +87,7 @@ githubRelease {
     // "shadowJarExecutableChecksum" task does not declare checksum files
     // as output, only the whole output directory. As it uses the same directory
     // as "shadowJarExecutable" - just pass all the files from that directory
-    project(":ktlint").tasks.named("shadowJarExecutable").get()
+    projects.ktlint.dependencyProject.tasks.named("shadowJarExecutable").get()
       .outputs
       .files
       .getFiles()

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   api deps.logback
 
   // Standard ruleset is required for EditConfigLoaderTest only
-  testImplementation project(":ktlint-ruleset-standard")
+  testImplementation projects.ktlintRulesetStandard
   testImplementation deps.junit5
   testImplementation deps.assertj
   testImplementation deps.jimfs

--- a/ktlint-reporter-baseline/build.gradle
+++ b/ktlint-reporter-baseline/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-reporter-checkstyle/build.gradle
+++ b/ktlint-reporter-checkstyle/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-reporter-html/build.gradle
+++ b/ktlint-reporter-html/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-reporter-json/build.gradle
+++ b/ktlint-reporter-json/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-reporter-plain/build.gradle
+++ b/ktlint-reporter-plain/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-reporter-sarif/build.gradle
+++ b/ktlint-reporter-sarif/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation project(':ktlint-core')
+    implementation projects.ktlintCore
     implementation deps.sarif4k
 
     testImplementation deps.junit5

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
 
   testImplementation project(':ktlint-test')
   testImplementation project(':ktlint-ruleset-standard')

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   implementation projects.ktlintCore
 
   testImplementation projects.ktlintTest
-  testImplementation project(':ktlint-ruleset-standard')
+  testImplementation projects.ktlintRulesetStandard
   testImplementation deps.junit5
   testImplementation deps.assertj
 }

--- a/ktlint-ruleset-experimental/build.gradle
+++ b/ktlint-ruleset-experimental/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
   implementation projects.ktlintCore
 
-  testImplementation project(':ktlint-test')
+  testImplementation projects.ktlintTest
   testImplementation project(':ktlint-ruleset-standard')
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   implementation projects.ktlintCore
   implementation deps.logging
 
-  testImplementation project(':ktlint-test')
+  testImplementation projects.ktlintTest
   testImplementation deps.junit5
   testImplementation deps.assertj
 }

--- a/ktlint-ruleset-standard/build.gradle
+++ b/ktlint-ruleset-standard/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
   implementation deps.logging
 
   testImplementation project(':ktlint-test')

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -26,7 +26,7 @@ configurations {
 }
 
 dependencies {
-  ktlint project(':ktlint')
+  ktlint projects.ktlint
 
   compileOnly project(':ktlint-core')
 

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compileOnly projects.ktlintCore
 
   testImplementation projects.ktlintCore
-  testImplementation project(':ktlint-test')
+  testImplementation projects.ktlintTest
   testImplementation deps.junit5
   testImplementation deps.assertj
 }

--- a/ktlint-ruleset-template/build.gradle
+++ b/ktlint-ruleset-template/build.gradle
@@ -28,9 +28,9 @@ configurations {
 dependencies {
   ktlint projects.ktlint
 
-  compileOnly project(':ktlint-core')
+  compileOnly projects.ktlintCore
 
-  testImplementation project(':ktlint-core')
+  testImplementation projects.ktlintCore
   testImplementation project(':ktlint-test')
   testImplementation deps.junit5
   testImplementation deps.assertj

--- a/ktlint-ruleset-test/build.gradle
+++ b/ktlint-ruleset-test/build.gradle
@@ -4,5 +4,5 @@ plugins {
 }
 
 dependencies {
-  api project(':ktlint-core')
+  api projects.ktlintCore
 }

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   api projects.ktlintCore
-  api project(':ktlint-ruleset-test')
+  api projects.ktlintRulesetTest
 
   implementation deps.junit5
   implementation deps.assertj

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  api project(':ktlint-core')
+  api projects.ktlintCore
   api project(':ktlint-ruleset-test')
 
   implementation deps.junit5

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -21,14 +21,14 @@ shadowJar {
 
 dependencies {
   implementation projects.ktlintCore
-  implementation project(':ktlint-reporter-baseline')
-  implementation project(':ktlint-reporter-checkstyle')
-  implementation project(':ktlint-reporter-json')
-  implementation project(':ktlint-reporter-html')
-  implementation project(':ktlint-reporter-plain')
-  implementation project(':ktlint-reporter-sarif')
-  implementation project(':ktlint-ruleset-experimental')
-  implementation project(':ktlint-ruleset-standard')
+  implementation projects.ktlintReporterBaseline
+  implementation projects.ktlintReporterCheckstyle
+  implementation projects.ktlintReporterJson
+  implementation projects.ktlintReporterHtml
+  implementation projects.ktlintReporterPlain
+  implementation projects.ktlintReporterSarif
+  implementation projects.ktlintRulesetExperimental
+  implementation projects.ktlintRulesetStandard
   implementation projects.ktlintRulesetTest
   implementation deps.kotlin.compiler
   implementation deps.klob

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -20,7 +20,7 @@ shadowJar {
 }
 
 dependencies {
-  implementation project(':ktlint-core')
+  implementation projects.ktlintCore
   implementation project(':ktlint-reporter-baseline')
   implementation project(':ktlint-reporter-checkstyle')
   implementation project(':ktlint-reporter-json')

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   implementation project(':ktlint-reporter-sarif')
   implementation project(':ktlint-ruleset-experimental')
   implementation project(':ktlint-ruleset-standard')
-  implementation project(':ktlint-ruleset-test')
+  implementation projects.ktlintRulesetTest
   implementation deps.kotlin.compiler
   implementation deps.klob
   implementation deps.picocli

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
   }
 }
 
-rootProject.name = 'ktlint'
+rootProject.name = 'ktlint-root'
 
 include ':ktlint'
 include ':ktlint-core'

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,8 @@ pluginManagement {
 
 rootProject.name = 'ktlint-root'
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include ':ktlint'
 include ':ktlint-core'
 include ':ktlint-reporter-baseline'


### PR DESCRIPTION
## Description

https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors

Ref https://github.com/detekt/detekt/pull/3742


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
