### PR TITLE
Get rid of direct usages of KtStubElementTypes#FILE

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/ElementType.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/ElementType.kt
@@ -5,11 +5,12 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.kdoc.lexer.KDocTokens
 import org.jetbrains.kotlin.kdoc.parser.KDocElementTypes
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 @Suppress("unused")
 public object ElementType {
-    public val FILE: IElementType = KtStubElementTypes.FILE
+    public val FILE: IElementType = KtFileElementType.INSTANCE
 
     // KtNodeTypes
     public val CLASS: IElementType = KtNodeTypes.CLASS


### PR DESCRIPTION
[KtStubElementTypes#FILE](https://github.com/JetBrains/kotlin/blob/master/compiler/psi/src/org/jetbrains/kotlin/psi/stubs/elements/KtStubElementTypes.java) will be dropped from `KtStubElementTypes`

Details in
https://github.com/JetBrains/kotlin/commit/298494fa08d11b9c374368aac4ae547b6f972f1a

```
FILE elements are always registered eagerly on parser definition load
and should not be mentioned in stubElementTypeHolder interfaces.
KtFileElementType.INSTANCE was defined in 2 places, first as
getFileNodeType of KotlinParserDefinition and second is
KtStubElementTypes. In order to ensure that there are no conflicts
in stubs the platform needs to recheck these 2 declarations,
and it triggers loading of KtStubElementTypes fields. We do not need
to declare FILE element in KtStubElementTypes and may just remove this
declaration as excessive. This will delay init of KtStubElementTypes
to the moment when Kotlin files appear in indexes.
```

https://youtrack.jetbrains.com/issue/KTIJ-22750

