### PR TITLE
Allow to set a default logger modifier

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
@@ -12,8 +12,26 @@ public const val KTLINT_UNIT_TEST_DUMP_AST = "KTLINT_UNIT_TEST_DUMP_AST"
 public const val KTLINT_UNIT_TEST_ON_PROPERTY = "ON"
 
 /**
- * Initializes the logger. Optionally the logger can be modified using the [loggerModifier].
+ * Default modifier for the KLogger of new instances of classes calling [initKtLintKLogger]. Classes for which
+ * [initKtLintKLogger] has been called before setting this variable will not be changed. Also note, that this modifier
+ * can only be set once.
+ */
+public lateinit var defaultLoggerModifier: (KLogger) -> Unit
+
+/**
+ * Initializes the logger with the [defaultLoggerModifier] when set.
+ */
+public fun KLogger.initKtLintKLogger(): KLogger {
+    return if (::defaultLoggerModifier.isInitialized) {
+        apply { defaultLoggerModifier(this) }
+    } else {
+        this
+    }
+}
+
+/**
+ * Initializes the logger with the [loggerModifier].
  */
 public fun KLogger.initKtLintKLogger(
-    loggerModifier: (KLogger) -> Unit = { _ -> }
+    loggerModifier: (KLogger) -> Unit
 ): KLogger = apply { loggerModifier(this) }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -13,6 +13,7 @@ import com.pinterest.ktlint.core.RuleExecutionException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import com.pinterest.ktlint.core.VisitorProvider
+import com.pinterest.ktlint.core.defaultLoggerModifier
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.core.internal.containsLintError
 import com.pinterest.ktlint.core.internal.loadBaseline
@@ -254,7 +255,14 @@ class KtlintCommandLine {
         if (verbose) {
             debug = true
         }
-        logger = configureLogger()
+        defaultLoggerModifier = { logger ->
+            (logger.underlyingLogger as Logger).level = when {
+                trace -> Level.TRACE
+                debug -> Level.DEBUG
+                else -> Level.INFO
+            }
+        }
+        logger = KotlinLogging.logger {}.initKtLintKLogger()
 
         failOnOldRulesetProviderUsage()
 
@@ -293,17 +301,6 @@ class KtlintCommandLine {
             exitProcess(1)
         }
     }
-
-    private fun configureLogger() =
-        KotlinLogging
-            .logger {}
-            .initKtLintKLogger { logger ->
-                (logger.underlyingLogger as Logger).level = when {
-                    trace -> Level.TRACE
-                    debug -> Level.DEBUG
-                    else -> Level.INFO
-                }
-            }
 
     private fun lintFiles(
         ruleSetProviders: Map<String, RuleSetProvider>,


### PR DESCRIPTION
## Description

* The default loggerModifier can only be set once.
* It is still possible to override the loggerModifier for a specific class by passing a loggerModifier to initKtLintKLogger.
* When initKtLintKLogger is called without parameter, the defaultLoggerModifier is applied when set.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
