### PR TITLE
Warn on no files matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Do not show deprecation warning about property "disabled_rules" when using CLi-p
 ### Added
 
 ### Changed
+* Display warning instead of error when no files are matched, and return with exit code 0. ([#1624](https://github.com/pinterest/ktlint/issues/1624))
 
 ### Removed
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -274,11 +274,12 @@ internal class KtlintCommandLine {
             )
         }
         reporter.afterAll()
-        if (fileNumber.get() == 0) {
-            logger.error { "No files matched $patterns" }
-            exitProcess(1)
-        }
         logger.debug { "${System.currentTimeMillis() - start}ms / $fileNumber file(s) / $errorNumber error(s)" }
+        if (fileNumber.get() == 0) {
+            // Do not return an error as this would implicate that in a multi-module project, each module has to contain
+            // at least one kotlin file.
+            logger.warn { "No files matched $patterns" }
+        }
         if (tripped.get()) {
             exitProcess(1)
         }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/BaseCLITest.kt
@@ -151,7 +151,7 @@ abstract class BaseCLITest {
 
     companion object {
         private const val WAIT_INTERVAL_DURATION = 100L
-        private const val WAIT_INTERVAL_MAX_OCCURRENCES = 100
+        private const val WAIT_INTERVAL_MAX_OCCURRENCES = 1000
         val testProjectsPath: Path = Paths.get("src", "test", "resources", "cli")
         const val BASE_DIR_PLACEHOLDER = "__TEMP_DIR__"
     }

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/EditorConfigDefaultsLoaderCLITest.kt
@@ -100,7 +100,7 @@ class EditorConfigDefaultsLoaderCLITest : BaseCLITest() {
         val projectDirectory = "$BASE_DIR_PLACEHOLDER/editorconfig-path/project"
         runKtLintCliProcess(
             "editorconfig-path",
-            listOf("--editorconfig=$projectDirectory/editorconfig-boolean-setting", "--debug"),
+            listOf("--editorconfig=$projectDirectory/editorconfig-boolean-setting"),
         ) {
             assertErrorExitCode()
 

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -69,7 +69,7 @@ class SimpleCLITest : BaseCLITest() {
             "too-many-empty-lines",
             listOf("SomeOtherFile.kt"),
         ) {
-            assertErrorExitCode()
+            assertNormalExitCode()
 
             assert(normalOutput.find { it.contains("No files matched [SomeOtherFile.kt]") } != null) {
                 "Unexpected output:\n${normalOutput.joinToString(separator = "\n")}"


### PR DESCRIPTION
## Description

Display warning instead of error when no files are matched, and return with exit code 0.

Closes #1624 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
