### PR TITLE
Bump Kotlin dev version to 1.7.0-Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 
 ### Removed
 
-### Removed
-
 ## [0.45.2] - 2022-04-06
 
 ### Fixed
@@ -81,8 +79,6 @@ This section is applicable when providing rules that depend on one or more value
 ### Changed
 - Print the rule id always in the PlainReporter ([#1121](https://github.com/pinterest/ktlint/issues/1121))
 - All wrapping logic is moved from the `indent` rule to the new rule `wrapping` (as part of the `standard` ruleset). In case you currently have disabled the `indent` rule, you may want to reconsider whether this is still necessary or that you also want to disable the new `wrapping` rule to keep the status quo. Both rules can be run independent of each other. ([#835](https://github.com/pinterest/ktlint/issues/835))
-
-### Removed
 
 ## [0.44.0] - 2022-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Fix check of spacing in the receiver type of an anonymous function ([#1440](https://github.com/pinterest/ktlint/issues/1440))
 
 ### Changed
-* Set Kotlin development version to `1.6.21` and Kotlin version to `1.6.21`.
+* Set Kotlin development version to `1.7.0-Beta` and Kotlin version to `1.6.21`.
 
 ### Removed
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 // Pass '-PkotlinDev' to command line to enable kotlin-in-development version
 val kotlinVersion = if (project.hasProperty("kotlinDev")) {
     logger.warn("Enabling kotlin dev version!")
-    "1.6.21"
+    "1.7.0-Beta"
 } else {
     "1.6.21"
 }


### PR DESCRIPTION
## Description

https://github.com/JetBrains/kotlin/releases/tag/v1.7.0-Beta

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [x] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
