### PR TITLE
Wrapping element of type BLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### API Changes & RuleSet providers
 
 ### Added
+* Wrap blocks in case the max line length is exceeded or in case the block contains a new line `wrapping` ([#1643](https://github.com/pinterest/ktlint/issue/1643))
 
 ### Fixed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ArgumentListWrappingRule.kt
@@ -37,7 +37,18 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * in addition, "(" and ")" must be on separates line if any of the arguments are (otherwise on the same)
  */
 public class ArgumentListWrappingRule :
-    Rule("argument-list-wrapping"),
+    Rule(
+        id = "argument-list-wrapping",
+        visitorModifiers = setOf(
+            VisitorModifier.RunAfterRule(
+                // ArgumentListWrapping should only be used in case after normal wrapping the max_line_length is still
+                // violated
+                ruleId = "wrapping",
+                loadOnlyWhenOtherRuleIsLoaded = false,
+                runOnlyWhenOtherRuleIsEnabled = false,
+            ),
+        ),
+    ),
     UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRule.kt
@@ -2,12 +2,15 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.IndentConfig
 import com.pinterest.ktlint.core.Rule
-import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentSizeProperty
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStyleProperty
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.core.ast.ElementType
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
+import com.pinterest.ktlint.core.ast.ElementType.BLOCK
 import com.pinterest.ktlint.core.ast.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.CLOSING_QUOTE
 import com.pinterest.ktlint.core.ast.ElementType.COMMA
@@ -40,8 +43,10 @@ import com.pinterest.ktlint.core.ast.ElementType.WHEN_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.children
 import com.pinterest.ktlint.core.ast.isPartOfComment
+import com.pinterest.ktlint.core.ast.isWhiteSpace
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.isWhiteSpaceWithoutNewline
+import com.pinterest.ktlint.core.ast.lastChildLeafOrSelf
 import com.pinterest.ktlint.core.ast.lineIndent
 import com.pinterest.ktlint.core.ast.nextCodeLeaf
 import com.pinterest.ktlint.core.ast.nextCodeSibling
@@ -61,6 +66,7 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
@@ -78,19 +84,22 @@ public class WrappingRule :
     UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> =
         listOf(
-            DefaultEditorConfigProperties.indentSizeProperty,
-            DefaultEditorConfigProperties.indentStyleProperty,
+            indentSizeProperty,
+            indentStyleProperty,
+            maxLineLengthProperty,
         )
 
     private var line = 1
     private lateinit var indentConfig: IndentConfig
+    private var maxLineLength: Int = -1
 
     override fun beforeFirstNode(editorConfigProperties: EditorConfigProperties) {
         line = 1
         indentConfig = IndentConfig(
-            indentStyle = editorConfigProperties.getEditorConfigValue(DefaultEditorConfigProperties.indentStyleProperty),
-            tabWidth = editorConfigProperties.getEditorConfigValue(DefaultEditorConfigProperties.indentSizeProperty),
+            indentStyle = editorConfigProperties.getEditorConfigValue(indentStyleProperty),
+            tabWidth = editorConfigProperties.getEditorConfigValue(indentSizeProperty),
         )
+        maxLineLength = editorConfigProperties.getEditorConfigValue(maxLineLengthProperty)
     }
 
     override fun beforeVisitChildNodes(
@@ -99,12 +108,60 @@ public class WrappingRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         when (node.elementType) {
-            LPAR, LBRACE, LBRACKET -> rearrangeBlock(node, autoCorrect, emit) // TODO: LT
+            BLOCK -> beforeVisitBlock(node, autoCorrect, emit)
+            LPAR, LBRACKET -> rearrangeBlock(node, autoCorrect, emit) // TODO: LT
             SUPER_TYPE_LIST -> rearrangeSuperTypeList(node, autoCorrect, emit)
             VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(node, autoCorrect, emit)
             ARROW -> rearrangeArrow(node, autoCorrect, emit)
             WHITE_SPACE -> line += node.text.count { it == '\n' }
             CLOSING_QUOTE -> rearrangeClosingQuote(node, autoCorrect, emit)
+        }
+    }
+
+    private fun beforeVisitBlock(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(node.elementType == BLOCK)
+
+        val startOfBlock = node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+        if (startOfBlock?.elementType != LBRACE) {
+            return
+        }
+        val blockIsPrecededByWhitespaceContainingNewline = startOfBlock.nextLeaf().isWhiteSpaceWithNewline()
+        val endOfBlock = node.lastChildLeafOrSelf().nextLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+        val blockIsFollowedByWhitespaceContainingNewline = endOfBlock?.prevLeaf().isWhiteSpaceWithNewline()
+        val wrapBlock =
+            when {
+                blockIsPrecededByWhitespaceContainingNewline -> false
+                node.textContains('\n') || blockIsFollowedByWhitespaceContainingNewline -> {
+                    // A multiline block should always be wrapped
+                    true
+                }
+                maxLineLength > 0 -> {
+                    val startOfLine = node.prevLeaf { it.isWhiteSpaceWithNewline() }
+                    val endOfLine = node.nextLeaf { it.isWhiteSpaceWithNewline() }
+                    val line =
+                        startOfLine
+                            ?.leaves()
+                            ?.takeWhile { it != endOfLine }
+                            ?.joinToString(separator = "", prefix = startOfLine.text.removePrefix("\n")) { it.text }
+                            .orEmpty()
+                    line.length > maxLineLength
+                }
+                else -> false
+            }
+        if (wrapBlock) {
+            startOfBlock
+                ?.takeIf { !it.nextLeaf().isWhiteSpaceWithNewline() }
+                ?.let { leafNodeBeforeBlock ->
+                    requireNewlineAfterLeaf(
+                        leafNodeBeforeBlock,
+                        autoCorrect,
+                        emit,
+                    )
+                }
         }
     }
 
@@ -501,6 +558,34 @@ public class WrappingRule :
             node = node.nextSibling { true }
         }
         return true
+    }
+
+    override fun afterVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType == BLOCK) {
+            val startOfBlock = node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+            if (startOfBlock?.elementType != LBRACE) {
+                return
+            }
+            val blockIsPrecededByWhitespaceContainingNewline = startOfBlock.nextLeaf().isWhiteSpaceWithNewline()
+            val endOfBlock = node.lastChildLeafOrSelf().nextLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+            val blockIsFollowedByWhitespaceContainingNewline = endOfBlock?.prevLeaf().isWhiteSpaceWithNewline()
+            val wrapBlock =
+                !blockIsFollowedByWhitespaceContainingNewline && (
+                    blockIsPrecededByWhitespaceContainingNewline || node.textContains('\n')
+                    )
+            if (wrapBlock && endOfBlock != null) {
+                requireNewlineBeforeLeaf(
+                    endOfBlock,
+                    autoCorrect,
+                    emit,
+                    node.treeParent.lineIndent(),
+                )
+            }
+        }
     }
 
     private companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
