### PR TITLE
Improve trailing comma in when entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Although, Ktlint 0.47.0 falls back on property `disabled_rules` whenever `ktlint
 * Prevent class cast exception on ".editorconfig" property `ktlint_code_style`  ([#1559](https://github.com/pinterest/ktlint/issues/1559))
 * Handle trailing comma in enums `trailing-comma` ([#1542](https://github.com/pinterest/ktlint/pull/1542))
 * Split rule `trailing-comma` into `trailing-comma-on-call-site` and `trailing-comma-on-declaration-site` ([#1555](https://github.com/pinterest/ktlint/pull/1555))
+* Fix indent of when entry with a dot qualified expression instead of simple value when trailing comma is required ([#1519](https://github.com/pinterest/ktlint/pull/1519))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Although, Ktlint 0.47.0 falls back on property `disabled_rules` whenever `ktlint
 * Handle trailing comma in enums `trailing-comma` ([#1542](https://github.com/pinterest/ktlint/pull/1542))
 * Split rule `trailing-comma` into `trailing-comma-on-call-site` and `trailing-comma-on-declaration-site` ([#1555](https://github.com/pinterest/ktlint/pull/1555))
 * Fix indent of when entry with a dot qualified expression instead of simple value when trailing comma is required ([#1519](https://github.com/pinterest/ktlint/pull/1519))
+* Fix whitespace between trailing comma and arrow in when entry when trailing comma is required ([#1519](https://github.com/pinterest/ktlint/pull/1519))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRule.kt
@@ -13,7 +13,6 @@ import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
@@ -24,7 +23,6 @@ import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
-import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 
 /**
  * Linting trailing comma for call site.
@@ -166,33 +164,13 @@ public class TrailingCommaOnCallSiteRule :
                 }
             }
             TrailingCommaState.MISSING -> if (isTrailingCommaAllowed) {
-                val addNewLineBeforeArrowInWhenEntry = addNewLineBeforeArrowInWhen()
                 val prevNode = inspectNode.prevCodeLeaf()!!
-                if (addNewLineBeforeArrowInWhenEntry) {
-                    emit(
-                        prevNode.startOffset + prevNode.textLength,
-                        "Missing trailing comma and newline before \"${inspectNode.text}\"",
-                        true
-                    )
-                } else {
-                    emit(
-                        prevNode.startOffset + prevNode.textLength,
-                        "Missing trailing comma before \"${inspectNode.text}\"",
-                        true
-                    )
-                }
+                emit(
+                    prevNode.startOffset + prevNode.textLength,
+                    "Missing trailing comma before \"${inspectNode.text}\"",
+                    true
+                )
                 if (autoCorrect) {
-                    if (addNewLineBeforeArrowInWhenEntry) {
-                        val parentIndent = (prevNode.psi.parent.prevLeaf() as? PsiWhiteSpace)?.text ?: "\n"
-                        val leafBeforeArrow = (psi as KtWhenEntry).arrow?.prevLeaf()
-                        if (leafBeforeArrow != null && leafBeforeArrow is PsiWhiteSpace) {
-                            val newLine = KtPsiFactory(prevNode.psi).createWhiteSpace(parentIndent)
-                            leafBeforeArrow.replace(newLine)
-                        } else {
-                            val newLine = KtPsiFactory(prevNode.psi).createWhiteSpace(parentIndent)
-                            prevNode.psi.parent.addAfter(newLine, prevNode.psi)
-                        }
-                    }
                     val comma = KtPsiFactory(prevNode.psi).createComma()
                     prevNode.psi.parent.addAfter(comma, prevNode.psi)
                 }
@@ -226,14 +204,6 @@ public class TrailingCommaOnCallSiteRule :
         }
         else -> element.textContains('\n')
     }
-
-    private fun ASTNode.addNewLineBeforeArrowInWhen() =
-        if (psi is KtWhenEntry) {
-            val leafBeforeArrow = (psi as KtWhenEntry).arrow?.prevLeaf()
-            !(leafBeforeArrow is PsiWhiteSpace && leafBeforeArrow.textContains('\n'))
-        } else {
-            false
-        }
 
     private fun ASTNode?.findPreviousTrailingCommaNodeOrNull(): ASTNode? {
         var node = this

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -308,6 +308,60 @@ class TrailingCommaOnDeclarationSiteRuleTest {
     }
 
     @Test
+    fun `Given that the trailing comma is required on declaration site and that the trailing comma exists but is not followed by a newline then add the newline before the arrow`() {
+        val code =
+            """
+            fun foo(bar: Any): String = when(bar) {
+                1,
+                2,-> {
+                    "a"
+                }
+                3,
+                4,-> {
+                    "b"
+                }
+                5,
+                6 /* some comment */,-> {
+                    "c"
+                }
+                else -> {
+                    "d"
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(bar: Any): String = when(bar) {
+                1,
+                2,
+                -> {
+                    "a"
+                }
+                3,
+                4,
+                -> {
+                    "b"
+                }
+                5,
+                6 /* some comment */,
+                -> {
+                    "c"
+                }
+                else -> {
+                    "d"
+                }
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaProperty to true)
+            .hasLintViolations(
+                LintViolation(3, 6, "Expected a newline between the trailing comma and  \"->\""),
+                LintViolation(7, 6, "Expected a newline between the trailing comma and  \"->\""),
+                LintViolation(11, 25, "Expected a newline between the trailing comma and  \"->\"")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given that the trailing comma is not allowed on declaration site then remove it from the destructuring declaration when present`() {
         val code =
             """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -274,6 +274,40 @@ class TrailingCommaOnDeclarationSiteRuleTest {
     }
 
     @Test
+    fun `Issue 1519 - Given a when entry which is not a simple value but a dot qualified expression and that the trailing comma is required on declaration site then add it when missing`() {
+        val code =
+            """
+            fun foo(bar: Any): String = when(bar) {
+                bar.foobar1(), bar.foobar2() -> "a"
+                bar.foobar3(), bar.foobar4() // The comma should be inserted before the comment
+                -> "a"
+                bar.foobar5(),
+                bar.foobar6() /* The comma should be inserted before the comment */
+                -> "a"
+                else -> "b"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(bar: Any): String = when(bar) {
+                bar.foobar1(), bar.foobar2() -> "a"
+                bar.foobar3(), bar.foobar4(), // The comma should be inserted before the comment
+                -> "a"
+                bar.foobar5(),
+                bar.foobar6(), /* The comma should be inserted before the comment */
+                -> "a"
+                else -> "b"
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaProperty to true)
+            .hasLintViolations(
+                LintViolation(3, 33, "Missing trailing comma before \"->\""),
+                LintViolation(6, 18, "Missing trailing comma before \"->\"")
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given that the trailing comma is not allowed on declaration site then remove it from the destructuring declaration when present`() {
         val code =
             """


### PR DESCRIPTION
## Description

Fix indent of when entry with a dot qualified expression (for example a qualified enum value) instead of simple value when trailing comma is required:
```
fun bla(value: Test) = when (value) {
    Test.TEST_1,
    Test.TEST_2, -> {
        println("1, 2")
    }
    Test.TEST_3 -> {
        println("3")
    }
}
```
and format as:
```
fun bla(value: Test) = when (value) {
    Test.TEST_1,
    Test.TEST_2,
    -> {
        println("1, 2")
    }
    Test.TEST_3 -> {
        println("3")
    }
}
```

If whitespace after trailing comma is missing or does not contain a newline:
```
fun bla(value: Test) = when (value) {
    Test.TEST_1,
    Test.TEST_2, -> {
        println("1, 2")
    }
    Test.TEST_3,
    Test.TEST_4,-> {
        println("3,4")
    }
    Test.TEST_5 -> {
        println("5")
    }
}
```
then format as:
```
fun bla(value: Test) = when (value) {
	Test.TEST_1,
	Test.TEST_2,
	-> {
		println("1, 2")
	}
	Test.TEST_3,
	Test.TEST_4,
	-> {
		println("3,4")
	}
	Test.TEST_5 -> {
		println("5")
	}
}
```

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
