### PR TITLE
Set property "ktlint_disabled_rules" with CLI "--disabled-rules"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+Do not show deprecation warning about property "disabled_rules" when using CLi-parameter `--disabled-rules` ([#1599](https://github.com/pinterest/ktlint/issues/1599)) 
+
 ### Added
 
 ### Changed

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -12,7 +12,7 @@ import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.api.Baseline.Status.INVALID
 import com.pinterest.ktlint.core.api.Baseline.Status.NOT_FOUND
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.codeStyleSetProperty
-import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.disabledRulesProperty
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.ktlintDisabledRulesProperty
 import com.pinterest.ktlint.core.api.EditorConfigDefaults
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigOverride.Companion.plus
@@ -251,7 +251,7 @@ internal class KtlintCommandLine {
             EditorConfigOverride
                 .emptyEditorConfigOverride
                 .applyIf(disabledRules.isNotBlank()) {
-                    plus(disabledRulesProperty to disabledRules)
+                    plus(ktlintDisabledRulesProperty to disabledRules)
                 }.applyIf(android) {
                     plus(codeStyleSetProperty to android)
                 }


### PR DESCRIPTION
## Description

Set property "ktlint_disabled_rules" instead of "disabled_rules" when using CLI parameter as otherwise the deprecation warning is displayed

Closes #1599

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
