### PR TITLE
Filename should not be restricted to top level class declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Update Kotlin development version to `1.7.0` and Kotlin version to `1.7.0`.
 - Update shadow plugin to `7.1.2` release
 - Update picocli to `4.6.3` release
-- Simplified rule `filename`. Only when the file contains a single class (including data class, enum class and sealed class) or a single interface, the file name should be identical to that class/interface. In all other cases the file name should be a descriptive name compliant with the PascalCase convention ([#1004](https://github.com/pinterest/ktlint/pull/1117))
+- A file containing only one (non private) top level declaration (class, interface, object or type alias) must be named after that declaration. The name also must comply with the Pascal Case convention. The same applies to a file containing one single top level class declaration and one ore more extension functions for that class. `filename` ([#1004](https://github.com/pinterest/ktlint/pull/1117))
 - Promote experimental rules to standard rules set: `annotation`, `annotation-spacing`, `argument-list-wrapping`, `double-colon-spacing`, `enum-entry-name-case`, `multiline-if-else`, `no-empty-first-line-in-method-block`, `package-name`, `traling-comma`, `spacing-around-angle-brackets`, `spacing-between-declarations-with-annotations`, `spacing-between-declarations-with-comments`, `unary-op-spacing` ([#1481](https://github.com/pinterest/ktlint/pull/1481))
 - The CLI parameter `--android` can be omitted when the `.editorconfig` property `ktlint_code_style = android` is defined
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ An AssertJ style API for testing KtLint rules ([#1444](https://github.com/pinter
 - Update Kotlin development version to `1.7.0` and Kotlin version to `1.7.0`.
 - Update shadow plugin to `7.1.2` release
 - Update picocli to `4.6.3` release
-- A file containing only one (non private) top level declaration (class, interface, object or type alias) must be named after that declaration. The name also must comply with the Pascal Case convention. The same applies to a file containing one single top level class declaration and one ore more extension functions for that class. `filename` ([#1004](https://github.com/pinterest/ktlint/pull/1117))
+- A file containing only one (non private) top level declaration (class, interface, object, type alias or function) must be named after that declaration. The name also must comply with the Pascal Case convention. The same applies to a file containing one single top level class declaration and one ore more extension functions for that class. `filename` ([#1004](https://github.com/pinterest/ktlint/pull/1117))
 - Promote experimental rules to standard rules set: `annotation`, `annotation-spacing`, `argument-list-wrapping`, `double-colon-spacing`, `enum-entry-name-case`, `multiline-if-else`, `no-empty-first-line-in-method-block`, `package-name`, `traling-comma`, `spacing-around-angle-brackets`, `spacing-between-declarations-with-annotations`, `spacing-between-declarations-with-comments`, `unary-op-spacing` ([#1481](https://github.com/pinterest/ktlint/pull/1481))
 - The CLI parameter `--android` can be omitted when the `.editorconfig` property `ktlint_code_style = android` is defined
  

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -78,7 +78,10 @@ public class FilenameRule : Rule(
             val topLevelDeclarations = node.topLevelDeclarations()
             if (topLevelDeclarations.size == 1) {
                 val topLevelDeclaration = topLevelDeclarations.first()
-                if (topLevelDeclaration.elementType == OBJECT_DECLARATION || topLevelDeclaration.elementType == TYPEALIAS) {
+                if (topLevelDeclaration.elementType == OBJECT_DECLARATION ||
+                    topLevelDeclaration.elementType == TYPEALIAS ||
+                    topLevelDeclaration.elementType == FUN
+                ) {
                     val pascalCaseIdentifier =
                         topLevelDeclaration
                             .identifier

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -3,10 +3,18 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.ast.ElementType.CLASS
+import com.pinterest.ktlint.core.ast.ElementType.FUN
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
+import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.OBJECT_DECLARATION
+import com.pinterest.ktlint.core.ast.ElementType.PROPERTY
+import com.pinterest.ktlint.core.ast.ElementType.TYPEALIAS
+import com.pinterest.ktlint.core.ast.ElementType.TYPE_REFERENCE
+import com.pinterest.ktlint.core.ast.children
 import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 
 /**
  * [Kotlin lang documentation](https://kotlinlang.org/docs/coding-conventions.html#source-file-names):
@@ -19,9 +27,17 @@ import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
  * According to issue https://youtrack.jetbrains.com/issue/KTIJ-21897/Kotlin-coding-convention-file-naming-for-class,
  * "class" above should be read as any type of class (data class, enum class, sealed class) and interfaces.
  *
+ * A strict implementation of guideline above had unwanted consequences:
+ *   - If the file contains a single top level private class, it does not make sense to force the name of file to be
+ *     identical to that class.
+ *   - If the file contains a coherent set of functions and one of those function returns an instance of a public class
+ *     which happens to be the only top level class in that file, it might not always be best to force the file to be
+ *     named after that class.
+ *   - Existing functionality regarding files containing a single top level object/typealias was lost.
+ *
  * Exceptions to this rule:
- * * file without `.kt` extension
- * * file with name `package.kt`
+ * - file without `.kt` extension
+ * - file with name `package.kt`
  */
 public class FilenameRule : Rule(
     id = "filename",
@@ -48,27 +64,60 @@ public class FilenameRule : Rule(
             return
         }
 
-        val topLevelClassNames = topLevelClassNames(node)
-        if (topLevelClassNames.size == 1) {
-            // If the file only contains one top level class, then its filename should be identical to the class name
-            fileName.shouldMatchClassName(topLevelClassNames.first(), emit)
+        val topLevelClassDeclarations = node.topLevelDeclarations(CLASS)
+        if (topLevelClassDeclarations.size == 1) {
+            val topLevelClassDeclaration = topLevelClassDeclarations.first()
+            if (node.hasTopLevelDeclarationNotExtending(topLevelClassDeclaration.identifier)) {
+                fileName.shouldMatchPascalCase(emit)
+            } else {
+                // If the file only contains one (non private) top level class and possibly some extension functions of
+                // that class, then its filename should be identical to the class name.
+                fileName.shouldMatchClassName(topLevelClassDeclaration.identifier, emit)
+            }
         } else {
-            fileName.shouldMatchPascalCase(emit)
+            val topLevelDeclarations = node.topLevelDeclarations()
+            if (topLevelDeclarations.size == 1) {
+                val topLevelDeclaration = topLevelDeclarations.first()
+                if (topLevelDeclaration.elementType == OBJECT_DECLARATION || topLevelDeclaration.elementType == TYPEALIAS) {
+                    val pascalCaseIdentifier =
+                        topLevelDeclaration
+                            .identifier
+                            .toPascalCase()
+                    fileName.shouldMatchFileName(pascalCaseIdentifier, emit)
+                } else {
+                    fileName.shouldMatchPascalCase(emit)
+                }
+            } else {
+                fileName.shouldMatchPascalCase(emit)
+            }
         }
     }
 
-    private fun topLevelClassNames(fileNode: ASTNode): List<String> {
-        return fileNode
-            .getChildren(null)
-            .filterNotNull()
-            .filter { it.elementType == CLASS }
-            .mapNotNull {
-                it
-                    .findChildByType(IDENTIFIER)
-                    ?.text
-                    ?.removeSurrounding("`")
-            }.toList()
-    }
+    private fun ASTNode.topLevelDeclarations(elementType: IElementType? = null): List<TopLevelDeclaration> =
+        children()
+            .filter { elementType == null || it.elementType == elementType }
+            .filter { it.doesNotHavePrivateModifier() }
+            .mapNotNull { it.toTopLevelDeclaration() }
+            .distinct()
+            .toList()
+
+    private fun ASTNode.doesNotHavePrivateModifier(): Boolean =
+        findChildByType(MODIFIER_LIST)
+            ?.children()
+            ?.none { it.text == "private" }
+            ?: true
+
+    private fun ASTNode.hasTopLevelDeclarationNotExtending(className: String) =
+        children()
+            .filter { it.doesNotHavePrivateModifier() }
+            .any { it.isNotClassRelatedTopLevelDeclaration() || it.isFunctionNotExtending(className) }
+
+    private fun ASTNode.isNotClassRelatedTopLevelDeclaration() =
+        elementType in NON_CLASS_RELATED_TOP_LEVEL_DECLARATION_TYPES
+
+    private fun ASTNode.isFunctionNotExtending(className: String) =
+        elementType == FUN &&
+            findChildByType(TYPE_REFERENCE)?.text?.let { !it.contains(className) } ?: true
 
     private fun String.shouldMatchClassName(
         className: String,
@@ -77,7 +126,23 @@ public class FilenameRule : Rule(
         if (this != className) {
             emit(
                 0,
-                "File '$this.kt' contains a single class and should be named same after that class '$className.kt'",
+                "File '$this.kt' contains a single class and possibly also extension functions for that class and should be named same after that class '$className.kt'",
+                false
+            )
+        }
+    }
+
+    private fun String.toPascalCase() =
+        replaceFirstChar { it.uppercaseChar() }
+
+    private fun String.shouldMatchFileName(
+        filename: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (this != filename) {
+            emit(
+                0,
+                "File '$this.kt' contains a single top level declaration and should be named '$filename.kt'",
                 false
             )
         }
@@ -91,7 +156,19 @@ public class FilenameRule : Rule(
         }
     }
 
+    private data class TopLevelDeclaration(
+        val elementType: IElementType,
+        val identifier: String
+    )
+
+    private fun ASTNode.toTopLevelDeclaration(): TopLevelDeclaration? =
+        findChildByType(IDENTIFIER)
+            ?.text
+            ?.removeSurrounding("`")
+            ?.let { TopLevelDeclaration(elementType, it) }
+
     private companion object {
         val pascalCaseRegEx = Regex("""^[A-Z][A-Za-z\d]*$""")
+        val NON_CLASS_RELATED_TOP_LEVEL_DECLARATION_TYPES = listOf(OBJECT_DECLARATION, TYPEALIAS, PROPERTY)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -44,7 +44,7 @@ class FilenameRuleTest {
     }
 
     @Test
-    fun `Given a file without a toplevel class declaration then the filename should conform to PascalCase`() {
+    fun `Given a file without a top level class declaration then the filename should conform to PascalCase`() {
         val code =
             """
             /*
@@ -81,10 +81,12 @@ class FilenameRuleTest {
     @ValueSource(
         strings = [
             "object Foo",
-            "typealias Foo = String"
+            "typealias Foo = String",
+            "fun String.foo() = {}",
+            "fun foo() = {}"
         ]
     )
-    fun `Given a file containing one toplevel declaration (object or type alias) then the file should be named after the identifier`(
+    fun `Given a file containing one top level declaration (no class or property) then the file should be named after the identifier`(
         code: String
     ) {
         fileNameRuleAssertThat(code)
@@ -95,12 +97,11 @@ class FilenameRuleTest {
     @ParameterizedTest(name = "Top level declaration: {0}")
     @ValueSource(
         strings = [
-            "fun String.foo() = {}",
-            "fun foo() = {}",
-            "val foo"
+            "val foo",
+            "const val FOO"
         ]
     )
-    fun `Given a file containing one toplevel declaration (not a class type, object or type alias) then the file should be named after the identifier`(
+    fun `Given a file containing one top level property declaration (non-private) then the file should conform to PascalCase`(
         code: String
     ) {
         fileNameRuleAssertThat(code)
@@ -111,12 +112,11 @@ class FilenameRuleTest {
     @ParameterizedTest(name = "Top level declaration: {0}")
     @ValueSource(
         strings = [
-            "fun String.foo() = {}",
-            "fun foo() = {}",
-            "val foo"
+            "val foo",
+            "const val FOO"
         ]
     )
-    fun `Given a file containing a single top level declaration (non-private and not a class) then the file should be named after that top level declaration`(
+    fun `Given a file containing a single top level property declaration (non-private) and one private top level class declaration then the file should conform to PascalCase`(
         topLevelDeclaration: String
     ) {
         val code =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -31,7 +31,7 @@ class FilenameRuleTest {
     }
 
     @Test
-    fun `Given a file without any toplevel declaration then the filename should conform to PascalCase`() {
+    fun testFileWithoutTopLevelDeclarations() {
         val code =
             """
             /*
@@ -39,7 +39,7 @@ class FilenameRuleTest {
              */
             """.trimIndent()
         fileNameRuleAssertThat(code)
-            .asFileWithPath("/some/path//some/path/FooBar.kt")
+            .asFileWithPath("/some/path/A.kt")
             .hasNoLintViolations()
     }
 
@@ -47,11 +47,13 @@ class FilenameRuleTest {
     fun `Given a file without a toplevel class declaration then the filename should conform to PascalCase`() {
         val code =
             """
-            val foo = "foo"
+            /*
+             * copyright
+             */
             """.trimIndent()
         fileNameRuleAssertThat(code)
-            .asFileWithPath("/some/path/not-pascal-case.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File name 'not-pascal-case.kt' should conform PascalCase")
+            .asFileWithPath("/some/path/$NON_PASCAL_CASE_NAME")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File name '$NON_PASCAL_CASE_NAME' should conform PascalCase")
     }
 
     @ParameterizedTest(name = "Class type: {0}, expected result: {1}")
@@ -71,32 +73,108 @@ class FilenameRuleTest {
     )
     fun `Given a file containing a single declaration of a class type then the filename should match the class name`(code: String) {
         fileNameRuleAssertThat(code)
-            .asFileWithPath("/some/path/bar.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'bar.kt' contains a single class and should be named same after that class 'Foo.kt'")
+            .asFileWithPath("/some/path/$UNEXPECTED_FILE_NAME")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
     }
 
-    @ParameterizedTest(name = "Other toplevel declaration: {0}")
+    @ParameterizedTest(name = "Top level declaration: {0}")
     @ValueSource(
         strings = [
-            "class Foo",
-            "class `Foo`",
-            "data class Foo(val v: Int)",
-            "sealed class Foo",
-            "interface Foo",
             "object Foo",
-            "enum class Foo {A}",
-            "typealias Foo = Set<Network.Node>",
-            "fun Foo.f() {}"
+            "typealias Foo = String"
         ]
     )
-    private fun `Given a file containing one toplevel class declaration and another toplevel declaration`(otherTopLevelDeclaration: String) {
+    fun `Given a file containing one toplevel declaration (object or type alias) then the file should be named after the identifier`(
+        code: String
+    ) {
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(UNEXPECTED_FILE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'")
+    }
+
+    @ParameterizedTest(name = "Top level declaration: {0}")
+    @ValueSource(
+        strings = [
+            "fun String.foo() = {}",
+            "fun foo() = {}",
+            "val foo"
+        ]
+    )
+    fun `Given a file containing one toplevel declaration (not a class type, object or type alias) then the file should be named after the identifier`(
+        code: String
+    ) {
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(NON_PASCAL_CASE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File name '$NON_PASCAL_CASE_NAME' should conform PascalCase")
+    }
+
+    @ParameterizedTest(name = "Top level declaration: {0}")
+    @ValueSource(
+        strings = [
+            "fun String.foo() = {}",
+            "fun foo() = {}",
+            "val foo"
+        ]
+    )
+    fun `Given a file containing a single top level declaration (non-private and not a class) then the file should be named after that top level declaration`(
+        topLevelDeclaration: String
+    ) {
         val code =
             """
-            class Bar
+            $topLevelDeclaration
+
+            private class Bar
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(NON_PASCAL_CASE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File name '$NON_PASCAL_CASE_NAME' should conform PascalCase")
+    }
+
+    @ParameterizedTest(name = "Other top level declaration: {0}")
+    @ValueSource(
+        strings = [
+            "fun String.bar() = {}",
+            "fun bar() = {}",
+            "object Bar",
+            "typealias Bar = String",
+            "val bar"
+        ]
+    )
+    fun `Given a file containing a single top level class (non-private) and another top level declaration (non-private, not extending that class) then the file should conform to PascalCase notation but does not need to be named after that class`(
+        otherTopLevelDeclaration: String
+    ) {
+        val code =
+            """
+            class Foo
             $otherTopLevelDeclaration
             """.trimIndent()
         fileNameRuleAssertThat(code)
-            .asFileWithPath("/some/path/SomeDescriptiveName.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File name 'foo.kt' should conform PascalCase")
+            .asFileWithPath(NON_PASCAL_CASE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File name '$NON_PASCAL_CASE_NAME' should conform PascalCase")
+    }
+
+    @ParameterizedTest(name = "Other top level declaration: {0}")
+    @ValueSource(
+        strings = [
+            "fun Foo.foo() = {}",
+            "private object Bar"
+        ]
+    )
+    fun `Given a file containing a single top level class (non-private) and another top level declaration (private and,x xor extending that class) then the file should be named after that class`(
+        otherTopLevelDeclaration: String
+    ) {
+        val code =
+            """
+            class Foo
+            $otherTopLevelDeclaration
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(UNEXPECTED_FILE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
+    }
+
+    private companion object {
+        const val NON_PASCAL_CASE_NAME = "nonPascalCaseName.kt"
+        const val UNEXPECTED_FILE_NAME = "UnexpectedFileName.kt"
     }
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -9,7 +9,7 @@ import com.pinterest.ktlint.internal.GitPreCommitHookSubCommand
 import com.pinterest.ktlint.internal.GitPrePushHookSubCommand
 import com.pinterest.ktlint.internal.KtlintCommandLine
 import com.pinterest.ktlint.internal.PrintASTSubCommand
-import com.pinterest.ktlint.internal.printHelpOrVersionUsage
+import com.pinterest.ktlint.internal.printCommandLineHelpOrVersionUsage
 import picocli.CommandLine
 
 fun main(args: Array<String>) {
@@ -23,7 +23,7 @@ fun main(args: Array<String>) {
         .addSubcommand(GenerateEditorConfigSubCommand.COMMAND_NAME, GenerateEditorConfigSubCommand())
     val parseResult = commandLine.parseArgs(*args)
 
-    commandLine.printHelpOrVersionUsage()
+    commandLine.printCommandLineHelpOrVersionUsage()
 
     if (parseResult.hasSubcommand()) {
         handleSubCommand(commandLine, parseResult)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ApplyToIDEAGloballySubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ApplyToIDEAGloballySubCommand.kt
@@ -24,7 +24,7 @@ class ApplyToIDEAGloballySubCommand : Runnable {
     private var forceApply: Boolean = false
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         ApplyToIDEACommandHelper(
             false,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ApplyToIDEAProjectSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/ApplyToIDEAProjectSubCommand.kt
@@ -24,7 +24,7 @@ class ApplyToIDEAProjectSubCommand : Runnable {
     private var forceApply: Boolean = false
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         ApplyToIDEACommandHelper(
             true,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -26,7 +26,7 @@ class GenerateEditorConfigSubCommand : Runnable {
     private lateinit var commandSpec: CommandLine.Model.CommandSpec
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         // For now we are using CLI invocation dir as path to load existing '.editorconfig'
         val generatedEditorConfig = KtLint.generateKotlinEditorConfigSection(
@@ -34,7 +34,7 @@ class GenerateEditorConfigSubCommand : Runnable {
                 fileName = "./test.kt",
                 text = "",
                 ruleSets = ktlintCommand.rulesetJarFiles
-                    .loadRulesets(
+                    .loadRuleSets(
                         ktlintCommand.experimental,
                         ktlintCommand.debug,
                         ktlintCommand.disabledRules

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
@@ -19,7 +19,7 @@ class GitPreCommitHookSubCommand : Runnable {
     private lateinit var commandSpec: CommandLine.Model.CommandSpec
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         GitHookInstaller.installGitHook("pre-commit") {
             loadHookContent()

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
@@ -19,7 +19,7 @@ class GitPrePushHookSubCommand : Runnable {
     private lateinit var commandSpec: CommandLine.Model.CommandSpec
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         GitHookInstaller.installGitHook("pre-push") {
             loadHookContent()

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -213,7 +213,7 @@ internal class KtlintCommandLine {
         val start = System.currentTimeMillis()
 
         val baselineResults = loadBaseline(baseline)
-        val ruleSetProviders = rulesetJarFiles.loadRulesets(experimental, debug, disabledRules)
+        val ruleSetProviders = rulesetJarFiles.loadRuleSets(experimental, debug, disabledRules)
         var reporter = loadReporter()
         if (baselineResults.baselineGenerationNeeded) {
             val baselineReporter = ReporterTemplate("baseline", null, emptyMap(), baseline)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/LoadRuleSets.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/LoadRuleSets.kt
@@ -15,7 +15,7 @@ private val logger = KotlinLogging.logger {}.initKtLintKLogger()
  *
  * @return map of ruleset ids to ruleset providers
  */
-internal fun JarFiles.loadRulesets(
+internal fun JarFiles.loadRuleSets(
     loadExperimental: Boolean,
     debug: Boolean,
     disabledRules: String

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintASTSubCommand.kt
@@ -48,7 +48,7 @@ internal class PrintASTSubCommand : Runnable {
     }
 
     override fun run() {
-        commandSpec.commandLine().printHelpOrVersionUsage()
+        commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         if (stdin) {
             printAST(KtLint.STDIN_FILE, String(System.`in`.readBytes()))

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintCommandLineHelpOrVersionUsage.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/PrintCommandLineHelpOrVersionUsage.kt
@@ -7,7 +7,7 @@ import picocli.CommandLine
  * Check if user requested either help or version options, if yes - print it
  * and exit process with [exitCode] exit code.
  */
-internal fun CommandLine.printHelpOrVersionUsage(
+internal fun CommandLine.printCommandLineHelpOrVersionUsage(
     exitCode: Int = 0
 ) {
     if (isUsageHelpRequested) {


### PR DESCRIPTION
## Description

As result of an earlier refactor of this rule to comply with the Pascal Case Convention, the rule no longer enforced naming of files containing a single top level declaration for an object, type alias and function.

A file containing only one (non private) top level declaration (class, interface, object or type alias) must be named after that declaration. The name also must comply with the Pascal Case convention. The same applies to a file containing one single top level class declaration and one ore more extension functions for that class.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
