### PR TITLE
brew bump-formula-pr needs a formula name now

### DIFF
--- a/.homebrew
+++ b/.homebrew
@@ -4,4 +4,4 @@
 if [ "$VERSION" == "" ]; then exit 1; fi
 
 brew update
-shasum -a 256 ./ktlint/build/run/ktlint | awk -v new_version="$VERSION" '{system(sprintf("brew bump-formula-pr --url=\"https://github.com/pinterest/ktlint/releases/download/%s/ktlint\" --sha256=\"%s\"", new_version, $1))}'
+shasum -a 256 ./ktlint/build/run/ktlint | awk -v new_version="$VERSION" '{system(sprintf("brew bump-formula-pr --url=\"https://github.com/pinterest/ktlint/releases/download/%s/ktlint\" --sha256=\"%s\" ktlint", new_version, $1))}'


### PR DESCRIPTION
When doing the 0.47.1 release, the homebrew step failed due to bump-formula-pr erroring out saying it needed a formula name. 