### PR TITLE
Ensure that rules in non-standard rulesets are prefixed with the rulesetId

### DIFF
--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 public class FunctionSignatureRule :
     Rule(
-        id = "function-signature",
+        id = "$experimentalRulesetId:function-signature",
         visitorModifiers = setOf(
             // Run after wrapping and spacing rules
             VisitorModifier.RunAsLateAsPossible

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -31,7 +31,11 @@ import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.prevSibling
 import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.core.ast.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.experimental.FunctionSignatureRule.FunctionBodyExpressionWrapping.always
+import com.pinterest.ktlint.ruleset.experimental.FunctionSignatureRule.FunctionBodyExpressionWrapping.default
+import com.pinterest.ktlint.ruleset.experimental.FunctionSignatureRule.FunctionBodyExpressionWrapping.multiline
 import org.ec4j.core.model.PropertyType
+import org.ec4j.core.model.PropertyType.PropertyValueParser.EnumValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -51,12 +55,14 @@ public class FunctionSignatureRule :
             indentSizeProperty,
             indentStyleProperty,
             maxLineLengthProperty,
-            functionSignatureWrappingMinimumParametersProperty
+            forceMultilineWhenParameterCountGreaterOrEqualThanProperty,
+            functionBodyExpressionWrappingProperty
         )
 
     private var indent: String? = null
     private var maxLineLength = -1
     private var functionSignatureWrappingMinimumParameters = -1
+    private var functionBodyExpressionWrapping = default
 
     override fun visit(
         node: ASTNode,
@@ -64,9 +70,8 @@ public class FunctionSignatureRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
-            functionSignatureWrappingMinimumParameters = node.getEditorConfigValue(
-                functionSignatureWrappingMinimumParametersProperty
-            )
+            functionSignatureWrappingMinimumParameters = node.getEditorConfigValue(forceMultilineWhenParameterCountGreaterOrEqualThanProperty)
+            functionBodyExpressionWrapping = node.getEditorConfigValue(functionBodyExpressionWrappingProperty)
             val indentConfig = IndentConfig(
                 indentStyle = node.getEditorConfigValue(indentStyleProperty),
                 tabWidth = node.getEditorConfigValue(indentSizeProperty)
@@ -499,14 +504,19 @@ public class FunctionSignatureRule :
                     }
                 }
 
-        functionBodyExpression
-            .joinTextToString()
-            .split("\n")
+        val functionBodyExpressionLines =
+            functionBodyExpression
+                .joinTextToString()
+                .split("\n")
+        functionBodyExpressionLines
             .firstOrNull()
             ?.also { firstLineOfBodyExpression ->
-                if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression) {
-                    if (whiteSpaceBeforeFunctionBodyExpression == null ||
-                        !whiteSpaceBeforeFunctionBodyExpression.textContains('\n')
+                if (whiteSpaceBeforeFunctionBodyExpression == null ||
+                    !whiteSpaceBeforeFunctionBodyExpression.textContains('\n')
+                ) {
+                    if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression ||
+                        (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size > 1) ||
+                        functionBodyExpressionWrapping == always
                     ) {
                         emit(
                             functionBodyExpression.first().startOffset,
@@ -522,14 +532,18 @@ public class FunctionSignatureRule :
                             }
                         }
                     }
-                } else if (whiteSpaceBeforeFunctionBodyExpression?.textContains('\n') == true) {
-                    emit(
-                        whiteSpaceBeforeFunctionBodyExpression.startOffset,
-                        "First line of body expression fits on same line as function signature",
-                        true
-                    )
-                    if (autoCorrect) {
-                        (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                } else if (whiteSpaceBeforeFunctionBodyExpression.textContains('\n')) {
+                    if (functionBodyExpressionWrapping == default ||
+                        (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size == 1)
+                    ) {
+                        emit(
+                            whiteSpaceBeforeFunctionBodyExpression.startOffset,
+                            "First line of body expression fits on same line as function signature",
+                            true
+                        )
+                        if (autoCorrect) {
+                            (whiteSpaceBeforeFunctionBodyExpression as LeafPsiElement).rawReplaceWithText(" ")
+                        }
                     }
                 }
             }
@@ -624,14 +638,10 @@ public class FunctionSignatureRule :
             ?.prevCodeLeaf()
 
     public companion object {
-        @Suppress("MemberVisibilityCanBePrivate")
-        public const val KTLINT_FUNCTION_SIGNATURE_RULE_FORCE_MULTILINE_WITH_AT_LEAST_PARAMETERS: String =
-            "ktlint_function_signature_rule_force_multiline_with_at_least_parameters"
-
-        public val functionSignatureWrappingMinimumParametersProperty: UsesEditorConfigProperties.EditorConfigProperty<Int> =
+        public val forceMultilineWhenParameterCountGreaterOrEqualThanProperty: UsesEditorConfigProperties.EditorConfigProperty<Int> =
             UsesEditorConfigProperties.EditorConfigProperty(
                 type = PropertyType.LowerCasingPropertyType(
-                    KTLINT_FUNCTION_SIGNATURE_RULE_FORCE_MULTILINE_WITH_AT_LEAST_PARAMETERS,
+                    "ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than",
                     "Force wrapping the parameters of the function signature in case it contains at least the specified " +
                         "number of parameters even in case the entire function signature would fit on a single line. " +
                         "By default this parameter is not enabled.",
@@ -640,5 +650,42 @@ public class FunctionSignatureRule :
                 ),
                 defaultValue = -1
             )
+
+        public val functionBodyExpressionWrappingProperty: UsesEditorConfigProperties.EditorConfigProperty<FunctionBodyExpressionWrapping> =
+            UsesEditorConfigProperties.EditorConfigProperty(
+                type = PropertyType.LowerCasingPropertyType(
+                    "ktlint_function_signature_body_expression_wrapping",
+                    "Determines how to wrap the body of function in case it is an expression. Use 'default' " +
+                        "to wrap the body expression only when the first line of the expression does not fit on the same " +
+                        "line as the function signature. Use 'multiline' to force wrapping of body expressions that " +
+                        "consists of multiple line. Use 'always' to force wrapping of body expression always.",
+                    EnumValueParser(FunctionBodyExpressionWrapping::class.java),
+                    FunctionBodyExpressionWrapping.values().map { it.name }.toSet()
+                ),
+                defaultValue = default
+            )
+    }
+
+    /**
+     * Code style to be used while linting and formatting. Note that the [EnumValueParser] requires values to be lowercase.
+     */
+    @Suppress("EnumEntryName", "ktlint:enum-entry-name-case")
+    public enum class FunctionBodyExpressionWrapping {
+        /**
+         * Keep the first line of the body expression on the same line as the function signature if max line length is
+         * not exceeded.
+         */
+        default,
+
+        /**
+         * Force the body expression to start on a separate line in case it is a multiline expression. A single line
+         * body expression is wrapped only when it does not fit on the same line as the function signature.
+         */
+        multiline,
+
+        /**
+         * Force the body expression to start on a separate line always.
+         */
+        always;
     }
 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -284,7 +284,7 @@ public class FunctionSignatureRule :
                         }
                         if (autoCorrect && !dryRun) {
                             if (whiteSpaceBeforeIdentifier == null) {
-                                (firstChildOfParameter as LeafElement).upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                (valueParameterList.firstChildNode as LeafElement).upsertWhitespaceAfterMe(expectedParameterIndent)
                             } else {
                                 (whiteSpaceBeforeIdentifier as LeafElement).rawReplaceWithText(
                                     expectedParameterIndent
@@ -684,7 +684,7 @@ public class FunctionSignatureRule :
         multiline,
 
         /**
-         * Force the body expression to start on a separate line always.
+         * Always force the body expression to start on a separate line.
          */
         always;
     }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -165,6 +165,32 @@ class FunctionSignatureRuleTest {
     }
 
     @Test
+    fun `Given a single line function signature and first parameter is annotated and function signature has a length greater than the max line length then reformat to multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(@Foo a: Any, b: Any, c: Any): String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun f(
+                @Foo a: Any,
+                b: Any,
+                c: Any
+            ): String = "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 20, "Parameter should start on a newline"),
+                LintViolation(2, 28, "Parameter should start on a newline"),
+                LintViolation(2, 34, "Newline expected before closing parenthesis")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given some function signatures containing at least one comment then do not reformat although the max line length is exceeded`() {
         val code =
             """

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -412,11 +412,7 @@ class FunctionSignatureRuleTest {
                 LintViolation(6, 9, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(7, 9, "Single whitespace expected before parameter"),
                 LintViolation(8, 9, "Single whitespace expected before parameter"),
-                LintViolation(
-                    8,
-                    15,
-                    "No whitespace expected between last parameter and closing parenthesis"
-                ),
+                LintViolation(8, 15, "No whitespace expected between last parameter and closing parenthesis"),
                 LintViolation(9, 9, "Newline expected before expression body")
             ).isFormattedAs(formattedCode)
     }
@@ -866,6 +862,63 @@ class FunctionSignatureRuleTest {
                     LintViolation(4, 11, "No whitespace expected between last parameter and closing parenthesis")
                 ).isFormattedAs(formattedCode)
         }
+    }
+
+    @ParameterizedTest(name = "bodyExpressionWrapping: {0}")
+    @EnumSource(
+        value = FunctionSignatureRule.FunctionBodyExpressionWrapping::class
+    )
+    fun `Given a multiline function signature without explicit return type and start of body expression on next line then keep first line of body expression body on the same line as the last line og the function signature`(
+        bodyExpressionWrapping: FunctionSignatureRule.FunctionBodyExpressionWrapping
+    ) {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) =
+                "some-result"
+                    .uppercase()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) = "some-result"
+                .uppercase()
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .withEditorConfigOverride(functionBodyExpressionWrappingProperty to bodyExpressionWrapping)
+            .addAdditionalRules(IndentationRule())
+            .hasLintViolation(5, 4, "First line of body expression fits on same line as function signature")
+            .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "bodyExpressionWrapping: {0}")
+    @EnumSource(
+        value = FunctionSignatureRule.FunctionBodyExpressionWrapping::class
+    )
+    fun `Given a multiline function signature without explicit return type and start of body expression on same line as last line of function signature then do not reformat`(
+        bodyExpressionWrapping: FunctionSignatureRule.FunctionBodyExpressionWrapping
+    ) {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            fun functionSignatureTooLongForSingleLine(
+                a: Any,
+                b: Any
+            ) = "some-result"
+                .uppercase()
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .withEditorConfigOverride(functionBodyExpressionWrappingProperty to bodyExpressionWrapping)
+            .addAdditionalRules(IndentationRule())
+            .hasNoLintViolations()
     }
 
     private companion object {

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -368,7 +368,7 @@ internal class KtlintCommandLine {
                     }
                 }
             } catch (e: Exception) {
-                result.add(LintErrorWithCorrectionInfo(e.toLintError(), false))
+                result.add(LintErrorWithCorrectionInfo(e.toLintError(fileName), false))
                 tripped.set(true)
                 fileContent // making sure `cat file | ktlint --stdint > file` is (relatively) safe
             }
@@ -395,7 +395,7 @@ internal class KtlintCommandLine {
                     }
                 }
             } catch (e: Exception) {
-                result.add(LintErrorWithCorrectionInfo(e.toLintError(), false))
+                result.add(LintErrorWithCorrectionInfo(e.toLintError(fileName), false))
                 tripped.set(true)
             }
         }
@@ -465,7 +465,7 @@ internal class KtlintCommandLine {
             }
     }
 
-    private fun Exception.toLintError(): LintError = this.let { e ->
+    private fun Exception.toLintError(filename: Any?): LintError = this.let { e ->
         when (e) {
             is ParseException ->
                 LintError(
@@ -475,12 +475,12 @@ internal class KtlintCommandLine {
                     "Not a valid Kotlin file (${e.message?.lowercase(Locale.getDefault())})"
                 )
             is RuleExecutionException -> {
-                logger.debug("Internal Error (${e.ruleId})", e)
+                logger.debug("Internal Error (${e.ruleId}) in file '$filename' at position '${e.line}:${e.col}", e)
                 LintError(
                     e.line,
                     e.col,
                     "",
-                    "Internal Error (${e.ruleId}). " +
+                    "Internal Error (${e.ruleId}) in file '$filename' at position '${e.line}:${e.col}. " +
                         "Please create a ticket at https://github.com/pinterest/ktlint/issues " +
                         "(if possible, please re-run with the --debug flag to get the stacktrace " +
                         "and provide the source code that triggered an error)"


### PR DESCRIPTION
## Description

Ensure that rules in non-standard rulesets are prefixed with the rulesetId

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
