### PR TITLE
Add `wrapping` rule to docs

### DIFF
--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -180,7 +180,7 @@ Rule id: `trailing-comma-on-declaration-site`
 
 ## Wrapping
 
-Inserts missing newlines (e.g. between parentheses of a multi-line function call).
+Inserts missing newlines (for example between parentheses of a multi-line function call).
 
 Rule id: `wrapping`
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -178,6 +178,12 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
 
 Rule id: `trailing-comma-on-declaration-site`
 
+## Wrapping
+
+Inserts missing newlines (e.g. between parentheses of a multi-line function call).
+
+Rule id: `wrapping`
+
 ## Spacing
 
 ### Annotation spacing


### PR DESCRIPTION
## Description
This standard rule is currently not listed in the docs.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
