### PR TITLE
Prevent class cast exception when retrieving ktlint_code_style property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ The callback function provided as parameter to the format function is now called
 * When a glob is specified then ensure that it matches files in the current directory and not only in subdirectories of the current directory ([#1533](https://github.com/pinterest/ktlint/issue/1533)).
 * Execute `ktlint` cli on default kotlin extensions only when an (existing) path to a directory is given. ([#917](https://github.com/pinterest/ktlint/issue/917)).
 * Invoke callback on `format` function for all errors including errors that are autocorrected ([#1491](https://github.com/pinterest/ktlint/issues/1491))
-
+* Prevent class cast exception on ".editorconfig" property `ktlint_code_style`  ([#1559](https://github.com/pinterest/ktlint/issues/1559))
 
 ### Changed
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -47,9 +47,23 @@ public interface UsesEditorConfigProperties {
         require(editorConfigProperties.contains(editorConfigProperty)) {
             "EditorConfigProperty '${editorConfigProperty.type.name}' may only be retrieved when it is registered in the editorConfigProperties."
         }
-        val codeStyle = getEditorConfigValue(codeStyleSetProperty, official)
-        return getEditorConfigValue(editorConfigProperty, codeStyle)
+
+        return getEditorConfigValue(editorConfigProperty, getEditorConfigCodeStyle())
     }
+
+    /**
+     * The code style property does not need to be defined in the [editorConfigProperties] of the class that defines
+     * this interface. Those classed should not need to be aware of the different coding styles except when setting
+     * different default values. As the property is not defined in the [editorConfigProperties] the value needs to
+     * be parsed explicitly to prevent class cast exceptions.
+     */
+    private fun EditorConfigProperties.getEditorConfigCodeStyle() =
+        codeStyleSetProperty
+            .type
+            .parse(
+                get(codeStyleSetProperty.type.name)?.sourceValue
+            ).parsed
+            ?: official
 
     /**
      * Get the value of [EditorConfigProperty] based on loaded [EditorConfigProperties] content for the current
@@ -61,8 +75,10 @@ public interface UsesEditorConfigProperties {
             "EditorConfigProperty '${editorConfigProperty.type.name}' may only be retrieved when it is registered in the editorConfigProperties."
         }
         val editorConfigPropertyValues = getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY)!!
-        val codeStyle = editorConfigPropertyValues.getEditorConfigValue(codeStyleSetProperty, official)
-        return editorConfigPropertyValues.getEditorConfigValue(editorConfigProperty, codeStyle)
+        return editorConfigPropertyValues.getEditorConfigValue(
+            editorConfigProperty,
+            editorConfigPropertyValues.getEditorConfigCodeStyle()
+        )
     }
 
     private fun <T> EditorConfigProperties.getEditorConfigValue(


### PR DESCRIPTION
## Description

Prevent class cast exception when retrieving ktlint_code_style property from ".editorconfig"

Closes #1559

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
