### PR TITLE
Pre-commit don't runt ktlint if nothing changed

### DIFF
--- a/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # https://github.com/pinterest/ktlint pre-commit hook
-git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs ktlint --relative
+git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs --no-run-if-empty ktlint --relative
 if [ $? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
If no kotlin files has changed, then it shouldn't run ktlint. As in the case where you just edited a README for example

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue than provide a link to that issue. -->

This changes the pre-commit hook so that it only runs ktlint if any kotlin files have been changed.

Existing behavior will run ktlint on all files in the event that no kotlin files were present in the changed files. For example, if the commit only changes a README file.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added

