### PR TITLE
Option `--patterns-from-stdin` and Git hook scripts update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* patterns can be read in from `stdin` with the `--patterns-from-stdin` command line options/flags ([#1606](https://github.com/pinterest/ktlint/pull/1606))
+
 ### Fixed
 
 * Let a rule process all nodes even in case the rule is suppressed for a node so that the rule can update the internal state ([#1644](https://github.com/pinterest/ktlint/issue/1644))

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -189,6 +189,9 @@ ktlint installGitPrePushHook
 
 `--relative`: Print files relative to the working directory (e.g. dir/file.kt instead of /home/user/project/dir/file.kt)
 
+`--patterns-from-stdin[=<delimiter>]`: Reads additional patterns from `stdin`, where the patterns are separated by `<delimiter>`. If `=<delimiter>` is omitted, newline is used as fallback delimiter. If an empty string is given, the `NUL` byte is used as delimiter instead.
+Options `--stdin` and `--patterns-from-stdin` are mutually exclusive, only one of them can be given at a time.
+
 `-v`, `--verbose` or `--debug`: Turn on debug output. Also option `--trace` is available, but this is meant for ktlint library developers.
 
 `-V` or `--version`: Prints version information and exit.

--- a/ktlint/src/main/resources/ktlint-git-pre-commit-hook-android.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-commit-hook-android.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# https://github.com/pinterest/ktlint pre-commit hook
-# On Linux xargs must be told to do nothing on no input. On MacOS (linux distribution "Darwin") this is default behavior and the xargs flag "--no-run-if-empty" flag does not exists
-[ "$(uname -s)" != "Darwin" ] && no_run_if_empty=--no-run-if-empty
-git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs $no_run_if_empty ktlint --android --relative
-if [ $? -ne 0 ]; then exit 1; fi
+
+# <https://github.com/pinterest/ktlint> pre-commit hook
+
+git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --android --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# https://github.com/pinterest/ktlint pre-commit hook
-# On Linux xargs must be told to do nothing on no input. On MacOS (linux distribution "Darwin") this is default behavior and the xargs flag "--no-run-if-empty" flag does not exists
-[ "$(uname -s)" != "Darwin" ] && no_run_if_empty=--no-run-if-empty
-git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs $no_run_if_empty ktlint --relative
-if [ $? -ne 0 ]; then exit 1; fi
+
+# <https://github.com/pinterest/ktlint> pre-commit hook
+
+git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-push-hook-android.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-push-hook-android.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# https://github.com/pinterest/ktlint pre-push hook
-# On Linux xargs must be told to do nothing on no input. On MacOS (linux distribution "Darwin") this is default behavior and the xargs flag "--no-run-if-empty" flag does not exists
-[ "$(uname -s)" != "Darwin" ] && no_run_if_empty=--no-run-if-empty
-git diff --name-only HEAD origin/$(git rev-parse --abbrev-ref HEAD) | grep '\.kt[s"]\?$' | xargs $no_run_if_empty ktlint --android --relative
-if [ $? -ne 0 ]; then exit 1; fi
+
+# <https://github.com/pinterest/ktlint> pre-push hook
+
+git diff --name-only -z HEAD "origin/$(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --android --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-push-hook.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-push-hook.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# https://github.com/pinterest/ktlint pre-push hook
-# On Linux xargs must be told to do nothing on no input. On MacOS (linux distribution "Darwin") this is default behavior and the xargs flag "--no-run-if-empty" flag does not exists
-[ "$(uname -s)" != "Darwin" ] && no_run_if_empty=--no-run-if-empty
-git diff --name-only HEAD origin/$(git rev-parse --abbrev-ref HEAD) | grep '\.kt[s"]\?$' | xargs $no_run_if_empty ktlint --relative
-if [ $? -ne 0 ]; then exit 1; fi
+
+# <https://github.com/pinterest/ktlint> pre-push hook
+
+git diff --name-only -z HEAD "origin/$(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint
 
 import java.io.File
+import java.io.InputStream
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -27,6 +28,7 @@ abstract class BaseCLITest {
     fun runKtLintCliProcess(
         testProjectName: String,
         arguments: List<String> = emptyList(),
+        stdin: InputStream? = null,
         executionAssertions: ExecutionResult.() -> Unit,
     ) {
         val projectPath = prepareTestProject(testProjectName)
@@ -43,6 +45,11 @@ abstract class BaseCLITest {
         environment["PATH"] = "${System.getProperty("java.home")}${File.separator}bin${File.pathSeparator}${System.getenv()["PATH"]}"
 
         val process = processBuilder.start()
+
+        if (stdin != null) {
+            process.outputStream.use(stdin::copyTo)
+        }
+
         if (process.completedInAllowedDuration()) {
             val output = process.inputStream.bufferedReader().use { it.readLines() }
             val error = process.errorStream.bufferedReader().use { it.readLines() }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
@@ -9,7 +9,11 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.TimeUnit
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.AbstractBooleanAssert
+import org.assertj.core.api.AbstractIntegerAssert
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ListAssert
 import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 
@@ -112,13 +116,33 @@ abstract class BaseCLITest {
         )
     }
 
+    protected fun ListAssert<String>.containsLineMatching(string: String): ListAssert<String> =
+        this.anyMatch {
+            it.contains(string)
+        }
+
+    protected fun ListAssert<String>.containsLineMatching(regex: Regex): ListAssert<String> =
+        this.anyMatch {
+            it.matches(regex)
+        }
+
+    protected fun ListAssert<String>.doesNotContainLineMatching(string: String): ListAssert<String> =
+        this.noneMatch {
+            it.contains(string)
+        }
+
+    protected fun ListAssert<String>.doesNotContainLineMatching(regex: Regex): ListAssert<String> =
+        this.noneMatch {
+            it.matches(regex)
+        }
+
     data class ExecutionResult(
         val exitCode: Int,
         val normalOutput: List<String>,
         val errorOutput: List<String>,
         val testProject: Path,
     ) {
-        fun assertNormalExitCode() {
+        fun assertNormalExitCode(): AbstractIntegerAssert<*> =
             assertThat(exitCode)
                 .withFailMessage(
                     "Expected process to exit with exitCode 0, but was $exitCode."
@@ -129,30 +153,32 @@ abstract class BaseCLITest {
                             ),
                         ),
                 ).isEqualTo(0)
-        }
 
-        fun assertErrorExitCode() {
+        fun assertErrorExitCode(): AbstractIntegerAssert<*> =
             assertThat(exitCode)
                 .withFailMessage("Execution was expected to finish with error. However, exitCode is $exitCode")
                 .isNotEqualTo(0)
-        }
 
-        fun assertErrorOutputIsEmpty() {
+        fun assertErrorOutputIsEmpty(): AbstractBooleanAssert<*> =
             assertThat(errorOutput.isEmpty())
                 .withFailMessage(
                     "Expected error output to be empty but was:".followedByIndentedList(errorOutput),
                 ).isTrue
-        }
 
-        fun assertSourceFileWasFormatted(
-            filePathInProject: String,
-        ) {
-            val originalFile = testProjectsPath.resolve(testProject.last()).resolve(filePathInProject)
-            val newFile = testProject.resolve(filePathInProject)
+        fun assertSourceFileWasFormatted(filePathInProject: String): AbstractAssert<*, *> {
+            val originalCode =
+                testProjectsPath
+                    .resolve(testProject.last())
+                    .resolve(filePathInProject)
+                    .toFile()
+                    .readText()
+            val formattedCode =
+                testProject
+                    .resolve(filePathInProject)
+                    .toFile()
+                    .readText()
 
-            assert(originalFile.toFile().readText() != newFile.toFile().readText()) {
-                "Format did not change source file $filePathInProject content:\n${originalFile.toFile().readText()}"
-            }
+            return assertThat(formattedCode).isNotEqualTo(originalCode)
         }
     }
 

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint
 
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.ListAssert
+import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
@@ -18,17 +17,17 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
             "editorconfig-path",
             listOf(),
         ) {
-            assertErrorExitCode()
-
-            val assertThat = assertThat(normalOutput)
-            assertThat
-                .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
-                .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
-                .containsLineMatching(Regex(".*foobar2.*File name 'foobar2.kt' should conform PascalCase.*"))
-                // The Bar files are not matched by any glob
-                .doesNotContainLineMatching(Regex(".*Bar.*"))
-                // The filename rule is disabled for the examples-directory only
-                .doesNotContainLineMatching(Regex(".*foobar1.*File name 'foobar1.kt' should conform PascalCase.*"))
+            SoftAssertions().apply {
+                assertErrorExitCode()
+                assertThat(normalOutput)
+                    .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
+                    .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
+                    .containsLineMatching(Regex(".*foobar2.*File name 'foobar2.kt' should conform PascalCase.*"))
+                    // The Bar files are not matched by any glob
+                    .doesNotContainLineMatching(Regex(".*Bar.*"))
+                    // The filename rule is disabled for the examples-directory only
+                    .doesNotContainLineMatching(Regex(".*foobar1.*File name 'foobar1.kt' should conform PascalCase.*"))
+            }.assertAll()
         }
     }
 
@@ -49,15 +48,15 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
             "editorconfig-path",
             listOf("--editorconfig=$projectDirectory/$editorconfigPath"),
         ) {
-            assertErrorExitCode()
-
-            val assertThat = assertThat(normalOutput)
-            assertThat
-                .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
-                .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
-                // Only the Bar-files fall back on the default editorconfig!
-                .containsLineMatching(Regex(".*BarTest.*Exceeded max line length \\(20\\).*"))
-                .containsLineMatching(Regex(".*Bar.*Exceeded max line length \\(20\\).*"))
+            SoftAssertions().apply {
+                assertErrorExitCode()
+                assertThat(normalOutput)
+                    .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
+                    .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
+                    // Only the Bar-files fall back on the default editorconfig!
+                    .containsLineMatching(Regex(".*BarTest.*Exceeded max line length \\(20\\).*"))
+                    .containsLineMatching(Regex(".*Bar.*Exceeded max line length \\(20\\).*"))
+            }.assertAll()
         }
     }
 
@@ -68,14 +67,14 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
             "editorconfig-path",
             listOf("--editorconfig=$projectDirectory/.editorconfig-default-max-line-length-on-tests-only"),
         ) {
-            assertErrorExitCode()
-
-            val assertThat = assertThat(normalOutput)
-            assertThat
-                .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
-                .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
-                // Only the BarTest-file falls back on the default editorconfig!
-                .containsLineMatching(Regex(".*BarTest.*Exceeded max line length \\(25\\).*"))
+            SoftAssertions().apply {
+                assertErrorExitCode()
+                assertThat(normalOutput)
+                    .containsLineMatching(Regex(".*FooTest.*Exceeded max line length \\(30\\).*"))
+                    .containsLineMatching(Regex(".*Foo.*Exceeded max line length \\(30\\).*"))
+                    // Only the BarTest-file falls back on the default editorconfig!
+                    .containsLineMatching(Regex(".*BarTest.*Exceeded max line length \\(25\\).*"))
+            }.assertAll()
         }
     }
 
@@ -86,12 +85,12 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
             "editorconfig-path",
             listOf("--editorconfig=$projectDirectory/.editorconfig-disable-filename-rule"),
         ) {
-            assertErrorExitCode()
-
-            val assertThat = assertThat(normalOutput)
-            assertThat
-                .doesNotContainLineMatching(Regex(".*foobar1.*File name 'foobar1.kt' should conform PascalCase.*"))
-                .doesNotContainLineMatching(Regex(".*foobar2.*File name 'foobar2.kt' should conform PascalCase.*"))
+            SoftAssertions().apply {
+                assertErrorExitCode()
+                assertThat(normalOutput)
+                    .doesNotContainLineMatching(Regex(".*foobar1.*File name 'foobar1.kt' should conform PascalCase.*"))
+                    .doesNotContainLineMatching(Regex(".*foobar2.*File name 'foobar2.kt' should conform PascalCase.*"))
+            }.assertAll()
         }
     }
 
