### PR TITLE
Fix crash when indentSize isn't set to an Int.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-### Bugfix on the indentSize to accept tab
-Return the tabWith on when the tabWith is set to a string.
-
 ### Promoting experimental rules to standard 
 
 The rules below are promoted from the `experimental` ruleset to the `standard` ruleset.
@@ -61,6 +58,9 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Fix formatting of a property delegate with a dot-qualified-expression `indent` ([#1340](https://github.com/pinterest/ktlint/ssues/1340))
 - Keep formatting of for-loop in sync with default IntelliJ formatter (`indent`) and a newline in the expression in a for-statement should not force to wrap it `wrapping` ([#1350](https://github.com/pinterest/ktlint/issues/1350))
 - Fix indentation of property getter/setter when the property has an initializer on a separate line `indent` ([#1335](https://github.com/pinterest/ktlint/issues/1335))
+- When `.editorconfig` setting `indentSize` is set to value `tab` then return the default tab width as value for `indentSize` ([#1485](https://github.com/pinterest/ktlint/issues/1485))
+
+
 
 ### Changed
 - Update Kotlin development version to `1.7.0-RC` and Kotlin version to `1.6.21`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Bugfix on the indentSize to accept tab
+Return the tabWith on when the tabWith is set to a string.
+
 ### Promoting experimental rules to standard 
 
 The rules below are promoted from the `experimental` ruleset to the `standard` ruleset.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -162,6 +162,7 @@ public object DefaultEditorConfigProperties {
                 when {
                     property == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
                     property.isUnset -> -1
+                    property.getValueAs<Int>() == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
                     else -> property.getValueAs()
                 }
             }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -160,8 +160,9 @@ public object DefaultEditorConfigProperties {
             defaultValue = IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth,
             propertyMapper = { property, _ ->
                 when {
-                    property?.getValueAs<Int>() == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
-                    property.isUnset -> -1
+                    property?.isUnset == true -> -1
+                    property?.getValueAs<Int>() == null ->
+                        IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
                     else -> property.getValueAs()
                 }
             }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -160,9 +160,8 @@ public object DefaultEditorConfigProperties {
             defaultValue = IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth,
             propertyMapper = { property, _ ->
                 when {
-                    property == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
+                    property?.getValueAs<Int>() == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
                     property.isUnset -> -1
-                    property.getValueAs<Int>() == null -> IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth
                     else -> property.getValueAs()
                 }
             }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
@@ -52,7 +52,7 @@ class UsesEditorConfigPropertiesTest {
     }
 
     @Test
-    fun `Given that editor config property indent_size is set to value 'tab' then return tabWidth as value via the getEditorConfigValue of the node`() {
+    fun `Issue 1485 - Given that editor config property indent_size is set to value 'tab' then return tabWidth as value via the getEditorConfigValue of the node`() {
         val testAstNode: ASTNode = DummyHolderElement("some-text")
         testAstNode.putUserData(
             KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
@@ -52,6 +52,21 @@ class UsesEditorConfigPropertiesTest {
     }
 
     @Test
+    fun `Given that editor config property indent_size is set to value 'tab' then return tabWidth as value via the getEditorConfigValue of the node`() {
+        val testAstNode: ASTNode = DummyHolderElement("some-text")
+        testAstNode.putUserData(
+            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
+            createPropertyWithValue(
+                DefaultEditorConfigProperties.indentSizeProperty,
+                "tab"
+            )
+        )
+        val actual = PropertyValueTester().testValue(testAstNode, DefaultEditorConfigProperties.indentSizeProperty)
+
+        assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
+    }
+
+    @Test
     fun `Given that editor config property indent_size is not set then return the default tabWidth as value via the getEditorConfigValue of the node`() {
         val testAstNode: ASTNode = DummyHolderElement("some-text")
         testAstNode.putUserData(


### PR DESCRIPTION
## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.
Check if getValueAs returns null.  This is the case when the indent size is set to anything else than an integer.  In my case,  it was set to tab,  which caused a NPE.

If the PR solves an issue than provide a link to that issue. -->
Fixes https://github.com/pinterest/ktlint/issues/1485.
## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
