### PR TITLE
Enforce trailing commas at declaration site by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Calling this API with a file path results in the `.editorconfig` files that will
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.
+* The default value for trailing comma's on declaration site is changed to `true` unless the `android codestyle` is enabled. Note that KtLint from a consistency viewpoint *enforces* the trailing comma on declaration site while default IntelliJ IDEA formatting only *allows* the trailing comma but leaves it up to the developer's discretion. ([#1669](https://github.com/pinterest/ktlint/pull/1669))
 
 ## [0.47.1] - 2022-09-07
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -176,6 +176,18 @@ Rule id: `trailing-comma-on-call-site`
 
 Consistent removal (default) or adding of trailing comma's on declaration site.
 
+!!! important
+KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at declaration site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
+
+!!! note
+In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
+
+    The Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) encourages the usage of trailing comma's on the declaration site, but leaves it to the developer's discretion to use trailing comma's on the call site. But next to this, it also states that usage of trailing commas has several benefits:
+    
+     * It makes version-control diffs cleaner – as all the focus is on the changed value.
+     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
+     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
+
 Rule id: `trailing-comma-on-declaration-site`
 
 ## Wrapping

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -449,6 +449,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                     BOOLEAN_VALUES_SET,
                 ),
                 defaultValue = true,
+                defaultAndroidValue = false
             )
 
         private val TYPES_ON_DECLARATION_SITE = TokenSet.create(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -448,7 +448,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                     PropertyValueParser.BOOLEAN_VALUE_PARSER,
                     BOOLEAN_VALUES_SET,
                 ),
-                defaultValue = false,
+                defaultValue = true,
             )
 
         private val TYPES_ON_DECLARATION_SITE = TokenSet.create(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -437,7 +437,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                     BOOLEAN_VALUES_SET,
                 ),
                 defaultValue = true,
-                defaultAndroidValue = false
+                defaultAndroidValue = false,
             )
 
         private val TYPES_ON_DECLARATION_SITE = TokenSet.create(


### PR DESCRIPTION
## Description
[Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) says:

>  The Kotlin style guide encourages the use of trailing commas at the declaration site

But ktlint's default config for this rule enforces no comma which directly conflicts with the coding conventions which _encourages_ trailing commas.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