@@ -102,20 +101,10 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
             "editorconfig-path",
             listOf("--editorconfig=$projectDirectory/editorconfig-boolean-setting"),
         ) {
-            assertErrorExitCode()
-
-            val assertThat = assertThat(errorOutput)
-            assertThat.doesNotContainLineMatching(Regex(".*java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean.*"))
+            SoftAssertions().apply {
+                assertErrorExitCode()
+                assertThat(errorOutput).doesNotContainLineMatching(Regex(".*java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean.*"))
+            }.assertAll()
         }
     }
-
-    private fun ListAssert<String>.containsLineMatching(regex: Regex) =
-        this.anyMatch {
-            it.matches(regex)
-        }
-
-    private fun ListAssert<String>.doesNotContainLineMatching(regex: Regex) =
-        this.noneMatch {
-            it.matches(regex)
-        }
 }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/RuleSetsLoaderCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/RuleSetsLoaderCLITest.kt
@@ -1,6 +1,6 @@
 package com.pinterest.ktlint
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,15 +20,12 @@ class RuleSetsLoaderCLITest : BaseCLITest() {
                 "custom-ruleset",
                 listOf("-R", "$BASE_DIR_PLACEHOLDER/$jarWithRulesetProviderV1"),
             ) {
-                assertNormalExitCode()
+                SoftAssertions().apply {
+                    assertNormalExitCode()
 
-                // "15:36:29.259 [main] WARN com.pinterest.ktlint.internal.LoadRuleProviders - JAR /var/folders/24/wtp_g21953x22nr8z86gvltc0000gp/T/junit5220922714985703035/custom-ruleset/rule-set-provider-v1/ktlint-reporter-html.jar, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.".matches(Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, contains a custom ruleset provider which is \\*NOT\\* compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project."))
-                assertThat(normalOutput)
-                    .anyMatch {
-                        it.matches(
-                            Regex(".* WARN .* JAR .*$jarWithRulesetProviderV1, provided as command line argument, contains a custom ruleset provider which will \\*NOT\\*.* be compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.*"),
-                        )
-                    }
+                    // "15:36:29.259 [main] WARN com.pinterest.ktlint.internal.LoadRuleProviders - JAR /var/folders/24/wtp_g21953x22nr8z86gvltc0000gp/T/junit5220922714985703035/custom-ruleset/rule-set-provider-v1/ktlint-reporter-html.jar, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.".matches(Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, contains a custom ruleset provider which is \\*NOT\\* compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project."))
+                    assertThat(normalOutput).containsLineMatching("$jarWithRulesetProviderV1, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.")
+                }.assertAll()
             }
         }
 
