### PR TITLE
Fix regression on command line argument "--disabled_rules"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+* Fix cli argument "--disabled_rules" ([#1520](https://github.com/pinterest/ktlint/issue/1520)).
+
+### Changed
+
+### Removed
+
 ## [0.46.1] - 2022-06-21
 
 Minor release to address some regressions introduced in 0.46.0

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -39,6 +39,7 @@ import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 import mu.KLogger
 import mu.KotlinLogging
+import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
@@ -220,13 +221,14 @@ internal class KtlintCommandLine {
             val reporterProviderById = loadReporters(emptyList())
             reporter = Reporter.from(reporter, baselineReporter.toReporter(reporterProviderById))
         }
-        val editorConfigOverride = EditorConfigOverride.emptyEditorConfigOverride
-        if (disabledRules.isNotBlank()) {
-            editorConfigOverride.plus(disabledRulesProperty to disabledRules)
-        }
-        if (android) {
-            editorConfigOverride.plus(codeStyleSetProperty to android)
-        }
+        val editorConfigOverride =
+            EditorConfigOverride
+                .emptyEditorConfigOverride
+                .applyIf(disabledRules.isNotBlank()) {
+                    plus(disabledRulesProperty to disabledRules)
+                }.applyIf(android) {
+                    plus(codeStyleSetProperty to android)
+                }
 
         reporter.beforeAll()
         if (stdin) {

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
@@ -8,10 +9,8 @@ import org.junit.jupiter.api.condition.OS
 @DisabledOnOs(OS.WINDOWS)
 @DisplayName("CLI basic checks")
 class SimpleCLITest : BaseCLITest() {
-
-    @DisplayName("Should print help")
     @Test
-    fun shouldOutputHelp() {
+    fun `Given CLI argument --help then return the help output`() {
         runKtLintCliProcess(
             "no-code-style-error",
             listOf("--help")
@@ -25,9 +24,8 @@ class SimpleCLITest : BaseCLITest() {
         }
     }
 
-    @DisplayName("Should print correct version")
     @Test
-    fun shouldCorrectlyPrintVersion() {
+    fun `Given CLI argument --version then return the version information output`() {
         runKtLintCliProcess(
             "no-code-style-error",
             listOf("--version")
@@ -42,9 +40,8 @@ class SimpleCLITest : BaseCLITest() {
         }
     }
 
-    @DisplayName("Should complete lint without errors")
     @Test
-    internal fun lintWithoutErrors() {
+    fun `Given some code without errors then return from lint with normal exit code and no error output`() {
         runKtLintCliProcess(
             "no-code-style-error"
         ) {
@@ -53,9 +50,8 @@ class SimpleCLITest : BaseCLITest() {
         }
     }
 
-    @DisplayName("Should complete lint with error")
     @Test
-    internal fun lintWithError() {
+    fun `Given some code with an error then return from lint with the error exit code and error output`() {
         runKtLintCliProcess(
             "too-many-empty-lines"
         ) {
@@ -67,9 +63,8 @@ class SimpleCLITest : BaseCLITest() {
         }
     }
 
-    @DisplayName("Should format without errors")
     @Test
-    fun formatWorks() {
+    fun `Given some code with an error which can be autocorrected then return from from with the normal exit code`() {
         runKtLintCliProcess(
             "too-many-empty-lines",
             listOf("-F")
@@ -79,6 +74,18 @@ class SimpleCLITest : BaseCLITest() {
             // assertErrorOutputIsEmpty()
 
             assertSourceFileWasFormatted("Main.kt")
+        }
+    }
+
+    @Test
+    fun `Given some code with an error for a rule which is disabled via CLI argument --disabled_rules then return from lint with the normal exit code and without error output`() {
+        runKtLintCliProcess(
+            "too-many-empty-lines",
+            listOf("disabled_rules=no-consecutive-blank-lines")
+        ) {
+            assertNormalExitCode()
+
+            assertThat(normalOutput).doesNotContain("Needless blank line(s)")
         }
     }
 }


### PR DESCRIPTION
## Description

Fix regression on command line argument "--disabled_rules" and align code other unit tests

Closes #1520

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
