### PR TITLE
Add API for retrieving the list of files that will be accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### API Changes & RuleSet providers
 
+#### Retrieve input files
+
+The list of files which will be accessed by KtLint when linting or formatting a given path can now be retrieved with the new API `KtLint.getInputPaths(path: Path): List<Path>`. Currently, the `.editorconfig` files are the only files which will be accessed during linting or formatting in addition to the source files itself. 
+
+This API can be called with either a file or a directory. It's intended usage is that it is called once with a directory path before actually linting or formatting files. When called with a directory path, all `.editorconfig` in the directory or any of its subdirectories (except hidden directories) are returned. In case the given directory does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned as well until a root `.editorconfig` file is found.
+
+Calling this API with a file path results in the `.editorconfig` files that will be accessed when processing that specific file. In case the directory in which the file resides does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned until a root `.editorconfig` file is found.
+
 ### Added
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### API Changes & RuleSet providers
 
-#### Retrieve input files
+#### Retrieve `.editorconfig`s
 
-The list of files which will be accessed by KtLint when linting or formatting a given path can now be retrieved with the new API `KtLint.getInputPaths(path: Path): List<Path>`. Currently, the `.editorconfig` files are the only files which will be accessed during linting or formatting in addition to the source files itself. 
+The list of `.editorconfig` files which will be accessed by KtLint when linting or formatting a given path can now be retrieved with the new API `KtLint.editorConfigFilePaths(path: Path): List<Path>`. 
 
-This API can be called with either a file or a directory. It's intended usage is that it is called once with a directory path before actually linting or formatting files. When called with a directory path, all `.editorconfig` in the directory or any of its subdirectories (except hidden directories) are returned. In case the given directory does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned as well until a root `.editorconfig` file is found.
+This API can be called with either a file or a directory. It's intended usage is that it is called once with the root directory of a project before actually linting or formatting files of that project. When called with a directory path, all `.editorconfig` files in the directory or any of its subdirectories (except hidden directories) are returned. In case the given directory does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned as well until a root `.editorconfig` file is found.
 
 Calling this API with a file path results in the `.editorconfig` files that will be accessed when processing that specific file. In case the directory in which the file resides does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned until a root `.editorconfig` file is found.
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -8,6 +8,7 @@ import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigOverride.Companion.emptyEditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.internal.EditorConfigFinder
 import com.pinterest.ktlint.core.internal.EditorConfigGenerator
 import com.pinterest.ktlint.core.internal.EditorConfigLoader
 import com.pinterest.ktlint.core.internal.RuleExecutionContext
@@ -21,6 +22,7 @@ import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
+import kotlin.io.path.isDirectory
 import org.ec4j.core.Resource
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -339,6 +341,15 @@ public object KtLint {
             Resource.Resources.ofPath(path, StandardCharsets.UTF_8),
         )
     }