@@ -39,14 +36,10 @@ class RuleSetsLoaderCLITest : BaseCLITest() {
                 "custom-ruleset",
                 listOf("-R", "$BASE_DIR_PLACEHOLDER/$jarWithoutRulesetProvider"),
             ) {
-                assertNormalExitCode()
-
-                assertThat(normalOutput)
-                    .anyMatch {
-                        it.matches(
-                            Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, does not contain a custom ruleset provider."),
-                        )
-                    }
+                SoftAssertions().apply {
+                    assertNormalExitCode()
+                    assertThat(normalOutput).containsLineMatching("$jarWithoutRulesetProvider, provided as command line argument, does not contain a custom ruleset provider.")
+                }.assertAll()
             }
         }
     }
@@ -61,15 +54,12 @@ class RuleSetsLoaderCLITest : BaseCLITest() {
                 "custom-ruleset",
                 listOf("-R", "$BASE_DIR_PLACEHOLDER/$jarWithRulesetProviderV2"),
             ) {
-                assertNormalExitCode()
+                SoftAssertions().apply {
+                    assertNormalExitCode()
 
-                // "15:36:29.259 [main] WARN com.pinterest.ktlint.internal.LoadRuleProviders - JAR /var/folders/24/wtp_g21953x22nr8z86gvltc0000gp/T/junit5220922714985703035/custom-ruleset/rule-set-provider-v1/ktlint-reporter-html.jar, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.".matches(Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, contains a custom ruleset provider which is \\*NOT\\* compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project."))
-                assertThat(normalOutput)
-                    .noneMatch {
-                        it.matches(
-                            Regex(".* WARN .* JAR .*$jarWithRulesetProviderV2, provided as command line argument, contains a custom ruleset provider which will \\*NOT\\*.* be compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.*"),
-                        )
-                    }
+                    // "15:36:29.259 [main] WARN com.pinterest.ktlint.internal.LoadRuleProviders - JAR /var/folders/24/wtp_g21953x22nr8z86gvltc0000gp/T/junit5220922714985703035/custom-ruleset/rule-set-provider-v1/ktlint-reporter-html.jar, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.".matches(Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, contains a custom ruleset provider which is \\*NOT\\* compatible with the next KtLint version \\(0.48\\). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project."))
+                    assertThat(normalOutput).doesNotContainLineMatching("$jarWithRulesetProviderV2, provided as command line argument, contains a custom ruleset provider which will *NOT* be compatible with the next KtLint version (0.48). Contact the maintainer of this ruleset. This JAR is not maintained by the KtLint project.")
+                }.assertAll()
             }
         }
 
