### PR TITLE
Newline inside value argument should not trigger trailing comma rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Let a rule process all nodes even in case the rule is suppressed for a node so that the rule can update the internal state ([#1644](https://github.com/pinterest/ktlint/issue/1644))
+* Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -386,7 +386,7 @@ public class IndentationRule :
     private fun adjustExpectedIndentInsideQualifiedExpression(n: ASTNode, ctx: IndentContext) {
         val p = n.parent({
             it.treeParent.elementType != DOT_QUALIFIED_EXPRESSION && it.treeParent.elementType != SAFE_ACCESS_EXPRESSION
-        },) ?: return
+        }) ?: return
         val nextSibling = n.treeNext
         if (!ctx.ignored.contains(p) && nextSibling != null) {
             if (p.treeParent.elementType == PROPERTY_DELEGATE &&

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRuleTest.kt
@@ -475,9 +475,39 @@ class TrailingCommaOnCallSiteRuleTest {
     fun `Issue 1602 - Given that an empty argument list with a comment, dot add a trailing comma`() {
         val code =
             """
-            val foo = setOf<Int>(
+            val foo1 = setOf<Int>(
                 // some comment
             )
+            val foo2 = setOf<Int>(
+            )
+            val foo1 = setOf<Int>()
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaOnCallSiteProperty to true)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1642 - Given a multiline argument then ignore the newline character and do not add a trailing comma`() {
+        val code =
+            """
+            fun main() {
+                bar(object : Foo {
+                    override fun foo() {
+                        TODO("Not yet implemented")
+                    }
+                })
+                bar("foo", object : Foo {
+                    override fun foo() {
+                        TODO("Not yet implemented")
+                    }
+                })
+                bar(object : Foo {
+                    override fun foo() {
+                        TODO("Not yet implemented")
+                    }
+                }, "foo")
+            }
             """.trimIndent()
         ruleAssertThat(code)
             .withEditorConfigOverride(allowTrailingCommaOnCallSiteProperty to true)


### PR DESCRIPTION
## Description

* Do not add a trailing comma in a function call if a newline character is only found inside a multiline argument. Only in case a newline character is found between arguments, this should be taken into account to add a trailing comma.

* Refactor and cleanup unused branches in isMultiline method

Closes #1642

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