+
+    /**
+     * Get the list of files which will be accessed by KtLint when linting or formatting the given file or directory.
+     */
+    public fun getInputPaths(path: Path): List<Path> =
+        EditorConfigFinder().findEditorConfigs(path) +
+            listOfNotNull(
+                path.takeIf { !it.isDirectory() },
+            )
 
     /**
      * Generates Kotlin `.editorconfig` file section content based on [ExperimentalParams].

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
@@ -31,7 +31,11 @@ internal class EditorConfigFinder {
             result += findEditorConfigsInSubDirectories(normalizedPath)
         }
         result += findEditorConfigsInParentDirectories(normalizedPath)
-        return result.toList()
+        return result
+            .map {
+                // Resolve against original path as the drive letter seems to get lost on WindowsOs
+                path.resolve(it)
+            }.toList()
     }
 
     private fun findEditorConfigsInSubDirectories(path: Path): List<Path> {

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
@@ -1,0 +1,85 @@
+package com.pinterest.ktlint.core.internal
+
+import com.pinterest.ktlint.core.initKtLintKLogger
+import com.pinterest.ktlint.core.internal.ThreadSafeEditorConfigCache.Companion.threadSafeEditorConfigCache
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.io.path.isDirectory
+import mu.KotlinLogging
+import org.ec4j.core.Resource
+import org.ec4j.core.ResourcePropertiesService
+import org.ec4j.core.model.Version
+import org.jetbrains.kotlin.konan.file.File
+
+private val logger = KotlinLogging.logger {}.initKtLintKLogger()
+
+internal class EditorConfigFinder {
+    /**
+     * Finds all relevant ".editorconfig" files for the given path.
+     */
+    fun findEditorConfigs(path: Path): List<Path> {
+        val result = mutableListOf<Path>()
+        val normalizedPath = path.normalize().toAbsolutePath()
+        if (path.isDirectory()) {
+            result += findEditorConfigsInSubDirectories(normalizedPath)
+        }
+        result += findEditorConfigsInParentDirectories(normalizedPath)
+        return result.toList()
+    }
+
+    private fun findEditorConfigsInSubDirectories(path: Path): List<Path> {
+        val result = mutableListOf<Path>()
+
+        Files.walkFileTree(
+            path,
+            object : SimpleFileVisitor<Path>() {
+                override fun visitFile(
+                    filePath: Path,
+                    fileAttrs: BasicFileAttributes,
+                ): FileVisitResult {
+                    if (filePath.File().name == ".editorconfig") {
+                        logger.trace { "- File: $filePath: add to list of accessed files" }
+                        result.add(filePath)
+                    }
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun preVisitDirectory(
+                    dirPath: Path,
+                    dirAttr: BasicFileAttributes,
+                ): FileVisitResult {
+                    return if (Files.isHidden(dirPath)) {
+                        logger.trace { "- Dir: $dirPath: Ignore" }
+                        FileVisitResult.SKIP_SUBTREE
+                    } else {
+                        logger.trace { "- Dir: $dirPath: Traverse" }
+                        FileVisitResult.CONTINUE
+                    }
+                }
+            },
+        )
+
+        return result.toList()
+    }
+
+    private fun findEditorConfigsInParentDirectories(path: Path): List<Path> {
+        // The logic to load parental ".editorconfig" files resides in the ec4j library. This library however uses a
+        // cache provided by KtLint. As of this the list of parental ".editorconfig" files can be extracted from the
+        // cache.
+        createLoaderService().queryProperties(path.resource())
+        return threadSafeEditorConfigCache.getPaths()
+    }
+
+    private fun Path?.resource() =
+        Resource.Resources.ofPath(this, StandardCharsets.UTF_8)
+
+    private fun createLoaderService() =
+        ResourcePropertiesService.builder()
+            .cache(threadSafeEditorConfigCache)
+            .loader(org.ec4j.core.EditorConfigLoader.of(Version.CURRENT))
+            .build()
+}

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.konan.file.File
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
 
 internal class EditorConfigFinder {
-    // Do not reuse the generic threadSageEditorConfigCache to prevent that results are incorrect due to other calls to
+    // Do not reuse the generic threadSafeEditorConfigCache to prevent that results are incorrect due to other calls to
     // KtLint that result in changing the cache
     private val editorConfigCache = ThreadSafeEditorConfigCache()
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/ThreadSafeEditorConfigCache.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/ThreadSafeEditorConfigCache.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.core.internal
 
 import com.pinterest.ktlint.core.initKtLintKLogger
+import java.nio.file.Paths
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
@@ -71,6 +72,14 @@ internal class ThreadSafeEditorConfigCache : Cache {
                 logger.trace { "Removing ${it.size} entries from the EditorConfig cache" }
             }.clear()
     }
