### PR TITLE
Trailing comma followed by a KDOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ if (node.isRoot()) {
 * Read `.editorconfig` when running CLI with options `--stdin` and `--editorconfig` ([#1651](https://github.com/pinterest/ktlint/issue/1651))
 * Do not add a trailing comma in case a multiline function call argument is found but no newline between the arguments `trailing-comma-on-call-site` ([#1642](https://github.com/pinterest/ktlint/issue/1642))
 * Add missing `ktlint_disabled_rules` to exposed `editorConfigProperties` ([#1671](https://github.com/pinterest/ktlint/issue/1671))
+* Do not add a second trailing comma, if the original trailing comma is followed by a KDOC `trailing-comma-on-declaration-site` and `trailing-comma-on-call-site` ([#1676](https://github.com/pinterest/ktlint/issue/1676))
 
 ### Changed
 * Update Kotlin development version to `1.7.20` and Kotlin version to `1.7.20`.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/package.kt
@@ -206,6 +206,13 @@ public fun ASTNode?.isWhiteSpaceWithoutNewline(): Boolean =
 public fun ASTNode.isRoot(): Boolean = elementType == ElementType.FILE
 public fun ASTNode.isLeaf(): Boolean = firstChildNode == null
 
+/**
+ * Check if the given [ASTNode] is a code leaf. E.g. it must be a leaf and may not be a whitespace or be part of a
+ * comment.
+ */
+public fun ASTNode.isCodeLeaf(): Boolean =
+    isLeaf() && !isWhiteSpace() && !isPartOfComment()
+
 public fun ASTNode.isPartOfComment(): Boolean =
     parent({ it.psi is PsiComment }, strict = false) != null
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRuleTest.kt
@@ -513,4 +513,27 @@ class TrailingCommaOnCallSiteRuleTest {
             .withEditorConfigOverride(allowTrailingCommaOnCallSiteProperty to true)
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 1676 - Given a trailing comma followed by a kdoc then do no add another trailing comma`() {
+        val code =
+            """
+            val foo1 = setOf(
+                1, /** Comment */
+            )
+            val foo1 = setOf(
+                2,
+                /** Comment */
+            )
+            val foo3 = setOf(
+                3,
+                /**
+                 * Comment
+                 */
+            )
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(TrailingCommaOnDeclarationSiteRule.allowTrailingCommaProperty to true)
+            .hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -957,4 +957,27 @@ class TrailingCommaOnDeclarationSiteRuleTest {
             .hasLintViolation(3, 15, "Missing trailing comma before \";\"")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 1676 - Given a trailing comma followed by a kdoc then do no add another trailing comma`() {
+        val code =
+            """
+            fun foo(
+                val bar: Bar, /** Comment */
+            )
+            fun foo(
+                val bar: Bar,
+                /** Comment */
+            )
+            fun foo(
+                val bar: Bar,
+                /**
+                 * Comment
+                 */
+            )
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(allowTrailingCommaProperty to true)
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not add a second trailing comma, if the original trailing comma is followed by a KDOC

Closes #1676

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
