### PR TITLE
Function signature body

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -22,6 +22,7 @@ import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
+import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
 import com.pinterest.ktlint.core.ast.nextCodeLeaf
 import com.pinterest.ktlint.core.ast.nextCodeSibling
@@ -161,6 +162,10 @@ public class FunctionSignatureRule :
                 node.hasMinimumNumberOfParameters()
             ) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
+                // Due to rewriting the function signature, the remaining length on the last line of the multiline
+                // signature needs to be recalculated
+                val lengthOfLastLine = recalculateRemainLengthForFirstLineOfBodyExpression(node)
+                fixFunctionBody(node, emit, autoCorrect, maxLineLength - lengthOfLastLine)
             } else {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
                 fixFunctionBody(node, emit, autoCorrect, maxLineLength - singleLineFunctionSignatureLength)
@@ -178,6 +183,22 @@ public class FunctionSignatureRule :
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
             }
         }
+    }
+
+    private fun recalculateRemainLengthForFirstLineOfBodyExpression(node: ASTNode): Int {
+        val closingParenthesis =
+            node
+                .findChildByType(VALUE_PARAMETER_LIST)
+                ?.findChildByType(RPAR)
+        val tailNodesOfFunctionSignature = node
+            .functionSignatureNodes()
+            .childrenBetween(
+                startASTNodePredicate = { it == closingParenthesis },
+                endASTNodePredicate = { false }
+            )
+
+        return node.lineIndent().length +
+            tailNodesOfFunctionSignature.sumOf { it.text.length }
     }
 
     private fun ASTNode.getFunctionSignatureLength() = lineIndent().length + getFunctionSignatureNodesLength()
@@ -452,74 +473,76 @@ public class FunctionSignatureRule :
         autoCorrect: Boolean,
         maxLengthRemainingForFirstLineOfBodyExpression: Int
     ) {
-        val leaves = node.collectLeavesRecursively()
-
-        val lastNodeOfFunctionSignatureWithBodyExpression =
-            node
-                .findChildByType(EQ)
-                ?.nextLeaf(includeEmpty = true)
-        leaves
-            .childrenBetween(
-                startASTNodePredicate = { it == lastNodeOfFunctionSignatureWithBodyExpression },
-                endASTNodePredicate = {
-                    // collect all remaining nodes
-                    false
-                }
-            ).takeIf { it.isNotEmpty() }
-            ?.fixFunctionBodyExpression(node, emit, autoCorrect, maxLengthRemainingForFirstLineOfBodyExpression)
-
-        val lastNodeOfFunctionSignatureWithBlockBody =
-            node
-                .getLastNodeOfFunctionSignatureWithBlockBody()
-                ?.nextLeaf(includeEmpty = true)
-        leaves
-            .childrenBetween(
-                startASTNodePredicate = { it == lastNodeOfFunctionSignatureWithBlockBody },
-                endASTNodePredicate = {
-                    // collect all remaining nodes
-                    false
-                }
-            ).takeIf { it.isNotEmpty() }
-            ?.fixFunctionBodyBlock(emit, autoCorrect)
+        if (node.findChildByType(EQ) == null) {
+            fixFunctionBodyBlock(node, emit, autoCorrect)
+        } else {
+            fixFunctionBodyExpression(node, emit, autoCorrect, maxLengthRemainingForFirstLineOfBodyExpression)
+        }
     }
 
