### PR TITLE
Allow a single whitespace line in chained expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Add experimental rule for consistent spacing before the start of the function body (`function-start-of-body-spacing`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
 
 ### Fixed
+- Allow a single whitespace line in chained expressions ([#1469](https://github.com/pinterest/ktlint/pull/1469))
 - Fix check of spacing in the receiver type of an anonymous function ([#1440](https://github.com/pinterest/ktlint/issues/1440))
 - Allow comment on same line as super class in class declaration `wrapping` ([#1457](https://github.com/pinterest/ktlint/pull/1457))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Add experimental rule for consistent spacing before the start of the function body (`function-start-of-body-spacing`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
 
 ### Fixed
-- Allow a single whitespace line in chained expressions ([#1469](https://github.com/pinterest/ktlint/pull/1469))
+- Separate out disallowing blank lines in chained method calls to a new rule ([#1469](https://github.com/pinterest/ktlint/pull/1469))
 - Fix check of spacing in the receiver type of an anonymous function ([#1440](https://github.com/pinterest/ktlint/issues/1440))
 - Allow comment on same line as super class in class declaration `wrapping` ([#1457](https://github.com/pinterest/ktlint/pull/1457))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Add experimental rule for consistent spacing before the start of the function body (`function-start-of-body-spacing`) ([#1341](https://github.com/pinterest/ktlint/issues/1341))
 
 ### Fixed
-- Separate out disallowing blank lines in chained method calls to a new rule ([#1469](https://github.com/pinterest/ktlint/pull/1469))
+- Move disallowing blank lines in chained method calls from `no-consecutive-blank-lines` to new rule (`no-blank-lines-in-chained-method-calls`) ([#1248](https://github.com/pinterest/ktlint/issues/1248))
 - Fix check of spacing in the receiver type of an anonymous function ([#1440](https://github.com/pinterest/ktlint/issues/1440))
 - Allow comment on same line as super class in class declaration `wrapping` ([#1457](https://github.com/pinterest/ktlint/pull/1457))
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It's also [easy to create your own](#creating-a-reporter).
 - `modifier-order`: Consistent order of modifiers
 - `no-blank-line-before-rbrace`: No blank lines before `}` 
 - `no-consecutive-blank-lines`: No consecutive blank lines
+- `no-blank-lines-in-chained-method-calls`: No blank lines in chained method expressions
 - `no-empty-class-body`: No empty (`{}`) class bodies
 - `no-line-break-after-else`: Disallows line breaks after the else keyword if that could lead to confusion, for example:
     ```kotlin

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ It's also [easy to create your own](#creating-a-reporter).
 - `max-line-length`: Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](#editorconfig) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to and comment that disables ktlint rules than that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.  
 - `modifier-order`: Consistent order of modifiers
 - `no-blank-line-before-rbrace`: No blank lines before `}` 
-- `no-consecutive-blank-lines`: No consecutive blank lines
 - `no-blank-lines-in-chained-method-calls`: No blank lines in chained method expressions
+- `no-consecutive-blank-lines`: No consecutive blank lines
 - `no-empty-class-body`: No empty (`{}`) class bodies
 - `no-line-break-after-else`: Disallows line breaks after the else keyword if that could lead to confusion, for example:
     ```kotlin

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chained-method-calls") {
     override fun visit(
@@ -14,6 +15,7 @@ public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chai
         val isBlankLine = node is PsiWhiteSpace && node.getText().contains("\n\n")
         if (isBlankLine && node.treeParent.elementType == DOT_QUALIFIED_EXPRESSION) {
             emit(node.startOffset + 1, "Needless blank line(s)", true)
+            (node as LeafPsiElement).rawReplaceWithText("\n" + node.getText().split("\n\n")[1])
         }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
@@ -1,0 +1,13 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chained-method-calls") {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
@@ -1,7 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 
 public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chained-method-calls") {
     override fun visit(
@@ -9,5 +11,9 @@ public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chai
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
+        val isBlankLine = node is PsiWhiteSpace && node.getText().contains("\n\n")
+        if (isBlankLine && node.treeParent.elementType == DOT_QUALIFIED_EXPRESSION) {
+            emit(node.startOffset + 1, "Needless blank line(s)", true)
+        }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
@@ -15,7 +15,10 @@ public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chai
         val isBlankLine = node is PsiWhiteSpace && node.getText().contains("\n\n")
         if (isBlankLine && node.treeParent.elementType == DOT_QUALIFIED_EXPRESSION) {
             emit(node.startOffset + 1, "Needless blank line(s)", true)
-            (node as LeafPsiElement).rawReplaceWithText("\n" + node.getText().split("\n\n")[1])
+
+            if (autoCorrect) {
+                (node as LeafPsiElement).rawReplaceWithText("\n" + node.getText().split("\n\n")[1])
+            }
         }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CLASS
-import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.core.ast.nextLeaf
@@ -25,20 +24,21 @@ public class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
             if (lfcount < 2) {
                 return
             }
+
             val eof = node.nextLeaf() == null
             val prevNode = node.treePrev
             val betweenClassAndPrimaryConstructor = prevNode.elementType == IDENTIFIER &&
                 prevNode.treeParent.elementType == CLASS &&
                 node.treeNext.elementType == PRIMARY_CONSTRUCTOR
-            val inDotQualifiedExpression = node.treeParent.elementType == DOT_QUALIFIED_EXPRESSION && lfcount > 1
-            if (lfcount > 2 || eof || betweenClassAndPrimaryConstructor || inDotQualifiedExpression) {
+
+            if (lfcount > 2 || eof || betweenClassAndPrimaryConstructor) {
                 val split = text.split("\n")
                 emit(node.startOffset + split[0].length + split[1].length + 2, "Needless blank line(s)", true)
                 if (autoCorrect) {
                     val newText = buildString {
                         append(split.first())
                         append("\n")
-                        if (!eof && !betweenClassAndPrimaryConstructor && !inDotQualifiedExpression) append("\n")
+                        if (!eof && !betweenClassAndPrimaryConstructor) append("\n")
                         append(split.last())
                     }
                     (node as LeafPsiElement).rawReplaceWithText(newText)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -18,6 +18,7 @@ public class StandardRuleSetProvider : RuleSetProvider {
         ModifierOrderRule(),
         NoBlankLineBeforeRbraceRule(),
         NoConsecutiveBlankLinesRule(),
+        NoBlankLinesInChainedMethodCallsRule(),
         NoEmptyClassBodyRule(),
         NoLineBreakAfterElseRule(),
         NoLineBreakBeforeAssignmentRule(),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
@@ -21,6 +21,14 @@ class NoBlankLinesInChainedMethodCallsRuleTest {
 
         noBlankLinesInChainedMethodCallsRuleAssertThat(code)
             .hasLintViolations(LintViolation(3, 1, "Needless blank line(s)"))
+            .isFormattedAs(
+                """
+                fun foo(inputText: String) {
+                    inputText
+                        .toLowerCase()
+                }
+                """.trimIndent()
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
@@ -1,11 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
-import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class NoBlankLinesInChainedMethodCallsRuleTest {
-
     private val noBlankLinesInChainedMethodCallsRuleAssertThat = NoBlankLinesInChainedMethodCallsRule().assertThat()
 
     @Test
@@ -18,17 +16,16 @@ class NoBlankLinesInChainedMethodCallsRuleTest {
                     .toLowerCase()
             }
             """.trimIndent()
-
+        val formattedCode =
+            """
+            fun foo(inputText: String) {
+                inputText
+                    .toLowerCase()
+            }
+            """.trimIndent()
         noBlankLinesInChainedMethodCallsRuleAssertThat(code)
-            .hasLintViolations(LintViolation(3, 1, "Needless blank line(s)"))
-            .isFormattedAs(
-                """
-                fun foo(inputText: String) {
-                    inputText
-                        .toLowerCase()
-                }
-                """.trimIndent()
-            )
+            .hasLintViolation(3, 1, "Needless blank line(s)")
+            .isFormattedAs(formattedCode)
     }
 
     @Test
@@ -41,7 +38,6 @@ class NoBlankLinesInChainedMethodCallsRuleTest {
                 bar()
             }
             """.trimIndent()
-
         noBlankLinesInChainedMethodCallsRuleAssertThat(code).hasNoLintViolations()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRuleTest.kt
@@ -1,0 +1,39 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Test
+
+class NoBlankLinesInChainedMethodCallsRuleTest {
+
+    private val noBlankLinesInChainedMethodCallsRuleAssertThat = NoBlankLinesInChainedMethodCallsRule().assertThat()
+
+    @Test
+    fun `single blank line in dot qualified expression returns lint error`() {
+        val code =
+            """
+            fun foo(inputText: String) {
+                inputText
+
+                    .toLowerCase()
+            }
+            """.trimIndent()
+
+        noBlankLinesInChainedMethodCallsRuleAssertThat(code)
+            .hasLintViolations(LintViolation(3, 1, "Needless blank line(s)"))
+    }
+
+    @Test
+    fun `single blank line between statements does not return lint error`() {
+        val code =
+            """
+            fun foo(inputText: String) {
+                bar()
+
+                bar()
+            }
+            """.trimIndent()
+
+        noBlankLinesInChainedMethodCallsRuleAssertThat(code).hasNoLintViolations()
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
@@ -3,7 +3,6 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
-import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -176,25 +175,41 @@ class NoConsecutiveBlankLinesRuleTest {
     }
 
     @Test
-    fun `should remove line in dot qualified expression`() {
-        assertThat(
-            NoConsecutiveBlankLinesRule().format(
+    fun `Given single blank line in dot qualified expression should not return lint errors`() {
+        val code =
+            """
+            fun foo(inputText: String) {
+                inputText
+
+                    .toLowerCase()
+            }
+            """.trimIndent()
+
+        noConsecutiveBlankLinesRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given multiple blank line in dot qualified expression should return lint error`() {
+        val code =
+            """
+            fun foo(inputText: String) {
+                inputText
+
+
+                    .toLowerCase()
+            }
+            """.trimIndent()
+
+        noConsecutiveBlankLinesRuleAssertThat(code)
+            .hasLintViolations(LintViolation(4, 1, "Needless blank line(s)"))
+            .isFormattedAs(
                 """
                 fun foo(inputText: String) {
                     inputText
-
 
                         .toLowerCase()
                 }
                 """.trimIndent()
             )
-        ).isEqualTo(
-            """
-            fun foo(inputText: String) {
-                inputText
-                    .toLowerCase()
-            }
-            """.trimIndent()
-        )
     }
 }


### PR DESCRIPTION
## Description

Closes #1248

There's a lot of discussion in the issues as to the right approach, but here's my proposal for a fix. Given the rule is intended to detect "consecutive" blank lines, I've made sure a single blank line is allowed in a chained expression (but that multiple is still disallowed and formats correctly). This will allow for the "blank line followed by a comment" examples brought up in the issue and keeps the whitespace rules consistent between regular statements and chained expressions.

The reasoning behind arguing for blank lines to be allowed in chained expressions is that there's nothing about disallowing them in either the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html) or the [Android Kotlin style guide](https://developer.android.com/kotlin/style-guide) (as far as I can see) and people have brought up use cases where it's useful in the issue.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] `CHANGELOG.md` is updated