@@ -80,14 +70,10 @@ class RuleSetsLoaderCLITest : BaseCLITest() {
                 "custom-ruleset",
                 listOf("-R", "$BASE_DIR_PLACEHOLDER/$jarWithoutRulesetProvider"),
             ) {
-                assertNormalExitCode()
-
-                assertThat(normalOutput)
-                    .anyMatch {
-                        it.matches(
-                            Regex(".* WARN .* JAR .*$jarWithoutRulesetProvider, provided as command line argument, does not contain a custom ruleset provider."),
-                        )
-                    }
+                SoftAssertions().apply {
+                    assertNormalExitCode()
+                    assertThat(normalOutput).containsLineMatching("$jarWithoutRulesetProvider, provided as command line argument, does not contain a custom ruleset provider.")
+                }.assertAll()
             }
         }
     }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint
 
+import java.io.ByteArrayInputStream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -103,6 +104,21 @@ class SimpleCLITest : BaseCLITest() {
                 "no-consecutive-blank-lines",
                 "no-empty-first-line-in-method-block",
             )
+        }
+    }
+
+    @Test
+    fun `Given some code with an error but a pattern read in from stdin which does not select the file`() {
+        runKtLintCliProcess(
+            "too-many-empty-lines",
+            listOf("--patterns-from-stdin"),
+            stdin = ByteArrayInputStream("SomeOtherFile.kt".toByteArray()),
+        ) {
+            assertNormalExitCode()
+
+            assert(normalOutput.find { it.contains("No files matched [SomeOtherFile.kt]") } != null) {
+                "Unexpected output:\n${normalOutput.joinToString(separator = "\n")}"
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR adds the option~~s~~ `--patterns-from-stdin[=<delimiter>]` ~~and `-z`~~ that'll read patterns separated by a delimiter (default is newline, giving an empty string ~~or using the `-z` option~~ is `NUL` byte) and add them to the patterns given on the command line.

Since the `--stdin` option would already read from `stdin`, it'll throw an exception if both `--stdin` and `--patterns-from-stdin`~~/`-z`~~ are given.

These options were primarily added to update the Git hook scripts.  
The main problems with the old ones were that files with special characters (e.g.: newline) in the name would not be passed along correctly (since Git quotes those filenames without the `-z` option) and that the `--no-run-if-empty` hack wouldn't work on non-GNU systems. (since that option is a GNU extension)

## Checklist

- [x] PR description added
- [x] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] CHANGELOG.md` is updated