+
+    /**
+     * Get the paths of files stored in the cache.
+     */
+    fun getPaths() =
+        inMemoryMap
+            .keys
+            .map { Paths.get(it.path.toString()) }
 
     private data class CacheValue(
         val editorConfigLoader: EditorConfigLoader,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -165,4 +165,5 @@ class EditorConfigFinderTest {
         absolutePathString()
             .removePrefix(tempDir.absolutePathString())
             .removePrefix(File.separator)
+            .replace(tempDir.fileSystem.separator, "/")
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -166,9 +166,9 @@ class EditorConfigFinderTest {
 
     private fun Path.createFile(fileName: String, content: String): Path {
         val dirPath = fileName.substringBeforeLast("/", "")
-        Files.createDirectories(plus(dirPath))
+        Files.createDirectories(this.plus(dirPath))
         return Files
-            .createFile(plus(fileName))
+            .createFile(this.plus(fileName))
             .also { it.writeText(content) }
     }
 

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -181,11 +181,11 @@ class EditorConfigFinderTest {
 
     private fun Path.toRelativePathStringIn(tempDir: Path): String? =
         this
+            .absolutePathString()
             .takeIf {
                 // Ignore files created in temp dirs of other tests
-                it.startsWith(tempDir)
-            }?.absolutePathString()
-            ?.removePrefix(tempDir.absolutePathString())
+                it.startsWith(tempDir.absolutePathString())
+            }?.removePrefix(tempDir.absolutePathString())
             ?.removePrefix(File.separator)
             ?.replace(tempDir.fileSystem.separator, "/")
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -1,0 +1,168 @@
+package com.pinterest.ktlint.core.internal
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.writeText
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.konan.file.File
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class EditorConfigFinderTest {
+    @TempDir
+    private lateinit var tempDir: Path
+
+    @Nested
+    inner class FindByFile {
+        @Test
+        fun `Given a kotlin file in a subdirectory and a root-editorconfig file in the same directory then get the path of that editorconfig file`() {
+            val someSubDir = "some-project/src/main/kotlin"
+            createFile("$someSubDir/.editorconfig", "root=true")
+            val kotlinFilePath = createFile("$someSubDir/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual).contains("$someSubDir/.editorconfig")
+        }
+
+        @Test
+        fun `Given a kotlin file in a subdirectory and a root-editorconfig file in a parent directory then get the path of that parent editorconfig file`() {
+            val someProjectDirectory = "some-project"
+            createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual).contains("$someProjectDirectory/.editorconfig")
+        }
+
+        @Test
+        fun `Given a kotlin file in a subdirectory and a non-root-editorconfig file in that same directory and a root-editorconfig file in a parent directory then get the paths of both editorconfig files`() {
+            val someProjectDirectory = "some-project"
+            createFile("$someProjectDirectory/.editorconfig", "root=true")
+            createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            val kotlinFilePath = createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual).contains(
+                "$someProjectDirectory/.editorconfig",
+                "$someProjectDirectory/src/main/.editorconfig",
+            )
+        }
+
+        @Test
+        fun `Given a kotlin file in a subdirectory and a root-editorconfig file in the parent directory and another root-editorconfig file in a great-parent directory then get the paths of editorconfig files excluding root-editorconfig once the first one is found`() {
+            val someProjectDirectory = "some-project"
+            createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual)
+                .contains(
+                    "$someProjectDirectory/src/main/.editorconfig",
+                    "$someProjectDirectory/src/.editorconfig",
+                ).doesNotContain(
+                    "$someProjectDirectory/.editorconfig",
+                )
+        }
+    }
+
+    @Nested
+    inner class FindByDirectory {
+        @Test
+        fun `Given a directory containing a root-editorconfig file and a subdirectory containing a editorconfig file then get the paths of both editorconfig files`() {
+            val someDirectory = "some-project"
+            createFile("$someDirectory/.editorconfig", "root=true")
+            createFile("$someDirectory/src/main/kotlin/.editorconfig", "some-property=some-value")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(toTempDirPath(someDirectory))
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual).contains(
+                "$someDirectory/.editorconfig",
+                "$someDirectory/src/main/kotlin/.editorconfig",
+            )
+        }
+
+        @Test
+        fun `Given a subdirectory containing an editorconfig file and a sibling subdirectory contain a editorconfig file in a parent directory then get the path of all editorconfig file except of the sibling subdirectory`() {
+            val someProjectDirectory = "some-project"
+            createFile("$someProjectDirectory/.editorconfig", "root=true")
+            createFile("$someProjectDirectory/src/main/kotlin/.editorconfig", "some-property=some-value")
+            createFile("$someProjectDirectory/src/test/kotlin/.editorconfig", "some-property=some-value")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(toTempDirPath("$someProjectDirectory/src/main/kotlin"))
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual)
+                .contains(
+                    "$someProjectDirectory/.editorconfig",
+                    "$someProjectDirectory/src/main/kotlin/.editorconfig",
+                ).doesNotContain(
+                    "$someProjectDirectory/src/test/kotlin/.editorconfig",
+                )
+        }
+
+        @Test
+        fun `Given a directory containing an editorconfig file and multiple subdirectores containing a editorconfig file then get the path of all editorconfig files`() {
+            val someProjectDirectory = "some-project"
+            createFile("$someProjectDirectory/.editorconfig", "root=true")
+            createFile("$someProjectDirectory/src/main/kotlin/.editorconfig", "some-property=some-value")
+            createFile("$someProjectDirectory/src/test/kotlin/.editorconfig", "some-property=some-value")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(toTempDirPath("$someProjectDirectory"))
+                    .map { it.toPathStringWithoutTempDirPrefix() }
+
+            assertThat(actual).contains(
+                "$someProjectDirectory/.editorconfig",
+                "$someProjectDirectory/src/main/kotlin/.editorconfig",
+                "$someProjectDirectory/src/test/kotlin/.editorconfig",
+            )
+        }
+    }
+
+    private fun createFile(fileName: String, content: String): Path {
+        val dirPath = fileName.substringBeforeLast("/", "")
+        Files.createDirectories(toTempDirPath(dirPath))
+        return Files
+            .createFile(toTempDirPath(fileName))
+            .also { it.writeText(content) }
+    }
+
+    private fun toTempDirPath(subPath: String): Path =
+        tempDir
+            .absolutePathString()
+            .plus(File.separator)
+            .plus(subPath)
+            .let { Paths.get(it) }
+
+    private fun Path.toPathStringWithoutTempDirPrefix() =
+        absolutePathString()
+            .removePrefix(tempDir.absolutePathString())
+            .removePrefix(File.separator)
+}

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -6,7 +6,6 @@ import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.writeText
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.konan.file.File
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -26,7 +25,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(kotlinFilePath)
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual).contains("$someSubDir/.editorconfig")
         }