-    private fun List<ASTNode>.fixFunctionBodyExpression(
+    private fun fixFunctionBodyExpression(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
         autoCorrect: Boolean,
         maxLengthRemainingForFirstLineOfBodyExpression: Int
     ) {
-        val (whiteSpaceBeforeFunctionBodyExpression, functionBodyExpression) =
-            this
-                .let {
-                    val whiteSpaceFirst =
-                        it.firstOrNull { first -> first.isWhiteSpace() }
-                    if (whiteSpaceFirst == null) {
-                        Pair(null, it)
-                    } else {
-                        Pair(
-                            it.firstOrNull { first -> first.isWhiteSpace() },
-                            it.drop(1)
-                        )
-                    }
-                }
+        val lastNodeOfFunctionSignatureWithBodyExpression =
+            node
+                .findChildByType(EQ)
+                ?.nextLeaf(includeEmpty = true)
+                ?: return
+        val bodyNodes = node.getFunctionBody(lastNodeOfFunctionSignatureWithBodyExpression)
+        val whiteSpaceBeforeFunctionBodyExpression = bodyNodes.getStartingWhitespaceOrNull()
+        val functionBodyExpressionNodes = bodyNodes.dropWhile { it.isWhiteSpace() }
 
-        val functionBodyExpressionLines =
-            functionBodyExpression
-                .joinTextToString()
-                .split("\n")
+        val functionBodyExpressionLines = functionBodyExpressionNodes
+            .joinTextToString()
+            .split("\n")
         functionBodyExpressionLines
             .firstOrNull()
             ?.also { firstLineOfBodyExpression ->
-                if (whiteSpaceBeforeFunctionBodyExpression == null ||
+                if (whiteSpaceBeforeFunctionBodyExpression.isWhiteSpaceWithNewline()) {
+                    if (functionBodyExpressionWrapping == default ||
+                        (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size == 1) ||
+                        node.isMultilineFunctionSignatureWithoutExplicitReturnType(lastNodeOfFunctionSignatureWithBodyExpression)
+                    ) {
+                        emit(
+                            whiteSpaceBeforeFunctionBodyExpression!!.startOffset,
+                            "First line of body expression fits on same line as function signature",
+                            true
+                        )
+                        if (autoCorrect) {
+                            (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                        }
+                    }
+                } else if (whiteSpaceBeforeFunctionBodyExpression == null ||
                     !whiteSpaceBeforeFunctionBodyExpression.textContains('\n')
                 ) {
-                    if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression ||
+                    if (node.isMultilineFunctionSignatureWithoutExplicitReturnType(lastNodeOfFunctionSignatureWithBodyExpression) &&
+                        firstLineOfBodyExpression.length + 1 <= maxLengthRemainingForFirstLineOfBodyExpression
+                    ) {
+                        if (whiteSpaceBeforeFunctionBodyExpression == null ||
+                            whiteSpaceBeforeFunctionBodyExpression.text != " "
+                        ) {
+                            emit(
+                                functionBodyExpressionNodes.first().startOffset,
+                                "Single whitespace expected before expression body",
+                                true
+                            )
+                            if (autoCorrect) {
+                                if (whiteSpaceBeforeFunctionBodyExpression != null) {
+                                    (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                                } else {
+                                    (functionBodyExpressionNodes.first() as LeafPsiElement).upsertWhitespaceBeforeMe(" ")
+                                }
+                            }
+                        }
+                    } else if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression ||
                         (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size > 1) ||
                         functionBodyExpressionWrapping == always
                     ) {
                         emit(
-                            functionBodyExpression.first().startOffset,
+                            functionBodyExpressionNodes.first().startOffset,
                             "Newline expected before expression body",
                             true
                         )
@@ -528,37 +551,40 @@ public class FunctionSignatureRule :
                             if (whiteSpaceBeforeFunctionBodyExpression != null) {
                                 (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(newLineAndIndent)
                             } else {
-                                (functionBodyExpression.first() as LeafPsiElement).upsertWhitespaceBeforeMe(newLineAndIndent)
+                                (functionBodyExpressionNodes.first() as LeafPsiElement).upsertWhitespaceBeforeMe(newLineAndIndent)
                             }
-                        }
-                    }
-                } else if (whiteSpaceBeforeFunctionBodyExpression.textContains('\n')) {
-                    if (functionBodyExpressionWrapping == default ||
-                        (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size == 1)
-                    ) {
-                        emit(
-                            whiteSpaceBeforeFunctionBodyExpression.startOffset,
-                            "First line of body expression fits on same line as function signature",
-                            true
-                        )
-                        if (autoCorrect) {
-                            (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
                         }
                     }
                 }
             }
     }
 
-    private fun List<ASTNode>.fixFunctionBodyBlock(
+    private fun ASTNode.isMultilineFunctionSignatureWithoutExplicitReturnType(
+        lastNodeOfFunctionSignatureWithBodyExpression: ASTNode?
+    ) = functionSignatureNodes()
+        .childrenBetween(
+            startASTNodePredicate = { true },
+            endASTNodePredicate = { it == lastNodeOfFunctionSignatureWithBodyExpression }
+        ).joinToString(separator = "") { it.text }
+        .split("\n")
+        .lastOrNull()
+        ?.matches(Regex("\\s*\\) ="))
+        ?: false
+
+    private fun fixFunctionBodyBlock(
+        node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
         autoCorrect: Boolean
     ) {
-        val (whiteSpaceBeforeFunctionBodyExpression, functionBodyBlock) =
-            this
-                .firstOrNull()
-                ?.takeIf { first -> first.isWhiteSpace() }
-                ?.let { Pair(it, this.drop(1)) }
-                ?: Pair(null, this)
+        val lastNodeOfFunctionSignatureWithBlockBody =
+            node
+                .getLastNodeOfFunctionSignatureWithBlockBody()
+                ?.nextLeaf(includeEmpty = true)
+                ?: return
+
+        val bodyNodes = node.getFunctionBody(lastNodeOfFunctionSignatureWithBlockBody)
+        val whiteSpaceBeforeFunctionBodyExpression = bodyNodes.getStartingWhitespaceOrNull()
+        val functionBodyBlock = bodyNodes.dropWhile { it.isWhiteSpace() }
 
         functionBodyBlock
             .joinTextToString()
@@ -578,6 +604,25 @@ public class FunctionSignatureRule :
                 }
             }
     }
+
+    private fun ASTNode.getFunctionBody(splitNode: ASTNode?): List<ASTNode> =
+        this
+            .collectLeavesRecursively()
+            .childrenBetween(
+                startASTNodePredicate = { it == splitNode },
+                endASTNodePredicate = {
+                    // collect all remaining nodes
+                    false
+                }
+            )
+
+    private fun List<ASTNode>.getStartingWhitespaceOrNull() =
+        this
+            .firstOrNull()
+            ?.takeIf { first -> first.isWhiteSpace() }
+
+    private fun List<ASTNode>.getBody() =
+        this.dropWhile { it.isWhiteSpace() }
 
     private fun isMaxLineLengthSet() = maxLineLength > -1
 

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -568,7 +568,7 @@ public class FunctionSignatureRule :
         ).joinToString(separator = "") { it.text }
         .split("\n")
         .lastOrNull()
-        ?.matches(Regex("\\s*\\) ="))
+        ?.matches(INDENT_WITH_CLOSING_PARENTHESIS)
         ?: false
 
     private fun fixFunctionBodyBlock(
@@ -709,6 +709,8 @@ public class FunctionSignatureRule :
                 ),
                 defaultValue = default
             )
+
+        private val INDENT_WITH_CLOSING_PARENTHESIS = Regex("\\s*\\) =")
     }
 
     /**

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 public class FunctionSignatureRule :
     Rule(
-        id = "function-signature",
+        id = "$experimentalRulesetId:function-signature",
         visitorModifiers = setOf(
             // Run after wrapping and spacing rules
             VisitorModifier.RunAsLateAsPossible

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -284,7 +284,7 @@ public class FunctionSignatureRule :
                         }
                         if (autoCorrect && !dryRun) {
                             if (whiteSpaceBeforeIdentifier == null) {
-                                (firstChildOfParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                (valueParameterList.firstChildNode as LeafElement).upsertWhitespaceAfterMe(expectedParameterIndent)
                             } else {
                                 (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(
                                     expectedParameterIndent
@@ -684,7 +684,7 @@ public class FunctionSignatureRule :
         multiline,
 
         /**
-         * Force the body expression to start on a separate line always.
+         * Always force the body expression to start on a separate line.
          */
         always;
     }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -165,6 +165,32 @@ class FunctionSignatureRuleTest {
     }
 
     @Test
