### PR TITLE
Update ImportOrdering to explain pointer

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -199,8 +199,10 @@ public class ImportOrderingRule :
         private val IDEA_PATTERN = parseImportsLayout("*,java.**,javax.**,kotlin.**,^")
 
         private const val IDEA_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between " +
-            "with \"java\", \"javax\", \"kotlin\" and aliases in the end"
-        private const val ASCII_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between"
+            "with \"java\", \"javax\", \"kotlin\" and aliases in the end. " +
+            "Pointer is at the start of the imports block. Error is somewhere in the whole block."
+        private const val ASCII_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between. " +
+            "Pointer is at the start of the imports block. Error is somewhere in the whole block."         
         private const val CUSTOM_ERROR_MESSAGE = "Imports must be ordered according to the pattern specified in .editorconfig"
 
         private val errorMessages = mapOf(


### PR DESCRIPTION
## Description

The import ordering rule always points to the first line of the import block.

This always seems to confuse people into thinking it's pointing at the line which is at fault. (it's not)

Expand the error message to explain that the error is somewhere in the whole imports block.

![image](https://user-images.githubusercontent.com/655860/186922817-83372dda-ce57-4940-b3ad-e5d2875b5756.png)


## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
