### PR TITLE
Add traling-comma rule in the standard rule list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ It's also [easy to create your own](#creating-a-reporter).
 - `package-name`: No underscores in package names
 - `parameter-list-wrapping`: When class/function signature doesn't fit on a single line, each parameter must be on a separate line
 - `string-template`: Consistent string templates (`$v` instead of `${v}`, `${p.v}` instead of `${p.v.toString()}`)
+- `trailing-comma`: No trailing commas
 
 ### Spacing
 - `annotation-spacing`: Annotations should be separated by a single line break

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It's also [easy to create your own](#creating-a-reporter).
 - `package-name`: No underscores in package names
 - `parameter-list-wrapping`: When class/function signature doesn't fit on a single line, each parameter must be on a separate line
 - `string-template`: Consistent string templates (`$v` instead of `${v}`, `${p.v}` instead of `${p.v.toString()}`)
-- `trailing-comma`: No trailing commas
+- `trailing-comma`: Consistent removal (default) or adding of trailing comma's (both on call and declaration site)
 
 ### Spacing
 - `annotation-spacing`: Annotations should be separated by a single line break


### PR DESCRIPTION
## Description

When this rule was promoted to the standard rule set it was not added to the standard rule list

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [x] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
