### PR TITLE
Refactor life cycle hooks on Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,29 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### API Changes & RuleSet providers
+
+If you are not an API user nor a RuleSet provider, then you can safely skip this section. Otherwise, please read below carefully and upgrade your usage of ktlint. In this and coming releases, we are changing and adapting important parts of our API in order to increase maintainability and flexibility for future changes. Please avoid skipping a releases as that will make it harder to migrate.
+
+#### Rule lifecycle hooks / deprecate RunOnRootOnly visitor modifier
+
+Up until ktlint 0.46 the Rule class provided only one life cycle hook. This "visit" hook was called in a depth-first-approach on all nodes in the file. A rule like the IndentationRule used the RunOnRootOnly visitor modifier to call this lifecycle hook for the root node only in combination with an alternative way of traversing the ASTNodes. Downside of this approach was that suppression of the rule on blocks inside a file was not possible ([#631](https://github.com/pinterest/ktlint/issues/631)). More generically, this applied to all rules, applying alternative traversals of the AST.
+
+The Rule class now offers new life cycle hooks:
+* beforeFirstNode: This method is called once before the first node is visited. It can be used to initialize the state of the rule before processing of nodes starts. The ".editorconfig" properties (including overrides) are provided as parameter.
+* beforeVisitChildNodes: This method is called on a node in AST before visiting its child nodes. This is repeated recursively for the child nodes resulting in a depth first traversal of the AST. This method is the equivalent of the "visit" life cycle hooks. However, note that in KtLint 0.48, the UserData of the rootnode no longer provides access to the ".editorconfig" properties. This method can be used to emit Lint Violations and to autocorrect if applicable.
+* afterVisitChildNodes: This method is called on a node in AST after all its child nodes have been visited. This method can be used to emit Lint Violations and to autocorrect if applicable.
+* afterLastNode: This method is called once after the last node in the AST is visited. It can be used for teardown of the state of the rule.
+
+The "visit" life cycle hook will be removed in Ktlint 0.48. In KtLint 0.47 the "visit" life cycle hook will be called *only* when hook "beforeVisitChildNodes" is not overridden. It is recommended to migrate to the new lifecycle hooks in KtLint 0.47. Please create an issue, in case you need additional assistence to implement the new life cycle hooks in your rules.
+
+
 ### Added
 
 ### Fixed
 
 * Fix cli argument "--disabled_rules" ([#1520](https://github.com/pinterest/ktlint/issue/1520)).
+* Disable/enable IndentationRule on blocks in middle of file. (`indent`) [#631](https://github.com/pinterest/ktlint/issues/631)
 
 ### Changed
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigOverride.Companion.emptyEditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.visit
 import com.pinterest.ktlint.core.internal.EditorConfigGenerator
 import com.pinterest.ktlint.core.internal.EditorConfigLoader
 import com.pinterest.ktlint.core.internal.PreparedCode
@@ -155,21 +156,34 @@ public object KtLint {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
-        // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
-        //  but because rules are free to emit (and fix!) errors at any position)
-        if (!preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)) {
-            try {
-                rule.visit(node, autoCorrect, emit)
-            } catch (e: Exception) {
-                if (autoCorrect) {
-                    // line/col cannot be reliably mapped as exception might originate from a node not present in the
-                    // original AST
-                    throw RuleExecutionException(0, 0, fqRuleId, e)
-                } else {
-                    val (line, col) = preparedCode.positionInTextLocator(node.startOffset)
-                    throw RuleExecutionException(line, col, fqRuleId, e)
+        try {
+            if (rule.runsOnRootNodeOnly()) {
+                // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
+                // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
+                //  but because rules are free to emit (and fix!) errors at any position)
+                if (!preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)) {
+                    rule.visit(node, autoCorrect, emit)
                 }
+            } else {
+                node.visit { childNode ->
+                    // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
+                    // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
+                    //  but because rules are free to emit (and fix!) errors at any position)
+                    if (!preparedCode.suppressedRegionLocator(childNode.startOffset, fqRuleId, childNode === preparedCode.rootNode)) {
+                        rule.visit(childNode, autoCorrect, emit)
+                    } else {
+                        Unit
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            if (autoCorrect) {
+                // line/col cannot be reliably mapped as exception might originate from a node not present in the
+                // original AST
+                throw RuleExecutionException(0, 0, fqRuleId, e)
+            } else {
+                val (line, col) = preparedCode.positionInTextLocator(node.startOffset)
+                throw RuleExecutionException(line, col, fqRuleId, e)
             }
         }
     }
@@ -252,6 +266,9 @@ public object KtLint {
             code
         }
     }
+
+    private fun Rule.runsOnRootNodeOnly() =
+        visitorModifiers.contains(Rule.VisitorModifier.RunOnRootNodeOnly)
 
     /**
      * Reduce memory usage of all internal caches.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -218,16 +218,16 @@ public object KtLint {
                                 )
                         }
                     }
-                }
-                val (line, col) = preparedCode.positionInTextLocator(offset)
-                errors.add(
-                    Pair(
-                        LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected),
-                        // It is assumed that a rule that emits that an error can be autocorrected, also
-                        // does correct the error.
-                        canBeAutoCorrected
+                    val (line, col) = preparedCode.positionInTextLocator(offset)
+                    errors.add(
+                        Pair(
+                            LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected),
+                            // It is assumed that a rule that emits that an error can be autocorrected, also
+                            // does correct the error.
+                            canBeAutoCorrected
+                        )
                     )
-                )
+                }
             }
         if (tripped) {
             visitorProvider

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -130,14 +130,8 @@ public object KtLint {
 
         VisitorProvider(params)
             .visitor(preparedCode.rootNode)
-            .invoke { node, rule, fqRuleId ->
-                visitNodeWithRule(
-                    preparedCode,
-                    node,
-                    rule,
-                    fqRuleId,
-                    false
-                ) { offset, errorMessage, canBeAutoCorrected ->
+            .invoke { rule, fqRuleId ->
+                preparedCode.executeRule(rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
                     val (line, col) = preparedCode.positionInTextLocator(offset)
                     errors.add(LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected))
                 }
@@ -148,8 +142,32 @@ public object KtLint {
             .forEach { e -> params.cb(e, false) }
     }
 
-    private fun visitNodeWithRule(
-        preparedCode: PreparedCode,
+    private fun PreparedCode.executeRule(
+        rule: Rule,
+        fqRuleId: String,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (rule.runsOnRootNodeOnly()) {
+            // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
+            // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
+            //  but because rules are free to emit (and fix!) errors at any position)
+            if (!suppressedRegionLocator(rootNode.startOffset, fqRuleId, true)) {
+                this.executeRuleOnNode(rootNode, rule, fqRuleId, autoCorrect, emit)
+            }
+        } else {
+            rootNode.visit { childNode ->
+                // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
+                // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
+                //  but because rules are free to emit (and fix!) errors at any position)
+                if (!suppressedRegionLocator(childNode.startOffset, fqRuleId, childNode === rootNode)) {
+                    this.executeRuleOnNode(childNode, rule, fqRuleId, autoCorrect, emit)
+                }
+            }
+        }
+    }
+
+    private fun PreparedCode.executeRuleOnNode(
         node: ASTNode,
         rule: Rule,
         fqRuleId: String,
@@ -157,32 +175,14 @@ public object KtLint {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         try {
-            if (rule.runsOnRootNodeOnly()) {
-                // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
-                // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
-                //  but because rules are free to emit (and fix!) errors at any position)
-                if (!preparedCode.suppressedRegionLocator(node.startOffset, fqRuleId, node === preparedCode.rootNode)) {
-                    rule.visit(node, autoCorrect, emit)
-                }
-            } else {
-                node.visit { childNode ->
-                    // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
-                    // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
-                    //  but because rules are free to emit (and fix!) errors at any position)
-                    if (!preparedCode.suppressedRegionLocator(childNode.startOffset, fqRuleId, childNode === preparedCode.rootNode)) {
-                        rule.visit(childNode, autoCorrect, emit)
-                    } else {
-                        Unit
-                    }
-                }
-            }
+            rule.visit(node, autoCorrect, emit)
         } catch (e: Exception) {
             if (autoCorrect) {
                 // line/col cannot be reliably mapped as exception might originate from a node not present in the
                 // original AST
                 throw RuleExecutionException(0, 0, fqRuleId, e)
             } else {
-                val (line, col) = preparedCode.positionInTextLocator(node.startOffset)
+                val (line, col) = positionInTextLocator(node.startOffset)
                 throw RuleExecutionException(line, col, fqRuleId, e)
             }
         }
@@ -204,16 +204,16 @@ public object KtLint {
         val visitorProvider = VisitorProvider(params = params)
         visitorProvider
             .visitor(preparedCode.rootNode)
-            .invoke { node, rule, fqRuleId ->
-                val originalCodeNode = node.text
-                visitNodeWithRule(preparedCode, node, rule, fqRuleId, true) { offset, errorMessage, canBeAutoCorrected ->
+            .invoke { rule, fqRuleId ->
+                val originalCodeNode = preparedCode.rootNode.text
+                preparedCode.executeRule(rule, fqRuleId, true) { offset, errorMessage, canBeAutoCorrected ->
                     tripped = true
                     if (canBeAutoCorrected) {
                         mutated = true
                     }
                 }
                 if (preparedCode.suppressedRegionLocator !== SuppressionLocatorBuilder.noSuppression &&
-                    originalCodeNode != node.text
+                    originalCodeNode != preparedCode.rootNode.text
                 ) {
                     preparedCode.suppressedRegionLocator =
                         SuppressionLocatorBuilder.buildSuppressedRegionsLocator(
@@ -233,12 +233,14 @@ public object KtLint {
         if (tripped) {
             visitorProvider
                 .visitor(preparedCode.rootNode)
-                .invoke { node, rule, fqRuleId ->
-                    visitNodeWithRule(preparedCode, node, rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
+                .invoke { rule, fqRuleId ->
+                    preparedCode.executeRule(rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
                         val (line, col) = preparedCode.positionInTextLocator(offset)
                         errors.add(
                             Pair(
                                 LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected),
+                                // It is assumed that a rule only corrects an error after it has emitted an
+                                // error and indicating that it actually can be autocorrected.
                                 // It is assumed that a rule only corrects an error after it has emitted an
                                 // error and indicating that it actually can be autocorrected.
                                 false

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -8,7 +8,6 @@ import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.internal.EditorConfigGenerator
 import com.pinterest.ktlint.core.internal.EditorConfigLoader
-import com.pinterest.ktlint.core.internal.KotlinPsiFileFactoryProvider
 import com.pinterest.ktlint.core.internal.PreparedCode
 import com.pinterest.ktlint.core.internal.SuppressionLocatorBuilder
 import com.pinterest.ktlint.core.internal.VisitorProvider
@@ -29,7 +28,6 @@ public object KtLint {
     internal const val UTF8_BOM = "\uFEFF"
     public const val STDIN_FILE: String = "<stdin>"
 
-    private val kotlinPsiFileFactoryProvider = KotlinPsiFileFactoryProvider()
     internal val editorConfigLoader = EditorConfigLoader(FileSystems.getDefault())
 
     /**
@@ -126,8 +124,7 @@ public object KtLint {
      * @throws RuleExecutionException in case of internal failure caused by a bug in rule implementation
      */
     public fun lint(params: ExperimentalParams) {
-        val psiFileFactory = kotlinPsiFileFactoryProvider.getKotlinPsiFileFactory(params.isInvokedFromCli)
-        val preparedCode = prepareCodeForLinting(psiFileFactory, params)
+        val preparedCode = prepareCodeForLinting(params)
         val errors = mutableListOf<LintError>()
 
         VisitorProvider(params)
@@ -185,8 +182,7 @@ public object KtLint {
      */
     public fun format(params: ExperimentalParams): String {
         val hasUTF8BOM = params.text.startsWith(UTF8_BOM)
-        val psiFileFactory = kotlinPsiFileFactoryProvider.getKotlinPsiFileFactory(params.isInvokedFromCli)
-        val preparedCode = prepareCodeForLinting(psiFileFactory, params)
+        val preparedCode = prepareCodeForLinting(params)
 
         var tripped = false
         var mutated = false

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 public object KtLint {
     public val FILE_PATH_USER_DATA_KEY: Key<String> = Key<String>("FILE_PATH")
+
     @Deprecated("Marked for removal in Ktlint 0.48.0")
     public val EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY: Key<EditorConfigProperties> =
         Key<EditorConfigProperties>("EDITOR_CONFIG_PROPERTIES")

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -205,20 +205,19 @@ public object KtLint {
         visitorProvider
             .visitor(preparedCode.rootNode)
             .invoke { rule, fqRuleId ->
-                val originalCodeNode = preparedCode.rootNode.text
                 preparedCode.executeRule(rule, fqRuleId, true) { offset, errorMessage, canBeAutoCorrected ->
                     tripped = true
                     if (canBeAutoCorrected) {
                         mutated = true
+                        if (preparedCode.suppressedRegionLocator !== SuppressionLocatorBuilder.noSuppression) {
+                            // Offsets of start and end positions of suppressed regions might have changed due to
+                            // updating the code
+                            preparedCode.suppressedRegionLocator =
+                                SuppressionLocatorBuilder.buildSuppressedRegionsLocator(
+                                    preparedCode.rootNode
+                                )
+                        }
                     }
-                }
-                if (preparedCode.suppressedRegionLocator !== SuppressionLocatorBuilder.noSuppression &&
-                    originalCodeNode != preparedCode.rootNode.text
-                ) {
-                    preparedCode.suppressedRegionLocator =
-                        SuppressionLocatorBuilder.buildSuppressedRegionsLocator(
-                            preparedCode.rootNode
-                        )
                 }
                 val (line, col) = preparedCode.positionInTextLocator(offset)
                 errors.add(

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -239,10 +239,8 @@ public object KtLint {
         val errors = mutableSetOf<Pair<LintError, Boolean>>()
         val visitorProvider = VisitorProvider(params = params)
         visitorProvider
-            .visitor(
-                preparedCode.rootNode,
-                concurrent = false
-            ).invoke { node, rule, fqRuleId ->
+            .visitor(preparedCode.rootNode)
+            .invoke { node, rule, fqRuleId ->
                 // fixme: enforcing suppression based on node.startOffset is wrong
                 // (not just because not all nodes are leaves but because rules are free to emit (and fix!) errors at any position)
                 if (

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -9,35 +9,28 @@ import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.internal.EditorConfigGenerator
 import com.pinterest.ktlint.core.internal.EditorConfigLoader
 import com.pinterest.ktlint.core.internal.KotlinPsiFileFactoryProvider
-import com.pinterest.ktlint.core.internal.LineAndColumn
-import com.pinterest.ktlint.core.internal.SuppressionLocator
+import com.pinterest.ktlint.core.internal.PreparedCode
 import com.pinterest.ktlint.core.internal.SuppressionLocatorBuilder
 import com.pinterest.ktlint.core.internal.VisitorProvider
-import com.pinterest.ktlint.core.internal.buildPositionInTextLocator
+import com.pinterest.ktlint.core.internal.prepareCodeForLinting
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
-import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 public object KtLint {
     public val FILE_PATH_USER_DATA_KEY: Key<String> = Key<String>("FILE_PATH")
     public val EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY: Key<EditorConfigProperties> =
         Key<EditorConfigProperties>("EDITOR_CONFIG_PROPERTIES")
-    private const val UTF8_BOM = "\uFEFF"
+    internal const val UTF8_BOM = "\uFEFF"
     public const val STDIN_FILE: String = "<stdin>"
 
     private val kotlinPsiFileFactoryProvider = KotlinPsiFileFactoryProvider()
-    private val editorConfigLoader = EditorConfigLoader(FileSystems.getDefault())
+    internal val editorConfigLoader = EditorConfigLoader(FileSystems.getDefault())
 
     /**
      * @param fileName path of file to lint/format
@@ -184,61 +177,6 @@ public object KtLint {
         }
     }
 
-    private fun prepareCodeForLinting(
-        psiFileFactory: PsiFileFactory,
-        params: ExperimentalParams
-    ): PreparedCode {
-        val normalizedText = normalizeText(params.text)
-        val positionInTextLocator = buildPositionInTextLocator(normalizedText)
-
-        val psiFileName = if (params.script) "file.kts" else "file.kt"
-        val psiFile = psiFileFactory.createFileFromText(
-            psiFileName,
-            KotlinLanguage.INSTANCE,
-            normalizedText
-        ) as KtFile
-
-        val errorElement = psiFile.findErrorElement()
-        if (errorElement != null) {
-            val (line, col) = positionInTextLocator(errorElement.textOffset)
-            throw ParseException(line, col, errorElement.errorDescription)
-        }
-
-        val rootNode = psiFile.node
-
-        val editorConfigProperties = editorConfigLoader.loadPropertiesForFile(
-            params.normalizedFilePath,
-            params.isStdIn,
-            params.editorConfigPath?.let { Paths.get(it) },
-            params.rules,
-            params.editorConfigOverride,
-            params.debug
-        )
-
-        if (!params.isStdIn) {
-            rootNode.putUserData(FILE_PATH_USER_DATA_KEY, params.normalizedFilePath.toString())
-        }
-        rootNode.putUserData(EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY, editorConfigProperties)
-
-        val suppressedRegionLocator = SuppressionLocatorBuilder.buildSuppressedRegionsLocator(rootNode)
-
-        return PreparedCode(
-            rootNode,
-            positionInTextLocator,
-            suppressedRegionLocator
-        )
-    }
-
-    @Deprecated(
-        message = "Should not be a part of public api. Will be removed in future release."
-    )
-    public fun normalizeText(text: String): String {
-        return text
-            .replace("\r\n", "\n")
-            .replace("\r", "\n")
-            .replaceFirst(UTF8_BOM, "")
-    }
-
     /**
      * Fix style violations.
      *
@@ -371,23 +309,4 @@ public object KtLint {
             else -> "\n"
         }
     }
-
-    private fun PsiElement.findErrorElement(): PsiErrorElement? {
-        if (this is PsiErrorElement) {
-            return this
-        }
-        this.children.forEach { child ->
-            val errorElement = child.findErrorElement()
-            if (errorElement != null) {
-                return errorElement
-            }
-        }
-        return null
-    }
-
-    private class PreparedCode(
-        val rootNode: FileASTNode,
-        val positionInTextLocator: (offset: Int) -> LineAndColumn,
-        var suppressedRegionLocator: SuppressionLocator
-    )
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 public object KtLint {
     public val FILE_PATH_USER_DATA_KEY: Key<String> = Key<String>("FILE_PATH")
+    @Deprecated("Marked for removal in Ktlint 0.48.0")
     public val EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY: Key<EditorConfigProperties> =
         Key<EditorConfigProperties>("EDITOR_CONFIG_PROPERTIES")
     internal const val UTF8_BOM = "\uFEFF"
@@ -128,7 +129,7 @@ public object KtLint {
         val errors = mutableListOf<LintError>()
 
         VisitorProvider(params)
-            .visitor(preparedCode.rootNode)
+            .visitor(preparedCode.editorConfigProperties)
             .invoke { rule, fqRuleId ->
                 preparedCode.executeRule(rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
                     val (line, col) = preparedCode.positionInTextLocator(offset)
@@ -147,7 +148,7 @@ public object KtLint {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        rule.beforeFirstNode(rootNode.getUserData(EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY)!!)
+        rule.beforeFirstNode(editorConfigProperties)
         this.executeRuleOnNodeRecursively(rootNode, rule, fqRuleId, autoCorrect, emit)
         rule.afterLastNode()
     }
@@ -201,7 +202,7 @@ public object KtLint {
         val errors = mutableSetOf<Pair<LintError, Boolean>>()
         val visitorProvider = VisitorProvider(params = params)
         visitorProvider
-            .visitor(preparedCode.rootNode)
+            .visitor(preparedCode.editorConfigProperties)
             .invoke { rule, fqRuleId ->
                 preparedCode.executeRule(rule, fqRuleId, true) { offset, errorMessage, canBeAutoCorrected ->
                     tripped = true
@@ -229,7 +230,7 @@ public object KtLint {
             }
         if (tripped) {
             visitorProvider
-                .visitor(preparedCode.rootNode)
+                .visitor(preparedCode.editorConfigProperties)
                 .invoke { rule, fqRuleId ->
                     preparedCode.executeRule(rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
                         val (line, col) = preparedCode.positionInTextLocator(offset)

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -149,12 +149,7 @@ public object KtLint {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (rule.runsOnRootNodeOnly()) {
-            // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189
-            // fixme: enforcing suppression based on node.startOffset is wrong (not just because not all nodes are leaves
-            //  but because rules are free to emit (and fix!) errors at any position)
-            if (!suppressedRegionLocator(rootNode.startOffset, fqRuleId, true)) {
-                this.executeRuleOnNode(rootNode, rule, fqRuleId, autoCorrect, emit)
-            }
+            this.executeRuleOnNode(rootNode, rule, fqRuleId, autoCorrect, emit)
         } else {
             rootNode.visit { childNode ->
                 // https://github.com/shyiko/ktlint/issues/158#issuecomment-462728189

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -52,8 +52,10 @@ public open class Rule(
         visit(node, autoCorrect, emit)
 
     /**
-     * For backwards compatibility reasons, this method is called by default implementation of [beforeVisitChildNodes].
-     * Existing implementations of the [visit] method should be renamed tp [beforeVisitChildNodes].
+     * Rules that override method [visit] should rename that method to [beforeVisitChildNodes]. For backwards
+     * compatibility reasons (in KtLint 0.47 only), this method is called via the default implementation of
+     * [beforeVisitChildNodes]. Whenever [beforeVisitChildNodes] is overridden with a custom implementation, this method
+     * will no longer be called.
      *
      * @param node AST node
      * @param autoCorrect indicates whether rule should attempt auto-correction

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -106,6 +106,12 @@ public open class Rule(
 
         object RunAsLateAsPossible : VisitorModifier()
 
+        @Deprecated(
+            """
+                Marked for removal in Ktlint 0.48. This modifier blocks the ability to suppress ktlint rules. See
+                changelog Ktlint 0.47 for details on how to modify a rule using this modifier.
+                """
+        )
         object RunOnRootNodeOnly : VisitorModifier()
     }
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.CodeStyleValue
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.CodeStyleValue.android
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.CodeStyleValue.official
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.codeStyleSetProperty
 import com.pinterest.ktlint.core.initKtLintKLogger
 import mu.KotlinLogging
 import org.ec4j.core.model.Property
@@ -42,18 +43,31 @@ public interface UsesEditorConfigProperties {
      * Get the value of [EditorConfigProperty] based on loaded [EditorConfigProperties] content for the current
      * [ASTNode].
      */
+    public fun <T> EditorConfigProperties.getEditorConfigValue(editorConfigProperty: EditorConfigProperty<T>): T {
+        require(editorConfigProperties.contains(editorConfigProperty)) {
+            "EditorConfigProperty '${editorConfigProperty.type.name}' may only be retrieved when it is registered in the editorConfigProperties."
+        }
+        val codeStyle = getEditorConfigValue(codeStyleSetProperty, official)
+        return getEditorConfigValue(editorConfigProperty, codeStyle)
+    }
+
+    /**
+     * Get the value of [EditorConfigProperty] based on loaded [EditorConfigProperties] content for the current
+     * [ASTNode].
+     */
+    @Deprecated(message = "Marked for deletion in Ktlint 0.48. EditorConfigProperties are now supplied to Rule via call on method beforeFirstNode")
     public fun <T> ASTNode.getEditorConfigValue(editorConfigProperty: EditorConfigProperty<T>): T {
         require(editorConfigProperties.contains(editorConfigProperty)) {
             "EditorConfigProperty '${editorConfigProperty.type.name}' may only be retrieved when it is registered in the editorConfigProperties."
         }
         val editorConfigPropertyValues = getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY)!!
-        val codeStyle = editorConfigPropertyValues.getEditorConfigValue(DefaultEditorConfigProperties.codeStyleSetProperty)
+        val codeStyle = editorConfigPropertyValues.getEditorConfigValue(codeStyleSetProperty, official)
         return editorConfigPropertyValues.getEditorConfigValue(editorConfigProperty, codeStyle)
     }
 
     private fun <T> EditorConfigProperties.getEditorConfigValue(
         editorConfigProperty: EditorConfigProperty<T>,
-        codeStyleValue: CodeStyleValue = official
+        codeStyleValue: CodeStyleValue
     ): T {
         val property = get(editorConfigProperty.type.name)
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
@@ -232,11 +232,13 @@ fun LeafElement.upsertWhitespaceAfterMe(text: String): LeafElement {
     }
 }
 
+@Deprecated(message = "Marked for removal in Ktlint 0.48. See Ktlint 0.47.0 changelog for more information.")
 fun ASTNode.visit(enter: (node: ASTNode) -> Unit) {
     enter(this)
     this.getChildren(null).forEach { it.visit(enter) }
 }
 
+@Deprecated(message = "Marked for removal in Ktlint 0.48. See Ktlint 0.47.0 changelog for more information.")
 fun ASTNode.visit(enter: (node: ASTNode) -> Unit, exit: (node: ASTNode) -> Unit) {
     enter(this)
     this.getChildren(null).forEach { it.visit(enter, exit) }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.ParseException
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -13,6 +14,7 @@ private val kotlinPsiFileFactoryProvider = KotlinPsiFileFactoryProvider()
 
 internal class PreparedCode(
     val rootNode: FileASTNode,
+    val editorConfigProperties: EditorConfigProperties,
     val positionInTextLocator: (offset: Int) -> LineAndColumn,
     var suppressedRegionLocator: SuppressionLocator
 )
@@ -53,12 +55,16 @@ internal fun prepareCodeForLinting(params: KtLint.ExperimentalParams): PreparedC
     if (!params.isStdIn) {
         rootNode.putUserData(KtLint.FILE_PATH_USER_DATA_KEY, params.normalizedFilePath.toString())
     }
+
+    // Keep for backwards compatibility in Ktlint 0.47.0 until ASTNode.getEditorConfigValue in UsesEditorConfigProperties
+    // is removed
     rootNode.putUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY, editorConfigProperties)
 
     val suppressedRegionLocator = SuppressionLocatorBuilder.buildSuppressedRegionsLocator(rootNode)
 
     return PreparedCode(
         rootNode,
+        editorConfigProperties,
         positionInTextLocator,
         suppressedRegionLocator
     )

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
@@ -2,13 +2,14 @@ package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.ParseException
+import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
-import java.nio.file.Paths
+
+private val kotlinPsiFileFactoryProvider = KotlinPsiFileFactoryProvider()
 
 internal class PreparedCode(
     val rootNode: FileASTNode,
@@ -16,10 +17,8 @@ internal class PreparedCode(
     var suppressedRegionLocator: SuppressionLocator
 )
 
-internal fun prepareCodeForLinting(
-    psiFileFactory: PsiFileFactory,
-    params: KtLint.ExperimentalParams
-): PreparedCode {
+internal fun prepareCodeForLinting(params: KtLint.ExperimentalParams): PreparedCode {
+    val psiFileFactory = kotlinPsiFileFactoryProvider.getKotlinPsiFileFactory(params.isInvokedFromCli)
     val normalizedText = normalizeText(params.text)
     val positionInTextLocator = buildPositionInTextLocator(normalizedText)
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/PreparedCode.kt
@@ -1,0 +1,86 @@
+package com.pinterest.ktlint.core.internal
+
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.ParseException
+import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Paths
+
+internal class PreparedCode(
+    val rootNode: FileASTNode,
+    val positionInTextLocator: (offset: Int) -> LineAndColumn,
+    var suppressedRegionLocator: SuppressionLocator
+)
+
+internal fun prepareCodeForLinting(
+    psiFileFactory: PsiFileFactory,
+    params: KtLint.ExperimentalParams
+): PreparedCode {
+    val normalizedText = normalizeText(params.text)
+    val positionInTextLocator = buildPositionInTextLocator(normalizedText)
+
+    val psiFileName = if (params.script) {
+        "file.kts"
+    } else {
+        "file.kt"
+    }
+    val psiFile = psiFileFactory.createFileFromText(
+        psiFileName,
+        KotlinLanguage.INSTANCE,
+        normalizedText
+    ) as KtFile
+
+    val errorElement = psiFile.findErrorElement()
+    if (errorElement != null) {
+        val (line, col) = positionInTextLocator(errorElement.textOffset)
+        throw ParseException(line, col, errorElement.errorDescription)
+    }
+
+    val rootNode = psiFile.node
+
+    val editorConfigProperties = KtLint.editorConfigLoader.loadPropertiesForFile(
+        params.normalizedFilePath,
+        params.isStdIn,
+        params.editorConfigPath?.let { Paths.get(it) },
+        params.rules,
+        params.editorConfigOverride,
+        params.debug
+    )
+
+    if (!params.isStdIn) {
+        rootNode.putUserData(KtLint.FILE_PATH_USER_DATA_KEY, params.normalizedFilePath.toString())
+    }
+    rootNode.putUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY, editorConfigProperties)
+
+    val suppressedRegionLocator = SuppressionLocatorBuilder.buildSuppressedRegionsLocator(rootNode)
+
+    return PreparedCode(
+        rootNode,
+        positionInTextLocator,
+        suppressedRegionLocator
+    )
+}
+
+private fun normalizeText(text: String): String {
+    return text
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replaceFirst(KtLint.UTF8_BOM, "")
+}
+
+private fun PsiElement.findErrorElement(): PsiErrorElement? {
+    if (this is PsiErrorElement) {
+        return this
+    }
+    this.children.forEach { child ->
+        val errorElement = child.findErrorElement()
+        if (errorElement != null) {
+            return errorElement
+        }
+    }
+    return null
+}

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.ast.prevLeaf
-import com.pinterest.ktlint.core.ast.visit
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -60,7 +59,7 @@ internal object SuppressionLocatorBuilder {
     ): List<SuppressionHint> {
         val result = ArrayList<SuppressionHint>()
         val open = ArrayList<SuppressionHint>()
-        rootNode.visit { node ->
+        rootNode.collect { node ->
             if (node is PsiComment) {
                 val text = node.getText()
                 if (text.startsWith("//")) {
@@ -108,6 +107,13 @@ internal object SuppressionLocatorBuilder {
             }
         )
         return result
+    }
+
+    private fun ASTNode.collect(block: (node: ASTNode) -> Unit) {
+        block(this)
+        this
+            .getChildren(null)
+            .forEach { it.collect(block) }
     }
 
     private fun parseHintArgs(

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
@@ -85,7 +85,7 @@ internal object SuppressionLocatorBuilder {
                                 val openingHint = open.removeAt(openHintIndex)
                                 result.add(
                                     SuppressionHint(
-                                        IntRange(openingHint.range.first, node.startOffset),
+                                        IntRange(openingHint.range.first, node.startOffset - 1),
                                         disabledRules
                                     )
                                 )

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -5,9 +5,6 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.disabledRulesProperty
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties.EditorConfigProperty
-import com.pinterest.ktlint.core.ast.visit
-import com.pinterest.ktlint.core.initKtLintKLogger
-import mu.KotlinLogging
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 /**
@@ -15,8 +12,6 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * executed, a singleton instance of the class is used to prevent that the logs are flooded with duplicate log lines.
  */
 private val ruleSorter = RuleSorter()
-
-private val logger = KotlinLogging.logger {}.initKtLintKLogger()
 
 internal class VisitorProvider(
     private val params: KtLint.ExperimentalParams,

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -92,18 +92,13 @@ internal class VisitorProvider(
                         ShortenedQualifiedRule(ruleReference.toShortenedQualifiedRuleId(), it)
                     }
             }
-        return sequentialVisitor(rules, rootNode)
-    }
-
-    private fun sequentialVisitor(
-        rules: List<ShortenedQualifiedRule>,
-        rootNode: ASTNode
-    ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit = { visit ->
-        rules.forEach {
-            if (it.rule.runsOnRootNodeOnly()) {
-                visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
-            } else {
-                rootNode.visit { node -> visit(node, it.rule, it.shortenedQualifiedRuleId) }
+        return { visit ->
+            rules.forEach {
+                if (it.rule.runsOnRootNodeOnly()) {
+                    visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
+                } else {
+                    rootNode.visit { node -> visit(node, it.rule, it.shortenedQualifiedRuleId) }
+                }
             }
         }
     }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -94,11 +94,7 @@ internal class VisitorProvider(
             }
         return { visit ->
             rules.forEach {
-                if (it.rule.runsOnRootNodeOnly()) {
-                    visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
-                } else {
-                    rootNode.visit { node -> visit(node, it.rule, it.shortenedQualifiedRuleId) }
-                }
+                visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
             }
         }
     }
@@ -111,9 +107,6 @@ internal class VisitorProvider(
                 // The rule set id in the disabled_rules setting may be omitted for rules in the standard rule set
                 it.toQualifiedRuleId() == qualifiedRuleId
             }
-
-    private fun Rule.runsOnRootNodeOnly() =
-        visitorModifiers.contains(Rule.VisitorModifier.RunOnRootNodeOnly)
 
     private data class ShortenedQualifiedRule(
         val shortenedQualifiedRuleId: String,

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -38,10 +38,7 @@ internal class VisitorProvider(
             ruleSorter
         }.getSortedRules(params.ruleSets, params.debug)
 
-    internal fun visitor(
-        rootNode: ASTNode,
-        concurrent: Boolean = true
-    ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
+    internal fun visitor(rootNode: ASTNode): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
         val enabledRuleReferences =
             ruleReferences
                 .filter { ruleReference -> isNotDisabled(rootNode, ruleReference.toQualifiedRuleId()) }
@@ -91,39 +88,18 @@ internal class VisitorProvider(
                         ShortenedQualifiedRule(ruleReference.toShortenedQualifiedRuleId(), it)
                     }
             }
-        return if (concurrent) {
-            concurrentVisitor(rules, rootNode)
-        } else {
-            sequentialVisitor(rules, rootNode)
-        }
-    }
-
-    private fun concurrentVisitor(
-        rules: List<ShortenedQualifiedRule>,
-        rootNode: ASTNode
-    ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
-        return { visit ->
-            rootNode.visit { node ->
-                rules.forEach {
-                    if (node == rootNode || !it.rule.runsOnRootNodeOnly()) {
-                        visit(node, it.rule, it.shortenedQualifiedRuleId)
-                    }
-                }
-            }
-        }
+        return sequentialVisitor(rules, rootNode)
     }
 
     private fun sequentialVisitor(
         rules: List<ShortenedQualifiedRule>,
         rootNode: ASTNode
-    ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
-        return { visit ->
-            rules.forEach {
-                if (it.rule.runsOnRootNodeOnly()) {
-                    visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
-                } else {
-                    rootNode.visit { node -> visit(node, it.rule, it.shortenedQualifiedRuleId) }
-                }
+    ): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit = { visit ->
+        rules.forEach {
+            if (it.rule.runsOnRootNodeOnly()) {
+                visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
+            } else {
+                rootNode.visit { node -> visit(node, it.rule, it.shortenedQualifiedRuleId) }
             }
         }
     }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -51,10 +51,12 @@ internal class VisitorProvider(
                     .filter { rule -> isNotDisabled(rootNode, toQualifiedRuleId(ruleSet.id, rule.id)) }
                     .map { rule -> toQualifiedRuleId(ruleSet.id, rule.id) to rule }
             }.toMap()
-        if (params.debug && enabledRules.isEmpty()) {
-            println(
-                "[DEBUG] Skipping file as no enabled rules are found to be executed"
-            )
+        if (enabledRules.isEmpty()) {
+            if (params.debug && enabledRules.isEmpty()) {
+                println(
+                    "[DEBUG] Skipping file as no enabled rules are found to be executed"
+                )
+            }
             return { _ -> }
         }
         val ruleReferencesToBeSkipped =
@@ -75,10 +77,12 @@ internal class VisitorProvider(
                 }
         }
         val ruleReferenceWithoutEntriesToBeSkipped = enabledRuleReferences - ruleReferencesToBeSkipped.toSet()
-        if (params.debug && ruleReferenceWithoutEntriesToBeSkipped.isEmpty()) {
-            println(
-                "[DEBUG] Skipping file as no enabled rules are found to be executed"
-            )
+        if (ruleReferenceWithoutEntriesToBeSkipped.isEmpty()) {
+            if (params.debug) {
+                println(
+                    "[DEBUG] Skipping file as no enabled rules are found to be executed"
+                )
+            }
             return { _ -> }
         }
         val rules = ruleReferences

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -38,7 +38,7 @@ internal class VisitorProvider(
             ruleSorter
         }.getSortedRules(params.ruleSets, params.debug)
 
-    internal fun visitor(rootNode: ASTNode): ((node: ASTNode, rule: Rule, fqRuleId: String) -> Unit) -> Unit {
+    internal fun visitor(rootNode: ASTNode): ((rule: Rule, fqRuleId: String) -> Unit) -> Unit {
         val enabledRuleReferences =
             ruleReferences
                 .filter { ruleReference -> isNotDisabled(rootNode, ruleReference.toQualifiedRuleId()) }
@@ -94,7 +94,7 @@ internal class VisitorProvider(
             }
         return { visit ->
             rules.forEach {
-                visit(rootNode, it.rule, it.shortenedQualifiedRuleId)
+                visit(it.rule, it.shortenedQualifiedRuleId)
             }
         }
     }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/DisabledRulesTest.kt
@@ -60,7 +60,7 @@ class DisabledRulesTest {
     }
 
     class NoVarRule : Rule("no-var") {
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -452,7 +452,7 @@ class KtLintTest {
                 cb = { _, _ -> }
             )
         )
-        assertThat(bus).isEqualTo(listOf("file:a", "file:b", "file:c", "file:d", "file:e", "b", "c", "e"))
+        assertThat(bus).isEqualTo(listOf("file:a", "file:b", "b", "file:c", "c", "file:d", "file:e", "e"))
     }
 
     @Test

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -4,9 +4,18 @@ import com.pinterest.ktlint.core.AutoCorrectErrorRule.Companion.STRING_VALUE_AFT
 import com.pinterest.ktlint.core.DummyRuleWithCustomEditorConfigProperty.Companion.SOME_CUSTOM_RULE_PROPERTY
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
-import com.pinterest.ktlint.core.VisitedNode.VisitNodeType.CHILD
-import com.pinterest.ktlint.core.VisitedNode.VisitNodeType.ROOT
+import com.pinterest.ktlint.core.RuleExecutionCall.RuleMethod.AFTER_CHILDREN
+import com.pinterest.ktlint.core.RuleExecutionCall.RuleMethod.AFTER_LAST
+import com.pinterest.ktlint.core.RuleExecutionCall.RuleMethod.BEFORE_CHILDREN
+import com.pinterest.ktlint.core.RuleExecutionCall.RuleMethod.BEFORE_FIRST
+import com.pinterest.ktlint.core.RuleExecutionCall.RuleMethod.VISIT
+import com.pinterest.ktlint.core.RuleExecutionCall.VisitNodeType.CHILD
+import com.pinterest.ktlint.core.RuleExecutionCall.VisitNodeType.ROOT
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.ElementType.FILE
+import com.pinterest.ktlint.core.ast.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.core.ast.ElementType.PACKAGE_DIRECTIVE
 import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.core.ast.isRoot
 import org.assertj.core.api.Assertions.assertThat
@@ -14,6 +23,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -395,120 +406,304 @@ class KtLintTest {
         }
     }
 
-    @Test
-    fun `Given a normal rule then execute on root node and child nodes`() {
-        val visitedNodes = mutableListOf<VisitedNode>()
-        KtLint.lint(
-            KtLint.ExperimentalParams(
-                text = "fun main() {}",
-                ruleSets = listOf(
-                    RuleSet(
-                        "standard",
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "a",
-                            visitorModifiers = setOf()
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "b",
-                            visitorModifiers = setOf(RunAsLateAsPossible)
+    @DisplayName("Calls to rules defined in ktlint 0.46.x or before")
+    @Nested
+    inner class RuleExecutionCallsLegacy {
+        @Test
+        fun `Given a normal rule then execute on root node and child nodes`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    // An empty file results in nodes with elementTypes FILE, PACKAGE_DIRECTIVE and IMPORT_LIST respectively
+                    text = "",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf()
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b",
+                                visitorModifiers = setOf(RunAsLateAsPossible)
+                            )
                         )
-                    )
-                ),
-                cb = { _, _ -> }
+                    ),
+                    cb = { _, _ -> }
+                )
             )
-        )
-        assertThat(visitedNodes).containsExactly(
-            VisitedNode(ROOT, "a"),
-            VisitedNode(CHILD, "a"),
-            VisitedNode(ROOT, "b"),
-            VisitedNode(CHILD, "b")
-        )
+            assertThat(ruleExecutionCalls).containsExactly(
+                RuleExecutionCall(VISIT, ROOT, "a", FILE),
+                RuleExecutionCall(VISIT, CHILD, "a", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(VISIT, CHILD, "a", IMPORT_LIST),
+                RuleExecutionCall(VISIT, ROOT, "b", FILE),
+                RuleExecutionCall(VISIT, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(VISIT, CHILD, "b", IMPORT_LIST)
+            )
+        }
+
+        @Test
+        fun `Given a run-on-root-node-only rule then execute on root node but not on child nodes`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    text = "fun main() {}",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf(RunOnRootNodeOnly)
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b",
+                                visitorModifiers = setOf(RunOnRootNodeOnly, RunAsLateAsPossible)
+                            )
+                        )
+                    ),
+                    cb = { _, _ -> }
+                )
+            )
+            assertThat(ruleExecutionCalls).containsExactly(
+                RuleExecutionCall(VISIT, ROOT, "a", FILE),
+                RuleExecutionCall(VISIT, ROOT, "b", FILE)
+            )
+        }
+
+        @Test
+        fun `Given multiple rules which have to run in a certain order`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    // An empty file results in nodes with elementTypes FILE, PACKAGE_DIRECTIVE and IMPORT_LIST respectively
+                    text = "",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "e",
+                                visitorModifiers = setOf(RunAsLateAsPossible)
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "d",
+                                visitorModifiers = setOf(
+                                    RunOnRootNodeOnly,
+                                    RunAsLateAsPossible
+                                )
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b"
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf(
+                                    RunOnRootNodeOnly
+                                )
+                            ),
+                            SimpleTestRuleLegacy(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "c"
+                            )
+                        )
+                    ),
+                    cb = { _, _ -> }
+                )
+            )
+            assertThat(ruleExecutionCalls).containsExactly(
+                RuleExecutionCall(VISIT, ROOT, "a", FILE),
+                RuleExecutionCall(VISIT, ROOT, "b", FILE),
+                RuleExecutionCall(VISIT, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(VISIT, CHILD, "b", IMPORT_LIST),
+                RuleExecutionCall(VISIT, ROOT, "c", FILE),
+                RuleExecutionCall(VISIT, CHILD, "c", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(VISIT, CHILD, "c", IMPORT_LIST),
+                RuleExecutionCall(VISIT, ROOT, "d", FILE),
+                RuleExecutionCall(VISIT, ROOT, "e", FILE),
+                RuleExecutionCall(VISIT, CHILD, "e", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(VISIT, CHILD, "e", IMPORT_LIST)
+            )
+        }
     }
 
-    @Test
-    fun `Given a run-on-root-node-only rule then execute on root node but not on child nodes`() {
-        val visitedNodes = mutableListOf<VisitedNode>()
-        KtLint.lint(
-            KtLint.ExperimentalParams(
-                text = "fun main() {}",
-                ruleSets = listOf(
-                    RuleSet(
-                        "standard",
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "a",
-                            visitorModifiers = setOf(RunOnRootNodeOnly)
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "b",
-                            visitorModifiers = setOf(RunOnRootNodeOnly, RunAsLateAsPossible)
+    @DisplayName("Calls to rules defined in ktlint 0.47 and after")
+    @Nested
+    inner class RuleExecutionCalls {
+        @Test
+        fun `Given a normal rule then execute on root node and child nodes`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    // An empty file results in nodes with elementTypes FILE, PACKAGE_DIRECTIVE and IMPORT_LIST respectively
+                    text = "",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf()
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b",
+                                visitorModifiers = setOf(RunAsLateAsPossible)
+                            )
                         )
-                    )
-                ),
-                cb = { _, _ -> }
+                    ),
+                    cb = { _, _ -> }
+                )
             )
-        )
-        assertThat(visitedNodes).containsExactly(
-            VisitedNode(ROOT, "a"),
-            VisitedNode(ROOT, "b")
-        )
-    }
+            assertThat(ruleExecutionCalls).containsExactly(
+                // File a
+                RuleExecutionCall(BEFORE_FIRST, null, "a", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "a", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "a", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "a", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "a", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "a", null),
+                // File b
+                RuleExecutionCall(BEFORE_FIRST, null, "b", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "b", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "b", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "b", null)
+            )
+        }
 
-    @Test
-    fun `Given multiple rules which have to run in a certain order`() {
-        val visitedNodes = mutableListOf<VisitedNode>()
-        KtLint.lint(
-            KtLint.ExperimentalParams(
-                text = "fun main() {}",
-                ruleSets = listOf(
-                    RuleSet(
-                        "standard",
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "e",
-                            visitorModifiers = setOf(RunAsLateAsPossible)
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "d",
-                            visitorModifiers = setOf(
-                                RunOnRootNodeOnly,
-                                RunAsLateAsPossible
+        @Test
+        fun `Given a run-on-root-node-only rule then execute on root node but not on child nodes`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    text = "fun main() {}",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf(RunOnRootNodeOnly)
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b",
+                                visitorModifiers = setOf(RunOnRootNodeOnly, RunAsLateAsPossible)
                             )
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "b"
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "a",
-                            visitorModifiers = setOf(
-                                RunOnRootNodeOnly
-                            )
-                        ),
-                        SimpleTestRule(
-                            visitedNodes = visitedNodes,
-                            id = "c"
                         )
-                    )
-                ),
-                cb = { _, _ -> }
+                    ),
+                    cb = { _, _ -> }
+                )
             )
-        )
-        assertThat(visitedNodes).containsExactly(
-            VisitedNode(ROOT, "a"),
-            VisitedNode(ROOT, "b"),
-            VisitedNode(CHILD, "b"),
-            VisitedNode(ROOT, "c"),
-            VisitedNode(CHILD, "c"),
-            VisitedNode(ROOT, "d"),
-            VisitedNode(ROOT, "e"),
-            VisitedNode(CHILD, "e")
-        )
+            assertThat(ruleExecutionCalls).containsExactly(
+                // File a
+                RuleExecutionCall(BEFORE_FIRST, null, "a", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "a", null),
+                // File b
+                RuleExecutionCall(BEFORE_FIRST, null, "b", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "b", null)
+            )
+        }
+
+        @Test
+        fun `Given multiple rules which have to run in a certain order`() {
+            val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
+            KtLint.lint(
+                KtLint.ExperimentalParams(
+                    // An empty file results in nodes with elementTypes FILE, PACKAGE_DIRECTIVE and IMPORT_LIST respectively
+                    text = "",
+                    ruleSets = listOf(
+                        RuleSet(
+                            "standard",
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "e",
+                                visitorModifiers = setOf(RunAsLateAsPossible)
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "d",
+                                visitorModifiers = setOf(
+                                    RunOnRootNodeOnly,
+                                    RunAsLateAsPossible
+                                )
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "b"
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "a",
+                                visitorModifiers = setOf(
+                                    RunOnRootNodeOnly
+                                )
+                            ),
+                            SimpleTestRule(
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                id = "c"
+                            )
+                        )
+                    ),
+                    cb = { _, _ -> }
+                )
+            )
+            assertThat(ruleExecutionCalls).containsExactly(
+                // File a (root only)
+                RuleExecutionCall(BEFORE_FIRST, null, "a", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "a", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "a", null),
+                // File b
+                RuleExecutionCall(BEFORE_FIRST, null, "b", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "b", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "b", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "b", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "b", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "b", null),
+                // File c
+                RuleExecutionCall(BEFORE_FIRST, null, "c", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "c", FILE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "c", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "c", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "c", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "c", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "c", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "c", null),
+                // File d (root only)
+                RuleExecutionCall(BEFORE_FIRST, null, "d", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "d", FILE),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "d", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "d", null),
+                // File e
+                RuleExecutionCall(BEFORE_FIRST, null, "e", null),
+                RuleExecutionCall(BEFORE_CHILDREN, ROOT, "e", FILE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "e", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "e", PACKAGE_DIRECTIVE),
+                RuleExecutionCall(BEFORE_CHILDREN, CHILD, "e", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, CHILD, "e", IMPORT_LIST),
+                RuleExecutionCall(AFTER_CHILDREN, ROOT, "e", FILE),
+                RuleExecutionCall(AFTER_LAST, null, "e", null)
+            )
+        }
     }
 
     @Test
@@ -606,33 +801,83 @@ private class AutoCorrectErrorRule : Rule("auto-correct") {
 }
 
 /**
- * Collects a maximum of two placeholders for a code sample. The first placeholder represent the root node of the code
- * sample and is returned as "root:<id>". The placeholder represents *all* other nodes of the code sample and is
- * represented as "<id>".
+ * Rule in style up to ktlint 0.46.x in which a rule only has to override method [Rule.visit]. For each invocation to
+ * this method a [RuleExecutionCall] is added to the list of previously calls made.
  */
-private open class SimpleTestRule(
-    private val visitedNodes: MutableList<VisitedNode>,
+private class SimpleTestRuleLegacy(
+    private val ruleExecutionCalls: MutableList<RuleExecutionCall>,
     id: String,
     visitorModifiers: Set<VisitorModifier> = emptySet()
 ) : Rule(id, visitorModifiers) {
-    private var done = false
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            visitedNodes.add(VisitedNode(ROOT, id))
-        } else if (!done) {
-            visitedNodes.add(VisitedNode(CHILD, id))
-            done = true
-        }
+        ruleExecutionCalls.add(RuleExecutionCall(VISIT, node.visitNodeType, id, node.elementType))
     }
 }
 
-private data class VisitedNode(val visitNodeType: VisitNodeType, val id: String) {
+/**
+ * Rule in style starting from ktlint 0.47.x in which a rule can can override method [Rule.beforeFirstNode],
+ * [Rule.beforeVisitChildNodes], [Rule.afterVisitChildNodes] and [Rule.afterLastNode]. For each invocation to
+ * this method a [RuleExecutionCall] is added to the list of previously calls made.
+ */
+private class SimpleTestRule(
+    private val ruleExecutionCalls: MutableList<RuleExecutionCall>,
+    id: String,
+    visitorModifiers: Set<VisitorModifier> = emptySet()
+) : Rule(id, visitorModifiers) {
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        ruleExecutionCalls.add(RuleExecutionCall(BEFORE_FIRST, null, id, null))
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        ruleExecutionCalls.add(RuleExecutionCall(BEFORE_CHILDREN, node.visitNodeType, id, node.elementType))
+    }
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        ruleExecutionCalls.add(RuleExecutionCall(VISIT, node.visitNodeType, id, node.elementType))
+    }
+
+    override fun afterVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        ruleExecutionCalls.add(RuleExecutionCall(AFTER_CHILDREN, node.visitNodeType, id, node.elementType))
+    }
+
+    override fun afterLastNode() {
+        ruleExecutionCalls.add(RuleExecutionCall(AFTER_LAST, null, id, null))
+    }
+}
+
+private data class RuleExecutionCall(
+    val ruleMethod: RuleMethod,
+    val visitNodeType: VisitNodeType?,
+    val id: String,
+    val file: IElementType?
+) {
+    enum class RuleMethod { BEFORE_FIRST, BEFORE_CHILDREN, VISIT, AFTER_CHILDREN, AFTER_LAST }
     enum class VisitNodeType { ROOT, CHILD }
 }
+
+private val ASTNode.visitNodeType: RuleExecutionCall.VisitNodeType
+    get() =
+        if (isRoot()) {
+            ROOT
+        } else {
+            CHILD
+        }
 
 private fun getResourceAsText(path: String) =
     (ClassLoader.getSystemClassLoader().getResourceAsStream(path) ?: throw RuntimeException("$path not found"))

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -2,6 +2,10 @@ package com.pinterest.ktlint.core
 
 import com.pinterest.ktlint.core.AutoCorrectErrorRule.Companion.STRING_VALUE_AFTER_AUTOCORRECT
 import com.pinterest.ktlint.core.DummyRuleWithCustomEditorConfigProperty.Companion.SOME_CUSTOM_RULE_PROPERTY
+import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
+import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
+import com.pinterest.ktlint.core.VisitedNode.VisitNodeType.CHILD
+import com.pinterest.ktlint.core.VisitedNode.VisitNodeType.ROOT
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.core.ast.isRoot
@@ -392,59 +396,102 @@ class KtLintTest {
     }
 
     @Test
-    fun testRuleExecutionOrder() {
-        open class R(
-            private val bus: MutableList<String>,
-            id: String,
-            visitorModifiers: Set<VisitorModifier> = emptySet()
-        ) : Rule(id, visitorModifiers) {
-            private var done = false
-            override fun visit(
-                node: ASTNode,
-                autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-            ) {
-                if (node.isRoot()) {
-                    bus.add("file:$id")
-                } else if (!done) {
-                    bus.add(id)
-                    done = true
-                }
-            }
-        }
-        val bus = mutableListOf<String>()
+    fun `Given a normal rule then execute on root node and child nodes`() {
+        val visitedNodes = mutableListOf<VisitedNode>()
         KtLint.lint(
             KtLint.ExperimentalParams(
                 text = "fun main() {}",
                 ruleSets = listOf(
                     RuleSet(
                         "standard",
-                        object : R(
-                            bus = bus,
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
+                            id = "a",
+                            visitorModifiers = setOf()
+                        ),
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
+                            id = "b",
+                            visitorModifiers = setOf(RunAsLateAsPossible)
+                        )
+                    )
+                ),
+                cb = { _, _ -> }
+            )
+        )
+        assertThat(visitedNodes).containsExactly(
+            VisitedNode(ROOT, "a"),
+            VisitedNode(CHILD, "a"),
+            VisitedNode(ROOT, "b"),
+            VisitedNode(CHILD, "b")
+        )
+    }
+
+    @Test
+    fun `Given a run-on-root-node-only rule then execute on root node but not on child nodes`() {
+        val visitedNodes = mutableListOf<VisitedNode>()
+        KtLint.lint(
+            KtLint.ExperimentalParams(
+                text = "fun main() {}",
+                ruleSets = listOf(
+                    RuleSet(
+                        "standard",
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
+                            id = "a",
+                            visitorModifiers = setOf(RunOnRootNodeOnly)
+                        ),
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
+                            id = "b",
+                            visitorModifiers = setOf(RunOnRootNodeOnly, RunAsLateAsPossible)
+                        )
+                    )
+                ),
+                cb = { _, _ -> }
+            )
+        )
+        assertThat(visitedNodes).containsExactly(
+            VisitedNode(ROOT, "a"),
+            VisitedNode(ROOT, "b")
+        )
+    }
+
+    @Test
+    fun `Given multiple rules which have to run in a certain order`() {
+        val visitedNodes = mutableListOf<VisitedNode>()
+        KtLint.lint(
+            KtLint.ExperimentalParams(
+                text = "fun main() {}",
+                ruleSets = listOf(
+                    RuleSet(
+                        "standard",
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
                             id = "e",
-                            visitorModifiers = setOf(VisitorModifier.RunAsLateAsPossible)
-                        ) {},
-                        object : R(
-                            bus = bus,
+                            visitorModifiers = setOf(RunAsLateAsPossible)
+                        ),
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
                             id = "d",
                             visitorModifiers = setOf(
-                                VisitorModifier.RunOnRootNodeOnly,
-                                VisitorModifier.RunAsLateAsPossible
+                                RunOnRootNodeOnly,
+                                RunAsLateAsPossible
                             )
-                        ) {},
-                        R(
-                            bus = bus,
+                        ),
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
                             id = "b"
                         ),
-                        object : R(
-                            bus = bus,
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
                             id = "a",
                             visitorModifiers = setOf(
-                                VisitorModifier.RunOnRootNodeOnly
+                                RunOnRootNodeOnly
                             )
-                        ) {},
-                        R(
-                            bus = bus,
+                        ),
+                        SimpleTestRule(
+                            visitedNodes = visitedNodes,
                             id = "c"
                         )
                     )
@@ -452,7 +499,16 @@ class KtLintTest {
                 cb = { _, _ -> }
             )
         )
-        assertThat(bus).isEqualTo(listOf("file:a", "file:b", "b", "file:c", "c", "file:d", "file:e", "e"))
+        assertThat(visitedNodes).containsExactly(
+            VisitedNode(ROOT, "a"),
+            VisitedNode(ROOT, "b"),
+            VisitedNode(CHILD, "b"),
+            VisitedNode(ROOT, "c"),
+            VisitedNode(CHILD, "c"),
+            VisitedNode(ROOT, "d"),
+            VisitedNode(ROOT, "e"),
+            VisitedNode(CHILD, "e")
+        )
     }
 
     @Test
@@ -547,6 +603,35 @@ private class AutoCorrectErrorRule : Rule("auto-correct") {
         const val ERROR_MESSAGE_CAN_BE_AUTOCORRECTED = "This string value is not allowed and can be autocorrected"
         const val ERROR_MESSAGE_CAN_NOT_BE_AUTOCORRECTED = "This string value is not allowed but can not be autocorrected"
     }
+}
+
+/**
+ * Collects a maximum of two placeholders for a code sample. The first placeholder represent the root node of the code
+ * sample and is returned as "root:<id>". The placeholder represents *all* other nodes of the code sample and is
+ * represented as "<id>".
+ */
+private open class SimpleTestRule(
+    private val visitedNodes: MutableList<VisitedNode>,
+    id: String,
+    visitorModifiers: Set<VisitorModifier> = emptySet()
+) : Rule(id, visitorModifiers) {
+    private var done = false
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.isRoot()) {
+            visitedNodes.add(VisitedNode(ROOT, id))
+        } else if (!done) {
+            visitedNodes.add(VisitedNode(CHILD, id))
+            done = true
+        }
+    }
+}
+
+private data class VisitedNode(val visitNodeType: VisitNodeType, val id: String) {
+    enum class VisitNodeType { ROOT, CHILD }
 }
 
 private fun getResourceAsText(path: String) =

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -730,13 +730,6 @@ private class DummyRuleWithCustomEditorConfigProperty :
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(someCustomRuleProperty)
 
