### PR TITLE
Merge first line of body expression with function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ The callback function provided as parameter to the format function is now called
 * When a glob is specified then ensure that it matches files in the current directory and not only in subdirectories of the current directory ([#1533](https://github.com/pinterest/ktlint/issue/1533)).
 * Execute `ktlint` cli on default kotlin extensions only when an (existing) path to a directory is given. ([#917](https://github.com/pinterest/ktlint/issue/917)).
 * Invoke callback on `format` function for all errors including errors that are autocorrected ([#1491](https://github.com/pinterest/ktlint/issues/1491))
+* Merge first line of body expression with function signature only when it fits on the same line `function-signature` ([#1527](https://github.com/pinterest/ktlint/issues/1527))
 
 
 ### Changed

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -522,8 +522,11 @@ public class FunctionSignatureRule :
             .firstOrNull()
             ?.also { firstLineOfBodyExpression ->
                 if (whiteSpaceBeforeFunctionBodyExpression.isWhiteSpaceWithNewline()) {
-                    if (functionBodyExpressionWrapping == default ||
-                        (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size == 1) ||
+                    val mergeWithFunctionSignature =
+                        functionBodyExpressionWrapping.keepFirstLineOfBodyExpressionTogetherWithFunctionSignature(
+                            firstLineOfBodyExpression.length < maxLengthRemainingForFirstLineOfBodyExpression
+                        )
+                    if (mergeWithFunctionSignature ||
                         node.isMultilineFunctionSignatureWithoutExplicitReturnType(lastNodeOfFunctionSignatureWithBodyExpression)
                     ) {
                         emit(
@@ -754,5 +757,12 @@ public class FunctionSignatureRule :
          * Always force the body expression to start on a separate line.
          */
         always;
+
+        internal fun keepFirstLineOfBodyExpressionTogetherWithFunctionSignature(fitOnSameLine: Boolean) =
+            if (this == default || this == multiline) {
+                fitOnSameLine
+            } else {
+                false
+            }
     }
 }


### PR DESCRIPTION
## Description

Merge first line of body expression with function signature only when it fits on the same line.

Closes #1527

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] `README.md` is updated
- [ ] Rule has been applied on Ktlint itself and violations are fixed
