### PR TITLE
Fix class cast exception caused by default ".editorconfig"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Do not add trailing comma in empty parameter/argument list with comments (`trailing-comma-on-call-site`, `trailing-comma-on-declaration-site`) ([#1602](https://github.com/pinterest/ktlint/issue/1602))
+* Fix class cast exception when specifying a non-string editorconfig setting in the default ".editorconfig" ([#1627](https://github.com/pinterest/ktlint/issue/1627)) 
 
 ### Added
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -108,7 +108,25 @@ public interface UsesEditorConfigProperties {
                 }
         }
 
-        return property?.getValueAs()
+        val propertyValue =
+            when {
+                property == null -> null
+                property.type != null -> property.getValueAs()
+                else -> {
+                    // In case the property was loaded from the default ".editorconfig" the type field is not known as
+                    // the property could not yet be linked to a property type that is defined in a rule. To prevent
+                    // class cast exceptions, lookup the property by name and convert to property type.
+                    @Suppress("UNCHECKED_CAST")
+                    this@UsesEditorConfigProperties
+                        .editorConfigProperties
+                        .find { it.type.name == property.name }
+                        ?.type
+                        ?.parse(property.sourceValue)
+                        ?.parsed as T?
+                }
+            }
+
+        return propertyValue
             ?: editorConfigProperty
                 .getDefaultValue(codeStyleValue)
                 .also {

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
@@ -95,6 +95,20 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
         }
     }
 
+    @Test
+    fun `Issue 1627 - Given a default editorconfig containing a boolean setting then do not throw a class cast exception`() {
+        val projectDirectory = "$BASE_DIR_PLACEHOLDER/editorconfig-path/project"
+        runKtLintCliProcess(
+            "editorconfig-path",
+            listOf("--editorconfig=$projectDirectory/editorconfig-boolean-setting", "--debug"),
+        ) {
+            assertErrorExitCode()
+
+            val assertThat = assertThat(errorOutput)
+            assertThat.doesNotContainLineMatching(Regex(".*java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean.*"))
+        }
+    }
+
     private fun ListAssert<String>.containsLineMatching(regex: Regex) =
         this.anyMatch {
             it.matches(regex)

--- a/ktlint/src/test/resources/cli/editorconfig-path/project/editorconfig-boolean-setting
+++ b/ktlint/src/test/resources/cli/editorconfig-path/project/editorconfig-boolean-setting
@@ -1,0 +1,5 @@
+root = true
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma=true
+ij_kotlin_allow_trailing_comma_on_call_site=true


### PR DESCRIPTION
## Description

Fix class cast exception when specifying a non-string editorconfig setting in the *default* `.editorconfig`. When reading the *default* `.editorconfig` the property can not yet be matched with any on the properties defined in the rulesets. As a result the type of the property is unknown (null). When retrieving a value from a property with type `null` this resulted in a class cast exception whenever a value of another type than `String` is expected. In this change, the `null` type is detected and the proper `type` is determined by reading the property type from the properties which are registered in the rule.

 Closes #1627

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
