### PR TITLE
Register missing ktlint_disabled_rules in editorConfigProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Calling this API with a file path results in the `.editorconfig` files that will
 * Let a rule process all nodes even in case the rule is suppressed for a node so that the rule can update the internal state ([#1644](https://github.com/pinterest/ktlint/issue/1644))
 * Read `.editorconfig` when running CLI with options `--stdin` and `--editorconfig` ([#1651](https://github.com/pinterest/ktlint/issue/1651))
 * Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
-* `ktlint_disabled_rules` is missing from `editorConfigProperties`
+* Add missing `ktlint_disabled_rules` to exposed `editorConfigProperties`
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Calling this API with a file path results in the `.editorconfig` files that will
 * Let a rule process all nodes even in case the rule is suppressed for a node so that the rule can update the internal state ([#1644](https://github.com/pinterest/ktlint/issue/1644))
 * Read `.editorconfig` when running CLI with options `--stdin` and `--editorconfig` ([#1651](https://github.com/pinterest/ktlint/issue/1651))
 * Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
+* `ktlint_disabled_rules` is missing from `editorConfigProperties`
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Calling this API with a file path results in the `.editorconfig` files that will
 * Let a rule process all nodes even in case the rule is suppressed for a node so that the rule can update the internal state ([#1644](https://github.com/pinterest/ktlint/issue/1644))
 * Read `.editorconfig` when running CLI with options `--stdin` and `--editorconfig` ([#1651](https://github.com/pinterest/ktlint/issue/1651))
 * Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
-* Add missing `ktlint_disabled_rules` to exposed `editorConfigProperties`
+* Add missing `ktlint_disabled_rules` to exposed `editorConfigProperties` ([#1671](https://github.com/pinterest/ktlint/issue/1671))
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,6 +114,6 @@ Like with other `@Suppress` annotations, it can be placed on targets supported b
 
 
 ## How do I globally disable a rule?
-With [`.editorConfig` property `disabled_rules`](../rules/configuration#disabled-rules) a rule can be disabled globally.
+With [`.editorConfig` property `ktlint_disabled_rules`](../rules/configuration-ktlint#disabled-rules) a rule can be disabled globally.
 
 You may also pass a list of disabled rules via the `--disabled_rules` command line flag. It has the same syntax as the EditorConfig property.

--- a/docs/rules/configuration-ktlint.md
+++ b/docs/rules/configuration-ktlint.md
@@ -15,12 +15,12 @@ ktlint_code_style = official
 
 ## Disabled rules
 
-By default, no rules are disabled. The property `disabled_rules` holds a comma separated list (without spaces). Rules which are not defined in the `standard` ruleset have to be prefixed. Rules defined in the `standard` ruleset may optionally be prefixed.
+By default, no rules are disabled. The property `ktlint_disabled_rules` holds a comma separated list (without spaces). Rules which are not defined in the `standard` ruleset have to be prefixed. Rules defined in the `standard` ruleset may optionally be prefixed.
 
 Example:
 ```ini
 [*.{kt,kts}]
-disabled_rules = some-standard-rule,experimental:some-experimental-rule,my-custom-ruleset:my-custom-rule
+ktlint_disabled_rules = some-standard-rule,experimental:some-experimental-rule,my-custom-ruleset:my-custom-rule
 ```
 
 ## Final newline
@@ -205,9 +205,9 @@ This setting only takes effect when rule `trailing-comma-on-declaration-site` is
 You can [override](https://editorconfig.org/#file-format-details) properties for specific directories inside your project:
 ```ini
 [*.{kt,kts}]
-disabled_rules=import-ordering
+ktlint_disabled_rules=import-ordering
 
  Note that in this case 'import-ordering' rule will be active and 'indent' will be disabled
 [api/*.{kt,kts}]
-disabled_rules=indent
+ktlint_disabled_rules=indent
 ```

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -331,6 +331,7 @@ public object DefaultEditorConfigProperties : UsesEditorConfigProperties {
     override val editorConfigProperties: List<UsesEditorConfigProperties.EditorConfigProperty<*>> = listOf(
         codeStyleSetProperty,
         disabledRulesProperty,
+        ktlintDisabledRulesProperty,
         indentStyleProperty,
         indentSizeProperty,
         insertNewLineProperty,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -36,6 +36,7 @@ internal class EditorConfigGeneratorTest {
             "indent_style = space",
             "insert_final_newline = true",
             "ktlint_code_style = official",
+            "ktlint_disabled_rules = ",
             "max_line_length = -1",
         )
     }

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -140,7 +140,7 @@ internal class EditorConfigGeneratorTest {
             $PROPERTY_1_NAME = false
             """.trimIndent(),
         )
-in
+
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -140,7 +140,7 @@ internal class EditorConfigGeneratorTest {
             $PROPERTY_1_NAME = false
             """.trimIndent(),
         )
-
+in
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,


### PR DESCRIPTION
## Description

`editorConfigProperties` seemed to be missing the newly created `ktlintDisabledRulesProperty`. For any downstream plugins that rely on this value to know what properties are valid for ktlint, they may filter out anything but these properties. 

Ultimately, this could leads to errors like the following if that's the only editor config override provided:
>Can not create an EditorConfigOverride without properties. Use 'emptyEditorConfigOverride' instead.

Or if it's not, I can safely assume that the disabled rules will be ignored if `disabled_rules` aren't provided as well.

Currently, `disabled_rules` still works but it spams a lot of messages stating that it is disabled. I find this to be an unpleasant developer experience and also leads to confusion for a developer who is simply switching to `ktlint_disabled_rules` from `disabled_rules` only to find that their disabled rules are no longer honored.

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue than provide a link to that issue. -->

I did not find an issue reported regarding this issue, but please feel free to link any issues if I missed something.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