+    fun `Given a single line function signature and first parameter is annotated and function signature has a length greater than the max line length then reformat to multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(@Foo a: Any, b: Any, c: Any): String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(
+                @Foo a: Any,
+                b: Any,
+                c: Any
+            ): String = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 20, "Parameter should start on a newline"),
+                LintViolation(2, 28, "Parameter should start on a newline"),
+                LintViolation(2, 34, "Newline expected before closing parenthesis")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given some function signatures containing at least one comment then do not reformat although the max line length is exceeded`() {
         val code =
             """

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -412,11 +412,7 @@ class FunctionSignatureRuleTest {
                 LintViolation(6, 9, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(7, 9, "Single whitespace expected before parameter"),
                 LintViolation(8, 9, "Single whitespace expected before parameter"),
-                LintViolation(
-                    8,
-                    15,
-                    "No whitespace expected between last parameter and closing parenthesis"
-                ),
+                LintViolation(8, 15, "No whitespace expected between last parameter and closing parenthesis"),
                 LintViolation(9, 9, "Newline expected before expression body")
             ).isFormattedAs(formattedCode)
     }
@@ -866,6 +862,63 @@ class FunctionSignatureRuleTest {
                     LintViolation(4, 11, "No whitespace expected between last parameter and closing parenthesis")
                 ).isFormattedAs(formattedCode)
         }
+    }
+
+    @ParameterizedTest(name = "bodyExpressionWrapping: {0}")
+    @EnumSource(
+        value = FunctionSignatureRule.FunctionBodyExpressionWrapping::class
+    )
+    fun `Given a multiline function signature without explicit return type and start of body expression on next line then keep first line of body expression body on the same line as the last line og the function signature`(
+        bodyExpressionWrapping: FunctionSignatureRule.FunctionBodyExpressionWrapping
+    ) {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) =
+                "some-result"
+                    .uppercase()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) = "some-result"
+                .uppercase()
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .withEditorConfigOverride(functionBodyExpressionWrappingProperty to bodyExpressionWrapping)
+            .addAdditionalRules(IndentationRule())
+            .hasLintViolation(5, 4, "First line of body expression fits on same line as function signature")
+            .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "bodyExpressionWrapping: {0}")
+    @EnumSource(
+        value = FunctionSignatureRule.FunctionBodyExpressionWrapping::class
+    )
+    fun `Given a multiline function signature without explicit return type and start of body expression on same line as last line of function signature then do not reformat`(
+        bodyExpressionWrapping: FunctionSignatureRule.FunctionBodyExpressionWrapping
+    ) {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) = "some-result"
+                .uppercase()
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .withEditorConfigOverride(functionBodyExpressionWrappingProperty to bodyExpressionWrapping)
+            .addAdditionalRules(IndentationRule())
+            .hasNoLintViolations()
     }
 
     private companion object {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -368,7 +368,7 @@ internal class KtlintCommandLine {
                     }
                 }
             } catch (e: Exception) {
-                result.add(LintErrorWithCorrectionInfo(e.toLintError(), false))
+                result.add(LintErrorWithCorrectionInfo(e.toLintError(fileName), false))
                 tripped.set(true)
                 fileContent // making sure `cat file | ktlint --stdint > file` is (relatively) safe
             }
@@ -395,7 +395,7 @@ internal class KtlintCommandLine {
                     }
                 }
             } catch (e: Exception) {
-                result.add(LintErrorWithCorrectionInfo(e.toLintError(), false))
+                result.add(LintErrorWithCorrectionInfo(e.toLintError(fileName), false))
                 tripped.set(true)
             }
         }
@@ -465,7 +465,7 @@ internal class KtlintCommandLine {
             }
     }
 
-    private fun Exception.toLintError(): LintError = this.let { e ->
+    private fun Exception.toLintError(filename: Any?): LintError = this.let { e ->
         when (e) {
             is ParseException ->
                 LintError(
@@ -475,12 +475,12 @@ internal class KtlintCommandLine {
                     "Not a valid Kotlin file (${e.message?.lowercase(Locale.getDefault())})"
                 )
             is RuleExecutionException -> {
-                logger.debug("Internal Error (${e.ruleId})", e)
+                logger.debug("Internal Error (${e.ruleId}) in file '$filename' at position '${e.line}:${e.col}", e)
                 LintError(
                     e.line,
                     e.col,
                     "",
-                    "Internal Error (${e.ruleId}). " +
+                    "Internal Error (${e.ruleId}) in file '$filename' at position '${e.line}:${e.col}. " +
                         "Please create a ticket at https://github.com/pinterest/ktlint/issues " +
                         "(if possible, please re-run with the --debug flag to get the stacktrace " +
                         "and provide the source code that triggered an error)"


### PR DESCRIPTION
## Description

By default the function signature rule kept the first line of a body expression on the same line as the function signature if the maximum line length is not exceeded (per Kotlin styleguide). This is very readable for multine function signature in which the return type has a short name or is omitted:
```
//                                                                             assume max line lenght is here ->
fun aVeryLoooooooooooooooooooooooongFunctionName(
     // some parameters causing the function signature to long for single line
) = listOf(foo())
     .filter { ... }
```

But in other case this can also result in more difficult to read code:
```
fun aVeryLoooooooooooooooooooooooongFunctionName() = listOf(foo())
     .filter { ... }
```

The `.editorconfig` parameter `ktlint_function_signature_body_expression_wrapping` can be used to determine how the expression body should be wrapped:
* default: Keep the first line of the body expression on the same line as the function signature if max line length is not exceeded.
* multiline: Force the body expression to start on a separate line in case it is a multiline expression. A single line body expression is wrapped only when it does not fit on the same line as the function signature.
* always: Always force the body expression to start on a separate line.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
