### PR TITLE
Add tests based on JDK 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This section is applicable when providing rules that depend on one or more value
 - Add new experimental rules for wrapping of block comment (`comment-wrapping`) ([#1403](https://github.com/pinterest/ktlint/pull/1403))
 - Add new experimental rules for wrapping of KDoc comment (`kdoc-wrapping`) ([#1403](https://github.com/pinterest/ktlint/pull/1403))
 - Add experimental rule for incorrect spacing after a type parameter list (`type-parameter-list-spacing`) ([#1366](https://github.com/pinterest/ktlint/pull/1366))
+- Expand check task to run tests on JDK 17 - "testOnJdk17"
 
 ### Fixed
 - Fix lint message to "Unnecessary long whitespace" (`no-multi-spaces`) ([#1394](https://github.com/pinterest/ktlint/issues/1394))

--- a/buildSrc/src/main/kotlin/ToolchainForTests.kt
+++ b/buildSrc/src/main/kotlin/ToolchainForTests.kt
@@ -7,16 +7,21 @@ import org.gradle.kotlin.dsl.register
 val Project.javaToolchains: JavaToolchainService
     get() = extensions.getByType(JavaToolchainService::class.java)
 
-fun Project.addJdk11Tests() {
-    val testTask = tasks.register<Test>("testOnJdk11") {
+fun Project.addAdditionalJdkVersionTests() {
+    // Tests should be run on all supported LTS versions of the JDK. For example, see https://endoflife.date/java
+    addJdkVersionTests("testOnJdk11", 11)
+    addJdkVersionTests("testOnJdk17", 17)
+}
+
+private fun Project.addJdkVersionTests(taskName: String, jdkVersion: Int) {
+    val jdkVersionTests = tasks.register<Test>(taskName) {
         javaLauncher.set(
             javaToolchains.launcherFor {
-                languageVersion.set(JavaLanguageVersion.of(11))
+                languageVersion.set(JavaLanguageVersion.of(jdkVersion))
             }
         )
     }
-
     tasks.named("check") {
-        dependsOn(testTask)
+        dependsOn(jdkVersionTests)
     }
 }

--- a/buildSrc/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -29,4 +29,4 @@ tasks
         }
     }
 
-addJdk11Tests()
+addAdditionalJdkVersionTests()


### PR DESCRIPTION
## Description

Tests should run on all supported Java versions. So added JDK 17. 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [N/A] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
