### PR TITLE
Temporarily hardcode the list of files to upload to github

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,9 +65,14 @@ val shadowJarExecutable: TaskProvider<Task> by lazy {
     projects.ktlint.dependencyProject.tasks.named("shadowJarExecutable")
 }
 
+val shadowJarExecutableChecksum: TaskProvider<Task> by lazy {
+    projects.ktlint.dependencyProject.tasks.named("shadowJarExecutableChecksum")
+}
+
 // Explicitly adding dependency on "shadowJarExecutable" as Gradle does not it set via "releaseAssets" property
 tasks.githubRelease {
     dependsOn(provider { shadowJarExecutable })
+    dependsOn(provider { shadowJarExecutableChecksum })
 }
 
 githubRelease {
@@ -77,7 +82,13 @@ githubRelease {
     tagName(project.property("VERSION_NAME").toString())
     releaseName(project.property("VERSION_NAME").toString())
     targetCommitish("master")
-    releaseAssets.from(provider { shadowJarExecutable.get().outputs.files.files.first().parentFile })
+    releaseAssets.from(
+        // Temp: Hardcode the list of files to upload
+        project.file("ktlint/build/run/ktlint"),
+        project.file("ktlint/build/run/ktlint.md5"),
+        project.file("ktlint/build/run/ktlint.asc"),
+        project.file("ktlint/build/run/ktlint.asc.md5"),
+    )
     overwrite(true)
     dryRun(false)
     body {


### PR DESCRIPTION
My previous fix for the githubRelease task didn't work, so temporarily hardcoding the files to upload.

cc @Goooler 

Despite the output being wrapped in a provider, if you clean first, running githubRelease as it was (both before and after my fix) results in the following error:
```
./gradlew githubRelease
Type-safe project accessors is an incubating feature.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':githubRelease'.
> Cannot query the value of this provider because it has no value available.
```

Do you think this needs to be fixed in the plugin or on our side? It seems to be querying the `releaseAssets` files at config time.

Dry run output:

```
> Task :githubRelease
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [CREATING NEW RELEASE 
{
    tag_name               = 0.49.0
    target_commitish       = master
    name                   = 0.49.0
    generate_release_notes = false
    body                   = 
    <clip> 
    draft                  = false
    prerelease             = false
}]
:githubRelease [UPLOADING /Users/shasha/code/ktlint/ktlint/build/run/ktlint]
:githubRelease [UPLOADING /Users/shasha/code/ktlint/ktlint/build/run/ktlint.md5]
:githubRelease [UPLOADING /Users/shasha/code/ktlint/ktlint/build/run/ktlint.asc]
:githubRelease [UPLOADING /Users/shasha/code/ktlint/ktlint/build/run/ktlint.asc.md5]
```