### PR TITLE
Use stable Kotlin compiler frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Remove experimental flag `-Xuse-k2` as it forces API Consumers to compile their projects with this same flag ([#1506](https://github.com/pinterest/ktlint/issues/1506)).
+
 ### Changed
 
 ### Removed

--- a/buildSrc/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -19,11 +19,4 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        @Suppress("SuspiciousCollectionReassignment")
-        freeCompilerArgs += listOf("-Xuse-k2")
-    }
-}
-
 addAdditionalJdkVersionTests()


### PR DESCRIPTION
## Description
Using K2 means library consumers must also use the new compiler (and may not be ready to), otherwise they will have errors like "\<classname> is compiled by the new Kotlin compiler frontend and cannot be loaded by the old compiler"
<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue than provide a link to that issue. -->

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
