### PR TITLE
Bump Kotlin dev version to 1.7.0-RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Fix indentation of property getter/setter when the property has an initializer on a separate line `indent` ([#1335](https://github.com/pinterest/ktlint/issues/1335))
 
 ### Changed
-- Update Kotlin development version to `1.7.0-RC` and Kotlin version to `1.6.21`.
+- Update Kotlin development version to `1.7.0-RC2` and Kotlin version to `1.6.21`.
 - Update shadow plugin to `7.1.2` release
 - Update picocli to `4.6.3` release
 - Simplified rule `filename`. Only when the file contains a single class (including data class, enum class and sealed class) or a single interface, the file name should be identical to that class/interface. In all other cases the file name should be a descriptive name compliant with the PascalCase convention ([#1004](https://github.com/pinterest/ktlint/pull/1117))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 // Pass '-PkotlinDev' to command line to enable kotlin-in-development version
 val kotlinVersion = if (project.hasProperty("kotlinDev")) {
     logger.warn("Enabling kotlin dev version!")
-    "1.7.0-RC"
+    "1.7.0-RC2"
 } else {
     "1.6.21"
 }


### PR DESCRIPTION
## Description

https://github.com/JetBrains/kotlin/releases/tag/v1.7.0-RC2

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
