### PR TITLE
Fix links on main doc page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 /.idea
 *.iml
 out
+/site

--- a/RELEASE_TESTING.MD
+++ b/RELEASE_TESTING.MD
@@ -1,6 +1,6 @@
 # Release testing
 
-Before releasing a new version of KtLint, the release candidate is tested on a selection of open source projects to improve the quality of the release.
+Before releasing a new version of KtLint, the release candidate is tested on a selection of open source projects to improve the quality of the release, and the documentation is tested for dead links.
 
 ## Setup infrastructure
 
@@ -114,3 +114,7 @@ Formatting projects in which ktlint is not used may result in a huge amount of f
    ktlint-dev --experimental --baseline=baseline.xml --relative # Do not call this command via the "./exec-in-each-project.sh" script as we want to use the one combined baseline.xml file for all projects.
    ```
    No violations should be expected.
+
+## Checking documentation
+[The documentation for KtLint](https://pinterest.github.io/ktlint/) should be checked for dead links.
+Follow the instructions for building the documentation in `/docs/readme.md`, and use a tool such as [Broken Link Checker Tool](https://www.deadlinkchecker.com/website-dead-link-checker.asp) to find broken links.

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -12,7 +12,7 @@ If you've found a security issue in one of our open source projects, please repo
 
 ## Code of Conduct
 
-Please be sure to read and understand our [`CODE_OF_CONDUCT.md`](/CODE_OF_CONDUCT.md). We work hard to ensure that our projects are welcoming and inclusive to as many people as possible.
+Please be sure to read and understand our [code of conduct](../code-of-conduct/). We work hard to ensure that our projects are welcoming and inclusive to as many people as possible.
 
 ## Reporting Issues
 

--- a/docs/extensions/custom-reporter.md
+++ b/docs/extensions/custom-reporter.md
@@ -1,9 +1,9 @@
 ## Build a custom reporter
-Take a look at [ktlint-reporter-plain](ktlint-reporter-plain).
+Take a look at [ktlint-reporter-plain](https://github.com/pinterest/ktlint/tree/master/ktlint-reporter-plain).
 
 In short, all you need to do is to implement a
-[Reporter](/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Reporter.kt) and make it available by registering
-a custom [ReporterProvider](/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt) using
+[Reporter](https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Reporter.kt) and make it available by registering
+a custom [ReporterProvider](https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ReporterProvider.kt) using
 `META-INF/services/com.pinterest.ktlint.core.ReporterProvider`. Pack all of that into a JAR and you're done.
 
 To load a custom (3rd party) reporter use `ktlint --reporter=name,artifact=/path/to/custom-ktlint-reporter.jar`

--- a/docs/extensions/custom-rule-set.md
+++ b/docs/extensions/custom-rule-set.md
@@ -1,13 +1,13 @@
 !!! Tip
     See [Writing your first ktlint rule](https://medium.com/@vanniktech/writing-your-first-ktlint-rule-5a1707f4ca5b) by [Niklas Baudy](https://github.com/vanniktech).
 
-In a nutshell: a "rule set" is a JAR containing one or more [Rule](/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt)s. `ktlint` is relying on the
+In a nutshell: a "rule set" is a JAR containing one or more [Rule](https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt)s. `ktlint` is relying on the
 [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) to discover all available "RuleSet"s on the classpath. As a ruleset author, all you need to do is to include a `META-INF/services/com.pinterest.ktlint.core.RuleSetProviderV2` file
-containing a fully qualified name of your [RuleSetProviderV2](/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt) implementation.
+containing a fully qualified name of your [RuleSetProviderV2](https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt) implementation.
 
 ## ktlint-ruleset-template
 
-A complete sample project (with tests and build files) is included in this repo under the [ktlint-ruleset-template](ktlint-ruleset-template) directory (make sure to check [NoVarRuleTest](/ktlint-ruleset-template/src/test/kotlin/yourpkgname/NoVarRuleTest.kt) as it contains some useful information).
+A complete sample project (with tests and build files) is included in this repo under the [ktlint-ruleset-template](https://github.com/pinterest/ktlint/tree/master/ktlint-ruleset-template) directory (make sure to check [NoVarRuleTest](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-template/src/test/kotlin/yourpkgname/NoVarRuleTest.kt) as it contains some useful information).
 
 ```shell title="Building the ktlint-ruleset-template"
 $ cd ktlint-ruleset-template/
