### PR TITLE
Replace FILE_PATH_USER_DATA_KEY with psi filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This API can be called with either a file or a directory. It's intended usage is
 
 Calling this API with a file path results in the `.editorconfig` files that will be accessed when processing that specific file. In case the directory in which the file resides does not contain an `.editorconfig` file or if it does not contain the `root=true` setting, the parent directories are scanned until a root `.editorconfig` file is found.
 
+#### Psi filename replaces FILE_PATH_USER_DATA_KEY
+
+Constant `KtLint.FILE_PATH_USER_DATA_KEY` is deprecated and will be removed in  KtLint version 0.49.0. The file name will be passed correctly to the node with element type FILE and can be retrieved as follows:
+```kotlin
+if (node.isRoot()) {
+    val fileName = (node.psi as? KtFile)?.name
+    ...
+}
+```
+
 ### Added
 * Wrap blocks in case the max line length is exceeded or in case the block contains a new line `wrapping` ([#1643](https://github.com/pinterest/ktlint/issue/1643))
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -30,6 +30,15 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 @Suppress("MemberVisibilityCanBePrivate")
 public object KtLint {
+    @Deprecated(
+        """
+            Marked for removal in KtLint 0.49.0. Use:
+                if (node.isRoot()) {
+                    val fileName = (node.psi as? KtFile)?.name
+                    ...
+                }
+            """,
+    )
     public val FILE_PATH_USER_DATA_KEY: Key<String> = Key<String>("FILE_PATH")
 
     @Deprecated("Marked for removal in Ktlint 0.48.0")

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/RuleExecutionContext.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/RuleExecutionContext.kt
@@ -33,10 +33,10 @@ internal fun createRuleExecutionContext(params: KtLint.ExperimentalParams): Rule
     val normalizedText = normalizeText(params.text)
     val positionInTextLocator = buildPositionInTextLocator(normalizedText)
 
-    val psiFileName = if (params.script) {
-        "file.kts"
-    } else {
-        "file.kt"
+    val psiFileName = when {
+        params.fileName != null -> params.fileName
+        params.script -> "file.kts"
+        else -> "file.kt"
     }
     val psiFile = psiFileFactory.createFileFromText(
         psiFileName,


### PR DESCRIPTION
## Description

The file name which is passed in via the `params.fileName` is now passed to the psi file node. When null, the name `file.kts` or `file.kt` is passed. As of this, the constant `FILE_PATH_USER_DATA_KEY` is no longer required but will only be removed in KtLint 0.49.0.

Closes #1667

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
