### PR TITLE
Function signature preceded by an annotation array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ if (node.isRoot()) {
 * Read `.editorconfig` when running CLI with options `--stdin` and `--editorconfig` ([#1651](https://github.com/pinterest/ktlint/issue/1651))
 * Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
 * Add missing `ktlint_disabled_rules` to exposed `editorConfigProperties` ([#1671](https://github.com/pinterest/ktlint/issue/1671))
+* A function signature preceded by an annotation array should be handled similar as function preceded by a singular annotation `function-signature` ([#1690](https://github.com/pinterest/ktlint/issue/1690))
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.indentStylePr
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.maxLineLengthProperty
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
@@ -132,7 +133,9 @@ public class FunctionSignatureRule :
                 var currentNode: ASTNode
                 while (iterator.hasNext()) {
                     currentNode = iterator.next()
-                    if (currentNode.elementType != ANNOTATION_ENTRY && currentNode.elementType != WHITE_SPACE) {
+                    if (currentNode.elementType != ANNOTATION &&
+                        currentNode.elementType != ANNOTATION_ENTRY &&
+                        currentNode.elementType != WHITE_SPACE) {
                         return currentNode
                     }
                 }

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -135,7 +135,8 @@ public class FunctionSignatureRule :
                     currentNode = iterator.next()
                     if (currentNode.elementType != ANNOTATION &&
                         currentNode.elementType != ANNOTATION_ENTRY &&
-                        currentNode.elementType != WHITE_SPACE) {
+                        currentNode.elementType != WHITE_SPACE
+                    ) {
                         return currentNode
                     }
                 }

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -1046,6 +1046,36 @@ class FunctionSignatureRuleTest {
             .hasNoLintViolations()
     }
 
+    @Test
+    fun `Issue 1690 - Given a function preceded by an annotation array`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            internal fun foo1(foo1: Foo, foo2: Foo): Foo =
+                "foooooooooooooooooooooooooooooooooooooo"
+
+            @Bar
+            internal fun foo2(foo1: Foo, foo2: Foo): Foo =
+                "foooooooooooooooooooooooooooooooooooooo"
+
+            @[Bar]
+            internal fun foo2(foo1: Foo, foo2: Foo): Foo =
+                "foooooooooooooooooooooooooooooooooooooo"
+
+            @[Bar1 Bar2 Bar3 Bar4 Bar5 Bar6 Bar7 Bar8 Bar9]
+            internal fun foo2(foo1: Foo, foo2: Foo): Foo =
+                "foooooooooooooooooooooooooooooooooooooo"
+
+            @[Bar1 // some comment
+            Bar2]
+            internal fun foo2(foo1: Foo, foo2: Foo): Foo =
+                "foooooooooooooooooooooooooooooooooooooo"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
     private companion object {
         const val EOL_CHAR = '#'
         const val UNEXPECTED_SPACES = "  "


### PR DESCRIPTION
## Description

Handle function signature preceded by an annotation array similar to function preceded by a singular annotation

Closes #1690

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
