### PR TITLE
Improve caching of API for retrieving the list of files that will be accessed

### DIFF
--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinder.kt
@@ -7,7 +7,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 import kotlin.io.path.isDirectory
+import kotlin.system.measureTimeMillis
 import mu.KotlinLogging
 import org.ec4j.core.Resource
 import org.ec4j.core.ResourcePropertiesService
@@ -17,58 +21,84 @@ import org.jetbrains.kotlin.konan.file.File
 private val logger = KotlinLogging.logger {}.initKtLintKLogger()
 
 internal class EditorConfigFinder {
-    // Do not reuse the generic threadSafeEditorConfigCache to prevent that results are incorrect due to other calls to
-    // KtLint that result in changing the cache
-    private val editorConfigCache = ThreadSafeEditorConfigCache()
-
     /**
      * Finds all relevant ".editorconfig" files for the given path.
      */
     fun findEditorConfigs(path: Path): List<Path> {
+        readWriteLock.read {
+            val cacheValue = inMemoryMap[path]
+                ?.also {
+                    logger.info { "Retrieving EditorConfig cache entry for path $path" }
+                }
+            return cacheValue
+                ?: readWriteLock.write {
+                    cacheEditorConfigs(path)
+                        .also { cacheValue ->
+                            logger.info { "Creating cache entry for path $path with value $cacheValue" }
+                        }
+                }
+        }
+    }
+
+    private fun cacheEditorConfigs(path: Path): List<Path> {
         val result = mutableListOf<Path>()
         val normalizedPath = path.normalize().toAbsolutePath()
         if (path.isDirectory()) {
             result += findEditorConfigsInSubDirectories(normalizedPath)
         }
         result += findEditorConfigsInParentDirectories(normalizedPath)
-        return result
-            .map {
-                // Resolve against original path as the drive letter seems to get lost on WindowsOs
-                path.resolve(it)
-            }.toList()
+
+        val editorConfigPaths =
+            result
+                .map {
+                    // Resolve against original path as the drive letter seems to get lost on WindowsOs
+                    path.resolve(it)
+                }.toList()
+        inMemoryMap[path] = editorConfigPaths
+
+        return editorConfigPaths
     }
 
     private fun findEditorConfigsInSubDirectories(path: Path): List<Path> {
         val result = mutableListOf<Path>()
+        var visitedDirectoryCount = 0
 
-        Files.walkFileTree(
-            path,
-            object : SimpleFileVisitor<Path>() {
-                override fun visitFile(
-                    filePath: Path,
-                    fileAttrs: BasicFileAttributes,
-                ): FileVisitResult {
-                    if (filePath.File().name == ".editorconfig") {
-                        logger.trace { "- File: $filePath: add to list of accessed files" }
-                        result.add(filePath)
+        measureTimeMillis {
+            Files.walkFileTree(
+                path,
+                object : SimpleFileVisitor<Path>() {
+                    override fun visitFile(
+                        filePath: Path,
+                        fileAttrs: BasicFileAttributes,
+                    ): FileVisitResult {
+                        if (filePath.File().name == ".editorconfig") {
+                            logger.trace { "- File: $filePath: add to list of accessed files" }
+                            result.add(filePath)
+                        }
+                        return FileVisitResult.CONTINUE
                     }
-                    return FileVisitResult.CONTINUE
-                }
 
-                override fun preVisitDirectory(
-                    dirPath: Path,
-                    dirAttr: BasicFileAttributes,
-                ): FileVisitResult {
-                    return if (Files.isHidden(dirPath)) {
-                        logger.trace { "- Dir: $dirPath: Ignore" }
-                        FileVisitResult.SKIP_SUBTREE
-                    } else {
-                        logger.trace { "- Dir: $dirPath: Traverse" }
-                        FileVisitResult.CONTINUE
+                    override fun preVisitDirectory(
+                        dirPath: Path,
+                        dirAttr: BasicFileAttributes,
+                    ): FileVisitResult {
+                        visitedDirectoryCount++
+                        return if (Files.isHidden(dirPath)) {
+                            logger.trace { "- Dir: $dirPath: Ignore" }
+                            FileVisitResult.SKIP_SUBTREE
+                        } else {
+                            logger.trace { "- Dir: $dirPath: Traverse" }
+                            FileVisitResult.CONTINUE
+                        }
                     }
-                }
-            },
-        )
+                },
+            )
+        }.also { duration ->
+            // TODO: Remove (or reduce loglevel to debug/trace) before release 0.48
+            logger.info {
+                "Scanning file system to find all '.editorconfig' files in directory '$path' scanned $visitedDirectoryCount directories in $duration ms"
+            }
+        }
 
         return result.toList()
     }
@@ -89,4 +119,13 @@ internal class EditorConfigFinder {
             .cache(editorConfigCache)
             .loader(org.ec4j.core.EditorConfigLoader.of(Version.CURRENT))
             .build()
+
+    private companion object {
+        // Do not reuse the generic threadSafeEditorConfigCache to prevent that results are incorrect due to other
+        // calls to KtLint that result in changing the cache
+        val editorConfigCache = ThreadSafeEditorConfigCache()
+
+        private val readWriteLock = ReentrantReadWriteLock()
+        private val inMemoryMap = HashMap<Path, List<Path>>()
+    }
 }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigFinderTest.kt
@@ -127,7 +127,7 @@ class EditorConfigFinderTest {
         }
 
         @Test
-        fun `Given a directory containing an editorconfig file and multiple subdirectores containing a editorconfig file then get the path of all editorconfig files`(
+        fun `Given a directory containing an editorconfig file and multiple subdirectories containing a editorconfig file then get the path of all editorconfig files`(
             @TempDir
             tempDir: Path,
         ) {


### PR DESCRIPTION
## Description

Attempt to improve performace of API with caching. See #1659 for context.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