@@ -43,7 +42,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(kotlinFilePath)
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual).contains("$someProjectDirectory/.editorconfig")
         }
@@ -61,7 +60,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(kotlinFilePath)
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual).contains(
                 "$someProjectDirectory/.editorconfig",
@@ -83,7 +82,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(kotlinFilePath)
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual)
                 .contains(
@@ -109,7 +108,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(tempDir.plus(someDirectory))
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual).contains(
                 "$someDirectory/.editorconfig",
@@ -130,7 +129,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(tempDir.plus("$someProjectDirectory/src/main/kotlin"))
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual)
                 .contains(
@@ -154,7 +153,7 @@ class EditorConfigFinderTest {
             val actual =
                 EditorConfigFinder()
                     .findEditorConfigs(tempDir.plus(someProjectDirectory))
-                    .mapNotNull { it.toRelativePathStringIn(tempDir) }
+                    .mapNotNull { it.removePrefixOrNull(tempDir) }
 
             assertThat(actual).contains(
                 "$someProjectDirectory/.editorconfig",
@@ -175,17 +174,17 @@ class EditorConfigFinderTest {
     private fun Path.plus(subPath: String): Path =
         this
             .absolutePathString()
-            .plus(File.separator)
+            .plus(this.fileSystem.separator)
             .plus(subPath)
             .let { Paths.get(it) }
 
-    private fun Path.toRelativePathStringIn(tempDir: Path): String? =
+    private fun Path.removePrefixOrNull(tempDir: Path): String? =
         this
             .absolutePathString()
             .takeIf {
                 // Ignore files created in temp dirs of other tests
                 it.startsWith(tempDir.absolutePathString())
             }?.removePrefix(tempDir.absolutePathString())
-            ?.removePrefix(File.separator)
+            ?.removePrefix(tempDir.fileSystem.separator)
             ?.replace(tempDir.fileSystem.separator, "/")
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -185,7 +185,7 @@ class EditorConfigFinderTest {
                 // Ignore files created in temp dirs of other tests
                 it.startsWith(tempDir)
             }?.absolutePathString()
-            ?.replace(tempDir.fileSystem.separator, "/")
             ?.removePrefix(tempDir.absolutePathString())
             ?.removePrefix(File.separator)
+            ?.replace(tempDir.fileSystem.separator, "/")
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -8,6 +8,9 @@ import kotlin.io.path.writeText
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 
 class EditorConfigFinderTest {
@@ -83,6 +86,174 @@ class EditorConfigFinderTest {
                 EditorConfigFinder()
                     .findEditorConfigs(kotlinFilePath)
                     .mapNotNull { it.removePrefixOrNull(tempDir) }
+
+            assertThat(actual)
+                .contains(
+                    "$someProjectDirectory/src/main/.editorconfig",
+                    "$someProjectDirectory/src/.editorconfig",
+                ).doesNotContain(
+                    "$someProjectDirectory/.editorconfig",
+                )
+        }
+
+        @Test
+        fun `What is happening here 0`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val someProjectDirectory = "some-project"
+            tempDir.createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            tempDir.createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            tempDir.createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = tempDir.createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+
+            assertThat(actual)
+                .contains(
+                    tempDir.plus("$someProjectDirectory/src/main/.editorconfig"),
+                    tempDir.plus("$someProjectDirectory/src/.editorconfig"),
+                ).doesNotContain(
+                    tempDir.plus("$someProjectDirectory/.editorconfig"),
+                )
+        }
+
+        @EnabledOnOs(OS.WINDOWS)
+        @Test
+        fun `What is happening here 1`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val someProjectDirectory = "some-project"
+            tempDir.createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            tempDir.createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            tempDir.createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = tempDir.createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .map { it.absolutePathString() }
+
+            assertThat(actual)
+                .contains(
+                    "$someProjectDirectory/src/main/.editorconfig",
+                    "$someProjectDirectory/src/.editorconfig",
+                ).doesNotContain(
+                    "$someProjectDirectory/.editorconfig",
+                )
+        }
+
+        @EnabledOnOs(OS.WINDOWS)
+        @Test
+        fun `What is happening here 2`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val someProjectDirectory = "some-project"
+            tempDir.createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            tempDir.createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            tempDir.createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = tempDir.createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .mapNotNull {
+                        it
+                            .absolutePathString()
+                            .takeIf {
+                                // Ignore files created in temp dirs of other tests
+                                it.startsWith(tempDir.absolutePathString())
+                            }?.removePrefix(tempDir.absolutePathString())
+                            ?.removePrefix(tempDir.fileSystem.separator)
+                            ?.replace(tempDir.fileSystem.separator, "/")
+                    }
+
+            assertAll(
+                {
+                    assertThat(tempDir.absolutePathString()).isEqualTo("something-else")
+                },
+                {
+                    assertThat(tempDir.fileSystem.separator)
+                        .withFailMessage("Path separator")
+                        .isEqualTo("something-else")
+                },
+                {
+                    assertThat(actual)
+                        .withFailMessage("Actual result")
+                        .contains(
+                            "$someProjectDirectory/src/main/.editorconfig",
+                            "$someProjectDirectory/src/.editorconfig",
+                        ).doesNotContain(
+                            "$someProjectDirectory/.editorconfig",
+                        )
+                },
+            )
+        }
+
+        @EnabledOnOs(OS.WINDOWS)
+        @Test
+        fun `What is happening here 3`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val someProjectDirectory = "some-project"
+            tempDir.createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            tempDir.createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            tempDir.createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = tempDir.createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .mapNotNull {
+                        it
+                            .absolutePathString()
+                            .takeIf {
+                                // Ignore files created in temp dirs of other tests
+                                it.startsWith(tempDir.absolutePathString())
+                            }?.removePrefix(tempDir.absolutePathString())
+                            ?.removePrefix(tempDir.fileSystem.separator)
+                            ?.replace(tempDir.fileSystem.separator, "/")
+                    }
+
+            assertThat(actual)
+                .contains(
+                    "$someProjectDirectory/src/main/.editorconfig",
+                    "$someProjectDirectory/src/.editorconfig",
+                ).doesNotContain(
+                    "$someProjectDirectory/.editorconfig",
+                )
+        }
+
+        @EnabledOnOs(OS.WINDOWS)
+        @Test
+        fun `What is happening here 4`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val someProjectDirectory = "some-project"
+            tempDir.createFile("$someProjectDirectory/src/main/.editorconfig", "root=false")
+            tempDir.createFile("$someProjectDirectory/src/.editorconfig", "root=true")
+            tempDir.createFile("$someProjectDirectory/.editorconfig", "root=true")
+            val kotlinFilePath = tempDir.createFile("$someProjectDirectory/src/main/kotlin/test.kt", "val foo = 42")
+
+            val actual =
+                EditorConfigFinder()
+                    .findEditorConfigs(kotlinFilePath)
+                    .mapNotNull {
+                        it
+                            .absolutePathString()
+                            .takeIf {
+                                // Ignore files created in temp dirs of other tests
+                                it.startsWith(tempDir.absolutePathString())
+                            }?.removePrefix(tempDir.absolutePathString())
+                            ?.removePrefix(tempDir.fileSystem.separator)
+                            ?.replace(tempDir.fileSystem.separator, "/")
+                    }
 
             assertThat(actual)
                 .contains(

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/ThreadSafeEditorConfigCacheTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/ThreadSafeEditorConfigCacheTest.kt
@@ -71,6 +71,18 @@ class ThreadSafeEditorConfigCacheTest {
     }
 
     @Test
+    fun `Given that a file is stored in the cache and then file is explicitly reloaded`() {
+        val threadSafeEditorConfigCache = ThreadSafeEditorConfigCache()
+
+        val editorConfigLoaderFile1 = EditorConfigLoaderMock(EDIT_CONFIG_1)
+        threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1)
+        threadSafeEditorConfigCache.reloadIfExists(FILE_1)
+        threadSafeEditorConfigCache.reloadIfExists(FILE_1)
+
+        assertThat(editorConfigLoaderFile1.loadCount).isEqualTo(3)
+    }
+
+    @Test
     fun `Given that a file is stored in the cache and then the cache is cleared and the file is requested again then the file is to be reloaded`() {
         val threadSafeEditorConfigCache = ThreadSafeEditorConfigCache()
 
@@ -81,18 +93,6 @@ class ThreadSafeEditorConfigCacheTest {
         threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1)
 
         assertThat(editorConfigLoaderFile1.loadCount).isEqualTo(2)
-    }
-
-    @Test
-    fun `Given that a file is stored in the cache and then file is explicitly reloaded`() {
-        val threadSafeEditorConfigCache = ThreadSafeEditorConfigCache()
-
-        val editorConfigLoaderFile1 = EditorConfigLoaderMock(EDIT_CONFIG_1)
-        threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1)
-        threadSafeEditorConfigCache.reloadIfExists(FILE_1)
-        threadSafeEditorConfigCache.reloadIfExists(FILE_1)
-
-        assertThat(editorConfigLoaderFile1.loadCount).isEqualTo(3)
     }
 
     private companion object {


### PR DESCRIPTION
## Description

The list of files which will be accessed by KtLint when linting or formatting a given path can now be retrieved with the new API `KtLint.getInputPaths(path: Path): List<Path>`. Currently, the `.editorconfig` files are the only files which will be accessed during linting or formatting in addition to the source files itself. 

This API can be called with either a file or a directory. It's intended usage is that it is called once with a directory path before actually linting or formatting files. When called with a directory path, all `.editorconfig` in the directory or any of its subdirectories (except hidden directories) are returned. In case the given directory does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned as well until a root `.editorconfig` file is found.

Calling this API with a file path results in the `.editorconfig` files that will be accessed when processing that specific file. In case the directory in which the file resides does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned until a root `.editorconfig` file is found.

Closes #1446

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
