### PR TITLE
Fix typo: maxOC -> macOS

### DIFF
--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -38,7 +38,7 @@ curl -sS https://keybase.io/shyiko/pgp_keys.asc | gpg --import && gpg --verify k
 
 `ktlint` can be installed via several OS specific package managers.
 
-Install with [brew on maxOC](https://brew.sh/) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux)
+Install with [brew on macOS](https://brew.sh/) or [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux)
 ```sh
 brew install ktlint
 ```


### PR DESCRIPTION
## Description

This PR simply fixes a typo in the cli docs.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
