### PR TITLE
Reformat to a multiline function signature fixes

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -20,12 +20,14 @@ import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.isLeaf
 import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.lineIndent
 import com.pinterest.ktlint.core.ast.nextCodeLeaf
 import com.pinterest.ktlint.core.ast.nextCodeSibling
 import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.nextSibling
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.prevSibling
@@ -35,6 +37,8 @@ import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 public class FunctionSignatureRule :
@@ -143,16 +147,13 @@ public class FunctionSignatureRule :
     ) {
         require(node.elementType == FUN)
 
+        val forceMultilineSignature =
+            node.hasMinimumNumberOfParameters() ||
+                node.containsParameterPrecededByAnnotationOnSeparateLine()
         if (isMaxLineLengthSet()) {
-            val actualFunctionSignatureLength = node.getFunctionSignatureLength()
-
-            // Calculate the length of the function signature in case it would be rewritten as single line (and without a
-            // maximum line length). The white space correction will be calculated via a dry run of the actual fix.
-            val singleLineFunctionSignatureLength =
-                actualFunctionSignatureLength +
-                    // Calculate the white space correction in case the signature would be rewritten to a single line
-                    fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = true)
-            if (singleLineFunctionSignatureLength > maxLineLength ||
+            val singleLineFunctionSignatureLength = calculateFunctionSignatureLengthAsSingleLineSignature(node, emit, autoCorrect)
+            if (forceMultilineSignature ||
+                singleLineFunctionSignatureLength > maxLineLength ||
                 node.hasMinimumNumberOfParameters()
             ) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
@@ -167,12 +168,36 @@ public class FunctionSignatureRule :
             val rewriteToSingleLineFunctionSignature = node
                 .functionSignatureNodes()
                 .none { it.textContains('\n') }
-            if (rewriteToSingleLineFunctionSignature) {
+            if (!forceMultilineSignature && rewriteToSingleLineFunctionSignature) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
             } else {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
             }
         }
+    }
+
+    private fun ASTNode.containsParameterPrecededByAnnotationOnSeparateLine(): Boolean =
+        findChildByType(VALUE_PARAMETER_LIST)
+            ?.children()
+            .orEmpty()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .mapNotNull {
+                // If the value parameter contains a modifier then this list is followed by a white space
+                it.findChildByType(MODIFIER_LIST)?.nextSibling { true }
+            }.any { it.textContains('\n') }
+
+    private fun calculateFunctionSignatureLengthAsSingleLineSignature(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ): Int {
+        val actualFunctionSignatureLength = node.getFunctionSignatureLength()
+
+        // Calculate the length of the function signature in case it would be rewritten as single line (and without a
+        // maximum line length). The white space correction will be calculated via a dry run of the actual fix.
+        return actualFunctionSignatureLength +
+            // Calculate the white space correction in case the signature would be rewritten to a single line
+            fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = true)
     }
 
     private fun ASTNode.getFunctionSignatureLength() = lineIndent().length + getFunctionSignatureNodesLength()
@@ -260,8 +285,8 @@ public class FunctionSignatureRule :
                 .children()
                 .first { it.elementType == VALUE_PARAMETER }
 
-        val firstChildOfParameter = firstParameterInList.firstChildNode
-        firstChildOfParameter
+        val firstParameter = firstParameterInList.firstChildNode
+        firstParameter
             ?.prevLeaf()
             ?.takeIf { it.elementType == WHITE_SPACE }
             .let { whiteSpaceBeforeIdentifier ->
@@ -279,7 +304,13 @@ public class FunctionSignatureRule :
                         }
                         if (autoCorrect && !dryRun) {
                             if (whiteSpaceBeforeIdentifier == null) {
-                                (firstChildOfParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                if (firstParameter.isLeaf()) {
+                                    (firstParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                } else {
+                                    (firstParameter.firstChildNode as TreeElement).rawInsertBeforeMe(
+                                        PsiWhiteSpaceImpl(expectedParameterIndent)
+                                    )
+                                }
                             } else {
                                 (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(
                                     expectedParameterIndent
@@ -293,7 +324,7 @@ public class FunctionSignatureRule :
                     if (whiteSpaceBeforeIdentifier != null) {
                         if (!dryRun) {
                             emit(
-                                firstChildOfParameter!!.startOffset,
+                                firstParameter!!.startOffset,
                                 "No whitespace expected between opening parenthesis and first parameter name",
                                 true
                             )


### PR DESCRIPTION
## Description

* Reformat to a multiline function signature when at least one parameter annotation is not on the same line as the parameter identifier.

* Reformat a single line function signature which fits on a single line in case the function has too many parameters

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
