### PR TITLE
Disable all rules or a list of specific rules in the entire file (#1029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Keep formatting of for-loop in sync with default IntelliJ formatter (`indent`) and a newline in the expression in a for-statement should not force to wrap it `wrapping` ([#1350](https://github.com/pinterest/ktlint/issues/1350))
 - Fix indentation of property getter/setter when the property has an initializer on a separate line `indent` ([#1335](https://github.com/pinterest/ktlint/issues/1335))
 - When `.editorconfig` setting `indentSize` is set to value `tab` then return the default tab width as value for `indentSize` ([#1485](https://github.com/pinterest/ktlint/issues/1485))
-
+- Allow suppressing all rules or a list of specific rules in the entire file with `@file:Suppress(...)`  ([#1029](https://github.com/pinterest/ktlint/issues/1029))
 
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -706,7 +706,13 @@ To suppress the violations of all ktlint rules, use:
 val foo = "some really looooooooooooooooong string exceeding the max line length"
 ```
 
-Like with other `@Suppress` annotations, it can be placed on targets supported by the annotation.
+Like with other `@Suppress` annotations, it can be placed on targets supported by the annotation. As of this it is possible to disable rules in the entire file with:
+```kotlin
+@file:Suppress("ktlint") // Suppressing all rules for the entire file
+// or
+@file:Suppress("ktlint:max-line-length","ktlint:experimental:trailing-comma") // Suppressing specific rules for the entire file
+```
+
 
 ### How do I globally disable a rule?
 See the [EditorConfig section](https://github.com/pinterest/ktlint#editorconfig) for details on how to use the `disabled_rules` property.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
@@ -26,7 +26,7 @@ internal object SuppressionLocatorBuilder {
         "RemoveCurlyBracesFromTemplate" to "string-template"
     )
     private val suppressAnnotations = setOf("Suppress", "SuppressWarnings")
-    private const val suppresAllKtlintRules = "ktlint-all"
+    private const val suppressAllKtlintRules = "ktlint-all"
 
     private val commentRegex = Regex("\\s")
 
@@ -40,21 +40,9 @@ internal object SuppressionLocatorBuilder {
         return if (hintsList.isEmpty()) {
             noSuppression
         } else { offset, ruleId, isRoot ->
-            if (isRoot) {
-                val h = hintsList[0]
-                h.range.last == 0 && (
-                    h.disabledRules.isEmpty() ||
-                        h.disabledRules.contains(ruleId)
-                    )
-            } else {
-                hintsList.any { hint ->
-                    (
-                        hint.disabledRules.isEmpty() ||
-                            hint.disabledRules.contains(ruleId)
-                        ) &&
-                        hint.range.contains(offset)
-                }
-            }
+            hintsList
+                .filter { offset in it.range }
+                .any { hint -> hint.disabledRules.isEmpty() || hint.disabledRules.contains(ruleId) }
         }
     }
 
@@ -166,7 +154,7 @@ internal object SuppressionLocatorBuilder {
             .let { suppressedRules ->
                 when {
                     suppressedRules.isEmpty() -> null
-                    suppressedRules.contains(suppresAllKtlintRules) ->
+                    suppressedRules.contains(suppressAllKtlintRules) ->
                         SuppressionHint(
                             IntRange(psi.startOffset, psi.endOffset),
                             emptySet()
@@ -187,7 +175,7 @@ internal object SuppressionLocatorBuilder {
                 when {
                     it == "ktlint" -> {
                         // Disable all rules
-                        suppresAllKtlintRules
+                        suppressAllKtlintRules
                     }
                     it.startsWith("ktlint:") -> {
                         // Disable specific rule

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilderTest.kt
@@ -154,7 +154,7 @@ class SuppressionLocatorBuilderTest {
     }
 
     @Test
-    private fun `Given that a NoFooIdentifierRule violation is suppressed with @Suppress for all rules at class level then do not find a violation for that rule in that class`() {
+    fun `Given that a NoFooIdentifierRule violation is suppressed with @Suppress for all rules at class level then do not find a violation for that rule in that class`() {
         val code =
             """
             @Suppress("ktlint")
@@ -165,6 +165,40 @@ class SuppressionLocatorBuilderTest {
 
                 val foo = "foo"
             }
+            """.trimIndent()
+        assertThat(lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `Given that the NoFooIdentifierRule is suppressed in the entire file with @file-colon-Suppress then do not find any NoFooIdentifierRule violation`() {
+        val code =
+            """
+            @file:Suppress("ktlint:no-foo-identifier-standard", "ktlint:custom:no-foo-identifier")
+
+            class Foo {
+                fun foo() {
+                    val fooNotReported = "foo"
+                }
+            }
+
+            val fooNotReported = "foo"
+            """.trimIndent()
+        assertThat(lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `Given that all rules are suppressed in the entire file with @file-colon-Suppress then do not find any violation`() {
+        val code =
+            """
+            @file:Suppress("ktlint")
+
+            class Foo {
+                fun foo() {
+                    val fooNotReported = "foo"
+                }
+            }
+
+            val fooNotReported = "foo"
             """.trimIndent()
         assertThat(lint(code)).isEmpty()
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
@@ -79,8 +79,8 @@ public class TrailingCommaRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            getEditorConfigValues(node)
-            return
+            allowTrailingComma = node.getEditorConfigValue(allowTrailingCommaProperty)
+            allowTrailingCommaOnCallSite = node.getEditorConfigValue(allowTrailingCommaOnCallSiteProperty)
         }
 
         // Keep processing of element types in sync with Intellij Kotlin formatting settings.
@@ -100,11 +100,6 @@ public class TrailingCommaRule :
             ElementType.VALUE_ARGUMENT_LIST -> visitValueList(node, emit, autoCorrect)
             else -> Unit
         }
-    }
-
-    private fun getEditorConfigValues(node: ASTNode) {
-        allowTrailingComma = node.getEditorConfigValue(allowTrailingCommaProperty)
-        allowTrailingCommaOnCallSite = node.getEditorConfigValue(allowTrailingCommaOnCallSiteProperty)
     }
 
     private fun visitCollectionLiteralExpression(


### PR DESCRIPTION
## Description

Add support to disable all rules in the entire file with:
```
@file:Suppress("ktlint")
```
or with a named list of rules:
```
@file:Suppress("ktlint:no-foo-identifier-standard", "ktlint:custom:no-foo-identifier")
```

Closes #1029 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [X] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