-    override fun visit(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-    ) {
-    }
-
     companion object {
         const val SOME_CUSTOM_RULE_PROPERTY = "some-custom-rule-property"
 
@@ -759,7 +752,7 @@ private class DummyRuleWithCustomEditorConfigProperty :
 private open class DummyRule(
     val block: (node: ASTNode) -> Unit = {}
 ) : Rule("dummy-rule") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
@@ -801,7 +794,7 @@ private class AutoCorrectErrorRule : Rule("auto-correct") {
 }
 
 /**
- * Rule in style up to ktlint 0.46.x in which a rule only has to override method [Rule.visit]. For each invocation to
+ * Rule in style up to ktlint 0.46.x in which a rule only has to override method [Rule.beforeVisitChildNodes]. For each invocation to
  * this method a [RuleExecutionCall] is added to the list of previously calls made.
  */
 private class SimpleTestRuleLegacy(
@@ -809,7 +802,7 @@ private class SimpleTestRuleLegacy(
     id: String,
     visitorModifiers: Set<VisitorModifier> = emptySet()
 ) : Rule(id, visitorModifiers) {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/KtLintTest.kt
@@ -802,7 +802,7 @@ private class SimpleTestRuleLegacy(
     id: String,
     visitorModifiers: Set<VisitorModifier> = emptySet()
 ) : Rule(id, visitorModifiers) {
-    override fun beforeVisitChildNodes(
+    override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/UsesEditorConfigPropertiesTest.kt
@@ -6,175 +6,172 @@ import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLength
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.model.Property
-import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.DummyHolderElement
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class UsesEditorConfigPropertiesTest {
-    class PropertyValueTester(editorConfigProperty: UsesEditorConfigProperties.EditorConfigProperty<Int>) : UsesEditorConfigProperties {
-        override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(editorConfigProperty)
-
-        fun <T> testValue(
-            node: ASTNode,
-            editorConfigProperty: UsesEditorConfigProperties.EditorConfigProperty<T>
-        ): T = node.getEditorConfigValue(editorConfigProperty)
-    }
-
-    @Test
-    fun `Given that editor config property indent_size is set to an integer value then return that integer value via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(
+    @Nested
+    inner class IndentSizeProperty {
+        @Test
+        fun `Given that editor config property indent_size is set to an integer value then return that integer value via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
                 indentSizeProperty,
                 SOME_INTEGER_VALUE.toString()
             )
-        )
-        val actual = PropertyValueTester(indentSizeProperty).testValue(testAstNode, indentSizeProperty)
 
-        assertThat(actual).isEqualTo(SOME_INTEGER_VALUE)
-    }
+            val actual = with(EditorConfigPropertiesTester(indentSizeProperty)) {
+                editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+            }
 
-    @Test
-    fun `Given that editor config property indent_size is set to value 'unset' then return -1 as value via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(
+            assertThat(actual).isEqualTo(SOME_INTEGER_VALUE)
+        }
+
+        @Test
+        fun `Given that editor config property indent_size is set to value 'unset' then return -1 as value via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
                 indentSizeProperty,
                 "unset"
             )
-        )
-        val actual = PropertyValueTester(indentSizeProperty).testValue(testAstNode, indentSizeProperty)
 
-        assertThat(actual).isEqualTo(-1)
-    }
+            val actual = with(EditorConfigPropertiesTester(indentSizeProperty)) {
+                editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+            }
 
