### PR TITLE
Account for separating spaces when parsing the disabled rules.

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -133,6 +133,6 @@ internal class VisitorProvider(
             .split(",")
             .none {
                 // The rule set id in the disabled_rules setting may be omitted for rules in the standard rule set
-                it.toQualifiedRuleId() == qualifiedRuleId
+                it.trim().toQualifiedRuleId() == qualifiedRuleId
             }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -241,11 +241,14 @@ class VisitorProviderTest {
                                     .name("disabled_rules")
                                     .type(disabledRulesProperty.type)
                                     .value(
-                                        setOf(
-                                            SOME_DISABLED_RULE_IN_STANDARD_RULE_SET,
-                                            "$EXPERIMENTAL:$SOME_DISABLED_RULE_IN_EXPERIMENTAL_RULE_SET",
-                                            "$CUSTOM_RULE_SET_A:$SOME_DISABLED_RULE_IN_CUSTOM_RULE_SET_A"
-                                        ).joinToString(separator = ",")
+                                        buildString {
+                                            append("$EXPERIMENTAL:$SOME_DISABLED_RULE_IN_EXPERIMENTAL_RULE_SET")
+                                            append(",")
+                                            append("$CUSTOM_RULE_SET_A:$SOME_DISABLED_RULE_IN_CUSTOM_RULE_SET_A")
+                                            // purposely separate with an additional whitespace
+                                            append(", ")
+                                            append(SOME_DISABLED_RULE_IN_STANDARD_RULE_SET)
+                                        }
                                     ).build()
                         )
                     )


### PR DESCRIPTION
IntelliJ reformats the disabled_rules of the editor config and adds spaces between the entries.

For example:
```properties
[*]
disabled_rules = import-ordering,filename,trailing-comma
```

Will be reformatted to:
```properties
[*]
disabled_rules = import-ordering, filename, trailing-comma
```

With the whitespace included, ktlint does not pick up these rules.

This PR accounts for these white spaces and modifies the existing tests to also cover this scenario.