### PR TITLE
Add `experimental:type-argument-list-spacing` rule to docs

### DIFF
--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -87,6 +87,12 @@ Consistent spacing between function name and opening parenthesis.
 
 Rule id: `experimental:spacing-between-function-name-and-opening-parenthesis`
 
+### Type argument list spacing
+
+Spacing before and after the angle brackets of a type argument list.
+
+Rule id: `experimental:type-argument-list-spacing`
+
 ### Type parameter list spacing
 
 Spacing after a type parameter list in function and class declarations.


### PR DESCRIPTION
## Description

This experimental rule is currently not listed in the docs.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
