### PR TITLE
Fix replaceWith syntax in visit deprecation

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -71,7 +71,7 @@ public open class Rule(
      */
     @Deprecated(
         message = "Marked for deletion in ktlint 0.48.0",
-        replaceWith = ReplaceWith("beforeVisitChildNodes(node, autocorrect, emit"),
+        replaceWith = ReplaceWith("beforeVisitChildNodes(node, autoCorrect, emit)"),
     )
     @Suppress("UNUSED_PARAMETER")
     public open fun visit(


### PR DESCRIPTION
## Description
I have this line:
`wrapping.visit(node, autoCorrect) { offset, message, _ ->`

When I use the IDE to automatically update based on the deprecation's replaceWith suggestion, it's replaced with:
`wrapping.beforeVisitChildNodes(node, autocorrect { offset, message, _ ->`

Which has incorrect syntax:
![image](https://user-images.githubusercontent.com/170028/187321180-8c59b793-b874-49f7-bc94-90006d9537ac.png)

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)