### PR TITLE
Add missing whitespace when else is on same line as true condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ The callback function provided as parameter to the format function is now called
 * Execute `ktlint` cli on default kotlin extensions only when an (existing) path to a directory is given. ([#917](https://github.com/pinterest/ktlint/issue/917)).
 * Invoke callback on `format` function for all errors including errors that are autocorrected ([#1491](https://github.com/pinterest/ktlint/issues/1491))
 * Add missing whitespace when else is on same line as true condition `multiline-if-else` ([#1560](https://github.com/pinterest/ktlint/issues/1560))
+* Fix multiline if-statements `multiline-if-else` ([#828](https://github.com/pinterest/ktlint/issues/828))
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ The callback function provided as parameter to the format function is now called
 * When a glob is specified then ensure that it matches files in the current directory and not only in subdirectories of the current directory ([#1533](https://github.com/pinterest/ktlint/issue/1533)).
 * Execute `ktlint` cli on default kotlin extensions only when an (existing) path to a directory is given. ([#917](https://github.com/pinterest/ktlint/issue/917)).
 * Invoke callback on `format` function for all errors including errors that are autocorrected ([#1491](https://github.com/pinterest/ktlint/issues/1491))
+* Add missing whitespace when else is on same line as true condition `multiline-if-else` ([#1560](https://github.com/pinterest/ktlint/issues/1560))
 
 
 ### Changed

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/SuppressionLocatorBuilder.kt
@@ -38,12 +38,17 @@ internal object SuppressionLocatorBuilder {
         val hintsList = collect(rootNode)
         return if (hintsList.isEmpty()) {
             noSuppression
-        } else { offset, ruleId, isRoot ->
+        } else {
+            toSuppressedRegionsLocator(hintsList)
+        }
+    }
+
+    private fun toSuppressedRegionsLocator(hintsList: List<SuppressionHint>): SuppressionLocator =
+        { offset, ruleId, isRoot ->
             hintsList
                 .filter { offset in it.range }
                 .any { hint -> hint.disabledRules.isEmpty() || hint.disabledRules.contains(ruleId) }
         }
-    }
 
     /**
      * @param range zero-based range of lines where lint errors should be suppressed

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationSpacingRule.kt
@@ -73,7 +73,9 @@ class AnnotationSpacingRule : Rule("annotation-spacing") {
                     val s = it.text
                     // Ensure at least one occurrence of two line breaks
                     s.indexOf("\n") != s.lastIndexOf("\n")
-                } else it.isPartOfComment() && !it.isCommentOnSameLineAsPrevLeaf()
+                } else {
+                    it.isPartOfComment() && !it.isCommentOnSameLineAsPrevLeaf()
+                }
             }
         )
         if (next != null) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRule.kt
@@ -35,7 +35,7 @@ class MultiLineIfElseRule :
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(
             DefaultEditorConfigProperties.indentSizeProperty,
-            DefaultEditorConfigProperties.indentStyleProperty,
+            DefaultEditorConfigProperties.indentStyleProperty
         )
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
@@ -480,7 +480,9 @@ class MultiLineIfElseRuleTest {
             fun test(a: Int, b: Int, c: Int, d: Int, bar: Boolean) {
                 foo(
                     a,
-                    if (bar) b else {
+                    if (bar) {
+                        b
+                    } else {
                         c
                     },
                     d
@@ -488,9 +490,10 @@ class MultiLineIfElseRuleTest {
             }
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code)
-            // TODO: It is not consistent that argument "b" is not wrapped in a block while argument "c" is wrapped
-            .hasLintViolation(6, 13, "Missing { ... }")
-            .isFormattedAs(formattedCode)
+            .hasLintViolations(
+                LintViolation(5, 18, "Missing { ... }"),
+                LintViolation(6, 13, "Missing { ... }")
+            ).isFormattedAs(formattedCode)
     }
 
     @Test
@@ -513,6 +516,57 @@ class MultiLineIfElseRuleTest {
             .hasLintViolations(
                 LintViolation(2, 5, "Missing { ... }"),
                 LintViolation(3, 5, "Missing { ... }")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 828 - Given an if statement with multiline statement starting on same line as if`() {
+        val code =
+            """
+            fun foo() {
+                if (true) 50
+                  .toString()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                if (true) {
+                    50
+                        .toString()
+                }
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolation(2, 15, "Missing { ... }")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 828 - Given an if statement with simple branches but the else branch is on a separate line`() {
+        val code =
+            """
+            fun foo() {
+                if (true) 50
+                else 55
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                if (true) {
+                    50
+                } else {
+                    55
+                }
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolations(
+                LintViolation(2, 15, "Missing { ... }"),
+                LintViolation(3, 10, "Missing { ... }")
             ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/MultiLineIfElseRuleTest.kt
@@ -492,4 +492,27 @@ class MultiLineIfElseRuleTest {
             .hasLintViolation(6, 13, "Missing { ... }")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 1560 - Given an if statement with else keyword on same line as true branch`() {
+        val code =
+            """
+            fun foo() = if (bar())
+                "a" else
+                "b"
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() = if (bar()) {
+                "a"
+            } else {
+                "b"
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 5, "Missing { ... }"),
+                LintViolation(3, 5, "Missing { ... }")
+            ).isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Add missing whitespace when else is on same line as true condition

 Closes #1560

Report violations for:
```
if (true) 50
  .toString()

if (true) 50
else 55
```

Closes #828

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
