### PR TITLE
1421 logger initialization improvement

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLintKLoggerInitializer.kt
@@ -12,8 +12,26 @@ public const val KTLINT_UNIT_TEST_DUMP_AST = "KTLINT_UNIT_TEST_DUMP_AST"
 public const val KTLINT_UNIT_TEST_ON_PROPERTY = "ON"
 
 /**
- * Initializes the logger. Optionally the logger can be modified using the [loggerModifier].
+ * Default modifier for the KLogger of new instances of classes calling [initKtLintKLogger]. Classes for which
+ * [initKtLintKLogger] has been called before setting this variable will not be changed. Also note, that this modifier
+ * can only be set once.
+ */
+public lateinit var defaultLoggerModifier: (KLogger) -> Unit
+
+/**
+ * Initializes the logger with the [defaultLoggerModifier] when set.
+ */
+public fun KLogger.initKtLintKLogger(): KLogger {
+    return if (::defaultLoggerModifier.isInitialized) {
+        apply { defaultLoggerModifier(this) }
+    } else {
+        this
+    }
+}
+
+/**
+ * Initializes the logger with the [loggerModifier].
  */
 public fun KLogger.initKtLintKLogger(
-    loggerModifier: (KLogger) -> Unit = { _ -> }
+    loggerModifier: (KLogger) -> Unit
 ): KLogger = apply { loggerModifier(this) }

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.initKtLintKLogger
+import com.pinterest.ktlint.core.setDefaultLoggerModifier
 import com.pinterest.ruleset.test.DumpASTRule
 import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
@@ -16,7 +17,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 private val logger =
     KotlinLogging
         .logger {}
-        .initKtLintKLogger { logger ->
+        .setDefaultLoggerModifier { logger ->
             if (!logger.isTraceEnabled || !logger.isDebugEnabled) {
                 logger.info {
                     """
@@ -26,7 +27,7 @@ private val logger =
                     """.trimIndent()
                 }
             }
-        }
+        }.initKtLintKLogger()
 
 // Via command line parameter "--trace" the end user of ktlint can change the logging behavior. As unit tests are not
 // invoked via the main ktlint runtime, this command line parameter can not be used to change the logging behavior while

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -13,7 +13,6 @@ import com.pinterest.ktlint.core.RuleExecutionException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import com.pinterest.ktlint.core.VisitorProvider
-import com.pinterest.ktlint.core.defaultLoggerModifier
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.core.internal.containsLintError
 import com.pinterest.ktlint.core.internal.loadBaseline

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -13,11 +13,11 @@ import com.pinterest.ktlint.core.RuleExecutionException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import com.pinterest.ktlint.core.VisitorProvider
-import com.pinterest.ktlint.core.defaultLoggerModifier
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.core.internal.containsLintError
 import com.pinterest.ktlint.core.internal.loadBaseline
 import com.pinterest.ktlint.core.internal.relativeRoute
+import com.pinterest.ktlint.core.setDefaultLoggerModifier
 import com.pinterest.ktlint.internal.ApplyToIDEAGloballySubCommand
 import com.pinterest.ktlint.internal.ApplyToIDEAProjectSubCommand
 import com.pinterest.ktlint.internal.GenerateEditorConfigSubCommand
@@ -255,14 +255,7 @@ class KtlintCommandLine {
         if (verbose) {
             debug = true
         }
-        defaultLoggerModifier = { logger ->
-            (logger.underlyingLogger as Logger).level = when {
-                trace -> Level.TRACE
-                debug -> Level.DEBUG
-                else -> Level.INFO
-            }
-        }
-        logger = KotlinLogging.logger {}.initKtLintKLogger()
+        logger = configureLogger()
 
         failOnOldRulesetProviderUsage()
 
@@ -301,6 +294,18 @@ class KtlintCommandLine {
             exitProcess(1)
         }
     }
+
+    private fun configureLogger() =
+        KotlinLogging
+            .logger {}
+            .setDefaultLoggerModifier { logger ->
+                (logger.underlyingLogger as Logger).level = when {
+                    trace -> Level.TRACE
+                    debug -> Level.DEBUG
+                    else -> Level.INFO
+                }
+            }
+            .initKtLintKLogger()
 
     private fun lintFiles(
         ruleSetProviders: Map<String, RuleSetProvider>,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -13,6 +13,7 @@ import com.pinterest.ktlint.core.RuleExecutionException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import com.pinterest.ktlint.core.VisitorProvider
+import com.pinterest.ktlint.core.defaultLoggerModifier
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.core.internal.containsLintError
 import com.pinterest.ktlint.core.internal.loadBaseline
@@ -254,7 +255,14 @@ class KtlintCommandLine {
         if (verbose) {
             debug = true
         }
-        logger = configureLogger()
+        defaultLoggerModifier = { logger ->
+            (logger.underlyingLogger as Logger).level = when {
+                trace -> Level.TRACE
+                debug -> Level.DEBUG
+                else -> Level.INFO
+            }
+        }
+        logger = KotlinLogging.logger {}.initKtLintKLogger()
 
         failOnOldRulesetProviderUsage()
 
@@ -293,17 +301,6 @@ class KtlintCommandLine {
             exitProcess(1)
         }
     }
-
-    private fun configureLogger() =
-        KotlinLogging
-            .logger {}
-            .initKtLintKLogger { logger ->
-                (logger.underlyingLogger as Logger).level = when {
-                    trace -> Level.TRACE
-                    debug -> Level.DEBUG
-                    else -> Level.INFO
-                }
-            }
 
     private fun lintFiles(
         ruleSetProviders: Map<String, RuleSetProvider>,


### PR DESCRIPTION
## Description

Hide variable defaultLoggerModifier and enforce that it can be set via function setDefaultLoggerModifier only. In this way, a warning can be printed if it is set more than once which could lead to unpredictable behavior.
## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