-    @Test
-    fun `Issue 1485 - Given that editor config property indent_size is set to value 'tab' then return tabWidth as value via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(
+            assertThat(actual).isEqualTo(-1)
+        }
+
+        @Test
+        fun `Issue 1485 - Given that editor config property indent_size is set to value 'tab' then return tabWidth as value via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
                 indentSizeProperty,
                 "tab"
             )
-        )
-        val actual = PropertyValueTester(indentSizeProperty).testValue(testAstNode, indentSizeProperty)
 
-        assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
+            val actual = with(EditorConfigPropertiesTester(indentSizeProperty)) {
+                editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+            }
+
+            assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
+        }
+
+        @Test
+        fun `Given that editor config property indent_size is not set then return the default tabWidth as value via the getEditorConfigValue of the node`() {
+            val actual = with(EditorConfigPropertiesTester(indentSizeProperty)) {
+                emptyMap<String, Property>().getEditorConfigValue(indentSizeProperty)
+            }
+
+            assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
+
+            assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
+        }
     }
 
-    @Test
-    fun `Given that editor config property indent_size is not set then return the default tabWidth as value via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            emptyMap()
-        )
-        val actual = PropertyValueTester(indentSizeProperty).testValue(testAstNode, indentSizeProperty)
-
-        assertThat(actual).isEqualTo(IndentConfig.DEFAULT_INDENT_CONFIG.tabWidth)
-    }
-
-    @Test
-    fun `Given that editor config property max_line_length is set to an integer value then return that integer value via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(
+    @Nested
+    inner class MaxLineLengthProperty {
+        @Test
+        fun `Given that editor config property max_line_length is set to an integer value then return that integer value via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
                 maxLineLengthProperty,
                 SOME_INTEGER_VALUE.toString()
             )
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
 
-        assertThat(actual).isEqualTo(SOME_INTEGER_VALUE)
-    }
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+            }
 
-    @Test
-    fun `Given that editor config property max_line_length is set to value 'off' then return -1 via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(
+            assertThat(actual).isEqualTo(SOME_INTEGER_VALUE)
+        }
+
+        @Test
+        fun `Given that editor config property max_line_length is set to value 'off' then return -1 via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
                 maxLineLengthProperty,
                 "off"
             )
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
 
-        assertThat(actual).isEqualTo(-1)
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+            }
+
+            assertThat(actual).isEqualTo(-1)
+        }
+
+        @Test
+        fun `Given that editor config property max_line_length is set to value 'unset' for android then return 100 via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
+                maxLineLengthProperty,
+                "unset"
+            ).plus(ANDROID_CODE_STYLE)
+
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+            }
+
+            assertThat(actual).isEqualTo(100)
+        }
+
+        @Test
+        fun `Given that editor config property max_line_length is set to value 'unset' for non-android then return -1 via the getEditorConfigValue of the node`() {
+            val editorConfigProperties = createEditorConfigPropertiesFrom(
+                maxLineLengthProperty,
+                "unset"
+            ).plus(OFFICIAL_CODE_STYLE)
+
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+            }
+
+            assertThat(actual).isEqualTo(-1)
+        }
+
+        @Test
+        fun `Given that editor config property max_line_length is not set for android then return 100 via the getEditorConfigValue of the node`() {
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                ANDROID_CODE_STYLE.getEditorConfigValue(maxLineLengthProperty)
+            }
+
+            assertThat(actual).isEqualTo(100)
+        }
+
+        @Test
+        fun `Given that editor config property max_line_length is not set for non-android then return -1 via the getEditorConfigValue of the node`() {
+            val actual = with(EditorConfigPropertiesTester(maxLineLengthProperty)) {
+                OFFICIAL_CODE_STYLE.getEditorConfigValue(maxLineLengthProperty)
+            }
+
+            assertThat(actual).isEqualTo(-1)
+        }
     }
 