@@ -70,7 +70,7 @@ $ ktlint -R build/libs/ktlint-ruleset-template.jar --log-level=debug --relative 
 
 ## AST
 
-While writing/debugging [Rule](/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt)s it's often helpful to have an AST
+While writing/debugging [Rule](https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt)s it's often helpful to have an AST
 printed out to see the structure rules have to work with. ktlint >= 0.15.0 has a `printAST` subcommand (or `--print-ast` flag for ktlint < 0.34.0) specifically for this purpose
 (usage: `ktlint --color printAST <file>`).
 An example of the output is shown below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,16 +20,16 @@
 - **No configuration required**  
  `ktlint` aims to capture the [official Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) and [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html). In some aspects `ktlint` is a bit more strict[*](https://github.com/pinterest/ktlint/issues/284#issuecomment-425177186).
 - **Rule sets**  
-  `ktlint` offers a `standard` and an `experimental` rule set. Next to this, it is easy to provide [custom rule sets](#creating-a-ruleset).
+  `ktlint` offers a `standard` and an `experimental` rule set. Next to this, it is easy to provide [custom rule sets](https://pinterest.github.io/ktlint/extensions/custom-rule-set/).
 - **.editorconfig**  
-  Some rules do allow further configuration, but in all cases a reasonable default is set when not provided. `ktlint` primarily uses the [.editorconfig file](#editorconfig) to read default `.editorconfig`, IntelliJ IDEA specific and Ktlint specific properties.
+  Some rules do allow further configuration, but in all cases a reasonable default is set when not provided. `ktlint` primarily uses the [.editorconfig file](https://pinterest.github.io/ktlint/rules/configuration-ktlint/#overriding-editorconfig-properties-for-specific-directories) to read default `.editorconfig`, IntelliJ IDEA specific and Ktlint specific properties.
 - **Disable rules**  
   If need be, rules can be disabled easily[*](https://pinterest.github.io/ktlint/faq/#how-do-i-globally-disable-a-rule).
 - **Built-in formatter**  
   Most lint violations don't need to be fixed manually. `ktlint` has a built-in formatter which fixes violations when possible. Some violations can not be fixed in a deterministic way, and need manual action.
-- **Customizable output**  
+- **Customizable output**
   Several reporters are available out-of-the-box: `plain` (+ `plain?group_by_file`), `plain-summary`, `json`, `html` and `checkstyle`.
-  It's also easy to [create a custom reporter](#creating-a-reporter).
+  It's also easy to [create a custom reporter](https://pinterest.github.io/ktlint/extensions/custom-reporter/).
 - **Executable jar**  
   `ktlint` is released as a single executable jar with all dependencies included.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,16 +20,16 @@
 - **No configuration required**  
  `ktlint` aims to capture the [official Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) and [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html). In some aspects `ktlint` is a bit more strict[*](https://github.com/pinterest/ktlint/issues/284#issuecomment-425177186).
 - **Rule sets**  
-  `ktlint` offers a `standard` and an `experimental` rule set. Next to this, it is easy to provide [custom rule sets](https://pinterest.github.io/ktlint/extensions/custom-rule-set/).
+  `ktlint` offers a `standard` and an `experimental` rule set. Next to this, it is easy to provide [custom rule sets](extensions/custom-rule-set/).
 - **.editorconfig**  
-  Some rules do allow further configuration, but in all cases a reasonable default is set when not provided. `ktlint` primarily uses the [.editorconfig file](https://pinterest.github.io/ktlint/rules/configuration-ktlint/#overriding-editorconfig-properties-for-specific-directories) to read default `.editorconfig`, IntelliJ IDEA specific and Ktlint specific properties.
+  Some rules do allow further configuration, but in all cases a reasonable default is set when not provided. `ktlint` primarily uses the [.editorconfig file](rules/configuration-ktlint/) to read default `.editorconfig`, IntelliJ IDEA specific and Ktlint specific properties.
 - **Disable rules**  
-  If need be, rules can be disabled easily[*](https://pinterest.github.io/ktlint/faq/#how-do-i-globally-disable-a-rule).
+  If need be, rules can be disabled easily[*](faq/#how-do-i-globally-disable-a-rule).
 - **Built-in formatter**  
   Most lint violations don't need to be fixed manually. `ktlint` has a built-in formatter which fixes violations when possible. Some violations can not be fixed in a deterministic way, and need manual action.
 - **Customizable output**
   Several reporters are available out-of-the-box: `plain` (+ `plain?group_by_file`), `plain-summary`, `json`, `html` and `checkstyle`.
-  It's also easy to [create a custom reporter](https://pinterest.github.io/ktlint/extensions/custom-reporter/).
+  It's also easy to [create a custom reporter](extensions/custom-reporter/).
 - **Executable jar**  
   `ktlint` is released as a single executable jar with all dependencies included.
 

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -131,7 +131,7 @@ By default, the `info` log level is used meaning that all log lines at level `in
 
 ### Rule configuration (`.editorconfig`)
 
-Some rules can be tweaked via the [`editorconfig file`](rules/configuration-ktlint/).
+Some rules can be tweaked via the [`editorconfig file`](../../rules/configuration-ktlint/).
 
 A scaffold of the `.editorconfig file` can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -54,19 +54,19 @@ On Arch Linux install package [ktlint <sup>AUR</sup>](https://aur.archlinux.org/
 
 ### Rule set(s)
 
-When no arguments are specified, the style of all Kotlin files (ending with '.kt' or '.kts') inside the current dir (recursively) are validated with the rules from the [standard ruleset](https://pinterest.github.io/ktlint/rules/standard/). Hidden folders will be skipped.
+When no arguments are specified, the style of all Kotlin files (ending with '.kt' or '.kts') inside the current dir (recursively) are validated with the rules from the [standard ruleset](../../rules/standard/). Hidden folders will be skipped.
 
 ```shell title="Default validation with standard ruleset"
 ktlint
 ```
 
-To validate with the [standard ruleset](https://pinterest.github.io/ktlint/rules/standard/) and the [experimental rulesset](https://pinterest.github.io/ktlint/rules/experimental/) run command below: 
+To validate with the [standard ruleset](../../rules/standard/) and the [experimental rulesset](../../rules/experimental/) run command below: 
 
 ```shell title="Validation with standard and experimental ruleset"
 ktlint --experimental
 ```
 
-To validate with a [custom ruleset](https://pinterest.github.io/ktlint/extensions/custom-rule-set/) run command below:  
+To validate with a [custom ruleset](../../extensions/custom-rule-set/) run command below:  
 
 ```shell title="Validation with standard and a custom ruleset"
 ktlint --ruleset=/path/to/custom-ruleset.jar
@@ -131,7 +131,7 @@ By default, the `info` log level is used meaning that all log lines at level `in
 
 ### Rule configuration (`.editorconfig`)
 
-Some rules can be tweaked via the [`editorconfig file`](https://pinterest.github.io/ktlint/rules/configuration/).
+Some rules can be tweaked via the [`editorconfig file`](rules/configuration-ktlint/).
 
 A scaffold of the `.editorconfig file` can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
@@ -170,7 +170,7 @@ ktlint --stdin -F
 
 !!! tip Suppress logging and error output
     Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
-    Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#error-reporting) to write the error output to a file.
+    Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
 
 
 ### Git hooks
@@ -187,11 +187,11 @@ ktlint installGitPrePushHook
 
 ### Miscellaneous flags and commands
 
-`-a` or `--android`: Turn on Android Kotlin Style Guide compatibility. This flag is most likely to be removed in a future version. Use `.editorconfig ktlint_code_style`(https://pinterest.github.io/ktlint/rules/configuration/#code-style). 
+`-a` or `--android`: Turn on Android Kotlin Style Guide compatibility. This flag is most likely to be removed in a future version. Use [`.editorconfig ktlint_code_style`](../../rules/configuration-ktlint/#code-style). 
 
 `--color` and `--color-name=<colorName>`: Make output colorful and optionally set the color name to use.
 
-`--disabled_rules=<disabledRules>`: A comma-separated list of rules to globally disable. To disable the standard ktlint rule-set use `--disabled_rules=standard`.  This flag is most likely to be removed in a future version. Use `.editorconfig disabled_rules`(https://pinterest.github.io/ktlint/rules/configuration/#disabled-rules).
+`--disabled_rules=<disabledRules>`: A comma-separated list of rules to globally disable. To disable the standard ktlint rule-set use `--disabled_rules=standard`.  This flag is most likely to be removed in a future version. Use [`.editorconfig disabled_rules`](../../rules/configuration-ktlint/#disabled-rules).
 
 `-h` or `--help`: Prints help information.
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,17 +4,29 @@ The documentation of ktlint is served with [mkdocs-material](https://squidfunk.g
 
 To build and test documentation on your local development machine, follow steps below:
 
-* In IntelliJ IDEA
-  * Open `Preferences`
-  * Search for `JSON Schema mappings`
-  * Add new schema for url `https://squidfunk.github.io/mkdocs-material/schema.json` and add file `mkdocs.yml` for this url.
-* Pull docker image
-  ```shell
-  $ docker pull squidfunk/mkdocs-material
-  ```
-* Start mkdocs server from root of project (e.g. from same directory where file mkdocs.yml is located) 
-  ```shell
-  docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
-  ```
-* Visit page `http://0.0.0.0:8000/` in your browser.
-* Edit the documentation and explicitly save the file. The mkdocs server refreshes its cached and the current page in the browser is automatically refreshed.
+## Setup
+1. In IntelliJ IDEA
+    * Open `Preferences`
+    * Search for `JSON Schema mappings`
+    * Add new schema for url `https://squidfunk.github.io/mkdocs-material/schema.json` and add file `mkdocs.yml` for this url.
+2. Pull docker image
+   ```shell
+   $ docker pull squidfunk/mkdocs-material
+   ```
+
+## Build server
+The following steps build and host the documentation locally, updating automatically whenever a local file is changed.
+
+1. Start mkdocs server from root of project (e.g. from same directory where file mkdocs.yml is located)
+   ```shell
+   docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+   ```
+2. Visit page `http://0.0.0.0:8000/` in your browser.
+3. Edit the documentation and explicitly save the file. The mkdocs server refreshes its cached and the current page in the browser is automatically refreshed.
+
+## Build once
+If you do not want to run a local server, or if you want to inspect the built files, you can run the following command from the project's main directory to build the documentation in the `site/` directory.
+
+```shell
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material build
+```

--- a/docs/rules/dependencies.md
+++ b/docs/rules/dependencies.md
@@ -1,3 +1,3 @@
 Preferably rules run independent of each other. In some case this is however not feasible. The diagram below shows the dependencies between the rules (both standard and experimental) provided by KtLint.
 
-![Image](/assets/images/rule-dependencies.png)
+![Image](../../assets/images/rule-dependencies.png)

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -30,7 +30,7 @@ Rule id: `filename`
 
 Ensures consistent usage of a newline at the end of each file. 
 
-This rule can be configured with `.editorconfig` property [`insert_final_newline`](../configuration/#final-newline).
+This rule can be configured with `.editorconfig` property [`insert_final_newline`](../configuration-ktlint/#final-newline).
 
 Rule id: `final-newline`
 
@@ -42,13 +42,13 @@ Rule id: `import-ordering`
 
 ## Indentation
 
-Indentation formatting - respects `.editorconfig` `indent_size` with no continuation indent (see [EditorConfig](#editorconfig) section for more).
+Indentation formatting - respects `.editorconfig` `indent_size` with no continuation indent (see [EditorConfig](../configuration-ktlint/) section for more).
 
 Rule id: `indent`
 
 ## Max line length
 
-Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](#editorconfig) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to and comment that disables ktlint rules than that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
+Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to and comment that disables ktlint rules than that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
 
 Rule id: `max-line-length`
 


### PR DESCRIPTION
## Description
[The website's front page](https://pinterest.github.io/ktlint/) has a few broken links. They use anchors (e.g. `#editorconfig`), but clicking them doesn't do anything.

I tried to fix them by changing them to absolute links. I considered using relative links, but saw that that page also has other absolute links to the documentation itself.

I wasn't sure where to link the `#editorconfig` to, because there are multiple places where EditorConfig is discussed in different ways. In the end I just guessed which one would be more appropriate, but maybe the right answer was to remove the link?

## Checklist
- [x] PR description added
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated

PS: I just noticed there are also other dead links on the website :/
PPS: In the [rule configuration section](https://pinterest.github.io/ktlint/install/cli/#rule-configuration-editorconfig), there is a link to [another rule configuration section](https://pinterest.github.io/ktlint/rules/configuration/), but [that page](https://pinterest.github.io/ktlint/rules/configuration/) is _totally_ broken. Would you like me to open an issue for that?