### PR TITLE
Run rules during unit tests in correct order

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * Implementation **doesn't** have to be thread-safe or stateless
  * (provided [RuleSetProvider] creates a new instance on each `get()` call).
  *
- * @param id must be unique within the ruleset
+ * @param id: For non-standard rules, it is expected that this id consist of the ruleSetId and ruleId, e.g. "some-rule-set-id:some-rule-id"
  * @param visitorModifiers: set of modifiers of the visitor. Preferably a rule has no modifiers at all, meaning that it
  * is completely independent of all other rules.
  *
@@ -20,7 +20,7 @@ abstract class Rule(
     public val visitorModifiers: Set<VisitorModifier> = emptySet()
 ) {
     init {
-        IdNamingPolicy.enforceNaming(id)
+        IdNamingPolicy.enforceRuleIdNaming(id)
     }
 
     /**

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSet.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSet.kt
@@ -12,7 +12,7 @@ open class RuleSet(
 ) : Iterable<Rule> {
 
     init {
-        IdNamingPolicy.enforceNaming(id)
+        IdNamingPolicy.enforceRuleSetIdNaming(id)
         require(rules.isNotEmpty()) { "At least one rule must be provided" }
     }
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/IdNamingPolicy.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/IdNamingPolicy.kt
@@ -4,14 +4,23 @@ package com.pinterest.ktlint.core.internal
  * Provides policy to have consistent and restricted `id` field naming style.
  */
 internal object IdNamingPolicy {
-    private const val ID_REGEX = "[a-z]+([-][a-z]+)*"
-    private val idRegex = ID_REGEX.toRegex()
+    private const val SIMPLE_ID_REGEX = "[a-z]+([-][a-z]+)*"
+    private val ruleIdRegex = "($SIMPLE_ID_REGEX:)?($SIMPLE_ID_REGEX)".toRegex()
+    private val ruleSetIdRegex = "($SIMPLE_ID_REGEX)".toRegex()
 
     /**
-     * Checks provided [id] is valid.
+     * Checks provided [ruleId] is valid.
      *
-     * Will throw [IllegalArgumentException] on invalid [id] name.
+     * Will throw [IllegalArgumentException] on invalid [ruleId] name.
      */
-    internal fun enforceNaming(id: String) =
-        require(id.matches(idRegex)) { "id $id must match $ID_REGEX" }
+    internal fun enforceRuleIdNaming(ruleId: String) =
+        require(ruleId.matches(ruleIdRegex)) { "Rule id '$ruleId' must match '${ruleIdRegex.pattern}'" }
+
+    /**
+     * Checks provided [ruleSetId] is valid.
+     *
+     * Will throw [IllegalArgumentException] on invalid [ruleSetId] name.
+     */
+    internal fun enforceRuleSetIdNaming(ruleSetId: String) =
+        require(ruleSetId.matches(ruleSetIdRegex)) { "RuleSet id '$ruleSetId' must match '${ruleSetIdRegex.pattern}'" }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -580,10 +580,7 @@ class VisitorProviderTest {
         return VisitorProvider(
             ruleSets = ruleSetList,
             // Enable debug mode as it is helpful when a test fails
-            debug = true,
-            // Although this is a unit test, the isUnitTestContext is disabled by default so that rules marked with
-            // RunAfterRule can be tested as well.
-            isUnitTestContext = isUnitTestContext ?: false
+            debug = true
         ).run {
             var visits: MutableList<Visit>? = null
             visitor(ruleSetList, SOME_ROOT_AST_NODE, concurrent ?: false)

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationRule.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
  *
  * @see [AnnotationSpacingRule] for white space rules. Moved since
  */
-class AnnotationRule : Rule("annotation") {
+class AnnotationRule : Rule("$experimentalRulesetId:annotation") {
 
     companion object {
         const val multipleAnnotationsOnSameLineAsAnnotatedConstructErrorMessage =

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/AnnotationSpacingRule.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
  *
  * https://kotlinlang.org/docs/reference/coding-conventions.html#annotation-formatting
  */
-class AnnotationSpacingRule : Rule("annotation-spacing") {
+class AnnotationSpacingRule : Rule("$experimentalRulesetId:annotation-spacing") {
 
     companion object {
         const val ERROR_MESSAGE = "Annotations should occur immediately before the annotated construct"

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRule.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 @OptIn(FeatureInAlphaState::class)
 class ArgumentListWrappingRule :
-    Rule("argument-list-wrapping"),
+    Rule("$experimentalRulesetId:argument-list-wrapping"),
     UsesEditorConfigProperties {
     private var editorConfigIndent = IndentConfig.DEFAULT_INDENT_CONFIG
     private var maxLineLength = -1

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/BlockCommentInitialStarAlignmentRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/BlockCommentInitialStarAlignmentRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
  */
 class BlockCommentInitialStarAlignmentRule :
     Rule(
-        "block-comment-initial-star-alignment",
+        "$experimentalRulesetId:block-comment-initial-star-alignment",
         visitorModifiers = setOf(
             // The block comment is a node which can contain multiple lines. The indent of the second and later line
             // should be determined based on the indent of the block comment node. This indent is determined by the

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
  */
 @OptIn(FeatureInAlphaState::class)
 public class CommentWrappingRule :
-    Rule("comment-wrapping"),
+    Rule("$experimentalRulesetId:comment-wrapping"),
     UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/DiscouragedCommentLocationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/DiscouragedCommentLocationRule.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  *         foo(t: T) = "some-result"
  * ```
  */
-public class DiscouragedCommentLocationRule : Rule("discouraged-comment-location") {
+public class DiscouragedCommentLocationRule : Rule("$experimentalRulesetId:discouraged-comment-location") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/EnumEntryNameCaseRule.kt
@@ -5,8 +5,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.psi.KtEnumEntry
 
-public class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
-
+public class EnumEntryNameCaseRule : Rule("$experimentalRulesetId:enum-entry-name-case") {
     internal companion object {
         val regex = Regex("[A-Z]([A-Za-z\\d]*|[A-Z_\\d]*)")
     }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt
@@ -4,10 +4,11 @@ import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import com.pinterest.ktlint.ruleset.experimental.trailingcomma.TrailingCommaRule
 
-public class ExperimentalRuleSetProvider : RuleSetProvider {
+public const val experimentalRulesetId = "experimental"
 
+public class ExperimentalRuleSetProvider : RuleSetProvider {
     override fun get(): RuleSet = RuleSet(
-        "experimental",
+        experimentalRulesetId,
         AnnotationRule(),
         ArgumentListWrappingRule(),
         MultiLineIfElseRule(),

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunKeywordSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunKeywordSpacingRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 /**
  * Lints and formats the spacing after the fun keyword
  */
-public class FunKeywordSpacingRule : Rule("fun-keyword-spacing") {
+public class FunKeywordSpacingRule : Rule("$experimentalRulesetId:fun-keyword-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeSpacingRule.kt
@@ -10,7 +10,7 @@ import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 
-public class FunctionReturnTypeSpacingRule : Rule("function-return-type-spacing") {
+public class FunctionReturnTypeSpacingRule : Rule("$experimentalRulesetId:function-return-type-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 /**
  * Lints and formats the spacing after the fun keyword
  */
-public class FunctionStartOfBodySpacingRule : Rule("function-start-of-body-spacing") {
+public class FunctionStartOfBodySpacingRule : Rule("$experimentalRulesetId:function-start-of-body-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionTypeReferenceSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionTypeReferenceSpacingRule.kt
@@ -9,7 +9,7 @@ import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.nextSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class FunctionTypeReferenceSpacingRule : Rule("function-type-reference-spacing") {
+public class FunctionTypeReferenceSpacingRule : Rule("$experimentalRulesetId:function-type-reference-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  */
 @OptIn(FeatureInAlphaState::class)
 public class KdocWrappingRule :
-    Rule("kdoc-wrapping"),
+    Rule("$experimentalRulesetId:kdoc-wrapping"),
     UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ModifierListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ModifierListSpacingRule.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 /**
  * Lint and format the spacing between the modifiers in and after the last modifier in a modifier list.
  */
-public class ModifierListSpacingRule : Rule("modifier-list-spacing") {
+public class ModifierListSpacingRule : Rule("$experimentalRulesetId:modifier-list-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRule.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
  *
  * TODO: if, for, when branch, do, while
  */
-class MultiLineIfElseRule : Rule("multiline-if-else") {
+class MultiLineIfElseRule : Rule("$experimentalRulesetId:multiline-if-else") {
 
     override fun visit(
         node: ASTNode,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NoEmptyFirstLineInMethodBlockRule.kt
@@ -10,8 +10,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
-class NoEmptyFirstLineInMethodBlockRule : Rule("no-empty-first-line-in-method-block") {
-
+class NoEmptyFirstLineInMethodBlockRule : Rule("$experimentalRulesetId:no-empty-first-line-in-method-block") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRule.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.core.ast.prevLeaf
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
-public class NullableTypeSpacingRule : Rule("nullable-type-spacing") {
+public class NullableTypeSpacingRule : Rule("$experimentalRulesetId:nullable-type-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/PackageNameRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/PackageNameRule.kt
@@ -5,8 +5,7 @@ import com.pinterest.ktlint.core.ast.ElementType.PACKAGE_DIRECTIVE
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
-class PackageNameRule : Rule("package-name") {
-
+class PackageNameRule : Rule("$experimentalRulesetId:package-name") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ParameterListSpacingRule.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * comma's and colons. However, it does have a more complete view on the higher concept of the parameter-list without
  * interfering of the parameter-list-wrapping rule.
  */
-public class ParameterListSpacingRule : Rule("parameter-list-spacing") {
+public class ParameterListSpacingRule : Rule("$experimentalRulesetId:parameter-list-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketsRule.kt
@@ -13,7 +13,7 @@ import com.pinterest.ktlint.core.ast.prevLeaf
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 
-class SpacingAroundAngleBracketsRule : Rule("spacing-around-angle-brackets") {
+class SpacingAroundAngleBracketsRule : Rule("$experimentalRulesetId:spacing-around-angle-brackets") {
     private fun String.trimBeforeLastLine() = this.substring(this.lastIndexOf('\n'))
 
     override fun visit(

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundDoubleColonRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundDoubleColonRule.kt
@@ -11,8 +11,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
-class SpacingAroundDoubleColonRule : Rule("double-colon-spacing") {
-
+class SpacingAroundDoubleColonRule : Rule("$experimentalRulesetId:double-colon-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundUnaryOperatorRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundUnaryOperatorRule.kt
@@ -12,8 +12,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  *
  * @see [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html#horizontal-whitespace)
  */
-class SpacingAroundUnaryOperatorRule : Rule("unary-op-spacing") {
-
+class SpacingAroundUnaryOperatorRule : Rule("$experimentalRulesetId:unary-op-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -17,8 +17,7 @@ import org.jetbrains.kotlin.psi.psiUtil.prevLeafs
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35106
  */
-class SpacingBetweenDeclarationsWithAnnotationsRule : Rule("spacing-between-declarations-with-annotations") {
-
+class SpacingBetweenDeclarationsWithAnnotationsRule : Rule("$experimentalRulesetId:spacing-between-declarations-with-annotations") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -16,8 +16,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35088
  */
-class SpacingBetweenDeclarationsWithCommentsRule : Rule("spacing-between-declarations-with-comments") {
-
+class SpacingBetweenDeclarationsWithCommentsRule : Rule("$experimentalRulesetId:spacing-between-declarations-with-comments") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.nextSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class SpacingBetweenFunctionNameAndOpeningParenthesisRule : Rule("spacing-between-function-name-and-opening-parenthesis") {
+public class SpacingBetweenFunctionNameAndOpeningParenthesisRule : Rule("$experimentalRulesetId:spacing-between-function-name-and-opening-parenthesis") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeArgumentListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeArgumentListSpacingRule.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 /**
  * Lints and formats the spacing before and after the angle brackets of a type argument list.
  */
-public class TypeArgumentListSpacingRule : Rule("type-argument-list-spacing") {
+public class TypeArgumentListSpacingRule : Rule("$experimentalRulesetId:type-argument-list-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeParameterListSpacingRule.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 /**
  * Lints and formats the spacing before and after the angle brackets of a type parameter list.
  */
-public class TypeParameterListSpacingRule : Rule("type-parameter-list-spacing") {
+public class TypeParameterListSpacingRule : Rule("$experimentalRulesetId:type-parameter-list-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 /**
  * Ensures there are no unnecessary parentheses before a trailing lambda.
  */
-class UnnecessaryParenthesesBeforeTrailingLambdaRule : Rule("unnecessary-parentheses-before-trailing-lambda") {
+class UnnecessaryParenthesesBeforeTrailingLambdaRule : Rule("$experimentalRulesetId:unnecessary-parentheses-before-trailing-lambda") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/trailingcomma/TrailingCommaRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.core.ast.containsLineBreakInRange
 import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
+import com.pinterest.ktlint.ruleset.experimental.experimentalRulesetId
 import kotlin.properties.Delegates
 import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser
@@ -33,7 +34,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 @OptIn(FeatureInAlphaState::class)
 public class TrailingCommaRule :
     Rule(
-        id = "trailing-comma",
+        id = "$experimentalRulesetId:trailing-comma",
         visitorModifiers = setOf(
             VisitorModifier.RunAfterRule(
                 ruleId = "standard:indent",

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/ArgumentListWrappingRuleTest.kt
@@ -61,7 +61,7 @@ class ArgumentListWrappingRuleTest {
             )
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 9, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(2, 14, "Argument should be on a separate line (unless all arguments can fit a single line)"),
@@ -281,7 +281,7 @@ class ArgumentListWrappingRuleTest {
             }
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 10, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(2, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -56,7 +56,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .addAdditionalFormattingRule(FunctionStartOfBodySpacingRule())
+            .addAdditionalRules(FunctionStartOfBodySpacingRule())
             .hasLintViolation(2, 38, "Expected a single space before body block")
             .isFormattedAs(formattedCode)
     }
@@ -481,8 +481,8 @@ class FunctionSignatureRuleTest {
                 fun f7(): List<String>? = null
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
-                .addAdditionalFormattingRule(NullableTypeSpacingRule())
-                .hasNoLintViolationsExceptInAdditionalFormattingRules()
+                .addAdditionalRules(NullableTypeSpacingRule())
+                .hasNoLintViolationsExceptInAdditionalRules()
                 .isFormattedAs(formattedCode)
         }
 
@@ -553,7 +553,7 @@ class FunctionSignatureRuleTest {
                 fun f29(block: (T) -> String) = "some-result"
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
-                .addAdditionalFormattingRule(
+                .addAdditionalRules(
                     NoMultipleSpacesRule(),
                     SpacingAroundAngleBracketsRule(),
                     SpacingAroundParensRule(),
@@ -603,7 +603,7 @@ class FunctionSignatureRuleTest {
                 fun f11(block: (T) -> String) = "some-result"
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
-                .addAdditionalFormattingRule(
+                .addAdditionalRules(
                     TypeParameterListSpacingRule(),
                     FunctionStartOfBodySpacingRule(),
                     FunctionTypeReferenceSpacingRule(),

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/MultiLineIfElseRuleTest.kt
@@ -425,7 +425,7 @@ class MultiLineIfElseRuleTest {
             }
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(4, 9, "Missing { ... }"),
                 LintViolation(7, 9, "Missing { ... }")
@@ -454,7 +454,7 @@ class MultiLineIfElseRuleTest {
             }
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(3, 9, "Missing { ... }"),
                 LintViolation(5, 9, "Missing { ... }")

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRuleTest.kt
@@ -1,10 +1,6 @@
 package com.pinterest.ktlint.ruleset.experimental
 
-import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
-import com.pinterest.ktlint.test.format
-import com.pinterest.ktlint.test.lint
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 
 class NullableTypeSpacingRuleTest {
@@ -20,10 +16,9 @@ class NullableTypeSpacingRuleTest {
             """
             val foo : String? = null
             """.trimIndent()
-        Assertions.assertThat(NullableTypeSpacingRule().lint(code)).containsExactly(
-            LintError(1, 17, "nullable-type-spacing", "Unexpected whitespace")
-        )
-        Assertions.assertThat(NullableTypeSpacingRule().format(code)).isEqualTo(formattedCode)
+        nullableTypeSpacingRuleAssertThat(code)
+            .hasLintViolation(1, 17, "Unexpected whitespace")
+            .isFormattedAs(formattedCode)
     }
 
     @Test

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingAroundAngleBracketRuleTest.kt
@@ -60,7 +60,7 @@ class SpacingAroundAngleBracketRuleTest {
                 > = mapOf()
             """.trimIndent()
         spacingAroundAngleBracketsRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(1, 12, "Unexpected spacing after \"<\""),
                 LintViolation(2, 23, "Unexpected spacing before \">\""),
@@ -110,7 +110,7 @@ class SpacingAroundAngleBracketRuleTest {
                 > {}
             """.trimIndent()
         spacingAroundAngleBracketsRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 19, "Unexpected spacing after \"<\""),
                 LintViolation(3, 31, "Unexpected spacing before \">\""),

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.experimental.trailingcomma.TrailingCommaRule
 import com.pinterest.ktlint.ruleset.experimental.trailingcomma.TrailingCommaRule.Companion.allowTrailingCommaOnCallSiteProperty
 import com.pinterest.ktlint.ruleset.experimental.trailingcomma.TrailingCommaRule.Companion.allowTrailingCommaProperty
+import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import com.pinterest.ktlint.ruleset.standard.NoUnusedImportsRule
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
 import com.pinterest.ktlint.test.LintViolation
@@ -11,7 +12,13 @@ import org.junit.jupiter.api.Test
 
 @OptIn(FeatureInAlphaState::class)
 class TrailingCommaRuleTest {
-    private val trailingCommaRuleAssertThat = TrailingCommaRule().assertThat()
+    private val trailingCommaRuleAssertThat =
+        TrailingCommaRule()
+            .assertThat(
+                // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                // correct.
+                IndentationRule()
+            )
 
     @Test
     fun `Given property allow trailing comma on call site is not set then remove trailing comma's`() {
@@ -124,8 +131,8 @@ class TrailingCommaRuleTest {
             ) -> Int = when (x) {
                 1, 2
                 -> {
-                    foo,
-                    bar /* The comma should be inserted before the comment */
+                        foo,
+                        bar /* The comma should be inserted before the comment */
                     ->
                     block(
                         foo * bar,
@@ -146,8 +153,8 @@ class TrailingCommaRuleTest {
             ) -> Int = when (x) {
                 1, 2,
                 -> {
-                    foo,
-                    bar, /* The comma should be inserted before the comment */
+                        foo,
+                        bar, /* The comma should be inserted before the comment */
                     ->
                     block(
                         foo * bar,
@@ -164,7 +171,7 @@ class TrailingCommaRuleTest {
                 LintViolation(4, 29, "Missing trailing comma before \")\""),
                 LintViolation(6, 13, "Missing trailing comma before \")\""),
                 LintViolation(8, 9, "Missing trailing comma before \"->\""),
-                LintViolation(11, 12, "Missing trailing comma before \"->\""),
+                LintViolation(11, 16, "Missing trailing comma before \"->\""),
                 LintViolation(15, 22, "Missing trailing comma before \")\"")
             ).isFormattedAs(formattedCode)
     }
@@ -244,28 +251,28 @@ class TrailingCommaRuleTest {
             """
             data class Foo1(val bar: Int,)
             data class Foo2(
-               val bar: Int, // The comma before the comment should be removed without removing the comment itself
+                val bar: Int, // The comma before the comment should be removed without removing the comment itself
             )
             data class Foo3(
-               val bar: Int, /* The comma before the comment should be removed without removing the comment itself */
+                val bar: Int, /* The comma before the comment should be removed without removing the comment itself */
             )
             """.trimIndent()
         val formattedCode =
             """
             data class Foo1(val bar: Int)
             data class Foo2(
-               val bar: Int // The comma before the comment should be removed without removing the comment itself
+                val bar: Int // The comma before the comment should be removed without removing the comment itself
             )
             data class Foo3(
-               val bar: Int /* The comma before the comment should be removed without removing the comment itself */
+                val bar: Int /* The comma before the comment should be removed without removing the comment itself */
             )
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaProperty to false)
             .hasLintViolations(
                 LintViolation(1, 29, "Unnecessary trailing comma before \")\""),
-                LintViolation(3, 16, "Unnecessary trailing comma before \")\""),
-                LintViolation(6, 16, "Unnecessary trailing comma before \")\"")
+                LintViolation(3, 17, "Unnecessary trailing comma before \")\""),
+                LintViolation(6, 17, "Unnecessary trailing comma before \")\"")
             ).isFormattedAs(formattedCode)
     }
 
@@ -275,27 +282,27 @@ class TrailingCommaRuleTest {
             """
             data class Foo1(val bar: Int)
             data class Foo2(
-               val bar: Int // The comma should be inserted before the comment
+                val bar: Int // The comma should be inserted before the comment
             )
             data class Foo3(
-               val bar: Int /* The comma should be inserted before the comment */
+                val bar: Int /* The comma should be inserted before the comment */
             )
             """.trimIndent()
         val formattedCode =
             """
             data class Foo1(val bar: Int)
             data class Foo2(
-               val bar: Int, // The comma should be inserted before the comment
+                val bar: Int, // The comma should be inserted before the comment
             )
             data class Foo3(
-               val bar: Int, /* The comma should be inserted before the comment */
+                val bar: Int, /* The comma should be inserted before the comment */
             )
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaProperty to true)
             .hasLintViolations(
-                LintViolation(3, 16, "Missing trailing comma before \")\""),
-                LintViolation(6, 16, "Missing trailing comma before \")\"")
+                LintViolation(3, 17, "Missing trailing comma before \")\""),
+                LintViolation(6, 17, "Missing trailing comma before \")\"")
             ).isFormattedAs(formattedCode)
     }
 
@@ -307,11 +314,11 @@ class TrailingCommaRuleTest {
             class Foo2<
                 A,
                 B, // The comma before the comment should be removed without removing the comment itself
-            > {}
+                > {}
             class Foo3<
                 A,
                 B, /* The comma before the comment should be removed without removing the comment itself */
-            > {}
+                > {}
             """.trimIndent()
         val formattedCode =
             """
@@ -319,11 +326,11 @@ class TrailingCommaRuleTest {
             class Foo2<
                 A,
                 B // The comma before the comment should be removed without removing the comment itself
-            > {}
+                > {}
             class Foo3<
                 A,
                 B /* The comma before the comment should be removed without removing the comment itself */
-            > {}
+                > {}
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaProperty to false)
@@ -342,11 +349,11 @@ class TrailingCommaRuleTest {
             class Foo2<
                 A,
                 B // The comma should be inserted before the comment
-            > {}
+                > {}
             class Foo3<
                 A,
                 B /* The comma should be inserted before the comment */
-            > {}
+                > {}
             """.trimIndent()
         val formattedCode =
             """
@@ -354,11 +361,11 @@ class TrailingCommaRuleTest {
             class Foo2<
                 A,
                 B, // The comma should be inserted before the comment
-            > {}
+                > {}
             class Foo3<
                 A,
                 B, /* The comma should be inserted before the comment */
-            > {}
+                > {}
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaProperty to true)
@@ -528,13 +535,13 @@ class TrailingCommaRuleTest {
             """
             val fooBar1: (Int, Int) -> Int = { foo, bar, -> foo * bar }
             val fooBar2: (Int, Int) -> Int = {
-                foo,
-                bar, // The comma before the comment should be removed without removing the comment itself
+                    foo,
+                    bar, // The comma before the comment should be removed without removing the comment itself
                 -> foo * bar
             }
             val fooBar3: (Int, Int) -> Int = {
-                foo,
-                bar, /* The comma before the comment should be removed without removing the comment itself */
+                    foo,
+                    bar, /* The comma before the comment should be removed without removing the comment itself */
                 -> foo * bar
             }
             """.trimIndent()
@@ -542,13 +549,13 @@ class TrailingCommaRuleTest {
             """
             val fooBar1: (Int, Int) -> Int = { foo, bar -> foo * bar }
             val fooBar2: (Int, Int) -> Int = {
-                foo,
-                bar // The comma before the comment should be removed without removing the comment itself
+                    foo,
+                    bar // The comma before the comment should be removed without removing the comment itself
                 -> foo * bar
             }
             val fooBar3: (Int, Int) -> Int = {
-                foo,
-                bar /* The comma before the comment should be removed without removing the comment itself */
+                    foo,
+                    bar /* The comma before the comment should be removed without removing the comment itself */
                 -> foo * bar
             }
             """.trimIndent()
@@ -556,8 +563,8 @@ class TrailingCommaRuleTest {
             .withEditorConfigOverride(allowTrailingCommaProperty to false)
             .hasLintViolations(
                 LintViolation(1, 44, "Unnecessary trailing comma before \"->\""),
-                LintViolation(4, 8, "Unnecessary trailing comma before \"->\""),
-                LintViolation(9, 8, "Unnecessary trailing comma before \"->\"")
+                LintViolation(4, 12, "Unnecessary trailing comma before \"->\""),
+                LintViolation(9, 12, "Unnecessary trailing comma before \"->\"")
             ).isFormattedAs(formattedCode)
     }
 
@@ -567,13 +574,13 @@ class TrailingCommaRuleTest {
             """
             val fooBar1: (Int, Int) -> Int = { foo, bar -> foo * bar }
             val fooBar2: (Int, Int) -> Int = {
-                foo,
-                bar // The comma should be inserted before the comment
+                    foo,
+                    bar // The comma should be inserted before the comment
                 -> foo * bar
             }
             val fooBar3: (Int, Int) -> Int = {
-                foo,
-                bar /* The comma should be inserted before the comment */
+                    foo,
+                    bar /* The comma should be inserted before the comment */
                 -> foo * bar
             }
             """.trimIndent()
@@ -581,21 +588,21 @@ class TrailingCommaRuleTest {
             """
             val fooBar1: (Int, Int) -> Int = { foo, bar -> foo * bar }
             val fooBar2: (Int, Int) -> Int = {
-                foo,
-                bar, // The comma should be inserted before the comment
+                    foo,
+                    bar, // The comma should be inserted before the comment
                 -> foo * bar
             }
             val fooBar3: (Int, Int) -> Int = {
-                foo,
-                bar, /* The comma should be inserted before the comment */
+                    foo,
+                    bar, /* The comma should be inserted before the comment */
                 -> foo * bar
             }
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaProperty to true)
             .hasLintViolations(
-                LintViolation(4, 8, "Missing trailing comma before \"->\""),
-                LintViolation(9, 8, "Missing trailing comma before \"->\"")
+                LintViolation(4, 12, "Missing trailing comma before \"->\""),
+                LintViolation(9, 12, "Missing trailing comma before \"->\"")
             ).isFormattedAs(formattedCode)
     }
 
@@ -606,20 +613,20 @@ class TrailingCommaRuleTest {
             val list1: List<String,> = emptyList()
             val list2: List<
                 String, // The comma before the comment should be removed without removing the comment itself
-            > = emptyList()
+                > = emptyList()
             val list3: List<
                 String, /* The comma before the comment should be removed without removing the comment itself */
-            > = emptyList()
+                > = emptyList()
             """.trimIndent()
         val formattedCode =
             """
             val list1: List<String> = emptyList()
             val list2: List<
                 String // The comma before the comment should be removed without removing the comment itself
-            > = emptyList()
+                > = emptyList()
             val list3: List<
                 String /* The comma before the comment should be removed without removing the comment itself */
-            > = emptyList()
+                > = emptyList()
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaOnCallSiteProperty to false)
@@ -637,20 +644,20 @@ class TrailingCommaRuleTest {
             val list1: List<String> = emptyList()
             val list2: List<
                 String // The comma should be inserted before the comment
-            > = emptyList()
+                > = emptyList()
             val list3: List<
                 String /* The comma should be inserted before the comment */
-            > = emptyList()
+                > = emptyList()
             """.trimIndent()
         val formattedCode =
             """
             val list1: List<String> = emptyList()
             val list2: List<
                 String, // The comma should be inserted before the comment
-            > = emptyList()
+                > = emptyList()
             val list3: List<
                 String, /* The comma should be inserted before the comment */
-            > = emptyList()
+                > = emptyList()
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaOnCallSiteProperty to true)
@@ -898,9 +905,9 @@ class TrailingCommaRuleTest {
         val code =
             """
             class Test {
-              var foo = Bar()
-                set(value) {
-                }
+                var foo = Bar()
+                    set(value) {
+                    }
             }
             """.trimIndent()
         trailingCommaRuleAssertThat(code)
@@ -979,7 +986,7 @@ class TrailingCommaRuleTest {
             // was incorrectly seen as part of the type of variable "bar3" and a reference "EnumThree," (with the
             // trailing comma was added) which in turn resulted in not recognizing that the import of EnumThree actually
             // was used.
-            .addAdditionalFormattingRule(NoUnusedImportsRule())
+            .addAdditionalRules(NoUnusedImportsRule())
             .withEditorConfigOverride(allowTrailingCommaProperty to true)
             .hasLintViolation(9, 24, "Missing trailing comma before \")\"")
             .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -2010,7 +2010,7 @@ internal class IndentationRuleTest {
             """.trimIndent()
                 .replacePlaceholderWithStringTemplate()
         indentationRuleAssertThat(code)
-            .addAdditionalFormattingRule(WrappingRule())
+            .addAdditionalRules(WrappingRule())
             .hasLintViolations(
                 LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
                 LintViolation(4, 1, "Unexpected indentation (4) (should be 8)")
@@ -2048,7 +2048,7 @@ internal class IndentationRuleTest {
             }
             """.trimIndent()
         indentationRuleAssertThat(code)
-            .addAdditionalFormattingRule(WrappingRule())
+            .addAdditionalRules(WrappingRule())
             .hasLintViolations(
                 LintViolation(5, 1, "Unexpected indent of multiline string closing quotes"),
                 LintViolation(7, 1, "Unexpected indent of multiline string closing quotes")
@@ -2088,7 +2088,7 @@ internal class IndentationRuleTest {
             """.trimIndent()
                 .replacePlaceholderWithStringTemplate()
         indentationRuleAssertThat(code)
-            .addAdditionalFormattingRule(WrappingRule())
+            .addAdditionalRules(WrappingRule())
             .hasLintViolations(
                 LintViolation(3, 1, "Unexpected indentation (0) (should be 8)"),
                 LintViolation(4, 1, "Unexpected indentation (4) (should be 8)"),
@@ -2669,7 +2669,7 @@ internal class IndentationRuleTest {
                 }
                 """.trimIndent()
             indentationRuleAssertThat(code)
-                .addAdditionalFormattingRule(WrappingRule())
+                .addAdditionalRules(WrappingRule())
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(6, 1, "Unexpected indent of multiline string closing quotes")
@@ -2730,7 +2730,7 @@ internal class IndentationRuleTest {
                 }
                 """.trimIndent()
             indentationRuleAssertThat(code)
-                .addAdditionalFormattingRule(WrappingRule())
+                .addAdditionalRules(WrappingRule())
                 .hasLintViolation(6, 1, "Unexpected indent of multiline string closing quotes")
                 .isFormattedAs(formattedCode)
         }
@@ -2900,7 +2900,7 @@ internal class IndentationRuleTest {
                 }
                 """.trimIndent()
             indentationRuleAssertThat(code)
-                .addAdditionalFormattingRule(WrappingRule())
+                .addAdditionalRules(WrappingRule())
                 .hasLintViolation(6, 1, "Unexpected indent of multiline string closing quotes")
                 .isFormattedAs(formattedCode)
         }
@@ -3718,6 +3718,34 @@ internal class IndentationRuleTest {
                 )
             """.trimIndent()
         indentationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Disabled("To be fixed as code as lambda with parameters on multiple line")
+    @Test
+    fun `Given a function with lambda parameters on multiple lines then align the parameters`() {
+        val code =
+            """
+            val fieldExample =
+                LongNameClass { paramA,
+                        paramB,
+                        paramC ->
+                    ClassB(paramA, paramB, paramC)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val fieldExample =
+                LongNameClass { paramA,
+                                paramB,
+                                paramC ->
+                    ClassB(paramA, paramB, paramC)
+                }
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 1, "Unexpected indentation (12) (should be 20)"),
+                LintViolation(4, 1, "Unexpected indentation (12) (should be 20)")
+            ).isFormattedAs(formattedCode)
     }
 
     private companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -11,13 +11,9 @@ class ParameterListWrappingRuleTest {
     private val parameterListWrappingRuleAssertThat =
         ParameterListWrappingRule()
             .assertThat(
-                additionalFormattingRules = listOf(
-                    // In case a parameter is wrapped to a separate line by the ParameterListWrappingRule() then its
-                    // indentation might still be incorrect until the IndentationRule has fixed it. Apply the
-                    // IndentationRule format after the ParameterListWrappingRule(), so that the formattedCode in the
-                    /* unit test looks correct. Note that the Lint Violations of the rule are suppressed!.*/
-                    IndentationRule()
-                )
+                // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                // correct.
+                IndentationRule()
             )
 
     @Test
@@ -182,13 +178,17 @@ class ParameterListWrappingRuleTest {
         val code =
             """
             val fieldExample =
-                  LongNameClass { paramA,
-                                  paramB,
-                                  paramC ->
-                      ClassB(paramA, paramB, paramC)
-                  }
+                LongNameClass { paramA,
+                                paramB,
+                                paramC ->
+                    ClassB(paramA, paramB, paramC)
+                }
             """.trimIndent()
-        parameterListWrappingRuleAssertThat(code).hasNoLintViolations()
+        val parameterListWrappingRuleWithoutIndentationRule = ParameterListWrappingRule().assertThat()
+        parameterListWrappingRuleWithoutIndentationRule(code).hasNoLintViolations()
+        // IndentationRule does alter the code while the code is accepted by the Default IDEA formatter. So statement
+        // below would fail!
+        // parameterListWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
     @Test
@@ -340,11 +340,11 @@ class ParameterListWrappingRuleTest {
         val code =
             """
             data class A(
-               /*
-                * comment
-                */
-               //
-               var v: String
+                /*
+                 * comment
+                 */
+                //
+                var v: String
             )
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code).hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRuleTest.kt
@@ -350,7 +350,7 @@ class StringTemplateRuleTest {
             }
             """.trimIndent()
         stringTemplateRuleAssertThat(code)
-            .addAdditionalFormattingRule(NoUnusedImportsRule())
+            .addAdditionalRules(NoUnusedImportsRule())
             .hasLintViolation(3, 21, "Redundant \"toString()\" call in string template")
             .isFormattedAs(formattedCode)
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
@@ -42,7 +42,7 @@ internal class WrappingRuleTest {
             """.trimIndent()
                 .replacePlaceholderWithStringTemplate()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 13, "Missing newline after \"(\""),
                 LintViolation(4, 6, "Missing newline before \")\"")
@@ -80,7 +80,7 @@ internal class WrappingRuleTest {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 13, "Missing newline after \"(\""),
                 LintViolation(3, 7, "Missing newline before \")\""),
@@ -124,7 +124,7 @@ internal class WrappingRuleTest {
             """.trimIndent()
                 .replacePlaceholderWithStringTemplate()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 10, "Missing newline after \"(\""),
                 LintViolation(8, 6, "Missing newline before \"\"\""),
@@ -158,7 +158,7 @@ internal class WrappingRuleTest {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 9, "Missing newline after \"(\""),
                 LintViolation(6, 30, "Missing newline before \")\"")
@@ -191,7 +191,7 @@ internal class WrappingRuleTest {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(2, 11, "Missing newline after \"(\""),
                 LintViolation(2, 49, "Missing newline after \",\""),
@@ -230,7 +230,7 @@ internal class WrappingRuleTest {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(1, 10, "Missing newline after \"(\""),
                 LintViolation(1, 33, "Missing newline after \",\""),
@@ -272,7 +272,7 @@ internal class WrappingRuleTest {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code)
-            .addAdditionalFormattingRule(IndentationRule())
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(6, 8, "Missing newline after \"(\""),
                 LintViolation(8, 8, "Missing newline before \")\"")

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -61,16 +61,10 @@ private fun List<Rule>.toRuleSets(): List<RuleSet> {
                 )
             )
         }
-    return listOfNotNull(
-        dumpAstRuleSet,
-        RuleSet(
-            // RuleSet id is always set to "standard" as this has the side effect that the ruleset id will
-            // be excluded from the ruleId in the LintError which makes the unit tests of the experimental
-            // rules easier to maintain as they will not contain the reference to the ruleset id.
-            "standard",
-            *toTypedArray()
-        )
-    )
+    return this
+        .groupBy { it.id.substringBefore(":", "standard") }
+        .map { (ruleSetId, rules) -> RuleSet(ruleSetId, *rules.toTypedArray()) }
+        .plus(listOfNotNull(dumpAstRuleSet))
 }
 
 /**
@@ -233,10 +227,7 @@ public fun List<Rule>.lint(
         experimentalParams,
         VisitorProvider(
             ruleSets = experimentalParams.ruleSets,
-            debug = experimentalParams.debug,
-            // When running unit tests, some VisitorModifiers have to be ignored. For example the RunAfterRule modifier
-            // should not be checked, if other that rule can only be tested together with the rule on which it depends.
-            isUnitTestContext = true
+            debug = experimentalParams.debug
         )
     )
     return res
@@ -399,10 +390,7 @@ public fun List<Rule>.format(
         experimentalParams,
         VisitorProvider(
             ruleSets = experimentalParams.ruleSets,
-            debug = experimentalParams.debug,
-            // When running unit tests, some VisitorModifiers have to be ignored. For example the RunAfterRule modifier
-            // should not be checked, if other that rule can only be tested together with the rule on which it depends.
-            isUnitTestContext = true
+            debug = experimentalParams.debug
         )
     )
 }


### PR DESCRIPTION
## Description

With KtLintAssertThat an AssertJ style `assertThat` is created for a specific rule. In addition to that rule, it is possible to run additional rules. In case the rule which is to be tested has defined a VisitorModifier which requires one or more additional rules to be loaded and to be enabled, it is mandatory that those rules are added to the unit test.

The goal is to execute the rules during unit tests in the same order as when running the CLI version of KtLint. During each unit test a dynamic RuleSet is being created for a limited set of rules (e.g. the rule for which the `assertThat` is created plus the additional rules specified in the unit tests). The rules in this minimized ruleSet are executed in the order as defined by the VisitorModifier as defined in the rules.

In order to achieve above, following is changed as well:
* Split naming policy of rule id and rule set id. The naming policy of the latter is not changed. The naming policy of the ruleId is changed so that the ruleSetId prefix can be specified optionally. If the ruleId is not prefixed with a ruleSetId then it is assumed to be equal to "standard". For all experimental rules, the ruleSetId has been added.
* Remove obsolete parameter "isUnitTestContext" from VisitorProvider
* As the VisitorModifiers are now also used and checked during unit tests, it is required to run the additional rules during the lint phase as well. Some code examples in tests in which the IndentationRule is added as additional rule are changed to comply with that rule.

Closes #1457

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
