### PR TITLE
Fix IndexOutOfBoundsException TrailingCommaOnDeclarationSiteRule

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 public fun ASTNode.nextLeaf(includeEmpty: Boolean = false, skipSubtree: Boolean = false): ASTNode? {
@@ -246,6 +247,16 @@ public fun ASTNode.visit(enter: (node: ASTNode) -> Unit, exit: (node: ASTNode) -
     exit(this)
 }
 
+/**
+ * Get the line number of the node in the original code sample. If the AST, prior to the current node, is changed by
+ * adding or removing a node containing a newline, the lineNumber will not be calculated correctly. Either it results in
+ * an incorrect lineNumber or an IndexOutOfBoundsException (Wrong offset). is thrown. The rule in which the problem
+ * manifest does not need to be the same rule which has changed the prior AST. Debugging such problems can be very hard.
+ */
+@Deprecated(
+    "Marked for removal in KtLint 0.48. The lineNumber is a calculated field. This calculation is not always " +
+        "reliable when formatting code.See KDOC for more information."
+)
 public fun ASTNode.lineNumber(): Int? =
     this.psi.containingFile?.viewProvider?.document?.getLineNumber(this.startOffset)?.let { it + 1 }
 
@@ -293,7 +304,40 @@ public fun ASTNode.logStructure(): ASTNode =
 private fun String.replaceTabAndNewline(): String =
     replace("\t", "\\t").replace("\n", "\\n")
 
+@Deprecated(
+    message = "This method is marked for removal in KtLint 0.48.0 as it is not reliable.",
+    replaceWith = ReplaceWith("hasWhiteSpaceWithNewLineInClosedRange(from, to)")
+)
 public fun containsLineBreakInRange(from: PsiElement, to: PsiElement): Boolean =
     from.siblings(forward = true, withItself = true)
         .takeWhile { !it.isEquivalentTo(to) }
         .any { it.textContains('\n') }
+
+/**
+ * Verifies that a whitespace leaf containing a newline exist in the closed range [from] - [to]. Also, returns true in
+ * case any of the boundary nodes [from] or [to] is a whitespace leaf containing a newline.
+ */
+public fun hasWhiteSpaceWithNewLineInClosedRange(from: ASTNode, to: ASTNode): Boolean =
+    from.isWhiteSpaceWithNewline() ||
+        leavesInOpenRange(from, to).any { it.isWhiteSpaceWithNewline() } ||
+        to.isWhiteSpaceWithNewline()
+
+/**
+ * Verifies that no whitespace leaf contains a newline in the closed range [from] - [to]. Also, the boundary nodes
+ * [from] and [to] should not be a whitespace leaf containing a newline.
+ */
+public fun noWhiteSpaceWithNewLineInClosedRange(from: ASTNode, to: ASTNode): Boolean =
+    !from.isWhiteSpaceWithNewline() &&
+        leavesInOpenRange(from, to).none { it.isWhiteSpaceWithNewline() } &&
+        !to.isWhiteSpaceWithNewline()
+
+/**
+ * Creates a sequence of leaf nodes in the open range [from] - [to]. This means that the boundary nodes are excluded
+ * from the range in case they would happen to be a leaf node. In case [from] is a [CompositeElement] than the first
+ * leaf node in the sequence is the first leaf node in this [CompositeElement]. In case [to] is a [CompositeElement]
+ * than the last node in the sequence is the last leaf node prior to this [CompositeElement].
+ */
+public fun leavesInOpenRange(from: ASTNode, to: ASTNode): Sequence<ASTNode> =
+    from
+        .leaves()
+        .takeWhile { it != to && it != to.firstChildNode }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ast/PackageKtTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/ast/PackageKtTest.kt
@@ -1,0 +1,269 @@
+package com.pinterest.ktlint.core.ast
+
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.RuleProvider
+import com.pinterest.ktlint.core.ast.ElementType.CLASS
+import com.pinterest.ktlint.core.ast.ElementType.CLASS_BODY
+import com.pinterest.ktlint.core.ast.ElementType.ENUM_ENTRY
+import com.pinterest.ktlint.core.internal.prepareCodeForLinting
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PackageKtTest {
+    @Test
+    fun `Given an enum class body then get all leaves in the open range of the class body`() {
+        val enumClassBody =
+            transformCodeToAST(
+                """
+                enum class Shape {
+                    FOO, FOOBAR, BAR
+                }
+                """.trimIndent()
+            ).toEnumClassBodySequence()
+
+        val actual =
+            leavesInOpenRange(enumClassBody.first(), enumClassBody.last())
+                .map { it.text }
+                .toList()
+
+        assertThat(actual).containsExactly(
+            // LBRACE is omitted from class body as it is an open range
+            "\n    ",
+            "FOO",
+            ",",
+            " ",
+            "FOOBAR",
+            ",",
+            " ",
+            "BAR",
+            "\n"
+            // RBRACE is omitted from class body as it is an open range
+        )
+    }
+
+    @Nested
+    inner class NoWhiteSpaceWithNewLineInClosedRange {
+        @Test
+        fun `Given an enum class with no whitespace leaf containing a newline between the first and last enum entry`() {
+            val enumEntries =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO, FOOBAR, BAR
+                    }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+                    .filter { it.elementType == ENUM_ENTRY }
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumEntries.first(), enumEntries.last())
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `Given a range of nodes starting with a whitespace leaf containing a newline but other whitespace leaves not containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO, FOOBAR, BAR } // Malformed on purpose for test
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isFalse
+        }
+
+        @Test
+        fun `Given a range of nodes not starting or ending with a whitespace leaf containing a newline but containing another whitespace leaf containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO,
+                        FOOBAR,
+                        BAR
+                    }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isFalse
+        }
+
+        @Test
+        fun `Given a range of nodes ending with a whitespace leaf containing a newline but other whitespace leaves not containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape { FOO, FOOBAR, BAR
+                    } // Malformed on purpose for test
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isFalse
+        }
+
+        @Test
+        fun `Given a range of nodes not containing a whitespace with a newline but having a block comment in between which does contain a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape { FOO, /*
+                    newline in a block comment is ignored as it is not part of a whitespace leaf
+                    */ FOOBAR, BAR }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isTrue
+        }
+    }
+
+    @Nested
+    inner class HasWhiteSpaceWithNewLineInClosedRange {
+        @Test
+        fun `Given an enum class with no whitespace leaf containing a newline between the first and last enum entry`() {
+            val enumEntries =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO, FOOBAR, BAR
+                    }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+                    .filter { it.elementType == ENUM_ENTRY }
+
+            val actual = hasWhiteSpaceWithNewLineInClosedRange(enumEntries.first(), enumEntries.last())
+
+            assertThat(actual).isFalse
+        }
+
+        @Test
+        fun `Given a range of nodes starting with a whitespace leaf containing a newline but other whitespace leaves not containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO, FOOBAR, BAR } // Malformed on purpose for test
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = hasWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `Given a range of nodes not starting or ending with a whitespace leaf containing a newline but containing another whitespace leaf containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape {
+                        FOO,
+                        FOOBAR,
+                        BAR
+                    }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = hasWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `Given a range of nodes ending with a whitespace leaf containing a newline but other whitespace leaves not containing a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape { FOO, FOOBAR, BAR
+                    } // Malformed on purpose for test
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = hasWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `Given a range of nodes not containing a whitespace with a newline but having a block comment in between which does contain a newline`() {
+            val enumClassBody =
+                transformCodeToAST(
+                    """
+                    enum class Shape { FOO, /*
+                    newline in a block comment is ignored as it is not part of a whitespace leaf
+                    */ FOOBAR, BAR }
+                    """.trimIndent()
+                ).toEnumClassBodySequence()
+
+            val actual = noWhiteSpaceWithNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+
+            assertThat(actual).isTrue
+        }
+    }
+
+    @Test
+    fun `Given a range of nodes not containing a whitespace with a newline but having a block comment in between which does contain a newline`() {
+        val enumClassBody =
+            transformCodeToAST(
+                """
+                enum class Shape { FOO, /*
+                newline in a block comment should be ignored as it is not part of a whitespace leaf
+                */ FOOBAR, BAR }
+                """.trimIndent()
+            ).toEnumClassBodySequence()
+
+        val actual = containsLineBreakInRange(enumClassBody.first().psi, enumClassBody.last().psi)
+
+        // This method should have returned false instead of true. As of that the method is deprecated.
+        assertThat(actual).isTrue
+    }
+
+    private fun transformCodeToAST(code: String) =
+        prepareCodeForLinting(
+            KtLint.ExperimentalParams(
+                text =
+                code,
+                ruleProviders = setOf(
+                    RuleProvider { DummyRule() }
+                ),
+                cb = { _, _ -> }
+            )
+        ).rootNode
+
+    private fun FileASTNode.toEnumClassBodySequence() =
+        findChildByType(CLASS)
+            ?.findChildByType(CLASS_BODY)
+            ?.children()
+            .orEmpty()
+}
+
+/**
+ * A dummy rule for testing. Optionally the rule can be created with a lambda to be executed for each node visited.
+ */
+private open class DummyRule(
+    val block: (node: ASTNode) -> Unit = {}
+) : Rule(DUMMY_RULE_ID) {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        block(node)
+    }
+
+    companion object {
+        const val DUMMY_RULE_ID = "dummy-rule"
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -5,12 +5,18 @@ import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
+import com.pinterest.ktlint.core.ast.ElementType.CLASS
+import com.pinterest.ktlint.core.ast.ElementType.DESTRUCTURING_DECLARATION
+import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.core.ast.ElementType.FUNCTION_TYPE
+import com.pinterest.ktlint.core.ast.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.core.ast.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.core.ast.ElementType.WHEN_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.containsLineBreakInRange
 import com.pinterest.ktlint.core.ast.lineIndent
-import com.pinterest.ktlint.core.ast.lineNumber
+import com.pinterest.ktlint.core.ast.noWhiteSpaceWithNewLineInClosedRange
 import com.pinterest.ktlint.core.ast.prevCodeLeaf
 import com.pinterest.ktlint.core.ast.prevLeaf
 import com.pinterest.ktlint.core.ast.upsertWhitespaceAfterMe
@@ -78,12 +84,12 @@ public class TrailingCommaOnDeclarationSiteRule :
         // Keep processing of element types in sync with Intellij Kotlin formatting settings.
         // https://github.com/JetBrains/intellij-kotlin/blob/master/formatter/src/org/jetbrains/kotlin/idea/formatter/trailingComma/util.kt
         when (node.elementType) {
-            ElementType.CLASS -> visitClass(node, emit, autoCorrect)
-            ElementType.DESTRUCTURING_DECLARATION -> visitDestructuringDeclaration(node, autoCorrect, emit)
-            ElementType.FUNCTION_LITERAL -> visitFunctionLiteral(node, autoCorrect, emit)
-            ElementType.TYPE_PARAMETER_LIST -> visitTypeList(node, autoCorrect, emit)
-            ElementType.VALUE_PARAMETER_LIST -> visitValueList(node, autoCorrect, emit)
-            ElementType.WHEN_ENTRY -> visitWhenEntry(node, autoCorrect, emit)
+            CLASS -> visitClass(node, emit, autoCorrect)
+            DESTRUCTURING_DECLARATION -> visitDestructuringDeclaration(node, autoCorrect, emit)
+            FUNCTION_LITERAL -> visitFunctionLiteral(node, autoCorrect, emit)
+            TYPE_PARAMETER_LIST -> visitTypeList(node, autoCorrect, emit)
+            VALUE_PARAMETER_LIST -> visitValueList(node, autoCorrect, emit)
+            WHEN_ENTRY -> visitWhenEntry(node, autoCorrect, emit)
             else -> Unit
         }
     }
@@ -127,7 +133,7 @@ public class TrailingCommaOnDeclarationSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
-        if (node.treeParent.elementType != ElementType.FUNCTION_LITERAL) {
+        if (node.treeParent.elementType != FUNCTION_LITERAL) {
             node
                 .children()
                 .lastOrNull { it.elementType == ElementType.RPAR }
@@ -228,7 +234,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                 .toList()
                 .takeLast(2)
 
-        return lastTwoEnumEntries.count() == 2 && lastTwoEnumEntries[0].lineNumber() == lastTwoEnumEntries[1].lineNumber()
+        return lastTwoEnumEntries.count() == 2 && noWhiteSpaceWithNewLineInClosedRange(lastTwoEnumEntries[0], lastTwoEnumEntries[1])
     }
 
     private fun ASTNode.reportAndCorrectTrailingCommaNodeBefore(
@@ -342,7 +348,7 @@ public class TrailingCommaOnDeclarationSiteRule :
     private fun ASTNode.getWhenEntryIndent() =
         // The when entry can be a simple value but might also be a complex expression.
         parents()
-            .last { it.elementType == ElementType.WHEN_ENTRY }
+            .last { it.elementType == WHEN_ENTRY }
             .lineIndent()
 
     private fun isMultiline(element: PsiElement): Boolean = when {
@@ -443,13 +449,13 @@ public class TrailingCommaOnDeclarationSiteRule :
             )
 
         private val TYPES_ON_DECLARATION_SITE = TokenSet.create(
-            ElementType.CLASS,
-            ElementType.DESTRUCTURING_DECLARATION,
-            ElementType.FUNCTION_LITERAL,
-            ElementType.FUNCTION_TYPE,
-            ElementType.TYPE_PARAMETER_LIST,
-            ElementType.VALUE_PARAMETER_LIST,
-            ElementType.WHEN_ENTRY
+            CLASS,
+            DESTRUCTURING_DECLARATION,
+            FUNCTION_LITERAL,
+            FUNCTION_TYPE,
+            TYPE_PARAMETER_LIST,
+            VALUE_PARAMETER_LIST,
+            WHEN_ENTRY
         )
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -876,4 +876,45 @@ class TrailingCommaOnDeclarationSiteRuleTest {
                 .isFormattedAs(formattedCode)
         }
     }
+
+    @Test
+    fun `Given that a trailing comma is required then add trailing comma after last enum member`() {
+        val code =
+            """
+            val foobar = if (true) {
+                "foo"
+            } else "bar"
+
+            enum class SomeEnum {
+                A, B
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foobar = if (true) {
+                "foo"
+            } else {
+                "bar"
+            }
+
+            enum class SomeEnum {
+                A, B
+            }
+            """.trimIndent()
+
+        // Ensure that AST before Enumeration class is changed by another rule before the running the
+        // TrailingCommaOnDeclarationSiteRule
+        val multiLineIfElseRuleAssertThat =
+            KtLintAssertThat.assertThatRule(
+                provider = { MultiLineIfElseRule() },
+                additionalRuleProviders = setOf(
+                    RuleProvider { TrailingCommaOnDeclarationSiteRule() },
+                    RuleProvider { IndentationRule() } // Required for TrailingCommaOnDeclarationSiteRule
+                )
+            )
+
+        multiLineIfElseRuleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaProperty to true)
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Fix IndexOutOfBoundsException in TrailingCommaOnDeclarationSiteRule when AST before an enumeration class is changed by some rule

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
