### PR TITLE
Fix backward incompatibility issues released via KtLint 0.45.0 and 0.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Fixed
+- Resolve compatibility issues introduced in 0.45.0 and 045.1 ([#1434](https://github.com/pinterest/ktlint/issues/1434))
 
 ### Changed
 * Set Kotlin development version to `1.6.20-RC2` and Kotlin version to `1.6.10`.

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   api deps.kotlin.compiler
   api deps.ec4j
   api deps.logging
+  api deps.assertj
 
   // Standard ruleset is required for EditConfigLoaderTest only
   testImplementation projects.ktlintRulesetStandard

--- a/ktlint-core/build.gradle
+++ b/ktlint-core/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   api deps.kotlin.compiler
   api deps.ec4j
   api deps.logging
-  api deps.assertj
 
   // Standard ruleset is required for EditConfigLoaderTest only
   testImplementation projects.ktlintRulesetStandard

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/EditorConfigOverride.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/EditorConfigOverride.kt
@@ -1,14 +1,18 @@
-package com.pinterest.ktlint.test
+package com.pinterest.ktlint.core.api
 
-import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties.EditorConfigProperty
 import org.ec4j.core.model.PropertyType
 
 /**
- * Properties set in [EditorConfigOverride] override values which are loaded from the ".EditorConfig" file. This
- * [EditorConfigOverride] is only to be used in unit tests. From the perspective of the unit test as well as from the
- * perspective of the rule, it is transparent whether an editor config property was loaded from an ".editorconfig" file
- * or from an override.
+ * The [EditorConfigOverride] allows to add or replace properties which are loaded from the ".editorconfig" file. It
+ * serves two purposes.
+ *
+ * Firstly, the [EditorConfigOverride] can be used by API consumers to run a rule with values which are not actually
+ * save to the ".editorconfig" file. When doing so, this should be clearly communicated to their consumers who will
+ * expect the settings in that file to be respected.
+ *
+ * Secondly, the [EditorConfigOverride] is used in unit tests, to test a rule with distinct values of a property without
+ * having to access an ".editorconfig" file from physical storage. This also improves readability of the tests.
  */
 @FeatureInAlphaState
 public class EditorConfigOverride {
@@ -22,8 +26,7 @@ public class EditorConfigOverride {
 
     public companion object {
         /**
-         * Creates EditorConfig properties with value to be used in unit test so that the unit test does not need to
-         * write an .editorconfig file.
+         * Creates the [EditorConfigOverride] based on one or more property-value mappings.
          */
         public fun from(
             vararg properties: Pair<EditorConfigProperty<*>, *>
@@ -40,8 +43,8 @@ public class EditorConfigOverride {
         }
 
         /**
-         * Get the empty EditorConfig properties. As it does not contain any properties, all properties fall back on
-         * their respective default value.
+         * Get the empty [EditorConfigOverride]. As it does not contain any properties, all properties fall back on
+         * their respective default values.
          */
         public val emptyEditorConfigOverride: EditorConfigOverride = EditorConfigOverride()
     }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -200,6 +200,13 @@ public object DefaultEditorConfigProperties {
                 }
             }
         )
+
+    public val defaultEditorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<out Any>> = listOf(
+        indentStyleProperty,
+        indentSizeProperty,
+        insertNewLineProperty,
+        maxLineLengthProperty
+    )
 }
 
 /**

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -1,11 +1,653 @@
 package com.pinterest.ktlint.core
 
+import com.pinterest.ktlint.core.DummyRuleWithCustomEditorConfigProperty.Companion.SOME_CUSTOM_RULE_PROPERTY
+import com.pinterest.ktlint.core.KtLint.EDITOR_CONFIG_USER_DATA_KEY
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.isRoot
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@OptIn(FeatureInAlphaState::class)
 class KtLintTest {
+    /**
+     * API Consumers directly use the ktlint-core module. Tests in this module should guarantee that the API is kept
+     * stable.
+     */
+    @Nested
+    inner class ApiConsumer {
+        @Nested
+        inner class LintViaDeprecatedParams {
+            @Test
+            fun `Given that an empty ruleSet is provided than throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = emptyList(),
+                            userData = emptyMap(),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("No runnable rules found. Please ensure that at least one is enabled.")
+            }
+
+            @Test
+            fun `Given a non empty ruleset and empty userData then do not throw an error`() {
+                var numberOfRootNodesVisited = 0
+                KtLint.lint(
+                    KtLint.Params(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
+                                }
+                            )
+                        ),
+                        userData = emptyMap(),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(numberOfRootNodesVisited).isEqualTo(1)
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains one default editor config property then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf("max_line_length" to "80"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [max_line_length]. Such properties " +
+                            "should be passed via the 'ExperimentalParams.editorConfigOverride' field. Note that " +
+                            "this is only required for properties that (potentially) contain a value that differs " +
+                            "from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains multiple default editor config properties then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf(
+                                "indent_style" to "space",
+                                "indent_size" to "4"
+                            ),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [indent_size, indent_style]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that refers to a custom Rule property then do throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRuleWithCustomEditorConfigProperty())
+                            ),
+                            userData = mapOf(SOME_CUSTOM_RULE_PROPERTY to "false"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [$SOME_CUSTOM_RULE_PROPERTY]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData not referring any custom or default editor config property then this userData is received in the node`() {
+                var actual: String? = null
+                KtLint.lint(
+                    KtLint.Params(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        actual = node.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.get(SOME_PROPERTY)
+                                    }
+                                }
+                            )
+                        ),
+                        userData = mapOf(SOME_PROPERTY to SOME_PROPERTY_VALUE),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE)
+            }
+        }
+
+        @Nested
+        inner class LintViaExperimentalParams {
+            @Test
+            fun `Given that an empty ruleSet is provided than throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = emptyList(),
+                            userData = emptyMap(),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("No runnable rules found. Please ensure that at least one is enabled.")
+            }
+
+            @Test
+            fun `Given a non empty ruleset and empty userData then do not throw an error`() {
+                var numberOfRootNodesVisited = 0
+                KtLint.lint(
+                    KtLint.ExperimentalParams(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
+                                }
+                            )
+                        ),
+                        userData = emptyMap(),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(numberOfRootNodesVisited).isEqualTo(1)
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains one default editor config property then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf("max_line_length" to "80"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [max_line_length]. Such properties " +
+                            "should be passed via the 'ExperimentalParams.editorConfigOverride' field. Note that " +
+                            "this is only required for properties that (potentially) contain a value that differs " +
+                            "from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains multiple default editor config properties then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf(
+                                "indent_style" to "space",
+                                "indent_size" to "4"
+                            ),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [indent_size, indent_style]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that refers to a custom Rule property then do throw an error`() {
+                assertThatThrownBy {
+                    KtLint.lint(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRuleWithCustomEditorConfigProperty())
+                            ),
+                            userData = mapOf(SOME_CUSTOM_RULE_PROPERTY to "false"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [$SOME_CUSTOM_RULE_PROPERTY]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData not referring any custom or default editor config property then this userData is received in the node`() {
+                var actual: String? = null
+                KtLint.lint(
+                    KtLint.ExperimentalParams(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        actual = node.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.get(SOME_PROPERTY)
+                                    }
+                                }
+                            )
+                        ),
+                        userData = mapOf(SOME_PROPERTY to SOME_PROPERTY_VALUE),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE)
+            }
+        }
+
+        @Nested
+        inner class FormatViaDeprecatedParams {
+            @Test
+            fun `Given that an empty ruleSet is provided than throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = emptyList(),
+                            userData = emptyMap(),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("No runnable rules found. Please ensure that at least one is enabled.")
+            }
+
+            @Test
+            fun `Given a non empty ruleset and empty userData then do not throw an error`() {
+                var numberOfRootNodesVisited = 0
+                KtLint.format(
+                    KtLint.Params(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
+                                }
+                            )
+                        ),
+                        userData = emptyMap(),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(numberOfRootNodesVisited).isEqualTo(1)
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains one default editor config property then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf("max_line_length" to "80"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [max_line_length]. Such properties " +
+                            "should be passed via the 'ExperimentalParams.editorConfigOverride' field. Note that " +
+                            "this is only required for properties that (potentially) contain a value that differs " +
+                            "from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains multiple default editor config properties then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf(
+                                "indent_style" to "space",
+                                "indent_size" to "4"
+                            ),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [indent_size, indent_style]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that refers to a custom Rule property then do throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.Params(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRuleWithCustomEditorConfigProperty())
+                            ),
+                            userData = mapOf(SOME_CUSTOM_RULE_PROPERTY to "false"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [$SOME_CUSTOM_RULE_PROPERTY]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData not referring any custom or default editor config property then this userData is received in the node`() {
+                var actual: String? = null
+                KtLint.format(
+                    KtLint.Params(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        actual = node.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.get(SOME_PROPERTY)
+                                    }
+                                }
+                            )
+                        ),
+                        userData = mapOf(SOME_PROPERTY to SOME_PROPERTY_VALUE),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE)
+            }
+        }
+
+        @Nested
+        inner class FormatViaExperimentalParams {
+            @Test
+            fun `Given that an empty ruleSet is provided than throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = emptyList(),
+                            userData = emptyMap(),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("No runnable rules found. Please ensure that at least one is enabled.")
+            }
+
+            @Test
+            fun `Given a non empty ruleset and empty userData then do not throw an error`() {
+                var numberOfRootNodesVisited = 0
+                KtLint.format(
+                    KtLint.ExperimentalParams(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
+                                }
+                            )
+                        ),
+                        userData = emptyMap(),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(numberOfRootNodesVisited).isEqualTo(1)
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains one default editor config property then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf("max_line_length" to "80"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [max_line_length]. Such properties " +
+                            "should be passed via the 'ExperimentalParams.editorConfigOverride' field. Note that " +
+                            "this is only required for properties that (potentially) contain a value that differs " +
+                            "from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that contains multiple default editor config properties then throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRule())
+                            ),
+                            userData = mapOf(
+                                "indent_style" to "space",
+                                "indent_size" to "4"
+                            ),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [indent_size, indent_style]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData that refers to a custom Rule property then do throw an error`() {
+                assertThatThrownBy {
+                    KtLint.format(
+                        KtLint.ExperimentalParams(
+                            fileName = "some-filename",
+                            text = "fun main() {}",
+                            ruleSets = listOf(
+                                RuleSet("standard", DummyRuleWithCustomEditorConfigProperty())
+                            ),
+                            userData = mapOf(SOME_CUSTOM_RULE_PROPERTY to "false"),
+                            cb = { _, _ -> },
+                            script = false,
+                            editorConfigPath = null,
+                            debug = false
+                        )
+                    )
+                }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "UserData should not contain '.editorconfig' properties [$SOME_CUSTOM_RULE_PROPERTY]. Such" +
+                            " properties should be passed via the 'ExperimentalParams.editorConfigOverride' field. " +
+                            "Note that this is only required for properties that (potentially) contain a value that " +
+                            "differs from the actual value in the '.editorconfig' file."
+                    )
+            }
+
+            @Test
+            fun `Given a non empty ruleset and userData not referring any custom or default editor config property then this userData is received in the node`() {
+                var actual: String? = null
+                KtLint.format(
+                    KtLint.ExperimentalParams(
+                        fileName = "some-filename",
+                        text = "fun main() {}",
+                        ruleSets = listOf(
+                            RuleSet(
+                                "standard",
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        actual = node.getUserData(EDITOR_CONFIG_USER_DATA_KEY)?.get(SOME_PROPERTY)
+                                    }
+                                }
+                            )
+                        ),
+                        userData = mapOf(SOME_PROPERTY to SOME_PROPERTY_VALUE),
+                        cb = { _, _ -> },
+                        script = false,
+                        editorConfigPath = null,
+                        debug = false
+                    )
+                )
+                assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE)
+            }
+        }
+    }
 
     @Test
     fun testRuleExecutionOrder() {
@@ -87,16 +729,55 @@ class KtLintTest {
 
         assertThat(actual).isEqualTo(code)
     }
+
+    private companion object {
+        const val SOME_PROPERTY = "some-property"
+        const val SOME_PROPERTY_VALUE = "some-property-value"
+    }
 }
 
-class DummyRule : Rule("dummy-rule") {
+@OptIn(FeatureInAlphaState::class)
+private class DummyRuleWithCustomEditorConfigProperty :
+    Rule("dummy-rule-with-custom-editor-config-property"),
+    UsesEditorConfigProperties {
+    override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
+        listOf(someCustomRuleProperty)
+
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        // The rule does not need to do anything except emit
-        emit(node.startOffset, "Dummy rule", true)
+    }
+
+    companion object {
+        const val SOME_CUSTOM_RULE_PROPERTY = "some-custom-rule-property"
+
+        val someCustomRuleProperty: UsesEditorConfigProperties.EditorConfigProperty<Boolean> =
+            UsesEditorConfigProperties.EditorConfigProperty(
+                type = PropertyType.LowerCasingPropertyType(
+                    SOME_CUSTOM_RULE_PROPERTY,
+                    "some-custom-rule-property-description",
+                    PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                    setOf(true.toString(), false.toString())
+                ),
+                defaultValue = false
+            )
+    }
+}
+
+/**
+ * A dummy rule for testing. Optionally the rule can be created with a lambda to be executed for each node visited.
+ */
+private open class DummyRule(
+    val block: (node: ASTNode) -> Unit = {}
+) : Rule("dummy-rule") {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        block(node)
     }
 }
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -4,6 +4,7 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.insertNewLineProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.internal.EditorConfigLoader.Companion.convertToRawValues
@@ -13,7 +14,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
-import org.ec4j.core.model.PropertyType
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.junit.jupiter.api.AfterEach
@@ -246,9 +246,7 @@ internal class EditorConfigLoaderTest {
         val parsedEditorConfig = editorConfigLoader.loadPropertiesForFile(
             filePath = null,
             rules = rules,
-            loadedValuesOverride = mapOf(
-                insertNewLineProperty to PropertyType.PropertyValue.valid("true", true)
-            )
+            editorConfigOverride = EditorConfigOverride.from(insertNewLineProperty to "true")
         )
 
         assertThat(parsedEditorConfig.convertToRawValues()).containsExactly(
@@ -261,9 +259,7 @@ internal class EditorConfigLoaderTest {
         val parsedEditorConfig = editorConfigLoader.loadPropertiesForFile(
             filePath = null,
             rules = rules,
-            loadedValuesOverride = mapOf(
-                insertNewLineProperty to PropertyType.PropertyValue.valid("true", true)
-            )
+            editorConfigOverride = EditorConfigOverride.from(insertNewLineProperty to "true")
         )
 
         assertThat(parsedEditorConfig.convertToRawValues()).containsExactly(
@@ -443,9 +439,7 @@ internal class EditorConfigLoaderTest {
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(
             lintFile,
             rules = rules.plus(FinalNewlineRule()),
-            loadedValuesOverride = mapOf(
-                insertNewLineProperty to PropertyType.PropertyValue.valid("true", true)
-            )
+            editorConfigOverride = EditorConfigOverride.from(insertNewLineProperty to "true")
         )
         val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 
@@ -475,9 +469,7 @@ internal class EditorConfigLoaderTest {
         val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(
             lintFile,
             rules = rules.plus(FinalNewlineRule()),
-            loadedValuesOverride = mapOf(
-                insertNewLineProperty to PropertyType.PropertyValue.valid("false", false)
-            )
+            editorConfigOverride = EditorConfigOverride.from(insertNewLineProperty to "false")
         )
         val parsedEditorConfig = editorConfigProperties.convertToRawValues()
 

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -2,9 +2,9 @@ package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
@@ -1,10 +1,10 @@
 package com.pinterest.ktlint.ruleset.experimental
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.experimental.trailingcomma.TrailingCommaRule
 import com.pinterest.ktlint.ruleset.standard.NoUnusedImportsRule
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRuleTest.kt
@@ -2,8 +2,8 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.insertNewLineProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -3,8 +3,8 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRuleTest.kt
@@ -2,9 +2,9 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.MaxLineLengthRule.Companion.ignoreBackTickedIdentifierProperty
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.NoWildcardImportsRule.Companion.packagesToUseImportOnDemandProperty
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -3,8 +3,8 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
@@ -3,8 +3,8 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.EditorConfig.Companion.indentSizeProperty
 import com.pinterest.ktlint.core.EditorConfig.Companion.indentStyleProperty
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard.importordering
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
-import com.pinterest.ktlint.test.EditorConfigOverride
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
## Description

* Deprecate data class 'Params' as it only provides the userData parameter  which prohibits API Consumers to split the '.editorconfig' properties  from the other user data.
* Deprecate function 'toExperimentalParams' to force API Consumers to  start using the 'ExperimentalParams'.
* In ExperimentalParams clarify that 'userData' should not contain any  '.editorconfig' properties. Now also a runtime error is thrown  whenever the lint/format methods are called and 'userData' contains  '.editorconfig' properties.
* Remove confusing TODO's about moving methods 'lint' and 'format' to  the 'ktlint-test' module.
* Update deprecation messages to clarify intention.
* The 'lint' and 'format' methods in module 'ktlint-core' no longer  call the 'VisitorProvider' with parameter 'isUnitTestContext'  enabled. API Consumers call these methods with production code  for which this parameter should be disabled.
* The RuleExtension calls the 'lint' and 'format' methods but do  provide a VisitorProvider for which the parameter  'isUnitTestContext' is enabled.
* Deprecate the 'format' which accepted the 'ExperimentalParams'  and 'Iterable<RuleSet>' while the latter is already included  in the first.
* Add new 'format' method which accepts 'ExperimentalParams' and 'VisitorProvider' only.
* Move 'EditorConfigOverride' from 'ktlint-test' to 'ktlint-core'

Closes #1434

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
