### PR TITLE
Fix regression bug caused by #1340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Remove experimental flag `-Xuse-k2` as it forces API Consumers to compile their projects with this same flag ([#1506](https://github.com/pinterest/ktlint/pull/1506)).
-* Account for separating spaces when parsing the disabled rules ([#1508](https://github.com/pinterest/ktlint/pull/1508)). 
+* Account for separating spaces when parsing the disabled rules ([#1508](https://github.com/pinterest/ktlint/pull/1508)).
+* A delegate property which starts on the same line as the property declaration should not have an extra indentation `indent` ([#1510](https://github.com/pinterest/ktlint/pull/1510))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -69,6 +69,7 @@ import com.pinterest.ktlint.core.ast.isPartOfComment
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithoutNewline
+import com.pinterest.ktlint.core.ast.lineNumber
 import com.pinterest.ktlint.core.ast.nextCodeSibling
 import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.nextSibling
@@ -446,7 +447,9 @@ public class IndentationRule :
         }) ?: return
         val nextSibling = n.treeNext
         if (!ctx.ignored.contains(p) && nextSibling != null) {
-            if (p.treeParent.elementType == PROPERTY_DELEGATE) {
+            if (p.treeParent.elementType == PROPERTY_DELEGATE &&
+                p.treeParent?.lineNumber() != p.treeParent.prevCodeSibling()?.lineNumber()
+            ) {
                 expectedIndent += 2
                 logger.trace { "$line: ++dot-qualified-expression in property delegate -> $expectedIndent" }
                 ctx.ignored.add(p)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -3048,6 +3048,16 @@ internal class IndentationRuleTest {
         }
 
         @Test
+        fun `Issue 1510 - Given a dot-qualified-expression as delegated property value starting on same line as previous code sibling`() {
+            val code =
+                """
+                val locale: Locale by option
+                    .default()
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
         fun `Issue 1340 - Given a dot-qualified-expression wrapped in a block as delegated property value`() {
             val code =
                 """


### PR DESCRIPTION
## Description

A delegate property which starts on the same line as the property declaration should not have an extra indentation. This fixes a regression bug introduced by the fix of #1340.

Closes #1510

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
