### PR TITLE
Add new experimental rule "function-signature"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Add experimental rule for incorrect spacing around the function return type (`function-return-type-spacing`) ([#1341](https://github.com/pinterest/ktlint/pull/1341))
 - Add experimental rule for unexpected spaces in a nullable type (`nullable-type-spacing`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
 - Do not add a space after the typealias name (`type-parameter-list-spacing`) ([#1435](https://github.com/pinterest/ktlint/issues/1435))
-
 - Add experimental rule for consistent spacing before the start of the function body (`function-start-of-body-spacing`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
+- Add experimental rule for rewriting the function signature (`function-signature`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
 
 ### Fixed
 - Fix check of spacing in the receiver type of an anonymous function ([#1440](https://github.com/pinterest/ktlint/issues/1440))

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ by passing the `--experimental` flag to `ktlint`.
 - `experimental:package-name`: No underscores in package names
 - `experimental:parameter-list-spacing`: Consistent spacing inside the parameter list
 - `experimental:unnecessary-parentheses-before-trailing-lambda`: An empty parentheses block before a lambda is redundant. For example `some-string".count() { it == '-' }`
+- `function-signature`: rewrites the function signature to a single line when possible (e.g. when not exceeding the `max_line_length` property) or a multiline signature otherwise. In case of function with a body expression, the body expression is placed on the same line as the function signature when not exceeding the `max_line_length` property. Optionally the function signature can be forced to be written as a multiline signature in case the function has more than a specified number of parameters (`.editorconfig' property `ktlint_function_signature_wrapping_rule_always_with_minimum_parameters`)
 
 ### Spacing
 - `experimental:annotation-spacing`: Annotations should be separated by the annotated declaration by a single line break

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -35,6 +35,7 @@ public class ExperimentalRuleSetProvider : RuleSetProvider {
         ParameterListSpacingRule(),
         FunctionReturnTypeSpacingRule(),
         FunctionStartOfBodySpacingRule(),
-        NullableTypeSpacingRule()
+        NullableTypeSpacingRule(),
+        FunctionSignatureRule()
     )
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -1,0 +1,652 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.IndentConfig
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.EQ
+import com.pinterest.ktlint.core.ast.ElementType.FUN
+import com.pinterest.ktlint.core.ast.ElementType.FUN_KEYWORD
+import com.pinterest.ktlint.core.ast.ElementType.LPAR
+import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.RPAR
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.isRoot
+import com.pinterest.ktlint.core.ast.isWhiteSpace
+import com.pinterest.ktlint.core.ast.lineIndent
+import com.pinterest.ktlint.core.ast.nextCodeLeaf
+import com.pinterest.ktlint.core.ast.nextCodeSibling
+import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.prevCodeLeaf
+import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.core.ast.prevSibling
+import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
+import org.ec4j.core.model.PropertyType
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
+
+@OptIn(FeatureInAlphaState::class)
+public class FunctionSignatureRule :
+    Rule(
+        id = "function-signature",
+        visitorModifiers = setOf(
+            // Run after wrapping, spacing and indentation rule
+            VisitorModifier.RunAfterRule("standard:indent"),
+            VisitorModifier.RunAsLateAsPossible
+        )
+    ),
+    UsesEditorConfigProperties {
+    override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
+        listOf(
+            indentSizeProperty,
+            indentStyleProperty,
+            maxLineLengthProperty,
+            functionSignatureWrappingMinimumParametersProperty
+        )
+
+    private var indent: String? = null
+    private var maxLineLength = -1
+    private var functionSignatureWrappingMinimumParameters = -1
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.isRoot()) {
+            functionSignatureWrappingMinimumParameters = node.getEditorConfigValue(
+                functionSignatureWrappingMinimumParametersProperty
+            )
+            val indentConfig = IndentConfig(
+                indentStyle = node.getEditorConfigValue(indentStyleProperty),
+                tabWidth = node.getEditorConfigValue(indentSizeProperty)
+            )
+            if (indentConfig.disabled) {
+                return
+            }
+            indent = indentConfig.indent
+            maxLineLength = node.getEditorConfigValue(maxLineLengthProperty)
+            return
+        }
+
+        if (node.elementType == FUN) {
+            node
+                .functionSignatureNodes()
+                .any { it.elementType == EOL_COMMENT || it.elementType == BLOCK_COMMENT }
+                .ifTrue {
+                    // Rewriting function signatures in a consistent manner is hard or sometimes even impossible. For
+                    // example a multiline signature which could fit on one line can not be rewritten in case it
+                    // contains an EOL comment. Rewriting a single line signature which exceeds the max line length to a
+                    // multiline signature is hard when it contains block comments. For now, it does not seem worth the
+                    // effort to attempt it.
+                    return
+                }
+
+            visitFunctionSignature(node, emit, autoCorrect)
+        }
+    }
+
+    private fun ASTNode.functionSignatureNodes(): List<ASTNode> {
+        // Find the signature including the element that has to be placed on the same line as the function signature
+        //     fun foo(bar: String) {
+        // or
+        //     fun foo(bar: String) =
+        val firstCodeChild = getFirstCodeChild()
+        val startOfBodyBlock =
+            this
+                .findChildByType(BLOCK)
+                ?.firstChildNode
+        val startOfBodyExpression = this.findChildByType(EQ)
+        return collectLeavesRecursively()
+            .childrenBetween(
+                startASTNodePredicate = { it == firstCodeChild },
+                endASTNodePredicate = { it == startOfBodyBlock || it == startOfBodyExpression }
+            )
+    }
+
+    private fun ASTNode.getFirstCodeChild(): ASTNode? {
+        val funNode = if (elementType == FUN_KEYWORD) {
+            this.treeParent
+        } else {
+            this
+        }
+        funNode
+            ?.findChildByType(MODIFIER_LIST)
+            ?.let { modifierList ->
+                val iterator = modifierList.children().iterator()
+                var currentNode: ASTNode
+                while (iterator.hasNext()) {
+                    currentNode = iterator.next()
+                    if (currentNode.elementType != ANNOTATION_ENTRY && currentNode.elementType != WHITE_SPACE) {
+                        return currentNode
+                    }
+                }
+                return modifierList.nextCodeSibling()
+            }
+        return funNode.nextCodeLeaf()
+    }
+
+    private fun ASTNode.isStartOfBodyExpression(): Boolean =
+        elementType == EQ && prevSibling { it.elementType == VALUE_PARAMETER_LIST } != null
+
+    private fun visitFunctionSignature(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        require(node.elementType == FUN)
+
+        if (isMaxLineLengthSet()) {
+            val actualFunctionSignatureLength = node.getFunctionSignatureLength()
+
+            // Calculate the length of the function signature in case it would be rewritten as single line (and without a
+            // maximum line length). The white space correction will be calculated via a dry run of the actual fix.
+            val singleLineFunctionSignatureLength =
+                actualFunctionSignatureLength +
+                    // Calculate the white space correction in case the signature would be rewritten to a single line
+                    fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = true)
+            if (singleLineFunctionSignatureLength > maxLineLength ||
+                node.hasMinimumNumberOfParameters()
+            ) {
+                fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
+            } else {
+                fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
+                fixFunctionBody(node, emit, autoCorrect, maxLineLength - singleLineFunctionSignatureLength)
+            }
+        } else {
+            // When max line length is not set then keep it as single line function signature only when the original
+            // signature already was a single line signature. Otherwise, rewrite the entire signature as a multiline
+            // signature.
+            val rewriteToSingleLineFunctionSignature = node
+                .functionSignatureNodes()
+                .none { it.textContains('\n') }
+            if (rewriteToSingleLineFunctionSignature) {
+                fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
+            } else {
+                fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
+            }
+        }
+    }
+
+    private fun ASTNode.getFunctionSignatureLength() = lineIndent().length + getFunctionSignatureNodesLength()
+
+    private fun ASTNode.getFunctionSignatureNodesLength() = functionSignatureNodes()
+        .joinTextToString()
+        .length
+
+    private fun fixWhiteSpacesInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = requireNotNull(node.findChildByType(VALUE_PARAMETER_LIST))
+        val firstParameterInList =
+            valueParameterList
+                .children()
+                .firstOrNull { it.elementType == VALUE_PARAMETER }
+
+        if (firstParameterInList == null) {
+            // handle empty parameter list
+            whiteSpaceCorrection +=
+                fixWhiteSpacesInEmptyValueParameterList(node, emit, autoCorrect, dryRun)
+        } else {
+            whiteSpaceCorrection +=
+                fixWhiteSpacesBeforeFirstParameterInValueParameterList(node, emit, autoCorrect, multiline, dryRun) +
+                fixWhiteSpacesBetweenParametersInValueParameterList(node, emit, autoCorrect, multiline, dryRun) +
+                fixWhiteSpaceBeforeClosingParenthesis(node, emit, autoCorrect, multiline, dryRun)
+        }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesInEmptyValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        dryRun: Boolean
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = requireNotNull(node.findChildByType(VALUE_PARAMETER_LIST))
+
+        valueParameterList
+            .children()
+            .filter { it.elementType != LPAR && it.elementType != RPAR }
+            .also { elementsInValueParameterList ->
+                // Functions with comments in the value parameter list are excluded from processing before. So an "empty" value
+                // parameter list should only contain a single whitespace element
+                require(elementsInValueParameterList.count() <= 1)
+            }
+            .firstOrNull()
+            ?.let { whiteSpace ->
+                if (!dryRun) {
+                    emit(
+                        whiteSpace.startOffset,
+                        "No whitespace expected in empty parameter list",
+                        true
+                    )
+                }
+                if (autoCorrect && !dryRun) {
+                    whiteSpace.treeParent.removeChild(whiteSpace)
+                } else {
+                    whiteSpaceCorrection -= whiteSpace.textLength
+                }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesBeforeFirstParameterInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = requireNotNull(node.findChildByType(VALUE_PARAMETER_LIST))
+        val firstParameterInList =
+            valueParameterList
+                .children()
+                .first { it.elementType == VALUE_PARAMETER }
+
+        val firstChildOfParameter = firstParameterInList.firstChildNode
+        firstChildOfParameter
+            ?.prevLeaf()
+            ?.takeIf { it.elementType == WHITE_SPACE }
+            .let { whiteSpaceBeforeIdentifier ->
+                if (multiline) {
+                    val expectedParameterIndent = "\n" + node.lineIndent() + indent
+                    if (whiteSpaceBeforeIdentifier == null ||
+                        whiteSpaceBeforeIdentifier.text != expectedParameterIndent
+                    ) {
+                        if (!dryRun) {
+                            emit(
+                                firstParameterInList.startOffset,
+                                "Newline expected after opening parenthesis",
+                                true
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            if (whiteSpaceBeforeIdentifier == null) {
+                                (firstChildOfParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                            } else {
+                                (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(
+                                    expectedParameterIndent
+                                )
+                            }
+                        } else {
+                            whiteSpaceCorrection += expectedParameterIndent.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                        }
+                    }
+                } else {
+                    if (whiteSpaceBeforeIdentifier != null) {
+                        if (!dryRun) {
+                            emit(
+                                firstChildOfParameter!!.startOffset,
+                                "No whitespace expected between opening parenthesis and first parameter name",
+                                true
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            whiteSpaceBeforeIdentifier.treeParent.removeChild(whiteSpaceBeforeIdentifier)
+                        } else {
+                            whiteSpaceCorrection -= whiteSpaceBeforeIdentifier.textLength
+                        }
+                    }
+                }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesBetweenParametersInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = requireNotNull(node.findChildByType(VALUE_PARAMETER_LIST))
+        val firstParameterInList =
+            valueParameterList
+                .children()
+                .first { it.elementType == VALUE_PARAMETER }
+
+        valueParameterList
+            .children()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .filter { it != firstParameterInList }
+            .forEach { valueParameter ->
+                val firstChildNodeInValueParameter = valueParameter.firstChildNode
+                firstChildNodeInValueParameter
+                    ?.prevLeaf()
+                    ?.takeIf { it.elementType == WHITE_SPACE }
+                    .let { whiteSpaceBeforeIdentifier ->
+                        if (multiline) {
+                            val expectedParameterIndent = "\n" + node.lineIndent() + indent
+                            if (whiteSpaceBeforeIdentifier == null ||
+                                whiteSpaceBeforeIdentifier.text != expectedParameterIndent
+                            ) {
+                                if (!dryRun) {
+                                    emit(
+                                        valueParameter.startOffset,
+                                        "Parameter should start on a newline",
+                                        true
+                                    )
+                                }
+                                if (autoCorrect && !dryRun) {
+                                    if (whiteSpaceBeforeIdentifier == null) {
+                                        (firstChildNodeInValueParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                    } else {
+                                        (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(
+                                            expectedParameterIndent
+                                        )
+                                    }
+                                } else {
+                                    whiteSpaceCorrection += expectedParameterIndent.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                }
+                            }
+                        } else {
+                            if (whiteSpaceBeforeIdentifier == null || whiteSpaceBeforeIdentifier.text != " ") {
+                                if (!dryRun) {
+                                    emit(
+                                        firstChildNodeInValueParameter!!.startOffset,
+                                        "Single whitespace expected before parameter",
+                                        true
+                                    )
+                                }
+                                if (autoCorrect && !dryRun) {
+                                    if (whiteSpaceBeforeIdentifier == null) {
+                                        (firstChildNodeInValueParameter as LeafElement).upsertWhitespaceBeforeMe(" ")
+                                    } else {
+                                        (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(" ")
+                                    }
+                                } else {
+                                    whiteSpaceCorrection += 1 - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                }
+                            }
+                        }
+                    }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpaceBeforeClosingParenthesis(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val newlineAndIndent = "\n" + node.lineIndent()
+        val valueParameterList = requireNotNull(node.findChildByType(VALUE_PARAMETER_LIST))
+
+        val closingParenthesis = valueParameterList.findChildByType(RPAR)
+        closingParenthesis
+            ?.prevSibling { true }
+            ?.takeIf { it.elementType == WHITE_SPACE }
+            .let { whiteSpaceBeforeClosingParenthesis ->
+                if (multiline) {
+                    if (whiteSpaceBeforeClosingParenthesis == null ||
+                        whiteSpaceBeforeClosingParenthesis.text != newlineAndIndent
+                    ) {
+                        if (!dryRun) {
+                            emit(
+                                closingParenthesis!!.startOffset,
+                                "Newline expected before closing parenthesis",
+                                true
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            (closingParenthesis as LeafElement).upsertWhitespaceBeforeMe(newlineAndIndent)
+                        } else {
+                            whiteSpaceCorrection += newlineAndIndent.length - (whiteSpaceBeforeClosingParenthesis?.textLength ?: 0)
+                        }
+                    }
+                } else {
+                    if (whiteSpaceBeforeClosingParenthesis != null &&
+                        whiteSpaceBeforeClosingParenthesis.nextLeaf()?.elementType == RPAR
+                    ) {
+                        if (!dryRun) {
+                            emit(
+                                whiteSpaceBeforeClosingParenthesis.startOffset,
+                                "No whitespace expected between last parameter and closing parenthesis",
+                                true
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            whiteSpaceBeforeClosingParenthesis.treeParent.removeChild(whiteSpaceBeforeClosingParenthesis)
+                        } else {
+                            whiteSpaceCorrection -= whiteSpaceBeforeClosingParenthesis.textLength
+                        }
+                    }
+                }
+            }
+        return whiteSpaceCorrection
+    }
+
+    private fun fixFunctionBody(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        maxLengthRemainingForFirstLineOfBodyExpression: Int
+    ) {
+        val leaves = node.collectLeavesRecursively()
+
+        val lastNodeOfFunctionSignatureWithBodyExpression =
+            node
+                .findChildByType(EQ)
+                ?.nextLeaf(includeEmpty = true)
+        leaves
+            .childrenBetween(
+                startASTNodePredicate = { it == lastNodeOfFunctionSignatureWithBodyExpression },
+                endASTNodePredicate = {
+                    // collect all remaining nodes
+                    false
+                }
+            ).takeIf { it.isNotEmpty() }
+            ?.fixFunctionBodyExpression(node, emit, autoCorrect, maxLengthRemainingForFirstLineOfBodyExpression)
+
+        val lastNodeOfFunctionSignatureWithBlockBody =
+            node
+                .getLastNodeOfFunctionSignatureWithBlockBody()
+                ?.nextLeaf(includeEmpty = true)
+        leaves
+            .childrenBetween(
+                startASTNodePredicate = { it == lastNodeOfFunctionSignatureWithBlockBody },
+                endASTNodePredicate = {
+                    // collect all remaining nodes
+                    false
+                }
+            ).takeIf { it.isNotEmpty() }
+            ?.fixFunctionBodyBlock(emit, autoCorrect)
+    }
+
+    private fun List<ASTNode>.fixFunctionBodyExpression(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        maxLengthRemainingForFirstLineOfBodyExpression: Int
+    ) {
+        val (whiteSpaceBeforeFunctionBodyExpression, functionBodyExpression) =
+            this
+                .let {
+                    val whiteSpaceFirst =
+                        it.firstOrNull { first -> first.isWhiteSpace() }
+                    if (whiteSpaceFirst == null) {
+                        Pair(null, it)
+                    } else {
+                        Pair(
+                            it.firstOrNull { first -> first.isWhiteSpace() },
+                            it.drop(1)
+                        )
+                    }
+                }
+
+        functionBodyExpression
+            .joinTextToString()
+            .split("\n")
+            .firstOrNull()
+            ?.also { firstLineOfBodyExpression ->
+                if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression) {
+                    if (whiteSpaceBeforeFunctionBodyExpression == null ||
+                        !whiteSpaceBeforeFunctionBodyExpression.textContains('\n')
+                    ) {
+                        emit(
+                            functionBodyExpression.first().startOffset,
+                            "Newline expected before expression body",
+                            true
+                        )
+                        if (autoCorrect) {
+                            val newLineAndIndent = "\n" + node.lineIndent() + indent
+                            if (whiteSpaceBeforeFunctionBodyExpression != null) {
+                                (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(newLineAndIndent)
+                            } else {
+                                (functionBodyExpression.first() as LeafPsiElement).upsertWhitespaceBeforeMe(newLineAndIndent)
+                            }
+                        }
+                    }
+                } else if (whiteSpaceBeforeFunctionBodyExpression?.textContains('\n') == true) {
+                    emit(
+                        whiteSpaceBeforeFunctionBodyExpression.startOffset,
+                        "First line of body expression fits on same line as function signature",
+                        true
+                    )
+                    if (autoCorrect) {
+                        (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                    }
+                }
+            }
+    }
+
+    private fun List<ASTNode>.fixFunctionBodyBlock(
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val (whiteSpaceBeforeFunctionBodyExpression, functionBodyBlock) =
+            this
+                .firstOrNull()
+                ?.takeIf { first -> first.isWhiteSpace() }
+                ?.let { Pair(it, this.drop(1)) }
+                ?: Pair(null, this)
+
+        functionBodyBlock
+            .joinTextToString()
+            .split("\n")
+            .firstOrNull()
+            ?.also { firstLineOfBodyBlock ->
+                if (whiteSpaceBeforeFunctionBodyExpression == null) {
+                    emit(functionBodyBlock.first().startOffset, "Expected a single space before body block", true)
+                    if (autoCorrect) {
+                        (functionBodyBlock.first().prevLeaf(true) as LeafPsiElement).upsertWhitespaceAfterMe(" ")
+                    }
+                } else if (whiteSpaceBeforeFunctionBodyExpression.text != " ") {
+                    emit(whiteSpaceBeforeFunctionBodyExpression.startOffset, "Expected a single space", true)
+                    if (autoCorrect) {
+                        (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                    }
+                }
+            }
+    }
+
+    private fun isMaxLineLengthSet() = maxLineLength > -1
+
+    private fun List<ASTNode>.collectLeavesRecursively(): List<ASTNode> = flatMap { it.collectLeavesRecursively() }
+
+    private fun ASTNode.collectLeavesRecursively(): List<ASTNode> = if (psi is LeafElement) {
+        listOf(this)
+    } else {
+        children()
+            .flatMap { it.collectLeavesRecursively() }
+            .toList()
+    }
+
+    private fun List<ASTNode>.childrenBetween(
+        startASTNodePredicate: (ASTNode) -> Boolean = { _ -> true },
+        endASTNodePredicate: (ASTNode) -> Boolean = { _ -> false }
+    ): List<ASTNode> {
+        val iterator = iterator()
+        var currentNode: ASTNode
+        val childrenBetween: MutableList<ASTNode> = mutableListOf()
+
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            if (startASTNodePredicate(currentNode)) {
+                childrenBetween.add(currentNode)
+                break
+            }
+        }
+
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            childrenBetween.add(currentNode)
+            if (endASTNodePredicate(currentNode)) {
+                break
+            }
+        }
+
+        return childrenBetween
+    }
+
+    private fun List<ASTNode>.joinTextToString(block: (ASTNode) -> String = { it.text }): String =
+        collectLeavesRecursively().joinToString(separator = "") { block(it) }
+
+    private fun ASTNode.hasMinimumNumberOfParameters(): Boolean =
+        functionSignatureWrappingMinimumParameters > 0 && countParameters() >= functionSignatureWrappingMinimumParameters
+
+    private fun ASTNode.countParameters(): Int {
+        val valueParameterList = requireNotNull(findChildByType(VALUE_PARAMETER_LIST))
+        return valueParameterList
+            .children()
+            .count { it.elementType == VALUE_PARAMETER }
+    }
+
+    private fun ASTNode.getLastNodeOfFunctionSignatureWithBlockBody(): ASTNode? =
+        this
+            .findChildByType(BLOCK)
+            ?.firstChildNode
+            ?.prevCodeLeaf()
+
+    public companion object {
+        @Suppress("MemberVisibilityCanBePrivate")
+        public const val KTLINT_FUNCTION_SIGNATURE_RULE_FORCE_MULTILINE_WITH_AT_LEAST_PARAMETERS: String =
+            "ktlint_function_signature_rule_force_multiline_with_at_least_parameters"
+
+        public val functionSignatureWrappingMinimumParametersProperty: UsesEditorConfigProperties.EditorConfigProperty<Int> =
+            UsesEditorConfigProperties.EditorConfigProperty(
+                type = PropertyType.LowerCasingPropertyType(
+                    KTLINT_FUNCTION_SIGNATURE_RULE_FORCE_MULTILINE_WITH_AT_LEAST_PARAMETERS,
+                    "Force wrapping the parameters of the function signature in case it contains at least the specified " +
+                        "number of parameters even in case the entire function signature would fit on a single line. " +
+                        "By default this parameter is not enabled.",
+                    PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+                    setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset")
+                ),
+                defaultValue = -1
+            )
+    }
+}

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -43,8 +43,7 @@ public class FunctionSignatureRule :
     Rule(
         id = "function-signature",
         visitorModifiers = setOf(
-            // Run after wrapping, spacing and indentation rule
-            VisitorModifier.RunAfterRule("standard:indent"),
+            // Run after wrapping and spacing rules
             VisitorModifier.RunAsLateAsPossible
         )
     ),

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
@@ -114,7 +114,7 @@ public class FunctionStartOfBodySpacingRule : Rule("function-start-of-body-spaci
                             emit(block.startOffset, "Expected a single white space before start of function body", true)
                             if (autoCorrect) {
                                 if (whiteSpaceBeforeExpressionBlock == null) {
-                                    (block.firstChildNode as LeafPsiElement).upsertWhitespaceBeforeMe(" ")
+                                    (block.firstChildNode.prevLeaf(true) as LeafPsiElement).upsertWhitespaceAfterMe(" ")
                                 } else {
                                     (whiteSpaceBeforeExpressionBlock as LeafElement).rawReplaceWithText(" ")
                                 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -1,0 +1,623 @@
+package com.pinterest.ktlint.ruleset.experimental
+
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.ruleset.experimental.FunctionSignatureRule.Companion.functionSignatureWrappingMinimumParametersProperty
+import com.pinterest.ktlint.ruleset.standard.NoMultipleSpacesRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundColonRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundCommaRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundDotRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundOperatorsRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundParensRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(FeatureInAlphaState::class)
+class FunctionSignatureRuleTest {
+    private val functionSignatureWrappingRuleAssertThat = FunctionSignatureRule().assertThat()
+
+    @Test
+    fun `Given a single line function signature which is smaller than or equal to the max line length, and the function is followed by a body block, then do no change the signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String {
+                // body
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line function signature which is equal to the max line length but missing a space before the opening brace of the body block, and the function is followed by a body block, then do no change the signature`() {
+        // Note: the remainder of the tests primarily uses the single expression body as it is a bit more concise than
+        // the block expression.
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String{
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalFormattingRule(FunctionStartOfBodySpacingRule())
+            .hasLintViolation(2, 38, "Expected a single space before body block")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature which is greater then the max line length then reformat to a multiline signature`() {
+        // Note: the remainder of the tests primarily uses the single expression body as it is a bit more concise than
+        // the block expression.
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ): String {
+                // body
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 15, "Parameter should start on a newline"),
+                LintViolation(2, 23, "Parameter should start on a newline"),
+                LintViolation(2, 29, "Newline expected before closing parenthesis")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature which is smaller than or equal to the max line length, and the function is followed by a body expression, then do not change the signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+            fun f(string: String): String = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line function signature which is smaller than or equal to the max line length, and the function is followed by a body expression which does not fit on that same line, then do not change the signature but wrap the expression body`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            fun f(string: String): String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            fun f(string: String): String =
+                "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 33, "Newline expected before expression body")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature and max-line-length is not set then do not rewrite a multiline signature`() {
+        val code =
+            """
+            // No max line length marker!
+            fun f(string: String): String = string.toUpperCase()
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line function signature with a length greater than the max line length then reformat to multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any): String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ): String = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 15, "Parameter should start on a newline"),
+                LintViolation(2, 23, "Parameter should start on a newline"),
+                LintViolation(2, 29, "Newline expected before closing parenthesis")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given some function signatures containing at least one comment then do not reformat although the max line length is exceeded`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            private /* some comment */ fun f1(a: Any, b: Any): String = "some-result"
+            private fun /* some comment */ f2(a: Any, b: Any): String = "some-result"
+            private fun f3 /* some comment */ (a: Any, b: Any): String = "some-result"
+            private fun f4( /* some comment */ a: Any, b: Any): String = "some-result"
+            private fun f5(a /* some comment */: Any, b: Any): String = "some-result"
+            private fun f6(a: /* some comment */ Any, b: Any): String = "some-result"
+            private fun f7(a: Any /* some comment */, b: Any): String = "some-result"
+            private fun f8(a: Any, b: Any) /* some comment */: String = "some-result"
+            private fun f9(a: Any, b: Any): /* some comment */ String = "some-result"
+            private fun f10(a: Any, b: Any): String /* some comment */ = "some-result"
+            private fun f11(
+                a: Any, // some-comment
+                b: Any
+            ): String = "f10"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a function signature with a newline between the last parameter in the parameter list and the closing parenthesis, but which does not fit on a single line then reformat to a proper multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any
+            ) = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER $EOL_CHAR
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ) = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 15, "Parameter should start on a newline"),
+                LintViolation(2, 23, "Parameter should start on a newline")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature with an expression body that is missing the required space just before the expression, but which after adding this spaces no longer fits on a single line, then push the expression body to the next line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any) ="some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any) =
+                "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 32, "Newline expected before expression body")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature with an expression body on the next line which actually fits on the same line as the function signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any) =
+                "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+            fun f(a: Any, b: Any, c: Any) = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 32, "First line of body expression fits on same line as function signature")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature returning a lambda which not entire fits on the same line, then push the lambda to the next line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                             $EOL_CHAR                                                                                                    $EOL_CHAR
+            fun foo(bar: String): (String) -> Boolean = { it == bar }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                             $EOL_CHAR                                                                                                    $EOL_CHAR
+            fun foo(bar: String): (String) -> Boolean =
+                { it == bar }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 45, "Newline expected before expression body")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function signature returning a lambda on the next line which actually fits on the same line as the function signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                              $EOL_CHAR                                                                                                    $EOL_CHAR
+            fun foo(bar: String): (String) -> Boolean =
+                { it == bar }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                              $EOL_CHAR                                                                                                    $EOL_CHAR
+            fun foo(bar: String): (String) -> Boolean = { it == bar }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 44, "First line of body expression fits on same line as function signature")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function without parameters but with at least one space between the parenthesis then reformat to a proper single line signature`() {
+        val code =
+            """
+            fun f( ) = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun f() = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 7, "No whitespace expected in empty parameter list")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function without parameters but with at least one newline between the parenthesis then reformat to a proper single line signature`() {
+        val code =
+            """
+            fun f(
+
+            ) = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun f() = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 7, "No whitespace expected in empty parameter list")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline function signature which actually fits on a single line but for which the expression body does not fit at that same line then reformat the signature and wrap the body expression to the next line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // Entire signature is just one character too long to fit on a single line
+            // ...a: Any, b: Any, c: Any) = "some-result"
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ) = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // Entire signature is just one character too long to fit on a single line
+            // ...a: Any, b: Any, c: Any) = "some-result"
+            fun f(a: Any, b: Any, c: Any) =
+                "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(5, 5, "No whitespace expected between opening parenthesis and first parameter name"),
+                LintViolation(6, 5, "Single whitespace expected before parameter"),
+                LintViolation(7, 5, "Single whitespace expected before parameter"),
+                LintViolation(7, 11, "No whitespace expected between last parameter and closing parenthesis"),
+                LintViolation(8, 5, "Newline expected before expression body")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class with a multiline function signature which actually fits on a single line but for which the expression body does not fit at that same line then reformat the signature and wrap the body expression to the next line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            // Entire signature is just one character too long to fit on a single line
+            //  fun(a: Any, b: Any, c: Any) = "some-result"
+            class Foo {
+                fun f(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                ) = "some-result"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            // Entire signature is just one character too long to fit on a single line
+            //  fun(a: Any, b: Any, c: Any) = "some-result"
+            class Foo {
+                fun f(a: Any, b: Any, c: Any) =
+                    "some-result"
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(6, 9, "No whitespace expected between opening parenthesis and first parameter name"),
+                LintViolation(7, 9, "Single whitespace expected before parameter"),
+                LintViolation(8, 9, "Single whitespace expected before parameter"),
+                LintViolation(
+                    8,
+                    15,
+                    "No whitespace expected between last parameter and closing parenthesis"
+                ),
+                LintViolation(9, 9, "Newline expected before expression body")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class MinimumNumberOfParameters {
+        @Test
+        fun `Given a single line function signature which is smaller than or equal to the max line length but having too many parameters then do reformat as multiline signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
+                fun f(a: Any, b: Any, c: Any): String {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
+                fun f(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                ): String {
+                    // body
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .withEditorConfigOverride(functionSignatureWrappingMinimumParametersProperty to 2)
+                .hasLintViolations(
+                    LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 15, "Parameter should start on a newline"),
+                    LintViolation(2, 23, "Parameter should start on a newline"),
+                    LintViolation(2, 29, "Newline expected before closing parenthesis")
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a function declaration without default implementation in an interface`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR                                                                                                       $EOL_CHAR
+            interface Foo {
+                fun foo(a: Any, b: Any): String
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an abstract function declaration`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR                                                                                                       $EOL_CHAR
+            abstract class Foo {
+                abstract fun foo(a: Any, b: Any): String
+            }
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    // The FunctionSignatureWrappingRule depends on a lot of different rules to do an initial clean up. The tests below
+    // ensure that those rules effectively clean up so that the FunctionSignatureWrappingRule does not need to check for
+    // it at all.
+    @Nested
+    inner class CleanUpByRelatedRules {
+        @Test
+        fun `Given a nullable type with a space before the quest then remove this space`() {
+            val code =
+                """
+                fun String${UNEXPECTED_SPACES}?.f1() = "some-result"
+                fun List<String${UNEXPECTED_SPACES}?>.f2() = "some-result"
+                fun f3(string: String${UNEXPECTED_SPACES}?) = "some-result"
+                fun f4(string: List<String${UNEXPECTED_SPACES}?>) = "some-result"
+                fun f5(): String${UNEXPECTED_SPACES}? = "some-result"
+                fun f6(): List<String${UNEXPECTED_SPACES}?> = listOf("some-result", null)
+                fun f7(): List<String>${UNEXPECTED_SPACES}? = null
+                """.trimIndent() // ktlint-disable string-template
+            val formattedCode =
+                """
+                fun String?.f1() = "some-result"
+                fun List<String?>.f2() = "some-result"
+                fun f3(string: String?) = "some-result"
+                fun f4(string: List<String?>) = "some-result"
+                fun f5(): String? = "some-result"
+                fun f6(): List<String?> = listOf("some-result", null)
+                fun f7(): List<String>? = null
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .addAdditionalFormattingRule(NullableTypeSpacingRule())
+                .hasNoLintViolationsExceptInAdditionalFormattingRules()
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function signature contains redundant spaces then ensure that those are removed before running the function signature rule`() {
+            val code =
+                """
+                private${UNEXPECTED_SPACES}fun f1() = "some-result"
+                fun f2$UNEXPECTED_SPACES() = "some-result"
+                fun f3(${UNEXPECTED_SPACES}a: Any) = "some-result"
+                fun f4(a$UNEXPECTED_SPACES: Any) = "some-result"
+                fun f5(a:${UNEXPECTED_SPACES}Any) = "some-result"
+                fun f6(a: Any$UNEXPECTED_SPACES, b: Any) = "some-result"
+                fun f7(a: Any,${UNEXPECTED_SPACES}b: Any) = "some-result"
+                fun f8(a: Any, b: Any$UNEXPECTED_SPACES) = "some-result"
+                fun f9(${UNEXPECTED_SPACES}vararg a: Any) = "some-result"
+                fun f10(vararg${UNEXPECTED_SPACES}a: Any) = "some-result"
+                fun f11()$UNEXPECTED_SPACES= "some-result"
+                fun f12()$UNEXPECTED_SPACES: String = "some-result"
+                fun f13():${UNEXPECTED_SPACES}String = "some-result"
+                fun f14(): String$UNEXPECTED_SPACES= "some-result"
+                fun f15() =$UNEXPECTED_SPACES"some-result"
+                fun <${UNEXPECTED_SPACES}T> f16(t: T) = "some-result"
+                fun <T>${UNEXPECTED_SPACES}f17(t: T) = "some-result"
+                fun <T$UNEXPECTED_SPACES, U> f18(t: T, u: U) = "some-result"
+                fun <T,${UNEXPECTED_SPACES}U> f19(t: T, u: U) = "some-result"
+                fun <T, U$UNEXPECTED_SPACES> f20(t: T) = "some-result"
+                fun Map<${UNEXPECTED_SPACES}Any, Any>.f21(a: Any, b: Any) = "some-result"
+                fun Map<Any$UNEXPECTED_SPACES, Any>.f22(a: Any, b: Any) = "some-result"
+                fun Map<Any,${UNEXPECTED_SPACES}Any>.f23(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any$UNEXPECTED_SPACES>.f24(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any>$UNEXPECTED_SPACES.f25(a: Any, b: Any) = "some-result"
+                fun f26(block: (${UNEXPECTED_SPACES}T) -> String) = "some-result"
+                fun f27(block: (T$UNEXPECTED_SPACES) -> String) = "some-result"
+                fun f28(block: (T)$UNEXPECTED_SPACES-> String) = "some-result"
+                fun f29(block: (T) ->${UNEXPECTED_SPACES}String) = "some-result"
+                """.trimIndent()
+            val formattedCode =
+                """
+                private fun f1() = "some-result"
+                fun f2() = "some-result"
+                fun f3(a: Any) = "some-result"
+                fun f4(a: Any) = "some-result"
+                fun f5(a: Any) = "some-result"
+                fun f6(a: Any, b: Any) = "some-result"
+                fun f7(a: Any, b: Any) = "some-result"
+                fun f8(a: Any, b: Any) = "some-result"
+                fun f9(vararg a: Any) = "some-result"
+                fun f10(vararg a: Any) = "some-result"
+                fun f11() = "some-result"
+                fun f12(): String = "some-result"
+                fun f13(): String = "some-result"
+                fun f14(): String = "some-result"
+                fun f15() = "some-result"
+                fun <T> f16(t: T) = "some-result"
+                fun <T> f17(t: T) = "some-result"
+                fun <T, U> f18(t: T, u: U) = "some-result"
+                fun <T, U> f19(t: T, u: U) = "some-result"
+                fun <T, U> f20(t: T) = "some-result"
+                fun Map<Any, Any>.f21(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any>.f22(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any>.f23(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any>.f24(a: Any, b: Any) = "some-result"
+                fun Map<Any, Any>.f25(a: Any, b: Any) = "some-result"
+                fun f26(block: (T) -> String) = "some-result"
+                fun f27(block: (T) -> String) = "some-result"
+                fun f28(block: (T) -> String) = "some-result"
+                fun f29(block: (T) -> String) = "some-result"
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .addAdditionalFormattingRule(
+                    NoMultipleSpacesRule(),
+                    SpacingAroundAngleBracketsRule(),
+                    SpacingAroundParensRule(),
+                    SpacingAroundDotRule(),
+                    SpacingAroundCommaRule(),
+                    SpacingAroundColonRule()
+                ).hasLintViolations(
+                    LintViolation(3, 10, "No whitespace expected between opening parenthesis and first parameter name"),
+                    LintViolation(7, 17, "Single whitespace expected before parameter"),
+                    LintViolation(
+                        8,
+                        22,
+                        "No whitespace expected between last parameter and closing parenthesis"
+                    ),
+                    LintViolation(9, 10, "No whitespace expected between opening parenthesis and first parameter name")
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function signature missing required spaces then ensure that those are added before running the function signature rule`() {
+            val code =
+                """
+                fun f1(a:${NO_SPACE}Any) = "some-result"
+                fun f2(a: Any,${NO_SPACE}b: Any) = "some-result"
+                fun f3()$NO_SPACE= "some-result"
+                fun f4():${NO_SPACE}String = "some-result"
+                fun f5(): String$NO_SPACE= "some-result"
+                fun f6() =$NO_SPACE"some-result"
+                fun <T>${NO_SPACE}f7(t: T) = "some-result"
+                fun <T,${NO_SPACE}U> f8(t: T, u: U) = "some-result"
+                fun Map<Any,${NO_SPACE}Any>.f9(a: Any, b: Any) = "some-result"
+                fun f10(block: (T)$NO_SPACE-> String) = "some-result"
+                fun f11(block: (T) ->${NO_SPACE}String) = "some-result"
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun f1(a: Any) = "some-result"
+                fun f2(a: Any, b: Any) = "some-result"
+                fun f3() = "some-result"
+                fun f4(): String = "some-result"
+                fun f5(): String = "some-result"
+                fun f6() = "some-result"
+                fun <T> f7(t: T) = "some-result"
+                fun <T, U> f8(t: T, u: U) = "some-result"
+                fun Map<Any, Any>.f9(a: Any, b: Any) = "some-result"
+                fun f10(block: (T) -> String) = "some-result"
+                fun f11(block: (T) -> String) = "some-result"
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .addAdditionalFormattingRule(
+                    TypeParameterListSpacingRule(),
+                    FunctionStartOfBodySpacingRule(),
+                    FunctionTypeReferenceSpacingRule(),
+                    SpacingAroundColonRule(),
+                    SpacingAroundCommaRule(),
+                    SpacingAroundOperatorsRule()
+                ).hasLintViolation(2, 15, "Single whitespace expected before parameter")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    private companion object {
+        const val EOL_CHAR = '#'
+        const val UNEXPECTED_SPACES = "  "
+        const val NO_SPACE = ""
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -105,7 +105,12 @@ public class IndentationRule :
         id = "indent",
         visitorModifiers = setOf(
             VisitorModifier.RunOnRootNodeOnly,
-            VisitorModifier.RunAsLateAsPossible
+            VisitorModifier.RunAsLateAsPossible,
+            VisitorModifier.RunAfterRule(
+                ruleId = "experimental:function-signature",
+                loadOnlyWhenOtherRuleIsLoaded = false,
+                runOnlyWhenOtherRuleIsEnabled = false
+            )
         )
     ),
     UsesEditorConfigProperties {

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/EditorConfigTestRule.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/EditorConfigTestRule.kt
@@ -32,10 +32,7 @@ public class EditorConfigTestRule {
      * values. Please, be aware that this class also contains a lot of deprecated methods which you should not use
      * either.
      */
-    public fun writeToEditorConfig(
-        content: Map<PropertyType<*>, String>,
-        lintedFileExtension: String = ".kt"
-    ): File {
+    public fun writeToEditorConfig(content: Map<PropertyType<*>, String>, lintedFileExtension: String = ".kt"): File {
         throw UnsupportedOperationException("This functionality has been removed. See deprecation notice and KDoc.")
     }
 }


### PR DESCRIPTION
## Description

This rule rewrites the function signature to a single line when possible (e.g. when not exceeding the "max_line_length" property) or a multiline signature otherwise. In case of function with a body expression, the body expression is placed on the same line as the function signature when not exceeding the "max_line_length" property. Optionally the function signature can be forced to be written as a multiline signature in case the function has more than a specified number of parameters (".editorconfig" property "ktlint_function_signature_wrapping_rule_always_with_minimum_parameters")

Fixed the FunctionStartOfBodySpacingRule to add the missing space before start of the block body before the BLOCK element type instead of as first element inside the BLOCK element.

Closes #1341 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [X] `README.md` is updated
- [X] Rule has been applied on Ktlint itself and violations are fixed
