### PR TITLE
Allow diacritics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Fix cli argument "--disabled_rules" ([#1520](https://github.com/pinterest/ktlint/issue/1520)).
+* Allow usage of letters with diacritics in enum values and filenames (`enum-entry-name-case`, `filename`) ([#1530](https://github.com/pinterest/ktlint/issue/1530)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+* Accept filename which is based on the fully qualified receiver class plus name of an extension function when it is the only top level declaration in a file `filename` ([#1521](https://github.com/pinterest/ktlint/issue/1521)).
+
 ### Removed
 
 ## [0.46.1] - 2022-06-21

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.ruleset.standard.internal.removeDiacriticsFromLetters
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.psi.KtEnumEntry
@@ -24,7 +25,7 @@ public class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
         val enumEntry = node.psi as? KtEnumEntry ?: return
         val name = enumEntry.name ?: return
 
-        if (!name.matches(regex)) {
+        if (!name.removeDiacriticsFromLetters().matches(regex)) {
             emit(
                 node.startOffset,
                 "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -154,7 +154,7 @@ public class FilenameRule : Rule(
                     "File '$this.kt' contains a single top level declaration and should be named '$filename.kt'",
                     false
                 )
-            qualifier != null && this != "$qualifier$filename" ->
+            qualifier != null && this != filename && this != "$qualifier$filename" ->
                 emit(
                     0,
                     "File '$this.kt' contains a single top level declaration and should be named '$filename.kt' or '$qualifier$filename.kt'",
@@ -188,6 +188,9 @@ public class FilenameRule : Rule(
                             .findChildByType(TYPE_REFERENCE)
                             ?.text
                             ?.replace(".", "")
+                            ?.replace("?", "")
+                            ?.replace("<", "")
+                            ?.replace(">", "")
                     TopLevelDeclaration(elementType, it, typeReference)
                 } else {
                     TopLevelDeclaration(elementType, it)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -11,6 +11,7 @@ import com.pinterest.ktlint.core.ast.ElementType.PROPERTY
 import com.pinterest.ktlint.core.ast.ElementType.TYPEALIAS
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.ruleset.standard.internal.removeDiacriticsFromLetters
 import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
@@ -90,7 +91,7 @@ public class FilenameRule : Rule(
                         topLevelDeclaration
                             .qualifier
                             ?.toPascalCase()
-                    fileName.shouldMatchFileName(pascalCaseQualifier, pascalCaseIdentifier, emit)
+                    fileName.shouldMatchIdentifier(pascalCaseQualifier, pascalCaseIdentifier, emit)
                 } else {
                     fileName.shouldMatchPascalCase(emit)
                 }
@@ -142,7 +143,7 @@ public class FilenameRule : Rule(
     private fun String.toPascalCase() =
         replaceFirstChar { it.uppercaseChar() }
 
-    private fun String.shouldMatchFileName(
+    private fun String.shouldMatchIdentifier(
         qualifier: String?,
         filename: String,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
@@ -166,7 +167,7 @@ public class FilenameRule : Rule(
     private fun String.shouldMatchPascalCase(
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (!pascalCaseRegEx.matches(this)) {
+        if (!this.removeDiacriticsFromLetters().matches(pascalCaseRegEx)) {
             emit(0, "File name '$this.kt' should conform PascalCase", false)
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/RemoveDiacriticsFromLetters.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/RemoveDiacriticsFromLetters.kt
@@ -1,0 +1,23 @@
+package com.pinterest.ktlint.ruleset.standard.internal
+
+import java.text.Normalizer
+
+/**
+ * Removes diacritics from letters. Note that ligatures æ (ae), œ (oe), Æ (AE), Œ (OE), and letters with strokes ł (l),
+ * ø (o), ß (s), Ł (L), Ø (O) are not changed.
+ */
+
+internal fun String.removeDiacriticsFromLetters() =
+    map { originalChar ->
+        Normalizer
+            // Decompose characters having a diacritic into an ascii alphabetic character (a-zA-Z) followed by the diacritic(s)
+            .normalize(originalChar.toString(), Normalizer.Form.NFD)
+            .let {
+                if (it.first().isLetterOrDigit()) {
+                    // Ignore all diacritics
+                    it.first()
+                } else {
+                    it
+                }
+            }
+    }.joinToString(separator = "")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRuleTest.kt
@@ -61,4 +61,16 @@ class EnumEntryNameCaseRuleTest {
                 LintViolation(4, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"")
             )
     }
+
+    @Test
+    fun `Issue 1530 - Given enum values containing diacritics are allowed`() {
+        val code =
+            """
+            enum class SomeEnum {
+                ŸÈŚ_THÎS_IS_ALLOWED,
+                ŸèśThîsIsAllowed,
+            }
+            """.trimIndent()
+        enumEntryNameCaseRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -238,6 +238,14 @@ class FilenameRuleTest {
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
     }
 
+    @Test
+    fun `Issue 1530 - Given a file which name should match PascalCase then this name may also contain letters with diacritics`() {
+        val code = "// some code"
+        fileNameRuleAssertThat(code)
+            .asFileWithPath("ŸëšThïsĮsÂllòwed.kt")
+            .hasNoLintViolations()
+    }
+
     private companion object {
         const val NON_PASCAL_CASE_NAME = "nonPascalCaseName.kt"
         const val UNEXPECTED_FILE_NAME = "UnexpectedFileName.kt"

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -115,6 +115,49 @@ class FilenameRuleTest {
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Image.kt' or 'FooStatusImage.kt'")
     }
 
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a custom receiver class defined in another file and the filename equals the qualifier followed by function name then do not report a lint violation`() {
+        val code =
+            """
+            fun Foo.Status.image() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath("FooStatusImage.kt")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a nullable custom receiver class defined in another file and the filename equals the qualifier followed by function name then do not report a lint violation`() {
+        val code =
+            """
+            fun Foo.Status?.image() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath("FooStatusImage.kt")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a generic custom receiver class defined in another file and the filename equals the qualifier followed by function name then do not report a lint violation`() {
+        val code =
+            """
+            fun List<Foo.Status?>.image() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath("ListFooStatusImage.kt")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a custom receiver class defined in another file and the filename equals the function name then do not report a lint violation`() {
+        val code =
+            """
+            fun Foo.Status.image() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath("Image.kt")
+            .hasNoLintViolations()
+    }
 
     @ParameterizedTest(name = "Top level declaration: {0}")
     @ValueSource(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRuleTest.kt
@@ -82,7 +82,6 @@ class FilenameRuleTest {
         strings = [
             "object Foo",
             "typealias Foo = String",
-            "fun String.foo() = {}",
             "fun foo() = {}"
         ]
     )
@@ -93,6 +92,29 @@ class FilenameRuleTest {
             .asFileWithPath(UNEXPECTED_FILE_NAME)
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'")
     }
+
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a standard receiver class defined in another file then allow the file to be named based upon the fully qualified receiver suffixed with the function name`() {
+        val code =
+            """
+            fun String.foo() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(UNEXPECTED_FILE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt' or 'StringFoo.kt'")
+    }
+
+    @Test
+    fun `Issue 1521 - Given a file containing a single toplevel extension function on a custom receiver class defined in another file then allow the file to be named based upon the fully qualified receiver suffixed with the function name`() {
+        val code =
+            """
+            fun Foo.Status.image() {}
+            """.trimIndent()
+        fileNameRuleAssertThat(code)
+            .asFileWithPath(UNEXPECTED_FILE_NAME)
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Image.kt' or 'FooStatusImage.kt'")
+    }
+
 
     @ParameterizedTest(name = "Top level declaration: {0}")
     @ValueSource(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/internal/RemoveDiacriticsFromLettersTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/internal/RemoveDiacriticsFromLettersTest.kt
@@ -1,0 +1,53 @@
+package com.pinterest.ktlint.ruleset.standard.internal
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class RemoveDiacriticsFromLettersTest {
+    @ParameterizedTest(name = "Original character: {0}, expected result: {1}")
+    @CsvSource(
+        value = [
+            "àáâäãåā,aaaaaaa",
+            "çćč,ccc",
+            "èéêëēėę,eeeeeee",
+            "îïíīįì,iiiiii",
+            "ñń,nn",
+            "ôöòóōõ,oooooo",
+            "śš,ss",
+            "ûüùúū,uuuuu",
+            "ÿ,y",
+            "žźż,zzz",
+            "ÀÁÂÄÃÅĀ,AAAAAAA",
+            "ÇĆČ,CCC",
+            "ÈÉÊËĒĖĘ,EEEEEEE",
+            "ÎÏÍĪĮÌ,IIIIII",
+            "ÑŃ,NN",
+            "ÔÖÒÓŌÕ,OOOOOO",
+            "ŚŠ,SS",
+            "ÛÜÙÚŪ,UUUUU",
+            "Ÿ,Y",
+            "ŽŹŻ,ZZZ"
+        ]
+    )
+    fun `Given a letter with a diacritic then remove it`(original: String, expected: String) {
+        assertThat(original.removeDiacriticsFromLetters()).isEqualTo(expected)
+    }
+
+    @ParameterizedTest(name = "Character: {0}")
+    @ValueSource(
+        strings = [
+            "æ", "ł", "œ", "ø", "ß", "Æ", "Ł", "Œ", "Ø"
+        ]
+    )
+    fun `Given a ligature or letter with stroke then keep it unchanged`(original: String) {
+        assertThat(original.removeDiacriticsFromLetters()).isEqualTo(original)
+    }
+
+    @Test
+    fun `Given a string containing`() {
+        assertThat("ÅÄÖāăąēîïĩíĝġńñšŝśûůŷ".removeDiacriticsFromLetters()).isEqualTo("AAOaaaeiiiiggnnsssuuy")
+    }
+}


### PR DESCRIPTION
## Description

Allow usage of letters with diacritics in enum values and filenames.

Closes #1530

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