@@ -1,9 +1,13 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.ec4j.core.model.PropertyType.IndentStyleValue.tab
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class WrappingRuleTest {
@@ -1588,6 +1592,117 @@ internal class WrappingRuleTest {
                 }
             """.trimIndent()
         wrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @DisplayName("Given a block not starting and/or ending on a separate line")
+    @Nested
+    inner class WrapBlock {
+        @Test
+        fun `A single line block on a line which does not exceed the max line length is not wrapped`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                                   $EOL_CHAR
+                class Bar {
+                    val bar by lazy { foo("foooooooooooooooooooooooooooooooooooooooo", true) }
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 1643 - Wrap a block in case line including the block is violating the max line length`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                                   $EOL_CHAR
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy { fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true) }
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                                   $EOL_CHAR
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy {
+                        fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true)
+                    }
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolation(3, 52, "Missing newline after \"{\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Wrap a multiline block not containing a newline between the LBRACE and the first statement in that block even in case the line containing the start of the block does not exceed the max-line-length`() {
+            val code =
+                """
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy { "foo"
+                    }
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy {
+                        "foo"
+                    }
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .hasLintViolation(2, 52, "Missing newline after \"{\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Wrap a multiline block not containing a newline between the last statement in the block and the RBRACE even in case the line containing the end of the block does not exceed the max-line-length`() {
+            val code =
+                """
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy {
+                        "foo" }
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Bar {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy {
+                        "foo"
+                    }
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .hasLintViolation(3, 14, "Missing newline before \"}\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Wrap a multiline block not containing whitespace elements before or after the block`() {
+            val code =
+                """
+                class Bar {
+                    val bar by lazy {${MULTILINE_STRING_QUOTE}foo
+                            foo${com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE}}
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Bar {
+                    val bar by lazy {
+                        ${MULTILINE_STRING_QUOTE}foo
+                            foo${com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE}
+                    }
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(2, 22, "Missing newline after \"{\""),
+                    LintViolation(3, 18, "Missing newline before \"}\""),
+                ).isFormattedAs(formattedCode)
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Description

Wrap start/end of an element of type BLOCK in case the line containing that element exceeds the max line length or in case the block contains a newline

Closes #1643

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
