### PR TITLE
Refactor exception handling during lint and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Class `com.pinterest.ktlint.core.KtLintParseException` has been replaced with `c
 
 #### RuleExecutionException
 
-Class `com.pinterest.ktlint.core.KtLintRuleExecutionException` has been replaced with `com.pinterest.ktlint.core.api.KtLintRuleExecutionException`.
+Class `com.pinterest.ktlint.core.RuleExecutionException` has been replaced with `com.pinterest.ktlint.core.api.KtLintRuleException`.
 
 #### Color
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
@@ -289,21 +289,25 @@ public object KtLint {
         }
         if (tripped) {
             try {
-            visitorProvider
-                .visitor(ruleExecutionContext.editorConfigProperties)
-                .invoke { rule, fqRuleId ->
-                    ruleExecutionContext.executeRule(rule, fqRuleId, false) { offset, errorMessage, canBeAutoCorrected ->
-                        val (line, col) = ruleExecutionContext.positionInTextLocator(offset)
-                        errors.add(
-                            Pair(
-                                LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected),
-                                // It is assumed that a rule only corrects an error after it has emitted an
-                                // error and indicating that it actually can be autocorrected.
-                                false,
-                            ),
-                        )
+                visitorProvider
+                    .visitor(ruleExecutionContext.editorConfigProperties)
+                    .invoke { rule, fqRuleId ->
+                        ruleExecutionContext.executeRule(
+                            rule,
+                            fqRuleId,
+                            false,
+                        ) { offset, errorMessage, canBeAutoCorrected ->
+                            val (line, col) = ruleExecutionContext.positionInTextLocator(offset)
+                            errors.add(
+                                Pair(
+                                    LintError(line, col, fqRuleId, errorMessage, canBeAutoCorrected),
+                                    // It is assumed that a rule only corrects an error after it has emitted an
+                                    // error and indicating that it actually can be autocorrected.
+                                    false,
+                                ),
+                            )
+                        }
                     }
-                }
             } catch (e: RuleExecutionException) {
                 throw e.toKtLintRuleException(params.fileName)
             }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/KtLintRuleException.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/KtLintRuleException.kt
@@ -1,15 +1,17 @@
 package com.pinterest.ktlint.core.api
 
 /**
- * [KtLintRuleExecutionException] is thrown whenever an error occurs during execution of a KtLint [Rule].
+ * [KtLintRuleException] is thrown whenever an error occurs during execution of a KtLint [Rule].
  *
  * @param line line number (one-based)
  * @param col column number (one-based)
  * @param ruleId rule id (prepended with "&lt;ruleSetId&gt;:" in case of non-standard ruleset)
+ * @param message description or error
  */
-public class KtLintRuleExecutionException(
+public class KtLintRuleException(
     public val line: Int,
     public val col: Int,
     public val ruleId: String,
-    cause: Throwable,
-) : RuntimeException(cause)
+    override val message: String,
+    override val cause: Throwable,
+) : RuntimeException(message, cause)

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -15,7 +15,7 @@ import com.pinterest.ktlint.core.api.EditorConfigDefaults
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.EditorConfigOverride.Companion.plus
 import com.pinterest.ktlint.core.api.KtLintParseException
-import com.pinterest.ktlint.core.api.KtLintRuleExecutionException
+import com.pinterest.ktlint.core.api.KtLintRuleException
 import com.pinterest.ktlint.core.api.doesNotContain
 import com.pinterest.ktlint.core.api.loadBaseline
 import com.pinterest.ktlint.core.api.relativeRoute
@@ -554,7 +554,7 @@ internal class KtlintCommandLine {
                     "",
                     "Not a valid Kotlin file (${e.message?.lowercase(Locale.getDefault())})",
                 )
-            is KtLintRuleExecutionException -> {
+            is KtLintRuleException -> {
                 logger.debug("Internal Error (${e.ruleId}) in file '$filename' at position '${e.line}:${e.col}", e)
                 LintError(
                     e.line,


### PR DESCRIPTION
## Description

Refactor exception handling during lint and format. Reduce length of stacktrace by propagating root cause only. Add filename to exception message.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
