### PR TITLE
Setup publication of documentation with mkdocs-material to github pages

### DIFF
--- a/.github/workflows/gradle-docs-publish.yml
+++ b/.github/workflows/gradle-docs-publish.yml
@@ -1,0 +1,15 @@
+name: Publish documentation
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome to Ktlint
+
+Currently, we are working on updating our documentation. For the time being, please visit [old documentation](https://github.com/pinterest/ktlint)

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Ktlint
+
+theme:
+  name: material

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,0 +1,24 @@
+# Build & test documentation on local machine
+
+The documentation of ktlint is served with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/creating-your-site/#advanced-configuration). For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+To build and test documentation on your local development machine, follow steps below:
+
+* In IntelliJ IDEA
+  * Open `Preferences`
+  * Search for `JSON Schema mappings`
+  * Add new schema for url `https://squidfunk.github.io/mkdocs-material/schema.json` and add file `mkdocs.yml` for this url.
+* Pull docker image
+  ```shell
+  $ docker pull squidfunk/mkdocs-material
+  ```
+* Navigate to root of documentation directory (`ktlint/doc`):
+  ```shell
+  $ cd doc
+  ```
+* Start mkdocs server:
+  ```shell
+  docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+  ```
+* Visit page `http://0.0.0.0:8000/` in your browser.
+* Edit the documentation and explicitly save the file. The mkdocs server refreshes its cached and the current page in the browser is automatically refreshed.


### PR DESCRIPTION
## Description

Replace old github pages documentation with mkdocs-material. This PR only configuration the build pipeline and replaces the old documentation with a temporary placeholder. Once it is verified that the pipeline works, we can start writing the new documentation.

Most likely, some additional steps are needed:
* [Configure the branch](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) for which admin settings are required
* Disabling publication of old site

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
