### PR TITLE
enum trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Do not add trailing comma in empty parameter/argument list with comments (`trailing-comma-on-call-site`, `trailing-comma-on-declaration-site`) ([#1602](https://github.com/pinterest/ktlint/issue/1602))
-* Fix class cast exception when specifying a non-string editorconfig setting in the default ".editorconfig" ([#1627](https://github.com/pinterest/ktlint/issue/1627)) 
+* Fix class cast exception when specifying a non-string editorconfig setting in the default ".editorconfig" ([#1627](https://github.com/pinterest/ktlint/issue/1627))
+* Fix indentation before semi-colon when it is pushed down after inserting a trailing comma  ([#1609](https://github.com/pinterest/ktlint/issue/1609))
 
 Do not show deprecation warning about property "disabled_rules" when using CLi-parameter `--disabled-rules` ([#1599](https://github.com/pinterest/ktlint/issues/1599)) 
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -317,7 +317,9 @@ public class TrailingCommaOnDeclarationSiteRule :
 
                         if (inspectNode.treeParent.elementType == ElementType.ENUM_ENTRY) {
                             with(KtPsiFactory(prevNode.psi)) {
-                                val parentIndent = (prevNode.psi.parent.prevLeaf() as? PsiWhiteSpace)?.text ?: "\n"
+                                val parentIndent =
+                                    (prevNode.psi.parent.prevLeaf() as? PsiWhiteSpace)?.text
+                                        ?: "\n${prevNode.lineIndent()}"
                                 val newline = createWhiteSpace(parentIndent)
                                 val enumEntry = inspectNode.treeParent.psi
                                 enumEntry.apply {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -930,4 +930,31 @@ class TrailingCommaOnDeclarationSiteRuleTest {
             .withEditorConfigOverride(allowTrailingCommaProperty to true)
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 1609 - Given that a trailing comma is required then add trailing comma after last enum member and indent the semi-colon`() {
+        val code =
+            """
+            enum class SomeEnum1(id: String) {
+                FOO("foo"),
+                BAR("bar");
+
+                fun doSomething(id: String) {}
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            enum class SomeEnum1(id: String) {
+                FOO("foo"),
+                BAR("bar"),
+                ;
+
+                fun doSomething(id: String) {}
+            }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaProperty to true)
+            .hasLintViolation(3, 15, "Missing trailing comma before \";\"")
+            .isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/FileUtils.kt
@@ -144,7 +144,7 @@ internal fun FileSystem.fileSequence(
     return result.asSequence()
 }
 
-internal fun FileSystem.expand(
+private fun FileSystem.expand(
     patterns: List<String>,
     rootDir: Path,
 ) =


### PR DESCRIPTION
## Description

Fix indentation before semi-colon when it is pushed down after inserting a trailing comma

Closes #1609 
## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
