### PR TITLE
Housekeeping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,9 @@ task ktlint(type: JavaExec, group: LifecycleBasePlugin.VERIFICATION_GROUP) {
     '--baseline=ktlint/src/test/resources/test-baseline.xml',
     // Experimental rules run by default run on the ktlint code base itself. Experimental rules should not be released if
     // we are not pleased ourselves with the results on the ktlint code base.
-    '--experimental',
-    '--verbose'
+    '--experimental'
+    // Do not run with option "--verbose" or "-v" as the lint violations are difficult to spot between the amount of
+    // debug output lines.
 }
 
 // Deployment tasks

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -407,7 +407,7 @@ public class KtLintAssertThatAssertable(
      */
     public fun isFormattedAs(formattedCode: String): KtLintAssertThatAssertable {
         check(formattedCode != code) {
-            "Use '.hasNoLintErrors()' instead of '.isFormattedAs(<original code>)'"
+            "Use '.hasNoLintViolations()' instead of '.isFormattedAs(<original code>)'"
         }
 
         val actualFormattedCode = format()

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -73,6 +73,7 @@ public fun Set<RuleProvider>.lint(
         userData = userData,
         script = script,
         cb = { e, _ -> res.add(e) },
+        debug = true,
     )
     KtLint.lint(
         experimentalParams,
@@ -96,6 +97,7 @@ public fun Set<RuleProvider>.format(
         userData = userData,
         script = script,
         cb = cb,
+        debug = true,
     )
     return KtLint.format(experimentalParams)
 }


### PR DESCRIPTION
## Description

* Do not run ktlint check with option "--verbose" or "-v" as the lint violations are difficult to spot between the amount of debug output lines
* Run lint and formatting from RuleExtension always with debug enabled so that order in which rules are executed is visible in logging
* Fix non-existing reference to method

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [N/A] PR description added
- [N/A] tests are added
- [N/A] KtLint has been applied on source code itself and violations are fixed
- [N/A] [documentation](https://pinterest.github.io/ktlint/) is updated
- [N/A] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