-    @Test
-    fun `Given that editor config property max_line_length is set to value 'unset' for android then return 100 via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(maxLineLengthProperty, "unset").plus(ANDROID_CODE_STYLE)
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
-
-        assertThat(actual).isEqualTo(100)
-    }
-
-    @Test
-    fun `Given that editor config property max_line_length is set to value 'unset' for non-android then return -1 via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            createPropertyWithValue(maxLineLengthProperty, "unset").plus(OFFICIAL_CODE_STYLE)
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
-
-        assertThat(actual).isEqualTo(-1)
-    }
-
-    @Test
-    fun `Given that editor config property max_line_length is not set for android then return 100 via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            ANDROID_CODE_STYLE
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
-
-        assertThat(actual).isEqualTo(100)
-    }
-
-    @Test
-    fun `Given that editor config property max_line_length is not set for non-android then return -1 via the getEditorConfigValue of the node`() {
-        val testAstNode: ASTNode = DummyHolderElement("some-text")
-        testAstNode.putUserData(
-            KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY,
-            OFFICIAL_CODE_STYLE
-        )
-        val actual = PropertyValueTester(maxLineLengthProperty).testValue(testAstNode, maxLineLengthProperty)
-
-        assertThat(actual).isEqualTo(-1)
+    class EditorConfigPropertiesTester<T>(
+        editorConfigProperty: UsesEditorConfigProperties.EditorConfigProperty<T>
+    ) : UsesEditorConfigProperties {
+        override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(editorConfigProperty)
     }
 
     private companion object {
         const val SOME_INTEGER_VALUE = 123
-        val ANDROID_CODE_STYLE = createPropertyWithValue(
+        val ANDROID_CODE_STYLE = createEditorConfigPropertiesFrom(
             DefaultEditorConfigProperties.codeStyleSetProperty,
             DefaultEditorConfigProperties.CodeStyleValue.android.name.lowercase()
         )
-        val OFFICIAL_CODE_STYLE = createPropertyWithValue(
+        val OFFICIAL_CODE_STYLE = createEditorConfigPropertiesFrom(
             DefaultEditorConfigProperties.codeStyleSetProperty,
             DefaultEditorConfigProperties.CodeStyleValue.official.name.lowercase()
         )
 
-        private fun <T : Any> createPropertyWithValue(
+        private fun <T : Any> createEditorConfigPropertiesFrom(
             editorConfigProperty: UsesEditorConfigProperties.EditorConfigProperty<T>,
             value: String
-        ) = mapOf(
-            editorConfigProperty.type.name to Property.builder()
-                .name(editorConfigProperty.type.name)
-                .type(editorConfigProperty.type)
-                .value(value)
-                .build()
-        )
+        ) =
+            with(editorConfigProperty) {
+                mapOf(
+                    type.name to Property.builder()
+                        .name(type.name)
+                        .type(type)
+                        .value(value)
+                        .build()
+                )
+            }
     }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -3,8 +3,6 @@ package com.pinterest.ktlint.core
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.disabledRulesProperty
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.ast.ElementType.FILE
-import com.pinterest.ktlint.core.ast.ElementType.IMPORT_LIST
-import com.pinterest.ktlint.core.ast.ElementType.PACKAGE_DIRECTIVE
 import com.pinterest.ktlint.core.internal.VisitorProvider
 import com.pinterest.ktlint.core.internal.initPsiFileFactory
 import org.assertj.core.api.Assertions.assertThat
@@ -17,19 +15,6 @@ import org.junit.jupiter.api.Test
 
 class VisitorProviderTest {
     @Test
-    fun `A normal rule visits all nodes`() {
-        val actual = testVisitorProvider(
-            NormalRule(NORMAL_RULE)
-        )
-
-        assertThat(actual).containsExactly(
-            Visit(NORMAL_RULE, FILE),
-            Visit(NORMAL_RULE, PACKAGE_DIRECTIVE),
-            Visit(NORMAL_RULE, IMPORT_LIST)
-        )
-    }
-
-    @Test
     fun `A root only rule only visits the FILE node only`() {
         val actual = testVisitorProvider(
             RootNodeOnlyRule(ROOT_NODE_ONLY_RULE)
@@ -41,15 +26,17 @@ class VisitorProviderTest {
     }
 
     @Test
-    fun `A run as late as possible rule visits all nodes`() {
+    fun `A run-as-late-as-possible-rule runs later than normal rules`() {
         val actual = testVisitorProvider(
-            RunAsLateAsPossibleRule(RUN_AS_LATE_AS_POSSIBLE_RULE)
+            NormalRule(RULE_A),
+            RunAsLateAsPossibleRule(RULE_B),
+            NormalRule(RULE_C)
         )
 
         assertThat(actual).containsExactly(
-            Visit(RUN_AS_LATE_AS_POSSIBLE_RULE, FILE),
-            Visit(RUN_AS_LATE_AS_POSSIBLE_RULE, PACKAGE_DIRECTIVE),
-            Visit(RUN_AS_LATE_AS_POSSIBLE_RULE, IMPORT_LIST)
+            Visit(RULE_A, FILE),
+            Visit(RULE_C, FILE),
+            Visit(RULE_B, FILE)
         )
     }
 
@@ -185,7 +172,6 @@ class VisitorProviderTest {
         const val EXPERIMENTAL = "experimental"
         const val CUSTOM_RULE_SET_A = "custom-rule-set-a"
         val SOME_ROOT_AST_NODE = initRootAstNode()
-        const val NORMAL_RULE = "normal-rule"
         const val ROOT_NODE_ONLY_RULE = "root-node-only-rule"
         const val RUN_AS_LATE_AS_POSSIBLE_RULE = "run-as-late-as-possible-rule"
         const val RULE_A = "rule-a"

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -241,7 +241,7 @@ class VisitorProviderTest {
     ) : Rule(id, visitorModifiers) {
         constructor(id: String, visitorModifier: VisitorModifier) : this(id, setOf(visitorModifier))
 
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -125,17 +125,13 @@ class VisitorProviderTest {
      * visit provider has invoked the correct rules in the correct order. Note that the testProvider does not invoke the
      * real visit method of the rule.
      */
-    private fun testVisitorProvider(
-        vararg rules: Rule,
-        concurrent: Boolean? = null
-    ): MutableList<Visit>? {
-        return testVisitorProvider(
+    private fun testVisitorProvider(vararg rules: Rule): MutableList<Visit>? =
+        testVisitorProvider(
             RuleSet(
                 STANDARD,
                 *rules
             )
         )
-    }
 
     /**
      * Create a visitor provider for a given list of rule sets. It returns a list of visits that the provider made

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -2,13 +2,11 @@ package com.pinterest.ktlint.core
 
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.disabledRulesProperty
 import com.pinterest.ktlint.core.api.EditorConfigOverride
-import com.pinterest.ktlint.core.ast.ElementType.FILE
 import com.pinterest.ktlint.core.internal.VisitorProvider
 import com.pinterest.ktlint.core.internal.initPsiFileFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Test
@@ -34,9 +32,9 @@ class VisitorProviderTest {
         )
 
         assertThat(actual).containsExactly(
-            Visit(RULE_A, FILE),
-            Visit(RULE_C, FILE),
-            Visit(RULE_B, FILE)
+            Visit(RULE_A),
+            Visit(RULE_C),
+            Visit(RULE_B)
         )
     }
 
@@ -47,7 +45,7 @@ class VisitorProviderTest {
         )
 
         assertThat(actual).containsExactly(
-            Visit(RUN_AS_LATE_AS_POSSIBLE_RULE, FILE)
+            Visit(RUN_AS_LATE_AS_POSSIBLE_RULE)
         )
     }
 
@@ -69,7 +67,7 @@ class VisitorProviderTest {
                 NormalRule(RULE_C),
                 NormalRule(SOME_DISABLED_RULE_IN_CUSTOM_RULE_SET_A)
             )
-        ).filterFileNodes()
+        )
 
         assertThat(actual).containsExactly(
             Visit(RULE_A),
@@ -150,22 +148,15 @@ class VisitorProviderTest {
         ).run {
             var visits: MutableList<Visit>? = null
             visitor(SOME_ROOT_AST_NODE)
-                .invoke { node, _, fqRuleId ->
+                .invoke { _, fqRuleId ->
                     if (visits == null) {
                         visits = mutableListOf()
                     }
-                    visits?.add(Visit(fqRuleId, node.elementType))
+                    visits?.add(Visit(fqRuleId))
                 }
             visits
         }
     }
-
-    /**
-     * When visiting a node with a normal rule, this results in multiple visits. In most tests this would bloat the
-     * assertion needlessly.
-     */
-    private fun List<Visit>?.filterFileNodes(): List<Visit>? =
-        this?.filter { it.elementType == FILE }
 
     private companion object {
         const val STANDARD = "standard"
@@ -261,17 +252,12 @@ class VisitorProviderTest {
         }
     }
 
-    private data class Visit(
-        val shortenedQualifiedRuleId: String,
-        val elementType: IElementType = FILE
-    ) {
+    private data class Visit(val shortenedQualifiedRuleId: String) {
         constructor(
             ruleSetId: String,
-            ruleId: String,
-            elementType: IElementType = FILE
+            ruleId: String
         ) : this(
-            shortenedQualifiedRuleId = "$ruleSetId:$ruleId",
-            elementType = elementType
+            shortenedQualifiedRuleId = "$ruleSetId:$ruleId"
         ) {
             require(!ruleSetId.contains(':')) {
                 "rule set id may not contain the ':' character"

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -119,24 +119,6 @@ class VisitorProviderTest {
         assertThat(actual).isNull()
     }
 
-    @Test
-    fun `Visits all rules on a node concurrently before proceeding to the next node`() {
-        val actual = testVisitorProvider(
-            NormalRule(RULE_A),
-            NormalRule(RULE_B),
-            concurrent = true
-        )
-
-        assertThat(actual).containsExactly(
-            Visit(RULE_A, FILE),
-            Visit(RULE_B, FILE),
-            Visit(RULE_A, PACKAGE_DIRECTIVE),
-            Visit(RULE_B, PACKAGE_DIRECTIVE),
-            Visit(RULE_A, IMPORT_LIST),
-            Visit(RULE_B, IMPORT_LIST)
-        )
-    }
-
     /**
      * Create a visitor provider for a given list of rules in the same rule set (STANDARD). It returns a list of visits
      * that the provider made after it was invoked. The tests of the visitor provider should only focus on whether the
@@ -151,8 +133,7 @@ class VisitorProviderTest {
             RuleSet(
                 STANDARD,
                 *rules
-            ),
-            concurrent = concurrent
+            )
         )
     }
 
@@ -162,10 +143,7 @@ class VisitorProviderTest {
      * invoked the correct rules in the correct order. Note that the testProvider does not invoke the real visit method
      * of the rule.
      */
-    private fun testVisitorProvider(
-        vararg ruleSets: RuleSet,
-        concurrent: Boolean? = null
-    ): MutableList<Visit>? {
+    private fun testVisitorProvider(vararg ruleSets: RuleSet): MutableList<Visit>? {
         val ruleSetList = ruleSets.toList()
         return VisitorProvider(
             params = KtLint.ExperimentalParams(
@@ -188,7 +166,7 @@ class VisitorProviderTest {
             recreateRuleSorter = true
         ).run {
             var visits: MutableList<Visit>? = null
-            visitor(SOME_ROOT_AST_NODE, concurrent ?: false)
+            visitor(SOME_ROOT_AST_NODE)
                 .invoke { node, _, fqRuleId ->
                     if (visits == null) {
                         visits = mutableListOf()

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -206,7 +206,7 @@ internal class EditorConfigGeneratorTest {
     }
 
     private open class TestRule(ruleId: String) : Rule(ruleId) {
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigLoaderTest.kt
@@ -482,7 +482,7 @@ internal class EditorConfigLoaderTest {
     private class TestRule : Rule("editorconfig-test"), UsesEditorConfigProperties {
         override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = emptyList()
 
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/RuleSorterTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/RuleSorterTest.kt
@@ -541,7 +541,7 @@ class RuleSorterTest {
     ) : Rule(id, visitorModifiers) {
         constructor(id: String, visitorModifier: VisitorModifier) : this(id, setOf(visitorModifier))
 
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilderTest.kt
@@ -204,7 +204,7 @@ class SuppressionLocatorBuilderTest {
     }
 
     private class NoFooIdentifierRule(id: String) : Rule(id) {
-        override fun visit(
+        override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/BlockCommentInitialStarAlignmentRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/BlockCommentInitialStarAlignmentRule.kt
@@ -19,7 +19,7 @@ class BlockCommentInitialStarAlignmentRule :
             VisitorModifier.RunAfterRule("standard:indent")
         )
     ) {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/CommentWrappingRule.kt
@@ -28,7 +28,7 @@ public class CommentWrappingRule :
             DefaultEditorConfigProperties.indentStyleProperty
         )
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/DiscouragedCommentLocationRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/DiscouragedCommentLocationRule.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * ```
  */
 public class DiscouragedCommentLocationRule : Rule("$experimentalRulesetId:discouraged-comment-location") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunKeywordSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunKeywordSpacingRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * Lints and formats the spacing after the fun keyword
  */
 public class FunKeywordSpacingRule : Rule("$experimentalRulesetId:fun-keyword-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionReturnTypeSpacingRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 
 public class FunctionReturnTypeSpacingRule : Rule("$experimentalRulesetId:function-return-type-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -66,7 +66,7 @@ public class FunctionSignatureRule :
     private var functionSignatureWrappingMinimumParameters = -1
     private var functionBodyExpressionWrapping = default
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK
@@ -20,7 +21,6 @@ import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
@@ -66,26 +66,24 @@ public class FunctionSignatureRule :
     private var functionSignatureWrappingMinimumParameters = -1
     private var functionBodyExpressionWrapping = default
 
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        with(editorConfigProperties) {
+            functionSignatureWrappingMinimumParameters = getEditorConfigValue(forceMultilineWhenParameterCountGreaterOrEqualThanProperty)
+            functionBodyExpressionWrapping = getEditorConfigValue(functionBodyExpressionWrappingProperty)
+            val indentConfig = IndentConfig(
+                indentStyle = getEditorConfigValue(indentStyleProperty),
+                tabWidth = getEditorConfigValue(indentSizeProperty)
+            )
+            indent = indentConfig.indent
+            maxLineLength = getEditorConfigValue(maxLineLengthProperty)
+        }
+    }
+
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            functionSignatureWrappingMinimumParameters = node.getEditorConfigValue(forceMultilineWhenParameterCountGreaterOrEqualThanProperty)
-            functionBodyExpressionWrapping = node.getEditorConfigValue(functionBodyExpressionWrappingProperty)
-            val indentConfig = IndentConfig(
-                indentStyle = node.getEditorConfigValue(indentStyleProperty),
-                tabWidth = node.getEditorConfigValue(indentSizeProperty)
-            )
-            if (indentConfig.disabled) {
-                return
-            }
-            indent = indentConfig.indent
-            maxLineLength = node.getEditorConfigValue(maxLineLengthProperty)
-            return
-        }
-
         if (node.elementType == FUN) {
             node
                 .functionSignatureNodes()

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionStartOfBodySpacingRule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * Lints and formats the spacing after the fun keyword
  */
 public class FunctionStartOfBodySpacingRule : Rule("$experimentalRulesetId:function-start-of-body-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionTypeReferenceSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionTypeReferenceSpacingRule.kt
@@ -10,7 +10,7 @@ import com.pinterest.ktlint.core.ast.nextSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 public class FunctionTypeReferenceSpacingRule : Rule("$experimentalRulesetId:function-type-reference-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/KdocWrappingRule.kt
@@ -27,7 +27,7 @@ public class KdocWrappingRule :
             DefaultEditorConfigProperties.indentStyleProperty
         )
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ModifierListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ModifierListSpacingRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * Lint and format the spacing between the modifiers in and after the last modifier in a modifier list.
  */
 public class ModifierListSpacingRule : Rule("$experimentalRulesetId:modifier-list-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/NullableTypeSpacingRule.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 public class NullableTypeSpacingRule : Rule("$experimentalRulesetId:nullable-type-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ParameterListSpacingRule.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * interfering of the parameter-list-wrapping rule.
  */
 public class ParameterListSpacingRule : Rule("$experimentalRulesetId:parameter-list-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.core.ast.nextSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 public class SpacingBetweenFunctionNameAndOpeningParenthesisRule : Rule("$experimentalRulesetId:spacing-between-function-name-and-opening-parenthesis") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeArgumentListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeArgumentListSpacingRule.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * Lints and formats the spacing before and after the angle brackets of a type argument list.
  */
 public class TypeArgumentListSpacingRule : Rule("$experimentalRulesetId:type-argument-list-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/TypeParameterListSpacingRule.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
  * Lints and formats the spacing before and after the angle brackets of a type parameter list.
  */
 public class TypeParameterListSpacingRule : Rule("$experimentalRulesetId:type-parameter-list-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * Ensures there are no unnecessary parentheses before a trailing lambda.
  */
 class UnnecessaryParenthesesBeforeTrailingLambdaRule : Rule("$experimentalRulesetId:unnecessary-parentheses-before-trailing-lambda") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -45,7 +45,7 @@ class AnnotationRule : Rule("annotation") {
             "File annotations should be separated from file contents with a blank line"
     }
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationSpacingRule.kt
@@ -30,7 +30,7 @@ class AnnotationSpacingRule : Rule("annotation-spacing") {
         const val ERROR_MESSAGE = "Annotations should occur immediately before the annotated construct"
     }
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRule.kt
@@ -5,13 +5,13 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.ElementType.ELSE
-import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.core.ast.column
 import com.pinterest.ktlint.core.ast.isPartOfComment
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtContainerNode
 import org.jetbrains.kotlin.psi.KtDoWhileExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
+import org.jetbrains.kotlin.psi.psiUtil.children
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
@@ -51,25 +52,41 @@ class ArgumentListWrappingRule :
             maxLineLengthProperty
         )
 
-    override fun visit(
+    // Keep state of argument list nodes for which the argument needs to be wrapped
+    private val wrapArgumentLists = mutableMapOf<ASTNode, NodeState>()
+
+    // TODO: Eliminate NodeState when it contains only one field?
+    private data class NodeState(val newIndentLevel: Int)
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        editorConfigIndent = IndentConfig(
+            indentStyle = editorConfigProperties.getEditorConfigValue(indentStyleProperty),
+            tabWidth = editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+        )
+        maxLineLength = editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+    }
+
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            editorConfigIndent = IndentConfig(
-                indentStyle = node.getEditorConfigValue(indentStyleProperty),
-                tabWidth = node.getEditorConfigValue(indentSizeProperty)
-            )
-            maxLineLength = node.getEditorConfigValue(maxLineLengthProperty)
-            return
-        }
         if (editorConfigIndent.disabled) {
             return
         }
 
-        if (node.elementType == ElementType.VALUE_ARGUMENT_LIST &&
-            // skip when there are no arguments
+        if (node.elementType == VALUE_ARGUMENT_LIST) {
+            if (needToWrapArgumentList(node)) {
+                val newIndentLevel = node.getNewIndentLevel()
+                node
+                    .children()
+                    .forEach { child -> wrapArgumentInList(newIndentLevel, child, emit, autoCorrect) }
+            }
+        }
+    }
+
+    private fun needToWrapArgumentList(node: ASTNode) =
+        if ( // skip when there are no arguments
             node.firstChildNode?.treeNext?.elementType != ElementType.RPAR &&
             // skip lambda arguments
             node.treeParent?.elementType != ElementType.FUNCTION_LITERAL &&
@@ -80,134 +97,140 @@ class ArgumentListWrappingRule :
             // - at least one of the arguments is
             // - maxLineLength exceeded (and separating arguments with \n would actually help)
             // in addition, "(" and ")" must be on separates line if any of the arguments are (otherwise on the same)
-            val putArgumentsOnSeparateLines =
-                node.textContainsIgnoringLambda('\n') ||
-                    // max_line_length exceeded
-                    maxLineLength > -1 && (node.column - 1 + node.textLength) > maxLineLength && !node.textContains('\n')
-            if (putArgumentsOnSeparateLines) {
-                val currentIndentLevel = editorConfigIndent.indentLevelFrom(node.lineIndent())
-                val newIndentLevel =
-                    when {
-                        // IDEA quirk:
-                        // generic<
-                        //     T,
-                        //     R>(
-                        //     1,
-                        //     2
-                        // )
-                        // instead of
-                        // generic<
-                        //     T,
-                        //     R>(
-                        //         1,
-                        //         2
-                        //     )
-                        currentIndentLevel > 0 && node.hasTypeArgumentListInFront() -> currentIndentLevel - 1
+            node.textContainsIgnoringLambda('\n') || node.exceedsMaxLineLength()
+        } else {
+            false
+        }
 
-                        // IDEA quirk:
-                        // foo
-                        //     .bar = Baz(
-                        //     1,
-                        //     2
-                        // )
-                        // instead of
-                        // foo
-                        //     .bar = Baz(
-                        //         1,
-                        //         2
-                        //     )
-                        currentIndentLevel > 0 && node.isPartOfDotQualifiedAssignmentExpression() -> currentIndentLevel - 1
+    private fun ASTNode.exceedsMaxLineLength() =
+        maxLineLength > -1 && (column - 1 + textLength) > maxLineLength && !textContains('\n')
 
-                        else -> currentIndentLevel
-                    }.let {
-                        if (node.isOnSameLineAsControlFlowKeyword()) {
-                            it + 1
-                        } else {
-                            it
+    private fun ASTNode.getNewIndentLevel(): Int {
+        val currentIndentLevel = editorConfigIndent.indentLevelFrom(lineIndent())
+        return when {
+            // IDEA quirk:
+            // generic<
+            //     T,
+            //     R>(
+            //     1,
+            //     2
+            // )
+            // instead of
+            // generic<
+            //     T,
+            //     R>(
+            //         1,
+            //         2
+            //     )
+            currentIndentLevel > 0 && hasTypeArgumentListInFront() -> currentIndentLevel - 1
+
+            // IDEA quirk:
+            // foo
+            //     .bar = Baz(
+            //     1,
+            //     2
+            // )
+            // instead of
+            // foo
+            //     .bar = Baz(
+            //         1,
+            //         2
+            //     )
+            currentIndentLevel > 0 && isPartOfDotQualifiedAssignmentExpression() -> currentIndentLevel - 1
+
+            else -> currentIndentLevel
+        }.let {
+            if (isOnSameLineAsControlFlowKeyword()) {
+                it + 1
+            } else {
+                it
+            }
+        }
+    }
+
+    private fun wrapArgumentInList(
+        newIndentLevel: Int,
+        child: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val indent = "\n" + editorConfigIndent.indent.repeat(newIndentLevel)
+        when (child.elementType) {
+            ElementType.LPAR -> {
+                val prevLeaf = child.prevLeaf()
+                if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
+                    emit(child.startOffset, errorMessage(child), true)
+                    if (autoCorrect) {
+                        prevLeaf.delete()
+                    }
+                }
+            }
+            ElementType.VALUE_ARGUMENT,
+            ElementType.RPAR -> {
+                var argumentInnerIndentAdjustment = 0
+
+                // aiming for
+                // ... LPAR
+                // <line indent + indentSize> VALUE_PARAMETER...
+                // <line indent> RPAR
+                val intendedIndent = if (child.elementType == ElementType.VALUE_ARGUMENT) {
+                    indent + editorConfigIndent.indent
+                } else {
+                    indent
+                }
+
+                val prevLeaf = child.prevWhiteSpaceWithNewLine() ?: child.prevLeaf()
+                if (prevLeaf is PsiWhiteSpace) {
+                    if (prevLeaf.getText().contains("\n")) {
+                        // The current child is already wrapped to a new line. Checking and fixing the
+                        // correct size of the indent is the responsibility of the IndentationRule.
+                        return
+                    } else {
+                        // The current child needs to be wrapped to a newline.
+                        emit(child.startOffset, errorMessage(child), true)
+                        if (autoCorrect) {
+                            // The indentation is purely based on the previous leaf only. Note that in
+                            // autoCorrect mode the indent rule, if enabled, runs after this rule and
+                            // determines the final indentation. But if the indent rule is disabled then the
+                            // indent of this rule is kept.
+                            argumentInnerIndentAdjustment = intendedIndent.length - prevLeaf.getTextLength()
+                            (prevLeaf as LeafPsiElement).rawReplaceWithText(intendedIndent)
                         }
                     }
-                val indent = "\n" + editorConfigIndent.indent.repeat(newIndentLevel)
+                } else {
+                    // Insert a new whitespace element in order to wrap the current child to a new line.
+                    emit(child.startOffset, errorMessage(child), true)
+                    if (autoCorrect) {
+                        argumentInnerIndentAdjustment = intendedIndent.length - child.column
+                        child.treeParent.addChild(PsiWhiteSpaceImpl(intendedIndent), child)
+                    }
+                }
+                if (argumentInnerIndentAdjustment != 0 && child.elementType == ElementType.VALUE_ARGUMENT) {
+                    child.visit { n ->
+                        if (n.elementType == ElementType.WHITE_SPACE && n.textContains('\n')) {
+                            val isInCollectionOrFunctionLiteral =
+                                n.treeParent?.elementType == ElementType.COLLECTION_LITERAL_EXPRESSION || n.treeParent?.elementType == ElementType.FUNCTION_LITERAL
 
-                nextChild@ for (child in node.children()) {
-                    when (child.elementType) {
-                        ElementType.LPAR -> {
-                            val prevLeaf = child.prevLeaf()
-                            if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
-                                emit(child.startOffset, errorMessage(child), true)
-                                if (autoCorrect) {
-                                    prevLeaf.delete()
-                                }
-                            }
-                        }
-                        ElementType.VALUE_ARGUMENT,
-                        ElementType.RPAR -> {
-                            var argumentInnerIndentAdjustment = 0
-
-                            // aiming for
-                            // ... LPAR
-                            // <line indent + indentSize> VALUE_PARAMETER...
-                            // <line indent> RPAR
-                            val intendedIndent = if (child.elementType == ElementType.VALUE_ARGUMENT) {
-                                indent + editorConfigIndent.indent
+                            // If we're inside a collection literal, let's recalculate the adjustment
+                            // because the items inside the collection should not be subject to the same
+                            // indentation as the brackets.
+                            val adjustment = if (isInCollectionOrFunctionLiteral) {
+                                val expectedPosition = intendedIndent.length + editorConfigIndent.indent.length
+                                expectedPosition - child.column
                             } else {
-                                indent
+                                argumentInnerIndentAdjustment
                             }
 
-                            val prevLeaf = child.prevWhiteSpaceWithNewLine() ?: child.prevLeaf()
-                            if (prevLeaf is PsiWhiteSpace) {
-                                if (prevLeaf.getText().contains("\n")) {
-                                    // The current child is already wrapped to a new line. Checking and fixing the
-                                    // correct size of the indent is the responsibility of the IndentationRule.
-                                    continue@nextChild
-                                } else {
-                                    // The current child needs to be wrapped to a newline.
-                                    emit(child.startOffset, errorMessage(child), true)
-                                    if (autoCorrect) {
-                                        // The indentation is purely based on the previous leaf only. Note that in
-                                        // autoCorrect mode the indent rule, if enabled, runs after this rule and
-                                        // determines the final indentation. But if the indent rule is disabled then the
-                                        // indent of this rule is kept.
-                                        argumentInnerIndentAdjustment = intendedIndent.length - prevLeaf.getTextLength()
-                                        (prevLeaf as LeafPsiElement).rawReplaceWithText(intendedIndent)
+                            val split = n.text.split("\n")
+                            (n as LeafElement).rawReplaceWithText(
+                                split.joinToString("\n") {
+                                    when {
+                                        it.isEmpty() -> it
+                                        adjustment > 0 -> it + " ".repeat(adjustment)
+                                        else -> it.substring(0, max(it.length + adjustment, 0))
                                     }
                                 }
-                            } else {
-                                // Insert a new whitespace element in order to wrap the current child to a new line.
-                                emit(child.startOffset, errorMessage(child), true)
-                                if (autoCorrect) {
-                                    argumentInnerIndentAdjustment = intendedIndent.length - child.column
-                                    node.addChild(PsiWhiteSpaceImpl(intendedIndent), child)
-                                }
-                            }
-                            if (argumentInnerIndentAdjustment != 0 && child.elementType == ElementType.VALUE_ARGUMENT) {
-                                child.visit { n ->
-                                    if (n.elementType == ElementType.WHITE_SPACE && n.textContains('\n')) {
-                                        val isInCollectionOrFunctionLiteral =
-                                            n.treeParent?.elementType == ElementType.COLLECTION_LITERAL_EXPRESSION || n.treeParent?.elementType == ElementType.FUNCTION_LITERAL
-
-                                        // If we're inside a collection literal, let's recalculate the adjustment
-                                        // because the items inside the collection should not be subject to the same
-                                        // indentation as the brackets.
-                                        val adjustment = if (isInCollectionOrFunctionLiteral) {
-                                            val expectedPosition = intendedIndent.length + editorConfigIndent.indent.length
-                                            expectedPosition - child.column
-                                        } else {
-                                            argumentInnerIndentAdjustment
-                                        }
-
-                                        val split = n.text.split("\n")
-                                        (n as LeafElement).rawReplaceWithText(
-                                            split.joinToString("\n") {
-                                                when {
-                                                    it.isEmpty() -> it
-                                                    adjustment > 0 -> it + " ".repeat(adjustment)
-                                                    else -> it.substring(0, max(it.length + adjustment, 0))
-                                                }
-                                            }
-                                        )
-                                    }
-                                }
-                            }
+                            )
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -40,7 +40,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     private val nextLineTokens = TokenSet.create(DOT, SAFE_ACCESS, ELVIS)
     private val noSpaceAroundTokens = TokenSet.create(DOT, SAFE_ACCESS)
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/CommentSpacingRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class CommentSpacingRule : Rule("comment-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/EnumEntryNameCaseRule.kt
@@ -13,7 +13,7 @@ public class EnumEntryNameCaseRule : Rule("enum-entry-name-case") {
         val regex = Regex("[A-Z]([A-Za-z\\d]*|[A-Z_\\d]*)")
     }
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FilenameRule.kt
@@ -11,6 +11,7 @@ import com.pinterest.ktlint.core.ast.ElementType.PROPERTY
 import com.pinterest.ktlint.core.ast.ElementType.TYPEALIAS
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.core.ast.children
+import com.pinterest.ktlint.core.ast.isRoot
 import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
@@ -39,59 +40,56 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
  * - file without `.kt` extension
  * - file with name `package.kt`
  */
-public class FilenameRule : Rule(
-    id = "filename",
-    visitorModifiers = setOf(
-        VisitorModifier.RunOnRootNodeOnly
-    )
-) {
-    override fun visit(
+public class FilenameRule : Rule("filename") {
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        node as FileASTNode? ?: error("node is not ${FileASTNode::class} but ${node::class}")
+        if (node.isRoot()) {
+            node as FileASTNode? ?: error("node is not ${FileASTNode::class} but ${node::class}")
 
-        val filePath = node.getUserData(KtLint.FILE_PATH_USER_DATA_KEY)
-        if (filePath?.endsWith(".kt") != true) {
-            // ignore all non ".kt" files (including ".kts")
-            return
-        }
-
-        val fileName = Paths.get(filePath).fileName.toString().substringBefore(".")
-        if (fileName == "package") {
-            // ignore package.kt filename
-            return
-        }
-
-        val topLevelClassDeclarations = node.topLevelDeclarations(CLASS)
-        if (topLevelClassDeclarations.size == 1) {
-            val topLevelClassDeclaration = topLevelClassDeclarations.first()
-            if (node.hasTopLevelDeclarationNotExtending(topLevelClassDeclaration.identifier)) {
-                fileName.shouldMatchPascalCase(emit)
-            } else {
-                // If the file only contains one (non private) top level class and possibly some extension functions of
-                // that class, then its filename should be identical to the class name.
-                fileName.shouldMatchClassName(topLevelClassDeclaration.identifier, emit)
+            val filePath = node.getUserData(KtLint.FILE_PATH_USER_DATA_KEY)
+            if (filePath?.endsWith(".kt") != true) {
+                // ignore all non ".kt" files (including ".kts")
+                return
             }
-        } else {
-            val topLevelDeclarations = node.topLevelDeclarations()
-            if (topLevelDeclarations.size == 1) {
-                val topLevelDeclaration = topLevelDeclarations.first()
-                if (topLevelDeclaration.elementType == OBJECT_DECLARATION ||
-                    topLevelDeclaration.elementType == TYPEALIAS ||
-                    topLevelDeclaration.elementType == FUN
-                ) {
-                    val pascalCaseIdentifier =
-                        topLevelDeclaration
-                            .identifier
-                            .toPascalCase()
-                    fileName.shouldMatchFileName(pascalCaseIdentifier, emit)
+
+            val fileName = Paths.get(filePath).fileName.toString().substringBefore(".")
+            if (fileName == "package") {
+                // ignore package.kt filename
+                return
+            }
+
+            val topLevelClassDeclarations = node.topLevelDeclarations(CLASS)
+            if (topLevelClassDeclarations.size == 1) {
+                val topLevelClassDeclaration = topLevelClassDeclarations.first()
+                if (node.hasTopLevelDeclarationNotExtending(topLevelClassDeclaration.identifier)) {
+                    fileName.shouldMatchPascalCase(emit)
+                } else {
+                    // If the file only contains one (non private) top level class and possibly some extension functions of
+                    // that class, then its filename should be identical to the class name.
+                    fileName.shouldMatchClassName(topLevelClassDeclaration.identifier, emit)
+                }
+            } else {
+                val topLevelDeclarations = node.topLevelDeclarations()
+                if (topLevelDeclarations.size == 1) {
+                    val topLevelDeclaration = topLevelDeclarations.first()
+                    if (topLevelDeclaration.elementType == OBJECT_DECLARATION ||
+                        topLevelDeclaration.elementType == TYPEALIAS ||
+                        topLevelDeclaration.elementType == FUN
+                    ) {
+                        val pascalCaseIdentifier =
+                            topLevelDeclaration
+                                .identifier
+                                .toPascalCase()
+                        fileName.shouldMatchFileName(pascalCaseIdentifier, emit)
+                    } else {
+                        fileName.shouldMatchPascalCase(emit)
+                    }
                 } else {
                     fileName.shouldMatchPascalCase(emit)
                 }
-            } else {
-                fileName.shouldMatchPascalCase(emit)
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/FinalNewlineRule.kt
@@ -2,33 +2,35 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.insertNewLineProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.isRoot
+import kotlin.properties.Delegates
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 
 public class FinalNewlineRule :
-    Rule(
-        id = "final-newline",
-        visitorModifiers = setOf(
-            VisitorModifier.RunOnRootNodeOnly
-        )
-    ),
+    Rule("final-newline"),
     UsesEditorConfigProperties {
 
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(
         insertNewLineProperty
     )
 
-    override fun visit(
+    private var insertFinalNewline by Delegates.notNull<Boolean>()
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        insertFinalNewline = editorConfigProperties.getEditorConfigValue(insertNewLineProperty)
+    }
+
+    override fun afterVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
             if (node.textLength == 0) return
-            val insertFinalNewline = node.getEditorConfigValue(insertNewLineProperty)
             val lastNode = lastChildNodeOf(node)
             if (insertFinalNewline) {
                 if (lastNode !is PsiWhiteSpace || !lastNode.textContains('\n')) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule.Companion.ASCII_PATTERN
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule.Companion.IDEA_PATTERN
@@ -46,6 +46,134 @@ public class ImportOrderingRule :
 
     private lateinit var importsLayout: List<PatternEntry>
     private lateinit var importSorter: ImportSorter
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        importsLayout = editorConfigProperties.getEditorConfigValue(ideaImportsLayoutProperty)
+        importSorter = ImportSorter(importsLayout)
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == ElementType.IMPORT_LIST) {
+            val children = node.getChildren(null)
+            if (children.isNotEmpty()) {
+                // Get unique imports and blank lines
+                val (autoCorrectDuplicateImports: Boolean, imports: List<ASTNode>) =
+                    getUniqueImportsAndBlankLines(children, emit)
+
+                val hasComments = children.any { it.elementType == ElementType.BLOCK_COMMENT || it.elementType == ElementType.EOL_COMMENT }
+                val sortedImports = imports
+                    .asSequence()
+                    .mapNotNull { it.psi as? KtImportDirective } // sorter expects KtImportDirective, whitespaces are inserted afterwards
+                    .sortedWith(importSorter)
+                    .map { it.node } // transform back to ASTNode in order to operate over its method (addChild)
+
+                // insert blank lines wherever needed
+                // traverse the list using fold to have previous and current element and decide if the blank line is needed in between
+                // based on the ImportSorter imported patterns and indexes from the comparator
+                val sortedImportsWithSpaces = mutableListOf<ASTNode>()
+                sortedImports.fold(null as ASTNode?) { prev, current ->
+                    val index1 = if (prev == null) -1 else importSorter.findImportIndex((prev.psi as KtImportDirective).importPath!!)
+                    val index2 = importSorter.findImportIndex((current.psi as KtImportDirective).importPath!!)
+
+                    var hasBlankLines = false
+                    for (i in (index1 + 1) until index2) {
+                        if (importSorter.patterns[i] == PatternEntry.BLANK_LINE_ENTRY) {
+                            hasBlankLines = true
+                            break
+                        }
+                    }
+                    if (hasBlankLines) {
+                        sortedImportsWithSpaces += PsiWhiteSpaceImpl("\n\n")
+                    }
+                    sortedImportsWithSpaces += current
+
+                    return@fold current
+                }
+
+                if (hasComments) {
+                    emit(
+                        node.startOffset,
+                        errorMessages.getOrDefault(importsLayout, CUSTOM_ERROR_MESSAGE) +
+                            " -- no autocorrection due to comments in the import list",
+                        false
+                    )
+                } else {
+                    val autoCorrectWhitespace = hasTooMuchWhitespace(children) && !isCustomLayout()
+                    val autoCorrectSortOrder = !importsAreEqual(imports, sortedImportsWithSpaces)
+                    if (autoCorrectSortOrder || autoCorrectWhitespace) {
+                        emit(
+                            node.startOffset,
+                            errorMessages.getOrDefault(importsLayout, CUSTOM_ERROR_MESSAGE),
+                            true
+                        )
+                    }
+                    if (autoCorrect && (autoCorrectDuplicateImports || autoCorrectSortOrder || autoCorrectWhitespace)) {
+                        node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
+                        sortedImportsWithSpaces.reduce { current, next ->
+                            node.addChild(current, null)
+                            if (current !is PsiWhiteSpace && next !is PsiWhiteSpace) {
+                                node.addChild(PsiWhiteSpaceImpl("\n"), null)
+                            }
+                            return@reduce next
+                        }
+                        node.addChild(sortedImportsWithSpaces.last(), null)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun getUniqueImportsAndBlankLines(
+        children: Array<ASTNode>,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ): Pair<Boolean, List<ASTNode>> {
+        var autoCorrectDuplicateImports = false
+        val imports = mutableListOf<ASTNode>()
+        val importTextSet = mutableSetOf<String>()
+
+        children.forEach { current ->
+            val isPsiWhiteSpace = current.psi is PsiWhiteSpace
+
+            if (current.elementType == ElementType.IMPORT_DIRECTIVE ||
+                isPsiWhiteSpace && current.textLength > 1 // also collect empty lines, that are represented as "\n\n"
+            ) {
+                if (isPsiWhiteSpace || importTextSet.add(current.text)) {
+                    imports += current
+                } else {
+                    emit(
+                        current.startOffset,
+                        "Duplicate '${current.text}' found",
+                        true
+                    )
+                    autoCorrectDuplicateImports = true
+                }
+            }
+        }
+
+        return autoCorrectDuplicateImports to imports
+    }
+
+    private fun importsAreEqual(actual: List<ASTNode>, expected: List<ASTNode>): Boolean {
+        if (actual.size != expected.size) return false
+
+        val combined = actual.zip(expected)
+        return combined.all { (first, second) ->
+            if (first is PsiWhiteSpace && second is PsiWhiteSpace) {
+                return@all (first as PsiWhiteSpace).text == (second as PsiWhiteSpace).text
+            }
+            return@all first == second
+        }
+    }
+
+    private fun isCustomLayout() = importsLayout != IDEA_PATTERN && importsLayout != ASCII_PATTERN
+
+    private fun hasTooMuchWhitespace(nodes: Array<ASTNode>): Boolean {
+        return nodes.any { it is PsiWhiteSpace && (it as PsiWhiteSpace).text != "\n" }
+    }
 
     public companion object {
         internal const val IDEA_IMPORTS_LAYOUT_PROPERTY_NAME = "ij_kotlin_imports_layout"
@@ -126,134 +254,5 @@ public class ImportOrderingRule :
                 defaultAndroidValue = ASCII_PATTERN,
                 propertyWriter = { it.joinToString(separator = ",") }
             )
-    }
-
-    private fun getUniqueImportsAndBlankLines(
-        children: Array<ASTNode>,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-    ): Pair<Boolean, List<ASTNode>> {
-        var autoCorrectDuplicateImports = false
-        val imports = mutableListOf<ASTNode>()
-        val importTextSet = mutableSetOf<String>()
-
-        children.forEach { current ->
-            val isPsiWhiteSpace = current.psi is PsiWhiteSpace
-
-            if (current.elementType == ElementType.IMPORT_DIRECTIVE ||
-                isPsiWhiteSpace && current.textLength > 1 // also collect empty lines, that are represented as "\n\n"
-            ) {
-                if (isPsiWhiteSpace || importTextSet.add(current.text)) {
-                    imports += current
-                } else {
-                    emit(
-                        current.startOffset,
-                        "Duplicate '${current.text}' found",
-                        true
-                    )
-                    autoCorrectDuplicateImports = true
-                }
-            }
-        }
-
-        return autoCorrectDuplicateImports to imports
-    }
-
-    override fun beforeVisitChildNodes(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-    ) {
-        if (node.isRoot()) {
-            importsLayout = node.getEditorConfigValue(ideaImportsLayoutProperty)
-            importSorter = ImportSorter(importsLayout)
-            return
-        }
-
-        if (node.elementType == ElementType.IMPORT_LIST) {
-            val children = node.getChildren(null)
-            if (children.isNotEmpty()) {
-                // Get unique imports and blank lines
-                val (autoCorrectDuplicateImports: Boolean, imports: List<ASTNode>) =
-                    getUniqueImportsAndBlankLines(children, emit)
-
-                val hasComments = children.any { it.elementType == ElementType.BLOCK_COMMENT || it.elementType == ElementType.EOL_COMMENT }
-                val sortedImports = imports
-                    .asSequence()
-                    .mapNotNull { it.psi as? KtImportDirective } // sorter expects KtImportDirective, whitespaces are inserted afterwards
-                    .sortedWith(importSorter)
-                    .map { it.node } // transform back to ASTNode in order to operate over its method (addChild)
-
-                // insert blank lines wherever needed
-                // traverse the list using fold to have previous and current element and decide if the blank line is needed in between
-                // based on the ImportSorter imported patterns and indexes from the comparator
-                val sortedImportsWithSpaces = mutableListOf<ASTNode>()
-                sortedImports.fold(null as ASTNode?) { prev, current ->
-                    val index1 = if (prev == null) -1 else importSorter.findImportIndex((prev.psi as KtImportDirective).importPath!!)
-                    val index2 = importSorter.findImportIndex((current.psi as KtImportDirective).importPath!!)
-
-                    var hasBlankLines = false
-                    for (i in (index1 + 1) until index2) {
-                        if (importSorter.patterns[i] == PatternEntry.BLANK_LINE_ENTRY) {
-                            hasBlankLines = true
-                            break
-                        }
-                    }
-                    if (hasBlankLines) {
-                        sortedImportsWithSpaces += PsiWhiteSpaceImpl("\n\n")
-                    }
-                    sortedImportsWithSpaces += current
-
-                    return@fold current
-                }
-
-                if (hasComments) {
-                    emit(
-                        node.startOffset,
-                        errorMessages.getOrDefault(importsLayout, CUSTOM_ERROR_MESSAGE) +
-                            " -- no autocorrection due to comments in the import list",
-                        false
-                    )
-                } else {
-                    val autoCorrectWhitespace = hasTooMuchWhitespace(children) && !isCustomLayout()
-                    val autoCorrectSortOrder = !importsAreEqual(imports, sortedImportsWithSpaces)
-                    if (autoCorrectSortOrder || autoCorrectWhitespace) {
-                        emit(
-                            node.startOffset,
-                            errorMessages.getOrDefault(importsLayout, CUSTOM_ERROR_MESSAGE),
-                            true
-                        )
-                    }
-                    if (autoCorrect && (autoCorrectDuplicateImports || autoCorrectSortOrder || autoCorrectWhitespace)) {
-                        node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
-                        sortedImportsWithSpaces.reduce { current, next ->
-                            node.addChild(current, null)
-                            if (current !is PsiWhiteSpace && next !is PsiWhiteSpace) {
-                                node.addChild(PsiWhiteSpaceImpl("\n"), null)
-                            }
-                            return@reduce next
-                        }
-                        node.addChild(sortedImportsWithSpaces.last(), null)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun importsAreEqual(actual: List<ASTNode>, expected: List<ASTNode>): Boolean {
-        if (actual.size != expected.size) return false
-
-        val combined = actual.zip(expected)
-        return combined.all { (first, second) ->
-            if (first is PsiWhiteSpace && second is PsiWhiteSpace) {
-                return@all (first as PsiWhiteSpace).text == (second as PsiWhiteSpace).text
-            }
-            return@all first == second
-        }
-    }
-
-    private fun isCustomLayout() = importsLayout != IDEA_PATTERN && importsLayout != ASCII_PATTERN
-
-    private fun hasTooMuchWhitespace(nodes: Array<ASTNode>): Boolean {
-        return nodes.any { it is PsiWhiteSpace && (it as PsiWhiteSpace).text != "\n" }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -158,7 +158,7 @@ public class ImportOrderingRule :
         return autoCorrectDuplicateImports to imports
     }
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.IndentConfig.IndentStyle.TAB
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
 import com.pinterest.ktlint.core.ast.ElementType.BINARY_EXPRESSION

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -67,6 +67,7 @@ import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.isPartOfComment
+import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithoutNewline
@@ -78,7 +79,6 @@ import com.pinterest.ktlint.core.ast.parent
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
 import com.pinterest.ktlint.core.ast.prevCodeSibling
 import com.pinterest.ktlint.core.ast.prevLeaf
-import com.pinterest.ktlint.core.ast.visit
 import com.pinterest.ktlint.core.initKtLintKLogger
 import com.pinterest.ktlint.ruleset.standard.IndentationRule.IndentContext.Block
 import com.pinterest.ktlint.ruleset.standard.IndentationRule.IndentContext.Block.BlockIndentationType.REGULAR
@@ -96,17 +96,10 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
 
-/**
- * Checks & correct indentation
- *
- * Current limitations:
- * - "all or nothing" (currently, rule can only be disabled for an entire file)
- */
 public class IndentationRule :
     Rule(
         id = "indent",
         visitorModifiers = setOf(
-            VisitorModifier.RunOnRootNodeOnly,
             VisitorModifier.RunAsLateAsPossible,
             VisitorModifier.RunAfterRule(
                 ruleId = "experimental:function-signature",
@@ -121,325 +114,278 @@ public class IndentationRule :
             indentSizeProperty,
             indentStyleProperty
         )
-
-    private companion object {
-        private val lTokenSet = TokenSet.create(LPAR, LBRACE, LBRACKET, LT)
-        private val rTokenSet = TokenSet.create(RPAR, RBRACE, RBRACKET, GT)
-        private val matchingRToken =
-            lTokenSet.types.zip(
-                rTokenSet.types
-            ).toMap()
-    }
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
 
     private var line = 1
     private var expectedIndent = 0 // TODO: merge into IndentContext
 
-    private fun reset() {
-        line = 1
-        expectedIndent = 0
+    private val ctx = IndentContext()
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        indentConfig = IndentConfig(
+            indentStyle = editorConfigProperties.getEditorConfigValue(indentStyleProperty),
+            tabWidth = editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+        )
     }
 
-    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
-
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        indentConfig = IndentConfig(
-            indentStyle = node.getEditorConfigValue(indentStyleProperty),
-            tabWidth = node.getEditorConfigValue(indentSizeProperty)
-        )
         if (indentConfig.disabled) {
             return
         }
 
-        reset()
-        indent(node, autoCorrect, emit)
-        // The expectedIndent should never be negative. If so, it is very likely that ktlint crashes at runtime when
-        // autocorrecting is executed while no error occurs with linting only. Such errors often are not found in unit
-        // tests, as the examples are way more simple than realistic code.
-        assert(expectedIndent >= 0)
-    }
-
-    private class IndentContext {
-        private val exitAdj = mutableMapOf<ASTNode, Int>()
-        val ignored = mutableSetOf<ASTNode>()
-        val blockStack: Deque<Block> = LinkedList()
-        var localAdj: Int = 0
-
-        fun exitAdjBy(node: ASTNode, change: Int) {
-            exitAdj.compute(node) { _, v -> (v ?: 0) + change }
-        }
-
-        fun clearExitAdj(node: ASTNode): Int? =
-            exitAdj.remove(node)
-
-        data class Block(
-            // Element type used for opening the block
-            val openingElementType: IElementType,
-            // Line at which the block is opened
-            val line: Int,
-            // Type of indentation to be used for the block
-            val blockIndentationType: BlockIndentationType
-        ) {
-            enum class BlockIndentationType {
-                /**
-                 * Indent the body of the block one level deeper by increasing the expected indentation level with 1.
-                 * Decrease the expected indentation level just before the closing element of the block.
-                 */
-                REGULAR,
-
-                /**
-                 * Keep the indent of the body of the block identical to the indent of the previous block, so do not change
-                 * the expected indentation level. The indentation of the closing element has to be decreased one level
-                 * without altering the expected indentation level.
-                 */
-                SAME_AS_PREVIOUS_BLOCK
+        if (node.isRoot()) {
+            val firstNotEmptyLeaf = node.nextLeaf()
+            if (firstNotEmptyLeaf?.let { it.elementType == WHITE_SPACE && !it.textContains('\n') } == true) {
+                visitWhiteSpace(firstNotEmptyLeaf, autoCorrect, emit, ctx)
             }
         }
+
+        when (node.elementType) {
+            LPAR, LBRACE, LBRACKET -> {
+                // ({[ should increase expectedIndent by 1
+                val prevBlock = ctx.blockStack.peek()
+                when {
+                    node.isClosedOnSameLine() -> {
+                        logger.trace {
+                            "$line: block starting with ${node.text} is opened and closed on the same line, " +
+                                "expected indent is kept unchanged -> $expectedIndent"
+                        }
+                        ctx.blockStack.push(
+                            Block(node.elementType, line, SAME_AS_PREVIOUS_BLOCK)
+                        )
+                    }
+                    node.isAfterValueParameterOnSameLine() -> {
+                        logger.trace {
+                            "$line: block starting with ${node.text} starts on same line as the previous value " +
+                                "parameter value ended, expected indent is kept unchanged -> $expectedIndent"
+                        }
+                        ctx.blockStack.push(
+                            Block(node.elementType, line, SAME_AS_PREVIOUS_BLOCK)
+                        )
+                    }
+                    prevBlock != null && line == prevBlock.line -> {
+                        logger.trace {
+                            "$line: block starting with ${node.text} starts on same line as the previous block, " +
+                                "expected indent is kept unchanged -> $expectedIndent"
+                        }
+                        ctx.blockStack.push(
+                            Block(node.elementType, line, SAME_AS_PREVIOUS_BLOCK)
+                        )
+                    }
+                    else -> {
+                        if (node.isPartOfForLoopConditionWithMultilineExpression()) {
+                            logger.trace { "$line: block starting with ${node.text} -> Keep at $expectedIndent" }
+                            ctx.blockStack.push(
+                                Block(node.elementType, line, SAME_AS_PREVIOUS_BLOCK)
+                            )
+                        } else {
+                            expectedIndent++
+                            logger.trace { "$line: block starting with ${node.text} -> Increase to $expectedIndent" }
+                            ctx.blockStack.push(
+                                Block(node.elementType, line, REGULAR)
+                            )
+                        }
+                    }
+                }
+                logger.trace {
+                    ctx.blockStack.iterator().asSequence().toList()
+                        .joinToString(
+                            separator = "\n\t",
+                            prefix = "Stack (newest first) after pushing new element:\n\t"
+                        )
+                }
+            }
+            RPAR, RBRACE, RBRACKET -> {
+                // ]}) should decrease expectedIndent by 1
+                logger.trace {
+                    ctx.blockStack.iterator().asSequence().toList()
+                        .joinToString(
+                            separator = "\n\t",
+                            prefix = "Stack before popping newest element from top of stack:\n\t"
+                        )
+                }
+                val block = ctx.blockStack.pop()
+                when (block.blockIndentationType) {
+                    SAME_AS_PREVIOUS_BLOCK -> {
+                        logger.trace { "$line: block closed with ${node.elementType}. BlockIndentationType ${block.blockIndentationType} -> keep indent unchanged at $expectedIndent" }
+                    }
+                    REGULAR -> {
+                        expectedIndent--
+                        logger.trace { "$line: block closed with ${node.elementType}.  -> Decrease indent to $expectedIndent" }
+                    }
+                }
+
+                val pairedLeft = node.pairedLeft()
+                val byKeywordOnSameLine = pairedLeft.prevLeafOnSameLine(BY_KEYWORD)
+                if (byKeywordOnSameLine != null &&
+                    byKeywordOnSameLine.prevLeaf()?.isWhiteSpaceWithNewline() == true &&
+                    node.leavesOnSameLine(forward = true).all { it.isWhiteSpace() || it.isPartOfComment() }
+                ) {
+                    expectedIndent--
+                    logger.trace { "$line: --on same line as by keyword ${node.text} -> $expectedIndent" }
+                }
+            }
+            LT ->
+                // <T>
+                if (node.treeParent.elementType.let { it == TYPE_PARAMETER_LIST || it == TYPE_ARGUMENT_LIST }) {
+                    expectedIndent++
+                    logger.trace { "$line: ++${node.text} -> $expectedIndent" }
+                }
+            GT ->
+                // <T>
+                if (node.treeParent.elementType.let { it == TYPE_PARAMETER_LIST || it == TYPE_ARGUMENT_LIST }) {
+                    expectedIndent--
+                    logger.trace { "$line: --${node.text} -> $expectedIndent" }
+                }
+            SUPER_TYPE_LIST ->
+                // class A :
+                //     SUPER_TYPE_LIST
+                adjustExpectedIndentInsideSuperTypeList(node)
+            SUPER_TYPE_CALL_ENTRY, DELEGATED_SUPER_TYPE_ENTRY -> {
+                // IDEA quirk:
+                //
+                // class A : B({
+                //     f() {}
+                // }),
+                //     C({
+                //         f() {}
+                //     })
+                //
+                // instead of expected
+                //
+                // class A : B({
+                //         f() {}
+                //     }),
+                //     C({
+                //         f() {}
+                //     })
+                adjustExpectedIndentInsideSuperTypeCall(node, ctx)
+            }
+            STRING_TEMPLATE ->
+                indentStringTemplate(node, autoCorrect, emit)
+            DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION, BINARY_EXPRESSION, BINARY_WITH_TYPE -> {
+                val prevBlock = ctx.blockStack.peek()
+                if (prevBlock != null && prevBlock.line == line) {
+                    ctx.ignored.add(node)
+                }
+            }
+            FUNCTION_LITERAL ->
+                adjustExpectedIndentInFunctionLiteral(node, ctx)
+            WHITE_SPACE ->
+                if (node.textContains('\n')) {
+                    if (
+                        !node.isPartOfComment() &&
+                        !node.isPartOfTypeConstraint() // FIXME IndentationRuleTest.testLintWhereClause not checked
+                    ) {
+                        val p = node.treeParent
+                        val nextSibling = node.treeNext
+                        val prevLeaf = node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpaceWithoutNewline() }
+                        when {
+                            p.elementType.let {
+                                it == DOT_QUALIFIED_EXPRESSION || it == SAFE_ACCESS_EXPRESSION
+                            } ->
+                                // value
+                                //     .x()
+                                //     .y
+                                adjustExpectedIndentInsideQualifiedExpression(node, ctx)
+                            p.elementType.let {
+                                it == BINARY_EXPRESSION || it == BINARY_WITH_TYPE
+                            } ->
+                                // value
+                                //     + x()
+                                //     + y
+                                adjustExpectedIndentInsideBinaryExpression(node, ctx)
+                            nextSibling?.elementType.let {
+                                it == THEN || it == ELSE || it == BODY
+                            } ->
+                                // if (...)
+                                //     THEN
+                                // else
+                                //     ELSE
+                                // while (...)
+                                //     BODY
+                                adjustExpectedIndentInFrontOfControlBlock(node, ctx)
+                            nextSibling?.elementType == PROPERTY_ACCESSOR ->
+                                // val f: Type =
+                                //     PROPERTY_ACCESSOR get() = ...
+                                //     PROPERTY_ACCESSOR set() = ...
+                                adjustExpectedIndentInFrontOfPropertyAccessor(node, ctx)
+                            nextSibling?.elementType == SUPER_TYPE_LIST ->
+                                // class C :
+                                //     SUPER_TYPE_LIST
+                                adjustExpectedIndentInFrontOfSuperTypeList(node, ctx)
+                            prevLeaf?.elementType == EQ && p.elementType != VALUE_ARGUMENT ->
+                                // v =
+                                //     value
+                                adjustExpectedIndentAfterEq(node, ctx)
+                            prevLeaf?.elementType == ARROW ->
+                                // when {
+                                //    v ->
+                                //        value
+                                // }
+                                adjustExpectedIndentAfterArrow(node, ctx)
+                            prevLeaf?.elementType == COLON ->
+                                // fun fn():
+                                //     Int
+                                adjustExpectedIndentAfterColon(node, ctx)
+                            prevLeaf?.elementType == LPAR &&
+                                p.elementType == VALUE_ARGUMENT_LIST &&
+                                p.parent(CONDITION)?.takeIf { !it.prevLeaf().isWhiteSpaceWithNewline() } != null ->
+                                // if (condition(
+                                //         params
+                                //     )
+                                // )
+                                adjustExpectedIndentAfterLparInsideCondition(node, ctx)
+                        }
+                        visitWhiteSpace(node, autoCorrect, emit, ctx)
+                        if (ctx.localAdj != 0) {
+                            expectedIndent += ctx.localAdj
+                            logger.trace { "$line: ++${ctx.localAdj} on whitespace containing new line (${node.elementType}) -> $expectedIndent" }
+                            ctx.localAdj = 0
+                        }
+                    } else if (node.isPartOf(KDOC)) {
+                        visitWhiteSpace(node, autoCorrect, emit, ctx)
+                    }
+                    line += node.text.count { it == '\n' }
+                }
+            EOL_COMMENT ->
+                if (node.text == "// ktlint-debug-print-expected-indent") {
+                    logger.trace { "$line: expected indent: $expectedIndent" }
+                }
+        }
     }
 
-    private fun indent(
+    override fun afterVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        val ctx = IndentContext()
-        val firstNotEmptyLeaf = node.nextLeaf()
-        if (firstNotEmptyLeaf?.let { it.elementType == WHITE_SPACE && !it.textContains('\n') } == true) {
-            visitWhiteSpace(firstNotEmptyLeaf, autoCorrect, emit, ctx)
+        if (indentConfig.disabled) {
+            return
         }
-        node.visit(
-            { n ->
-                when (n.elementType) {
-                    LPAR, LBRACE, LBRACKET -> {
-                        // ({[ should increase expectedIndent by 1
-                        val prevBlock = ctx.blockStack.peek()
-                        when {
-                            n.isClosedOnSameLine() -> {
-                                logger.trace {
-                                    "$line: block starting with ${n.text} is opened and closed on the same line, " +
-                                        "expected indent is kept unchanged -> $expectedIndent"
-                                }
-                                ctx.blockStack.push(
-                                    Block(n.elementType, line, SAME_AS_PREVIOUS_BLOCK)
-                                )
-                            }
-                            n.isAfterValueParameterOnSameLine() -> {
-                                logger.trace {
-                                    "$line: block starting with ${n.text} starts on same line as the previous value " +
-                                        "parameter value ended, expected indent is kept unchanged -> $expectedIndent"
-                                }
-                                ctx.blockStack.push(
-                                    Block(n.elementType, line, SAME_AS_PREVIOUS_BLOCK)
-                                )
-                            }
-                            prevBlock != null && line == prevBlock.line -> {
-                                logger.trace {
-                                    "$line: block starting with ${n.text} starts on same line as the previous block, " +
-                                        "expected indent is kept unchanged -> $expectedIndent"
-                                }
-                                ctx.blockStack.push(
-                                    Block(n.elementType, line, SAME_AS_PREVIOUS_BLOCK)
-                                )
-                            }
-                            else -> {
-                                if (n.isPartOfForLoopConditionWithMultilineExpression()) {
-                                    logger.trace { "$line: block starting with ${n.text} -> Keep at $expectedIndent" }
-                                    ctx.blockStack.push(
-                                        Block(n.elementType, line, SAME_AS_PREVIOUS_BLOCK)
-                                    )
-                                } else {
-                                    expectedIndent++
-                                    logger.trace { "$line: block starting with ${n.text} -> Increase to $expectedIndent" }
-                                    ctx.blockStack.push(
-                                        Block(n.elementType, line, REGULAR)
-                                    )
-                                }
-                            }
-                        }
-                        logger.trace {
-                            ctx.blockStack.iterator().asSequence().toList()
-                                .joinToString(
-                                    separator = "\n\t",
-                                    prefix = "Stack (newest first) after pushing new element:\n\t"
-                                )
-                        }
-                    }
-                    RPAR, RBRACE, RBRACKET -> {
-                        // ]}) should decrease expectedIndent by 1
-                        logger.trace {
-                            ctx.blockStack.iterator().asSequence().toList()
-                                .joinToString(
-                                    separator = "\n\t",
-                                    prefix = "Stack before popping newest element from top of stack:\n\t"
-                                )
-                        }
-                        val block = ctx.blockStack.pop()
-                        when (block.blockIndentationType) {
-                            SAME_AS_PREVIOUS_BLOCK -> {
-                                logger.trace { "$line: block closed with ${n.elementType}. BlockIndentationType ${block.blockIndentationType} -> keep indent unchanged at $expectedIndent" }
-                            }
-                            REGULAR -> {
-                                expectedIndent--
-                                logger.trace { "$line: block closed with ${n.elementType}.  -> Decrease indent to $expectedIndent" }
-                            }
-                        }
 
-                        val pairedLeft = n.pairedLeft()
-                        val byKeywordOnSameLine = pairedLeft.prevLeafOnSameLine(BY_KEYWORD)
-                        if (byKeywordOnSameLine != null &&
-                            byKeywordOnSameLine.prevLeaf()?.isWhiteSpaceWithNewline() == true &&
-                            n.leavesOnSameLine(forward = true).all { it.isWhiteSpace() || it.isPartOfComment() }
-                        ) {
-                            expectedIndent--
-                            logger.trace { "$line: --on same line as by keyword ${n.text} -> $expectedIndent" }
-                        }
-                    }
-                    LT ->
-                        // <T>
-                        if (n.treeParent.elementType.let { it == TYPE_PARAMETER_LIST || it == TYPE_ARGUMENT_LIST }) {
-                            expectedIndent++
-                            logger.trace { "$line: ++${n.text} -> $expectedIndent" }
-                        }
-                    GT ->
-                        // <T>
-                        if (n.treeParent.elementType.let { it == TYPE_PARAMETER_LIST || it == TYPE_ARGUMENT_LIST }) {
-                            expectedIndent--
-                            logger.trace { "$line: --${n.text} -> $expectedIndent" }
-                        }
-                    SUPER_TYPE_LIST ->
-                        // class A :
-                        //     SUPER_TYPE_LIST
-                        adjustExpectedIndentInsideSuperTypeList(n)
-                    SUPER_TYPE_CALL_ENTRY, DELEGATED_SUPER_TYPE_ENTRY -> {
-                        // IDEA quirk:
-                        //
-                        // class A : B({
-                        //     f() {}
-                        // }),
-                        //     C({
-                        //         f() {}
-                        //     })
-                        //
-                        // instead of expected
-                        //
-                        // class A : B({
-                        //         f() {}
-                        //     }),
-                        //     C({
-                        //         f() {}
-                        //     })
-                        adjustExpectedIndentInsideSuperTypeCall(n, ctx)
-                    }
-                    STRING_TEMPLATE ->
-                        indentStringTemplate(n, autoCorrect, emit)
-                    DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION, BINARY_EXPRESSION, BINARY_WITH_TYPE -> {
-                        val prevBlock = ctx.blockStack.peek()
-                        if (prevBlock != null && prevBlock.line == line) {
-                            ctx.ignored.add(n)
-                        }
-                    }
-                    FUNCTION_LITERAL ->
-                        adjustExpectedIndentInFunctionLiteral(n, ctx)
-                    WHITE_SPACE ->
-                        if (n.textContains('\n')) {
-                            if (
-                                !n.isPartOfComment() &&
-                                !n.isPartOfTypeConstraint() // FIXME IndentationRuleTest.testLintWhereClause not checked
-                            ) {
-                                val p = n.treeParent
-                                val nextSibling = n.treeNext
-                                val prevLeaf = n.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpaceWithoutNewline() }
-                                when {
-                                    p.elementType.let {
-                                        it == DOT_QUALIFIED_EXPRESSION || it == SAFE_ACCESS_EXPRESSION
-                                    } ->
-                                        // value
-                                        //     .x()
-                                        //     .y
-                                        adjustExpectedIndentInsideQualifiedExpression(n, ctx)
-                                    p.elementType.let {
-                                        it == BINARY_EXPRESSION || it == BINARY_WITH_TYPE
-                                    } ->
-                                        // value
-                                        //     + x()
-                                        //     + y
-                                        adjustExpectedIndentInsideBinaryExpression(n, ctx)
-                                    nextSibling?.elementType.let {
-                                        it == THEN || it == ELSE || it == BODY
-                                    } ->
-                                        // if (...)
-                                        //     THEN
-                                        // else
-                                        //     ELSE
-                                        // while (...)
-                                        //     BODY
-                                        adjustExpectedIndentInFrontOfControlBlock(n, ctx)
-                                    nextSibling?.elementType == PROPERTY_ACCESSOR ->
-                                        // val f: Type =
-                                        //     PROPERTY_ACCESSOR get() = ...
-                                        //     PROPERTY_ACCESSOR set() = ...
-                                        adjustExpectedIndentInFrontOfPropertyAccessor(n, ctx)
-                                    nextSibling?.elementType == SUPER_TYPE_LIST ->
-                                        // class C :
-                                        //     SUPER_TYPE_LIST
-                                        adjustExpectedIndentInFrontOfSuperTypeList(n, ctx)
-                                    prevLeaf?.elementType == EQ && p.elementType != VALUE_ARGUMENT ->
-                                        // v =
-                                        //     value
-                                        adjustExpectedIndentAfterEq(n, ctx)
-                                    prevLeaf?.elementType == ARROW ->
-                                        // when {
-                                        //    v ->
-                                        //        value
-                                        // }
-                                        adjustExpectedIndentAfterArrow(n, ctx)
-                                    prevLeaf?.elementType == COLON ->
-                                        // fun fn():
-                                        //     Int
-                                        adjustExpectedIndentAfterColon(n, ctx)
-                                    prevLeaf?.elementType == LPAR &&
-                                        p.elementType == VALUE_ARGUMENT_LIST &&
-                                        p.parent(CONDITION)?.takeIf { !it.prevLeaf().isWhiteSpaceWithNewline() } != null ->
-                                        // if (condition(
-                                        //         params
-                                        //     )
-                                        // )
-                                        adjustExpectedIndentAfterLparInsideCondition(n, ctx)
-                                }
-                                visitWhiteSpace(n, autoCorrect, emit, ctx)
-                                if (ctx.localAdj != 0) {
-                                    expectedIndent += ctx.localAdj
-                                    logger.trace { "$line: ++${ctx.localAdj} on whitespace containing new line (${n.elementType}) -> $expectedIndent" }
-                                    ctx.localAdj = 0
-                                }
-                            } else if (n.isPartOf(KDOC)) {
-                                visitWhiteSpace(n, autoCorrect, emit, ctx)
-                            }
-                            line += n.text.count { it == '\n' }
-                        }
-                    EOL_COMMENT ->
-                        if (n.text == "// ktlint-debug-print-expected-indent") {
-                            logger.trace { "$line: expected indent: $expectedIndent" }
-                        }
-                }
-            },
-            { n ->
-                when (n.elementType) {
-                    SUPER_TYPE_LIST ->
-                        adjustExpectedIndentAfterSuperTypeList(n)
-                    DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION, BINARY_EXPRESSION, BINARY_WITH_TYPE ->
-                        ctx.ignored.remove(n)
-                }
-                val adj = ctx.clearExitAdj(n)
-                if (adj != null) {
-                    expectedIndent += adj
-                    logger.trace { "$line: adjusted ${n.elementType} by $adj -> $expectedIndent" }
-                }
-            }
-        )
+        when (node.elementType) {
+            SUPER_TYPE_LIST ->
+                adjustExpectedIndentAfterSuperTypeList(node)
+            DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION, BINARY_EXPRESSION, BINARY_WITH_TYPE ->
+                ctx.ignored.remove(node)
+        }
+        val adj = ctx.clearExitAdj(node)
+        if (adj != null) {
+            expectedIndent += adj
+            logger.trace { "$line: adjusted ${node.elementType} by $adj -> $expectedIndent" }
+        }
+    }
+
+    override fun afterLastNode() {
+        // The expectedIndent should never be negative. If so, it is very likely that ktlint crashes at runtime when
+        // autocorrecting is executed while no error occurs with linting only. Such errors often are not found in unit
+        // tests, as the examples are way more simple than realistic code.
+        assert(expectedIndent >= 0)
     }
 
     private fun adjustExpectedIndentInsideQualifiedExpression(n: ASTNode, ctx: IndentContext) {
@@ -1009,6 +955,53 @@ public class IndentationRule :
             cur = cur.nextSibling { true }
         }
         return true
+    }
+
+    private class IndentContext {
+        private val exitAdj = mutableMapOf<ASTNode, Int>()
+        val ignored = mutableSetOf<ASTNode>()
+        val blockStack: Deque<Block> = LinkedList()
+        var localAdj: Int = 0
+
+        fun exitAdjBy(node: ASTNode, change: Int) {
+            exitAdj.compute(node) { _, v -> (v ?: 0) + change }
+        }
+
+        fun clearExitAdj(node: ASTNode): Int? =
+            exitAdj.remove(node)
+
+        data class Block(
+            // Element type used for opening the block
+            val openingElementType: IElementType,
+            // Line at which the block is opened
+            val line: Int,
+            // Type of indentation to be used for the block
+            val blockIndentationType: BlockIndentationType
+        ) {
+            enum class BlockIndentationType {
+                /**
+                 * Indent the body of the block one level deeper by increasing the expected indentation level with 1.
+                 * Decrease the expected indentation level just before the closing element of the block.
+                 */
+                REGULAR,
+
+                /**
+                 * Keep the indent of the body of the block identical to the indent of the previous block, so do not change
+                 * the expected indentation level. The indentation of the closing element has to be decreased one level
+                 * without altering the expected indentation level.
+                 */
+                SAME_AS_PREVIOUS_BLOCK
+            }
+        }
+    }
+
+    private companion object {
+        private val lTokenSet = TokenSet.create(LPAR, LBRACE, LBRACKET, LT)
+        private val rTokenSet = TokenSet.create(RPAR, RBRACE, RBRACKET, GT)
+        private val matchingRToken =
+            lTokenSet.types.zip(
+                rTokenSet.types
+            ).toMap()
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -43,7 +43,7 @@ class MaxLineLengthRule :
     private var maxLineLength: Int = maxLineLengthProperty.defaultValue
     private var rangeTree = RangeTree()
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.isPartOf
@@ -9,6 +10,7 @@ import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.nextLeaf
 import com.pinterest.ktlint.core.ast.parent
 import com.pinterest.ktlint.core.ast.prevCodeSibling
+import kotlin.properties.Delegates
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
@@ -42,18 +44,22 @@ class MaxLineLengthRule :
 
     private var maxLineLength: Int = maxLineLengthProperty.defaultValue
     private var rangeTree = RangeTree()
+    private var ignoreBackTickedIdentifier by Delegates.notNull<Boolean>()
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        ignoreBackTickedIdentifier = editorConfigProperties.getEditorConfigValue(ignoreBackTickedIdentifierProperty)
+        maxLineLength = editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+    }
 
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
+        if (maxLineLength <= 0) {
+            return
+        }
         if (node.isRoot()) {
-            val ignoreBackTickedIdentifier = node.getEditorConfigValue(ignoreBackTickedIdentifierProperty)
-            maxLineLength = node.getEditorConfigValue(maxLineLengthProperty)
-            if (maxLineLength <= 0) {
-                return
-            }
             val errorOffset = arrayListOf<Int>()
             node
                 .getElementsPerLine()
@@ -160,6 +166,7 @@ private data class ParsedLine(
     }
 }
 
+@Deprecated("Marked for removal from public API in ktlint 0.48")
 class RangeTree(seq: List<Int> = emptyList()) {
 
     private var emptyArrayView = ArrayView(0, 0)
@@ -173,6 +180,7 @@ class RangeTree(seq: List<Int> = emptyList()) {
 
     // runtime: O(log(n)+k), where k is number of matching points
     // space: O(1)
+    @Deprecated("Marked for removal from public API in ktlint 0.48")
     fun query(vmin: Int, vmax: Int): RangeTree.ArrayView {
         var r = arr.size - 1
         if (r == -1 || vmax < arr[0] || arr[r] < vmin) {
@@ -206,12 +214,16 @@ class RangeTree(seq: List<Int> = emptyList()) {
         return ArrayView(l, k)
     }
 
+    @Deprecated("Marked for removal from public API in ktlint 0.48")
     fun isEmpty() = arr.isEmpty()
 
+    @Deprecated("Marked for removal from public API in ktlint 0.48")
     inner class ArrayView(private var l: Int, private val r: Int) {
 
+        @Deprecated("Marked for removal from public API in ktlint 0.48")
         val size: Int = r - l
 
+        @Deprecated("Marked for removal from public API in ktlint 0.48")
         fun get(i: Int): Int {
             if (i < 0 || i >= size) {
                 throw IndexOutOfBoundsException()
@@ -219,6 +231,7 @@ class RangeTree(seq: List<Int> = emptyList()) {
             return arr[l + i]
         }
 
+        @Deprecated("Marked for removal from public API in ktlint 0.48")
         inline fun forEach(cb: (v: Int) -> Unit) {
             var i = 0
             while (i < size) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ModifierOrderRule.kt
@@ -59,7 +59,7 @@ class ModifierOrderRule : Rule("modifier-order") {
     )
     private val tokenSet = TokenSet.create(*order)
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
  * https://kotlinlang.org/docs/reference/coding-conventions.html#formatting-control-flow-statements
  */
 class MultiLineIfElseRule : Rule("multiline-if-else") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoBlankLinesInChainedMethodCallsRule.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 public class NoBlankLinesInChainedMethodCallsRule : Rule("no-blank-lines-in-chained-method-calls") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 public class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyClassBodyRule.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 
 class NoEmptyClassBodyRule : Rule("no-empty-class-body") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyFirstLineInMethodBlockRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoEmptyFirstLineInMethodBlockRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class NoEmptyFirstLineInMethodBlockRule : Rule("no-empty-first-line-in-method-block") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakAfterElseRule.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class NoLineBreakAfterElseRule : Rule("no-line-break-after-else") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoLineBreakBeforeAssignmentRule.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class NoLineBreakBeforeAssignmentRule : Rule("no-line-break-before-assignment") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun beforeVisitChildNodes(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == EQ) {
             val prevCodeSibling = node.prevCodeSibling()
             val hasLineBreakBeforeAssignment = prevCodeSibling

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 public class NoMultipleSpacesRule : Rule("no-multi-spaces") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 class NoSemicolonsRule : Rule("no-semi") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 
 class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnitReturnRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 class NoUnitReturnRule : Rule("no-unit-return") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -1,8 +1,10 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.BY_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.core.ast.ElementType.FILE
 import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
 import com.pinterest.ktlint.core.ast.ElementType.OPERATION_REFERENCE
@@ -10,189 +12,218 @@ import com.pinterest.ktlint.core.ast.ElementType.PACKAGE_DIRECTIVE
 import com.pinterest.ktlint.core.ast.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.core.ast.isPartOf
 import com.pinterest.ktlint.core.ast.isRoot
-import com.pinterest.ktlint.core.ast.visit
+import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.core.ast.nextLeaf
+import com.pinterest.ktlint.core.ast.nextSibling
+import com.pinterest.ktlint.core.ast.prevSibling
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
-import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
-import org.jetbrains.kotlin.kdoc.lexer.KDocTokens
+import org.jetbrains.kotlin.kdoc.lexer.KDocTokens.MARKDOWN_LINK
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.resolve.ImportPath
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
-class NoUnusedImportsRule : Rule("no-unused-imports") {
-
-    private val componentNRegex = Regex("^component\\d+$")
-
-    private val operatorSet = setOf(
-        // unary
-        "unaryPlus", "unaryMinus", "not",
-        // inc/dec
-        "inc", "dec",
-        // arithmetic
-        "plus", "minus", "times", "div", "rem", "mod", "rangeTo",
-        // in
-        "contains",
-        // indexed access
-        "get", "set",
-        // invoke
-        "invoke",
-        // augmented assignments
-        "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
-        // (in)equality
-        "equals",
-        // comparison
-        "compareTo",
-        // iteration (https://github.com/shyiko/ktlint/issues/40)
-        "iterator",
-        // by (https://github.com/shyiko/ktlint/issues/54)
-        "getValue", "setValue"
-    )
-
-    private val conditionalWhitelist = mapOf<(String) -> Boolean, (node: ASTNode) -> Boolean>(
-        Pair(
-            // Ignore provideDelegate if there is a `by` anywhere in the file
-            { importPath -> importPath.endsWith(".provideDelegate") },
-            { rootNode ->
-                var hasByKeyword = false
-                rootNode.visit { child ->
-                    if (child.elementType == BY_KEYWORD) {
-                        hasByKeyword = true
-                        return@visit
-                    }
-                }
-                hasByKeyword
-            }
-        )
-    )
-
-    private data class Reference(val text: String, val inDotQualifiedExpression: Boolean)
+public class NoUnusedImportsRule : Rule("no-unused-imports") {
     private val ref = mutableSetOf<Reference>()
     private val parentExpressions = mutableSetOf<String>()
-    private val imports = mutableSetOf<String>()
-    private val usedImportPaths = mutableSetOf<ImportPath>()
+    private val imports = mutableMapOf<ImportPath, ASTNode>()
     private var packageName = ""
     private var rootNode: ASTNode? = null
+    private var foundByKeyword = false
 
-    override fun visit(
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        // Rule can potentially be executed more than once (when formatting), so clear state first
+        ref.clear()
+        ref.add(Reference("*", false))
+        parentExpressions.clear()
+        imports.clear()
+        foundByKeyword = false
+    }
+
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node.isRoot()) {
             rootNode = node
-            ref.clear() // rule can potentially be executed more than once (when formatting)
-            ref.add(Reference("*", false))
-            parentExpressions.clear()
-            imports.clear()
-            usedImportPaths.clear()
-            node.visit { vnode ->
-                val psi = vnode.psi
-                val type = vnode.elementType
-                val text = vnode.text
-                if (checkIfExpressionHasParentImport(text, type)) {
-                    parentExpressions.add(text.substringBeforeLast("("))
+        }
+        when (node.elementType) {
+            PACKAGE_DIRECTIVE -> {
+                val packageDirective = node.psi as KtPackageDirective
+                packageName = packageDirective.qualifiedName
+            }
+            IMPORT_DIRECTIVE -> {
+                val importPath = (node.psi as KtImportDirective).importPath!!
+                if (imports.containsKey(importPath)) {
+                    // Emit directly when same import occurs more than once
+                    emit(node.startOffset, "Unused import", true)
+                    if (autoCorrect) {
+                        node.psi.delete()
+                    }
+                } else {
+                    imports[importPath] = node
                 }
-                if (type == KDocTokens.MARKDOWN_LINK && psi is KDocLink) {
-                    val linkText = psi.getLinkText().removeBackticks()
-                    ref.add(Reference(linkText.split('.').first(), false))
-                    ref.add(Reference(linkText.split('.').last(), false))
-                } else if ((type == REFERENCE_EXPRESSION || type == OPERATION_REFERENCE) &&
-                    !vnode.isPartOf(IMPORT_DIRECTIVE)
-                ) {
-                    val identifier = if (vnode is CompositeElement) {
-                        vnode.findChildByType(IDENTIFIER)
+            }
+            DOT_QUALIFIED_EXPRESSION -> {
+                if (node.isExpressionForStaticImportWithExistingParentImport()) {
+                    parentExpressions.add(node.text.substringBeforeLast("("))
+                }
+            }
+            MARKDOWN_LINK -> {
+                node
+                    .psi
+                    .safeAs<KDocLink>()
+                    ?.let { kdocLink ->
+                        val linkText = kdocLink.getLinkText().removeBackticksAndTrim()
+                        ref.add(Reference(linkText.split('.').first(), false))
+                        ref.add(Reference(linkText.split('.').last(), false))
+                    }
+            }
+            REFERENCE_EXPRESSION, OPERATION_REFERENCE -> {
+                if (!node.isPartOf(IMPORT_DIRECTIVE)) {
+                    val identifier = if (node is CompositeElement) {
+                        node.findChildByType(IDENTIFIER)
                     } else {
-                        vnode
+                        node
                     }
                     identifier
                         ?.let { identifier.text }
                         ?.takeIf { it.isNotBlank() }
                         ?.let {
-                            ref.add(Reference(it.removeBackticks(), psi.parentDotQualifiedExpression() != null))
+                            ref.add(
+                                Reference(
+                                    it.removeBackticksAndTrim(),
+                                    node.psi.parentDotQualifiedExpression() != null
+                                )
+                            )
                         }
-                } else if (type == IMPORT_DIRECTIVE) {
-                    val importPath = (vnode.psi as KtImportDirective).importPath!!
-                    if (!usedImportPaths.add(importPath)) {
-                        emit(vnode.startOffset, "Unused import", true)
+                }
+            }
+            BY_KEYWORD -> foundByKeyword = true
+        }
+    }
+
+    override fun afterVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == FILE) {
+            val directCalls = ref.filter { !it.inDotQualifiedExpression }.map { it.text }
+            parentExpressions.forEach { parent ->
+                imports
+                    .filterKeys { import ->
+                        val importPath = import.pathStr.removeBackticksAndTrim()
+                        importPath.endsWith(".$parent") && directCalls.none { importPath.endsWith(".$it") }
+                    }.forEach { (importPath, importNode) ->
+                        emit(importNode.startOffset, "Unused import", true)
                         if (autoCorrect) {
-                            vnode.psi.delete()
+                            imports.remove(importPath, importNode)
+                            importNode.removeImportDirective()
                         }
-                    } else {
-                        imports += importPath.pathStr.removeBackticks().trim()
+                    }
+            }
+
+            imports.forEach { (_, node) ->
+                val importDirective = node.psi as KtImportDirective
+                val name = importDirective.importPath?.importedName?.asString()?.removeBackticksAndTrim()
+                val importPath = importDirective.importPath?.pathStr?.removeBackticksAndTrim()!!
+                if (importDirective.aliasName == null &&
+                    (packageName.isEmpty() || importPath.startsWith("$packageName.")) &&
+                    importPath.substring(packageName.length + 1).indexOf('.') == -1
+                ) {
+                    emit(node.startOffset, "Unnecessary import", true)
+                    if (autoCorrect) {
+                        importDirective.delete()
+                    }
+                } else if (name != null && (!ref.map { it.text }.contains(name) || !isAValidImport(importPath)) &&
+                    !operatorSet.contains(name) &&
+                    !name.isComponentN() &&
+                    !importPath.ignoreProvideDelegate()
+                ) {
+                    emit(node.startOffset, "Unused import", true)
+                    if (autoCorrect) {
+                        importDirective.delete()
                     }
                 }
             }
-            val directCalls = ref.filter { !it.inDotQualifiedExpression }.map { it.text }
-            parentExpressions.forEach { parent ->
-                imports.removeIf { imp ->
-                    imp.endsWith(".$parent") && directCalls.none { imp.endsWith(".$it") }
-                }
-            }
-        } else if (node.elementType == PACKAGE_DIRECTIVE) {
-            val packageDirective = node.psi as KtPackageDirective
-            packageName = packageDirective.qualifiedName
-        } else if (node.elementType == IMPORT_DIRECTIVE) {
-            val importDirective = node.psi as KtImportDirective
-            val name = importDirective.importPath?.importedName?.asString()?.removeBackticks()
-            val importPath = importDirective.importPath?.pathStr?.removeBackticks()!!
-            if (importDirective.aliasName == null &&
-                (packageName.isEmpty() || importPath.startsWith("$packageName.")) &&
-                importPath.substring(packageName.length + 1).indexOf('.') == -1
-            ) {
-                emit(node.startOffset, "Unnecessary import", true)
-                if (autoCorrect) {
-                    importDirective.delete()
-                }
-            } else if (name != null && (!ref.map { it.text }.contains(name) || !isAValidImport(importPath)) &&
-                !operatorSet.contains(name) &&
-                !name.isComponentN() &&
-                conditionalWhitelist
-                    .filterKeys { selector -> selector(importPath) }
-                    .none { (_, condition) -> condition(rootNode!!) }
-            ) {
-                emit(node.startOffset, "Unused import", true)
-                if (autoCorrect) {
-                    importDirective.delete()
-                }
-            }
         }
     }
 
-    // Checks if any static method call is present in code with the parent import present in imports list
-    private fun checkIfExpressionHasParentImport(text: String, type: IElementType): Boolean {
-        val containsMethodCall = text.split(".").last().contains("(")
-        return type == DOT_QUALIFIED_EXPRESSION && containsMethodCall && checkIfParentImportExists(text.substringBeforeLast("("))
+    private fun String.ignoreProvideDelegate() =
+        if (endsWith(".provideDelegate")) {
+            // Ignore provideDelegate if the `by` keyword is found anywhere in the file
+            foundByKeyword
+        } else {
+            false
+        }
+
+    private fun ASTNode.removeImportDirective() {
+        require(this.elementType == IMPORT_DIRECTIVE)
+        when {
+            treeParent.firstChildNode == this -> {
+                nextSibling { true }
+                    ?.takeIf { it.isWhiteSpaceWithNewline() }
+                    ?.let { it.treeParent.removeChild(it) }
+            }
+            treeParent.lastChildNode == this -> {
+                prevSibling { true }
+                    ?.takeIf { it.isWhiteSpaceWithNewline() }
+                    ?.let { it.treeParent.removeChild(it) }
+            }
+            else -> {
+                nextLeaf(true)
+                    ?.takeIf { it.isWhiteSpaceWithNewline() }
+                    ?.let { it.treeParent.removeChild(it) }
+            }
+        }
+        treeParent.removeChild(this)
     }
 
-    // Contains list of all imports and checks if given import is present
-    private fun checkIfParentImportExists(text: String): Boolean {
-        // Only check static imports; identified if they start with a capital letter indicating a
-        // class name rather than a sub-package
-        if (text.isNotEmpty() && text[0] !in 'A'..'Z') {
+    private fun ASTNode.isExpressionForStaticImportWithExistingParentImport(): Boolean {
+        if (!containsMethodCall()) {
             return false
         }
 
-        val staticImports = imports.filter { it.endsWith(".$text") }
-        staticImports.forEach { import ->
-            val count = imports.count {
-                it.startsWith(import.substringBefore(text))
-            }
-            // Parent import and static import both are present
-            if (count > 1) {
-                return true
-            }
+        val methodCallExpression = text.substringBeforeLast(
+            "("
+        )
+
+        // Only check static imports; identified if they start with a capital letter indicating a
+        // class name rather than a sub-package
+        if (methodCallExpression.isNotEmpty() && methodCallExpression[0] !in 'A'..'Z') {
+            return false
         }
+
+        imports
+            .filterKeys { it.pathStr.removeBackticksAndTrim().endsWith(".$methodCallExpression") }
+            .forEach { import ->
+                val count = imports.count {
+                    it.key.pathStr.removeBackticksAndTrim().startsWith(
+                        import.key.pathStr.removeBackticksAndTrim().substringBefore(methodCallExpression)
+                    )
+                }
+                // Parent import and static import both are present
+                if (count > 1) {
+                    return true
+                }
+            }
         return false
     }
 
+    private fun ASTNode.containsMethodCall() = text.split(".").last().contains("(")
+
     // Check if the import being checked is present in the filtered import list
-    private fun isAValidImport(importPath: String): Boolean {
-        return imports.contains(importPath)
-    }
+    private fun isAValidImport(importPath: String) =
+        imports.any {
+            it.key.pathStr.removeBackticksAndTrim().contains(importPath)
+        }
 
     private fun String.isComponentN() = componentNRegex.matches(this)
 
@@ -201,5 +232,36 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
         return (callOrThis.parent as? KtDotQualifiedExpression)?.takeIf { it.selectorExpression == callOrThis }
     }
 
-    private fun String.removeBackticks() = replace("`", "")
+    private fun String.removeBackticksAndTrim() = replace("`", "").trim()
+
+    private data class Reference(val text: String, val inDotQualifiedExpression: Boolean)
+
+    private companion object {
+        val componentNRegex = Regex("^component\\d+$")
+
+        val operatorSet = setOf(
+            // unary
+            "unaryPlus", "unaryMinus", "not",
+            // inc/dec
+            "inc", "dec",
+            // arithmetic
+            "plus", "minus", "times", "div", "rem", "mod", "rangeTo",
+            // in
+            "contains",
+            // indexed access
+            "get", "set",
+            // invoke
+            "invoke",
+            // augmented assignments
+            "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
+            // (in)equality
+            "equals",
+            // comparison
+            "compareTo",
+            // iteration (https://github.com/shyiko/ktlint/issues/40)
+            "iterator",
+            // by (https://github.com/shyiko/ktlint/issues/54)
+            "getValue", "setValue"
+        )
+    }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -18,7 +18,7 @@ public class NoWildcardImportsRule :
         packagesToUseImportOnDemandProperty
     )
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -1,9 +1,9 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.IMPORT_DIRECTIVE
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.ruleset.standard.internal.importordering.PatternEntry
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -12,20 +12,21 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 public class NoWildcardImportsRule :
     Rule("no-wildcard-imports"),
     UsesEditorConfigProperties {
-    private var allowedWildcardImports: List<PatternEntry> = emptyList()
-
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(
         packagesToUseImportOnDemandProperty
     )
+
+    private lateinit var allowedWildcardImports: List<PatternEntry>
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        allowedWildcardImports = editorConfigProperties.getEditorConfigValue(packagesToUseImportOnDemandProperty)
+    }
 
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            allowedWildcardImports = node.getEditorConfigValue(packagesToUseImportOnDemandProperty)
-        }
         if (node.elementType == IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath ?: return

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/PackageNameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/PackageNameRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
  * https://kotlinlang.org/docs/coding-conventions.html#naming-rules
  */
 class PackageNameRule : Rule("package-name") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_TYPE
@@ -15,7 +16,6 @@ import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.TYPE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
-import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.column
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.lineIndent
@@ -29,9 +29,10 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.psiUtil.children
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
-class ParameterListWrappingRule :
+public class ParameterListWrappingRule :
     Rule("parameter-list-wrapping"),
     UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
@@ -44,26 +45,41 @@ class ParameterListWrappingRule :
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
     private var maxLineLength = -1
 
-    override fun visit(
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        indentConfig = IndentConfig(
+            indentStyle = editorConfigProperties.getEditorConfigValue(indentStyleProperty),
+            tabWidth = editorConfigProperties.getEditorConfigValue(indentSizeProperty)
+        )
+        maxLineLength = editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
+    }
+
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            indentConfig = IndentConfig(
-                indentStyle = node.getEditorConfigValue(indentStyleProperty),
-                tabWidth = node.getEditorConfigValue(indentSizeProperty)
-            )
-            maxLineLength = node.getEditorConfigValue(maxLineLengthProperty)
-            return
-        }
         if (indentConfig.disabled) {
             return
         }
 
+        when (node.elementType) {
+            NULLABLE_TYPE -> wrapNullableType(node, emit, autoCorrect)
+            VALUE_PARAMETER_LIST -> {
+                if (node.needToWrapParameterList()) {
+                    wrapParameterList(node, emit, autoCorrect)
+                }
+            }
+        }
+    }
+
+    private fun wrapNullableType(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        require(node.elementType == NULLABLE_TYPE)
         node
-            .takeIf { it.elementType == NULLABLE_TYPE }
-            ?.takeUnless {
+            .takeUnless {
                 // skip when max line length not set or does not exceed max line length
                 maxLineLength <= 0 || (node.column - 1 + node.textLength) <= maxLineLength
             }?.findChildByType(FUNCTION_TYPE)
@@ -94,102 +110,120 @@ class ParameterListWrappingRule :
                         }
                     }
             }
+    }
 
-        if (node.elementType == VALUE_PARAMETER_LIST &&
-            // skip when there are no parameters
-            node.firstChildNode?.treeNext?.elementType != RPAR &&
+    private fun ASTNode.needToWrapParameterList() =
+        if ( // skip when there are no parameters
+            firstChildNode?.treeNext?.elementType != RPAR &&
             // skip lambda parameters
-            node.treeParent?.elementType != FUNCTION_LITERAL &&
+            treeParent?.elementType != FUNCTION_LITERAL &&
             // skip when function type is wrapped in a nullable type [which was already when processing the nullable
             // type node itself.
-            !(node.treeParent.elementType == FUNCTION_TYPE && node.treeParent?.treeParent?.elementType == NULLABLE_TYPE)
+            !(treeParent.elementType == FUNCTION_TYPE && treeParent?.treeParent?.elementType == NULLABLE_TYPE)
         ) {
             // each parameter should be on a separate line if
             // - at least one of the parameters is
             // - maxLineLength exceeded (and separating parameters with \n would actually help)
             // in addition, "(" and ")" must be on separates line if any of the parameters are (otherwise on the same)
-            val putParametersOnSeparateLines =
-                node.textContains('\n') ||
-                    // max_line_length exceeded
-                    maxLineLength > -1 && (node.column - 1 + node.textLength) > maxLineLength && !node.textContains('\n')
-            if (putParametersOnSeparateLines) {
-                val currentIndentLevel = indentConfig.indentLevelFrom(node.lineIndent())
-                val newIndentLevel =
-                    when {
-                        // IDEA quirk:
-                        // fun <
-                        //     T,
-                        //     R> test(
-                        //     param1: T
-                        //     param2: R
-                        // )
-                        // instead of
-                        // fun <
-                        //     T,
-                        //     R> test(
-                        //         param1: T
-                        //         param2: R
-                        //     )
-                        currentIndentLevel > 0 && node.hasTypeParameterListInFront() -> currentIndentLevel - 1
+            textContains('\n') || this.exceedsMaxLineLength()
+        } else {
+            false
+        }
 
-                        else -> currentIndentLevel
-                    }
-                val indent = "\n" + indentConfig.indent.repeat(newIndentLevel)
+    private fun wrapParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val newIndentLevel = getNewIndentLevel(node)
+        node
+            .children()
+            .forEach { child -> wrapParemeterInList(newIndentLevel, child, emit, autoCorrect) }
+    }
 
-                nextChild@ for (child in node.children()) {
-                    when (child.elementType) {
-                        LPAR -> {
-                            val prevLeaf = child.prevLeaf()
-                            if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
-                                emit(child.startOffset, errorMessage(child), true)
-                                if (autoCorrect) {
-                                    prevLeaf.delete()
-                                }
-                            }
-                        }
-                        VALUE_PARAMETER,
-                        RPAR -> {
-                            // aiming for
-                            // ... LPAR
-                            // <line indent + indentSize> VALUE_PARAMETER...
-                            // <line indent> RPAR
-                            val intendedIndent = if (child.elementType == VALUE_PARAMETER) {
-                                indent + indentConfig.indent
-                            } else {
-                                indent
-                            }
+    private fun getNewIndentLevel(node: ASTNode): Int {
+        val currentIndentLevel = indentConfig.indentLevelFrom(node.lineIndent())
+        return when {
+            // IDEA quirk:
+            // fun <
+            //     T,
+            //     R> test(
+            //     param1: T
+            //     param2: R
+            // )
+            // instead of
+            // fun <
+            //     T,
+            //     R> test(
+            //         param1: T
+            //         param2: R
+            //     )
+            currentIndentLevel > 0 && node.hasTypeParameterListInFront() -> currentIndentLevel - 1
 
-                            val prevLeaf = child.prevLeaf()
-                            if (prevLeaf is PsiWhiteSpace) {
-                                if (prevLeaf.getText().contains("\n")) {
-                                    // The current child is already wrapped to a new line. Checking and fixing the
-                                    // correct size of the indent is the responsibility of the IndentationRule.
-                                    continue@nextChild
-                                } else {
-                                    // The current child needs to be wrapped to a newline.
-                                    emit(child.startOffset, errorMessage(child), true)
-                                    if (autoCorrect) {
-                                        // The indentation is purely based on the previous leaf only. Note that in
-                                        // autoCorrect mode the indent rule, if enabled, runs after this rule and
-                                        // determines the final indentation. But if the indent rule is disabled then the
-                                        // indent of this rule is kept.
-                                        (prevLeaf as LeafPsiElement).rawReplaceWithText(intendedIndent)
-                                    }
-                                }
-                            } else {
-                                // Insert a new whitespace element in order to wrap the current child to a new line.
-                                emit(child.startOffset, errorMessage(child), true)
-                                if (autoCorrect) {
-                                    node.addChild(PsiWhiteSpaceImpl(intendedIndent), child)
-                                }
-                            }
-                            // Indentation of child nodes need to be fixed by the IndentationRule.
-                        }
+            else -> currentIndentLevel
+        }
+    }
+
+    private fun wrapParemeterInList(
+        newIndentLevel: Int,
+        child: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        val indent = "\n" + indentConfig.indent.repeat(newIndentLevel)
+        when (child.elementType) {
+            LPAR -> {
+                val prevLeaf = child.prevLeaf()
+                if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
+                    emit(child.startOffset, errorMessage(child), true)
+                    if (autoCorrect) {
+                        prevLeaf.delete()
                     }
                 }
             }
+            VALUE_PARAMETER,
+            RPAR -> {
+                // aiming for
+                // ... LPAR
+                // <line indent + indentSize> VALUE_PARAMETER...
+                // <line indent> RPAR
+                val intendedIndent = if (child.elementType == VALUE_PARAMETER) {
+                    indent + indentConfig.indent
+                } else {
+                    indent
+                }
+
+                val prevLeaf = child.prevLeaf()
+                if (prevLeaf is PsiWhiteSpace) {
+                    if (prevLeaf.getText().contains("\n")) {
+                        // The current child is already wrapped to a new line. Checking and fixing the
+                        // correct size of the indent is the responsibility of the IndentationRule.
+                        return
+                    } else {
+                        // The current child needs to be wrapped to a newline.
+                        emit(child.startOffset, errorMessage(child), true)
+                        if (autoCorrect) {
+                            // The indentation is purely based on the previous leaf only. Note that in
+                            // autoCorrect mode the indent rule, if enabled, runs after this rule and
+                            // determines the final indentation. But if the indent rule is disabled then the
+                            // indent of this rule is kept.
+                            (prevLeaf as LeafPsiElement).rawReplaceWithText(intendedIndent)
+                        }
+                    }
+                } else {
+                    // Insert a new whitespace element in order to wrap the current child to a new line.
+                    emit(child.startOffset, errorMessage(child), true)
+                    if (autoCorrect) {
+                        child.treeParent.addChild(PsiWhiteSpaceImpl(intendedIndent), child)
+                    }
+                }
+                // Indentation of child nodes need to be fixed by the IndentationRule.
+            }
         }
     }
+
+    private fun ASTNode.exceedsMaxLineLength() =
+        maxLineLength > -1 && (column - 1 + textLength) > maxLineLength && !textContains('\n')
 
     private fun errorMessage(node: ASTNode) =
         when (node.elementType) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundAngleBracketsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundAngleBracketsRule.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 class SpacingAroundAngleBracketsRule : Rule("spacing-around-angle-brackets") {
     private fun String.trimBeforeLastLine() = this.substring(this.lastIndexOf('\n'))
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 class SpacingAroundColonRule : Rule("colon-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -21,7 +21,7 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
 
     private val rTokenSet = TokenSet.create(RPAR, RBRACKET, GT)
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDotRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class SpacingAroundDotRule : Rule("dot-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDoubleColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundDoubleColonRule.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 class SpacingAroundDoubleColonRule : Rule("double-colon-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -37,7 +37,7 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
 
     private val keywordsWithoutSpaces = create(GET_KEYWORD, SET_KEYWORD)
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -45,7 +45,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
         EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW
     )
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundParensRule.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
  */
 class SpacingAroundParensRule : Rule("paren-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 
 class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingAroundUnaryOperatorRule.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * @see [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html#horizontal-whitespace)
  */
 class SpacingAroundUnaryOperatorRule : Rule("unary-op-spacing") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.prevLeafs
  * @see https://youtrack.jetbrains.com/issue/KT-35106
  */
 class SpacingBetweenDeclarationsWithAnnotationsRule : Rule("spacing-between-declarations-with-annotations") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
  * @see https://youtrack.jetbrains.com/issue/KT-35088
  */
 class SpacingBetweenDeclarationsWithCommentsRule : Rule("spacing-between-declarations-with-comments") {
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StringTemplateRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtThisExpression
 
 class StringTemplateRule : Rule("string-template") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
@@ -73,7 +73,7 @@ public class TrailingCommaRule :
         allowTrailingCommaOnCallSiteProperty
     )
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaRule.kt
@@ -1,11 +1,11 @@
 package com.pinterest.ktlint.ruleset.experimental.trailingcomma
 
 import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.containsLineBreakInRange
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import kotlin.properties.Delegates
@@ -64,25 +64,24 @@ public class TrailingCommaRule :
         )
     ),
     UsesEditorConfigProperties {
-
-    private var allowTrailingComma by Delegates.notNull<Boolean>()
-    private var allowTrailingCommaOnCallSite by Delegates.notNull<Boolean>()
-
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(
         allowTrailingCommaProperty,
         allowTrailingCommaOnCallSiteProperty
     )
+
+    private var allowTrailingComma by Delegates.notNull<Boolean>()
+    private var allowTrailingCommaOnCallSite by Delegates.notNull<Boolean>()
+
+    override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
+        allowTrailingComma = editorConfigProperties.getEditorConfigValue(allowTrailingCommaProperty)
+        allowTrailingCommaOnCallSite = editorConfigProperties.getEditorConfigValue(allowTrailingCommaOnCallSiteProperty)
+    }
 
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.isRoot()) {
-            allowTrailingComma = node.getEditorConfigValue(allowTrailingCommaProperty)
-            allowTrailingCommaOnCallSite = node.getEditorConfigValue(allowTrailingCommaOnCallSiteProperty)
-        }
-
         // Keep processing of element types in sync with Intellij Kotlin formatting settings.
         // https://github.com/JetBrains/intellij-kotlin/blob/master/formatter/src/org/jetbrains/kotlin/idea/formatter/trailingComma/util.kt
         when (node.elementType) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRuleTest.kt
@@ -197,6 +197,7 @@ class ArgumentListWrappingRuleTest {
                 )
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code)
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(3, 18, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(5, 6, "Missing newline before \")\""),
@@ -354,6 +355,7 @@ class ArgumentListWrappingRuleTest {
             }
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code)
+            .addAdditionalRules(IndentationRule())
             .hasLintViolations(
                 LintViolation(4, 21, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(7, 10, "Missing newline before \")\"")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -3909,6 +3909,46 @@ internal class IndentationRuleTest {
         }
     }
 
+    @Nested
+    inner class SuppressionInMiddleOfFile {
+        @Test
+        fun `Issue 631 - Given some code for which indentation is disabled with ktlint-disable-enable-block then do not fix indentation of that block only`() {
+            val code =
+                """
+                val fooWithIndentationFixing1: String =
+                    "foo" +
+                        "bar"
+                // ktlint-disable indent
+                val fooWithIndentationFixingSuppressed: String =
+                    "foo" +
+                    "bar"
+                // ktlint-enable indent
+                val fooWithIndentationFixing2: String =
+                    "foo" +
+                        "bar"
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 631 - Given some code for which indentation is disabled with @Suppress on an element then do not fix indentation of that element only`() {
+            val code =
+                """
+                val fooWithIndentationFixing1: String =
+                    "foo" +
+                        "bar"
+                @Suppress("ktlint:indent")
+                val fooWithIndentationFixingSuppressed: String =
+                    "foo" +
+                    "bar"
+                val fooWithIndentationFixing2: String =
+                    "foo" +
+                        "bar"
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+    }
+
     private companion object {
         val INDENT_STYLE_TAB = indentStyleProperty to PropertyType.IndentStyleValue.tab
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -397,7 +397,9 @@ class NoUnusedImportsRuleTest {
                 package com.example
 
                 import org.mockito.Mockito
+                import org.mockito.Mockito.mock1
                 import org.mockito.Mockito.withSettings
+
                 fun foo() {
                         Mockito.mock(String::class.java, Mockito.withSettings().defaultAnswer {  })
                     }
@@ -407,13 +409,17 @@ class NoUnusedImportsRuleTest {
                 package com.example
 
                 import org.mockito.Mockito
+
                 fun foo() {
                         Mockito.mock(String::class.java, Mockito.withSettings().defaultAnswer {  })
                     }
                 """.trimIndent()
             noUnusedImportsRuleAssertThat(code)
-                .hasLintViolation(4, 1, "Unused import")
-                .isFormattedAs(formattedCode)
+//                .hasLintViolation(4, 1, "Unused import")
+                .hasLintViolations(
+                    LintViolation(4, 1, "Unused import"),
+                    LintViolation(5, 1, "Unused import")
+                ).isFormattedAs(formattedCode)
         }
 
         @Test

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 class NoVarRule : Rule("no-var") {
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/ktlint-ruleset-test/src/main/kotlin/com/pinterest/ruleset/test/DumpASTRule.kt
+++ b/ktlint-ruleset-test/src/main/kotlin/com/pinterest/ruleset/test/DumpASTRule.kt
@@ -25,7 +25,7 @@ public class DumpASTRule @JvmOverloads constructor(
     private var lineNumberColumnLength: Int = 0
     private var lastNode: ASTNode? = null
 
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -190,9 +190,6 @@ internal fun lintFile(
 /**
  * Format a kotlin file or script file
  */
-/**
- * Format a kotlin file or script file
- */
 internal fun formatFile(
     fileName: String,
     fileContents: String,

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -190,6 +190,9 @@ internal fun lintFile(
 /**
  * Format a kotlin file or script file
  */
+/**
+ * Format a kotlin file or script file
+ */
 internal fun formatFile(
     fileName: String,
     fileContents: String,


### PR DESCRIPTION
## Description

Up until ktlint 0.46 the Rule class provided only one life cycle hook. This "visit" hook was called in a depth-first-approach on all nodes in the file. A rule like the IndentationRule used the RunOnRootOnly visitor modifier to call this lifecycle hook for the root node only in combination with an alternative way of traversing the ASTNodes. Downside of this approach was that suppression of the rule on blocks inside a file was not possible ([#631](https://github.com/pinterest/ktlint/issues/631)). More generically, this applied to all rules, applying alternative traversals of the AST.

The Rule class now offers new life cycle hooks:
* beforeFirstNode: This method is called once before the first node is visited. It can be used to initialize the state of the rule before processing of nodes starts. The ".editorconfig" properties (including overrides) are provided as parameter.
* beforeVisitChildNodes: This method is called on a node in AST before visiting its child nodes. This is repeated recursively for the child nodes resulting in a depth first traversal of the AST. This method is the equivalent of the "visit" life cycle hooks. However, note that in KtLint 0.48, the UserData of the rootnode no longer provides access to the ".editorconfig" properties. This method can be used to emit Lint Violations and to autocorrect if applicable.
* afterVisitChildNodes: This method is called on a node in AST after all its child nodes have been visited. This method can be used to emit Lint Violations and to autocorrect if applicable.
* afterLastNode: This method is called once after the last node in the AST is visited. It can be used for teardown of the state of the rule.

The "visit" life cycle hook will be removed in Ktlint 0.48. In KtLint 0.47 the "visit" life cycle hook will be called *only* when hook "beforeVisitChildNodes" is not overridden. It is recommended to migrate to the new lifecycle hooks in KtLint 0.47. Please create an issue, in case you need additional assistence to implement the new life cycle hooks in your rules.

Closes #631 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
