### PR TITLE
Add new link to third-party reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ see https://github.com/pinterest/ktlint/issues/451.
 Third-party:
 * [kryanod/ktlint-junit-reporter](https://github.com/kryanod/ktlint-junit-reporter)
 * [musichin/ktlint-github-reporter](https://github.com/musichin/ktlint-github-reporter)
+* [tobi2k/ktlint-gitlab-reporter](https://github.com/tobi2k/ktlint-gitlab-reporter)
 
 ## Badge
 


### PR DESCRIPTION
## Description
I recently wrote a new custom ktlint reporter and this pull request adds a link to it in the README