### PR TITLE
Initialize the logger in Main only after the CLI parameters have bee parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This section is applicable when providing rules that depend on one or more value
 - Do not indent raw string literals that are not followed by either trimIndent() or trimMargin() (`indent`) ([#1375](https://github.com/pinterest/ktlint/issues/1375))
 - Revert remove unnecessary wildcard imports as introduced in Ktlint 0.43.0 (`no-unused-imports`) ([#1277](https://github.com/pinterest/ktlint/issues/1277)), ([#1393](https://github.com/pinterest/ktlint/issues/1393)), ([#1256](https://github.com/pinterest/ktlint/issues/1256))
 - (Possibly) resolve memory leak ([#1216](https://github.com/pinterest/ktlint/issues/1216))
+- Initialize loglevel in Main class after parsing the CLI parameters ([#1412](https://github.com/pinterest/ktlint/issues/1412))
 
 ### Changed
 - Print the rule id always in the PlainReporter ([#1121](https://github.com/pinterest/ktlint/issues/1121))

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 public enum class LogLevel { TRACE, DEBUG, INFO }
 
-public var logLevel: LogLevel? = null
+public var logLevel: LogLevel = LogLevel.INFO
 
 @Deprecated("Environment variable is replace by new variables below")
 private const val KTLINT_DEBUG = "KTLINT_DEBUG"
@@ -35,8 +35,10 @@ public fun KLogger.initKtLintKLogger(): KLogger =
                 logger.trace { "Enable TRACE logging as System environment variable $KTLINT_UNIT_TEST_TRACE is set to 'on'" }
                 logLevel = LogLevel.TRACE
             }
-        if (logLevel == LogLevel.TRACE) {
-            (logger.underlyingLogger as Logger).level = Level.TRACE
+        (logger.underlyingLogger as Logger).level = when (logLevel) {
+            LogLevel.INFO -> Level.INFO
+            LogLevel.DEBUG -> Level.DEBUG
+            LogLevel.TRACE -> Level.TRACE
         }
 
         System

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -49,13 +49,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlin.system.exitProcess
+import mu.KLogger
 import mu.KotlinLogging
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 
-private val logger = KotlinLogging.logger {}.initKtLintKLogger()
+private lateinit var logger: KLogger
 
 fun main(args: Array<String>) {
     val ktlintCommand = KtlintCommandLine()
@@ -250,11 +251,15 @@ class KtlintCommandLine {
     private val errorNumber = AtomicInteger()
 
     fun run() {
+        if (verbose) {
+            debug = true
+        }
         logLevel = when {
             trace -> LogLevel.TRACE
             debug -> LogLevel.DEBUG
             else -> LogLevel.INFO
         }
+        logger = KotlinLogging.logger {}.initKtLintKLogger()
 
         failOnOldRulesetProviderUsage()
 


### PR DESCRIPTION
## Description

Initialize the logger in Main only after the CLI parameters have bee parsed parsed. Also, propagate the log level correctly to the KLogger.

Closes #1412

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
