### PR TITLE
Set version number in documentation when publishing/announcing a new release

### DIFF
--- a/.announce
+++ b/.announce
@@ -31,7 +31,8 @@ escape_for_sed() { echo $1 | sed -e 's/[]\/$*.^|[]/\\&/g'; }
 
 # update readme.md
 
-sed -i "" "s/$(escape_for_sed $PREVIOUS_VERSION)/$(escape_for_sed $VERSION)/g" README.md
+sed -i "" "s/$(escape_for_sed $PREVIOUS_VERSION)/$(escape_for_sed $VERSION)/g" docs/install/cli.md
+sed -i "" "s/$(escape_for_sed $PREVIOUS_VERSION)/$(escape_for_sed $VERSION)/g" docs/install/integrations.md
 git --no-pager diff README.md
 
 # ask for user confirmation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Although, Ktlint 0.47.0 falls back on property `disabled_rules` whenever `ktlint
 * Invoke callback on `format` function for all errors including errors that are autocorrected ([#1491](https://github.com/pinterest/ktlint/issues/1491))
 * Improve rule `annotation` ([#1574](https://github.com/pinterest/ktlint/pull/1574))
 * Rename `.editorconfig` property `disabled_rules` to `ktlint_disabled_rules` ([#701](https://github.com/pinterest/ktlint/issues/701))
+* Update release scripting to set version number in mkdocs documentation ([#1575](https://github.com/pinterest/ktlint/issue/1575)).
 
 ### Removed
 * Remove support to generate IntelliJ IDEA configuration files as this no longer fits the scope of the ktlint project ([#701](https://github.com/pinterest/ktlint/issues/701))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,5 @@ signing.secretKeyRingFile=~/.gnupg/secring.gpg
 
 1. Update `VERSION_NAME` with new release version in project root `gradle.properties`
 2. Fill in `CHANGELOG.md` with related to new version changes.
-3. Run `./gradlew publishNewRelease` to build, upload new artifacts,
-update `README.md` and [https://ktlint.github.io](https://ktlint.github.io) site.
+3. Run `./gradlew publishNewRelease` to build, upload new artifacts, update KtLint version number on [CLI documentation](docs/install/cli.md) and [integrations documentation](docs/install/integrations.md) and [https://ktlint.github.io](https://ktlint.github.io) site.
 4. Update Github release notes with info from `CHANGELOG.md`


### PR DESCRIPTION
## Description

Update `.announce` to set the version number in the mkdocs documentation whenever publishing/announcing a new release.

Closes #1575 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
