### PR TITLE
Fix githubRelease script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,16 +77,7 @@ githubRelease {
     tagName(project.property("VERSION_NAME").toString())
     releaseName(project.property("VERSION_NAME").toString())
     targetCommitish("master")
-    releaseAssets(
-        project.files(
-            provider {
-                // "shadowJarExecutableChecksum" task does not declare checksum files
-                // as output, only the whole output directory. As it uses the same directory
-                // as "shadowJarExecutable" - just pass all the files from that directory
-                shadowJarExecutable.get().outputs.files.files.first().parentFile.listFiles()
-            },
-        ),
-    )
+    releaseAssets.from(provider { shadowJarExecutable.get().outputs.files.files.first().parentFile })
     overwrite(true)
     dryRun(false)
     body {


### PR DESCRIPTION
Previously, the task would throw an error:

```
$ ./gradlew githubRelease
Type-safe project accessors is an incubating feature.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':githubRelease'.
> Cannot query the value of this provider because it has no value available.
```

Tested via a dry run:
```
./gradlew githubRelease
Type-safe project accessors is an incubating feature.

> Task :githubRelease
Execution optimizations have been disabled for task ':githubRelease' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/shasha/code/ktlint/ktlint/build/run'. Reason: Task ':githubRelease' uses this output of task ':ktlint:shadowJarExecutableChecksum' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [CREATING NEW RELEASE
{
    tag_name               = 0.48.0
    target_commitish       = master
    name                   = 0.48.0
    generate_release_notes = false
    body                   =
        ## [0.48.0] - 2022-10-15

    <clip>

    draft                  = false
    prerelease             = false
}]
:githubRelease [UPLOADING /Users/shasha/code/ktlint/ktlint/build/run]
```

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue than provide a link to that issue. -->
