### PR TITLE
Fix traversing the directory hierarchy on WindowsOS / Ant-style path matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Traversing directory hierarchy at Windows ([#1600](https://github.com/pinterest/ktlint/issues/1600))
+* Ant-style path pattern support ([#1601](https://github.com/pinterest/ktlint/issues/1601))
+
 ### Added
 
 ### Changed

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -1,13 +1,11 @@
 package com.pinterest.ktlint.internal
 
-import ch.qos.logback.classic.Level
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.api.EditorConfigDefaults
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.initKtLintKLogger
-import com.pinterest.ktlint.core.setDefaultLoggerModifier
 import java.io.File
 import java.nio.file.FileSystem
 import java.nio.file.FileVisitResult
@@ -26,7 +24,6 @@ import mu.KotlinLogging
 import org.jetbrains.kotlin.util.prefixIfNot
 
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
-    .setDefaultLoggerModifier { Level.TRACE } // TODO: remove
 
 internal val workDir: String = File(".").canonicalPath
 
@@ -145,7 +142,7 @@ internal fun FileSystem.fileSequence(
     return result.asSequence()
 }
 
-internal fun FileSystem.expand(
+private fun FileSystem.expand(
     patterns: List<String>,
     rootDir: Path,
 ) =

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -15,6 +15,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.isDirectory
 import kotlin.system.exitProcess
 import kotlin.system.measureTimeMillis
@@ -95,8 +96,14 @@ internal fun FileSystem.fileSequence(
                     filePath: Path,
                     fileAttrs: BasicFileAttributes,
                 ): FileVisitResult {
-                    if (negatedPathMatchers.none { it.matches(filePath) } &&
-                        pathMatchers.any { it.matches(filePath) }
+                    val path =
+                        if (onWindowsOS) {
+                            Paths.get(filePath.absolutePathString().replace(File.separatorChar, '/'))
+                        } else {
+                            filePath
+                        }
+                    if (negatedPathMatchers.none { it.matches(path) } &&
+                        pathMatchers.any { it.matches(path) }
                     ) {
                         logger.trace { "- File: $filePath: Include" }
                         result.add(filePath)

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsTest.kt
@@ -2,11 +2,13 @@ package com.pinterest.ktlint.internal
 
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import com.pinterest.ktlint.core.initKtLintKLogger
 import java.io.File
 import java.nio.file.FileSystem
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Locale
+import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -17,6 +19,8 @@ import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
+private val logger = KotlinLogging.logger {}.initKtLintKLogger()
 
 /**
  * Tests for [fileSequence] method.
@@ -242,9 +246,16 @@ internal class FileUtilsFileSequenceTest {
     }
 
     // Jimfs does not currently support the Windows syntax for an absolute path on the current drive (e.g. "\foo\bar")
-    @DisabledOnOs(OS.WINDOWS)
+//    @DisabledOnOs(OS.WINDOWS)
     @Test
     fun `Given a (relative) directory path (but not a glob) from the workdir then find all files in that workdir and it subdirectories having the default kotlin extensions`() {
+        logger.info {
+            val patterns = "src/main/kotlin".normalizeGlob()
+            val dir = "${rootDir}project1".normalizePath()
+            "`Given a (relative) directory path (but not a glob) from the workdir then find all files in that workdir and it subdirectories having the default kotlin extensions`\n" +
+                "\tpatterns = $patterns\n" +
+                "\trootDir = $dir"
+        }
         val foundFiles = getFiles(
             patterns = listOf("src/main/kotlin".normalizeGlob()),
             rootDir = tempFileSystem.getPath("${rootDir}project1".normalizePath()),
@@ -296,6 +307,11 @@ internal class FileUtilsFileSequenceTest {
         .fileSequence(patterns, rootDir)
         .map { it.toString() }
         .toList()
+        .also {
+            logger.info {
+                "Getting files with [patterns = $patterns] and [rootdir = $rootDir] returns [files = $it]"
+            }
+        }
 }
 
 internal val rawGlobSeparator: String get() {

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsTest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/internal/FileUtilsTest.kt
@@ -7,15 +7,20 @@ import java.io.File
 import java.nio.file.FileSystem
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.isDirectory
 import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
@@ -254,6 +259,61 @@ internal class FileUtilsTest {
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(ktFile1InProjectSubDirectory)
             .doesNotContain(ktFile2InProjectSubDirectory)
+    }
+
+    @EnabledOnOs(OS.WINDOWS)
+    @Nested
+    inner class ExploreFileSystem {
+        val rootPath = Paths.get(rootDir)
+
+        @Test
+        fun `Is absolute path`() {
+            assertThat(rootPath.isAbsolute).isTrue
+        }
+
+        @Test
+        fun `Is directory`() {
+            assertThat(rootPath.isDirectory()).isTrue
+        }
+
+        @Test
+        fun `Has root dir name`() {
+            assertThat(rootPath.absolutePathString()).isEqualTo("C:\\")
+        }
+
+        @ParameterizedTest(name = "Path: {0}, expected result: {1}")
+        @CsvSource(
+            value = [
+                ", C:\\",
+                "project1, C:\\project1",
+                "project1/src, C:\\project1\\src",
+                "project1/src/main, C:\\project1\\src\\main",
+                "project1/src/main/kotlin, C:\\project1\\src\\main\\kotlin",
+                "project1/src/main/kotlin.One.kt, C:\\project1\\src\\main\\kotlin\\One.kt",
+            ],
+        )
+        fun `Resolve`(path: String?, expected: String) {
+            val actual = rootPath.resolve(Paths.get(path ?: ""))
+
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @ParameterizedTest(name = "Path: {0}, expected result: {1}")
+        @CsvSource(
+            value = [
+                ", C:\\",
+                "project1, C:\\project1",
+                "project1/src, C:\\project1\\src",
+                "project1/src/main, C:\\project1\\src\\main",
+                "project1/src/main/kotlin, C:\\project1\\src\\main\\kotlin",
+                "project1/src/main/kotlin.One.kt, C:\\project1\\src\\main\\kotlin\\One.kt",
+            ],
+        )
+        fun `Resolve normalized`(path: String?, expected: String) {
+            val actual = rootPath.resolve(Paths.get(path?.normalizePath() ?: ""))
+
+            assertThat(actual).isEqualTo(expected)
+        }
     }
 
     private fun String.normalizePath() = replace('/', File.separatorChar)


### PR DESCRIPTION
## Description

Globs always use a "/" as directory separator on all OS's. Input patterns containing a "\" on Windows OS are transformed to "/" as users on Windows more likely would assume that the "\" may be used.

On WindowsOS, transform "\" in the filepath to "/" before comparing the filename with the regular expression (of the glob) which always uses "/" as separator.

Refactor all logic which create globs based on an input path.
- If a path (absolute or relative) point to a directory, that path is expanded to the default globs (*.kt, *.kts) in that specific directory or any of its subdirectories.
- If a path (absolute or relative) does not point to a directory, e.g. it
  points to a file, or it is a pattern. See "**" replacement below.
- On Windows OS patters containing a "*" (or "**") can not be resolved with default Paths utilities. In such case the given input pattern is handled as is. See "**" replacement below.

Patterns that contain one or more occurrence of a "**" are split into multiple patterns so that files on that specific path and subdirectories will be matched.
- For example, for path "some/path/**/*.kt" an additional pattern "some/path/*.kt" is generated to make sure that not only the "*.kt" files in a subdirectory of "some/path/" are found but also the "*.kt" in directory "some/path" as well. This is in sync with the "**" notation in a glob which should be interpreted as having zero or more intermediate subdirectories.
- For example, for path "some/**/path/**/*.kt", multiple additional patterns are generated. As it contains two "**" patterns, 2 x 2 patterns are needed to match all possible combinations:
   - "some/**/path/**/*.kt"
   - "some/**/path/*.kt"
   - "some/path/**/*.kt"
   - "some/path/*.kt"

Finally, on Windows OS more fixes are needed as the resulting globs may not contain any drive destinations as the start of the path. Such a drive destination is replaced with a "**". So "D:/some/path/*.kt" becomes "/some/path/*.kt". Note that the last glob representation is less strict than the original pattern as it could match on other drives that "D:/" as well.

Extend trace logging.

Closes #1600
Closes #1601
## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
