### PR TITLE
Add `ktlint_official` codestyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### API changes
+
+#### EditorConfigProperty
+
+Field `defaultAndroidValue` has been renamed to `intellijIdeaCodeStyleDefaultValue`. Note that also new fields `ktlintOfficialCodeStyleDefaultValue` and `intellijIdeaCodeStyleDefaultValue`. Read more about this in the section "Ktlint Official code style".
+
+
+### 'Ktlint Official` code style and renaming of existing code styles
+
+A new code style with name `ktlint_offical` has been added. This code style makes it possible to innovate ktlint beyond current expectations of users that are familiar with the existing code styles. 
+
+The `ktlint_official` code style combines the best elements from the Kotlin Coding conventions (https://kotlinlang.org/docs/coding-conventions.html) and Android's Kotlin styleguide (https://developer.android.com/kotlin/style-guide). This codestyle also provides additional formatting on topics which are not (explicitly) mentioned in the before mentioned styleguide. Also, this code style sometimes formats code in a way which is not accepted by the default code formatters in IntelliJ IDEA and Android Studio. The formatters of those editors produce nicely formatted code in the vast majority of cases. But in a number of edge cases, the formatting contains bugs which are waiting to be fixed for several years. The new code style formats code in a way which is compatible with the default formatting of the editors whenever possible. When using this codestyle, it is best to disable (e.g. not use) code formatting in the editor. In the long run, this code style becomes the default code style provided by KtLint.
+
+The `official` code style has been renamed to `intellij_idea`. Code formatted with this code style aims to be compatible with default formatter of IntelliJ IDEA. This code style is based on Kotlin Coding conventions (https://kotlinlang.org/docs/coding-conventions.html). If `.editorconfig` property `ktlint_code_style` has been set to then do not forget to change the value of that property to `intellij_idea`. When not set, this is still the default code style of ktlint. Note that in the long run, the default code style is changed to `ktlint_official`.
+
+Code style `android` has been renamed to `android_studio`. Code formatted with this code style aims to be compatible with default formatter of Android Studio. This code style is based on Android's Kotlin styleguide (https://developer.android.com/kotlin/style-guide). If `.editorconfig` property `ktlint_code_style` has been set to then do not forget to change the value of that property to `android_studio`.
+
 ### Added
 
 ### Removed

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/UsesEditorConfigProperties.kt
@@ -2,6 +2,9 @@ package com.pinterest.ktlint.core.api
 
 import com.pinterest.ktlint.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue.android_studio
+import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue.intellij_idea
+import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.core.api.editorconfig.DEFAULT_EDITOR_CONFIG_PROPERTIES
 import com.pinterest.ktlint.core.api.editorconfig.DISABLED_RULES_PROPERTY
 import com.pinterest.ktlint.core.api.editorconfig.EditorConfigProperty
@@ -53,7 +56,7 @@ public interface UsesEditorConfigProperties {
             .parse(
                 get(CODE_STYLE_PROPERTY.name)?.sourceValue,
             ).parsed
-            ?: CodeStyleValue.official
+            ?: CODE_STYLE_PROPERTY.defaultValue
 
     /**
      * Get the value of [editorConfigProperty] from [EditorConfigProperties].
@@ -120,10 +123,13 @@ public interface UsesEditorConfigProperties {
     }
 
     private fun <T> EditorConfigProperty<T>.getDefaultValue(codeStyleValue: CodeStyleValue) =
-        if (codeStyleValue == CodeStyleValue.android) {
-            defaultAndroidValue
-        } else {
-            defaultValue
+        when (codeStyleValue) {
+            android_studio -> androidStudioCodeStyleDefaultValue
+            intellij_idea -> intellijIdeaCodeStyleDefaultValue
+            ktlint_official -> ktlintOfficialCodeStyleDefaultValue
+            else -> {
+                defaultValue
+            }
         }
 
     /**

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
@@ -8,7 +8,41 @@ import org.ec4j.core.model.PropertyType.PropertyValueParser.EnumValueParser
  */
 @Suppress("EnumEntryName")
 public enum class CodeStyleValue {
+    @Deprecated(
+        message = "Marked for removal in KtLint 0.50. Value is renamed to 'android_studio'.",
+        replaceWith = ReplaceWith("android_studio"),
+    )
     android,
+
+    /**
+     * Code formatting based on Android's Kotlin styleguide (https://developer.android.com/kotlin/style-guide). This
+     * code style aims to be compatible with code formatting in Android Studio.
+     */
+    android_studio,
+
+    /**
+     * Code formatting based on Kotlin Coding conventions (https://kotlinlang.org/docs/coding-conventions.html). This
+     * code style aims to be compatible with code formatting in IntelliJ IDEA.
+     */
+    intellij_idea,
+
+    /**
+     * Code formatting based on the best of both the Kotlin Coding conventions
+     * (https://kotlinlang.org/docs/coding-conventions.html) and Android's Kotlin styleguide
+     * (https://developer.android.com/kotlin/style-guide). This codestyle also provides additional formatting on topics
+     * which are not (explicitly) mentioned in the before mentioned styleguide. Also, this code style sometimes formats
+     * code in a way which is not compatible with the default code formatters in IntelliJ IDEA and Android Studio. When
+     * using this codestyle, it is best to disable (e.g. not use) automatic code formatting in the editor. Mean reason
+     * for deviating from the code formatting provided by the editor is that those contain bugs which after some years
+     * are still not fixed.
+     * In the long run, this code style becomes the default code style provided by KtLint.
+     */
+    ktlint_official,
+
+    @Deprecated(
+        message = "Marked for removal in KtLint 0.50. Value is renamed to 'intellij_idea'.",
+        replaceWith = ReplaceWith("intellij_idea"),
+    )
     official,
 }
 
@@ -16,10 +50,18 @@ public val CODE_STYLE_PROPERTY: EditorConfigProperty<CodeStyleValue> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
             "ktlint_code_style",
-            "The code style ('official' or 'android') to be applied. Defaults to 'official' when not set.",
+            "The code style ('intellij_idea', 'android_studio' or 'ktlint_official') to be applied. Currently, the " +
+                "value is defaulted to 'intellij_idea' when not set. However, in the future the default code style " +
+                "will be changed to 'ktlint_official'.",
             SafeEnumValueParser(CodeStyleValue::class.java),
             CodeStyleValue.values().map { it.name }.toSet(),
         ),
-        defaultValue = CodeStyleValue.official,
-        defaultAndroidValue = CodeStyleValue.android,
+        /**
+         * Once the [CodeStyleValue.ktlint_official] is matured, it will become the default code style of ktlint. Until
+         * then the [CodeStyleValue.intellij_idea] is used to remain backwards compatible.
+         */
+        defaultValue = CodeStyleValue.intellij_idea,
+        androidStudioCodeStyleDefaultValue = CodeStyleValue.android_studio,
+        intellijIdeaCodeStyleDefaultValue = CodeStyleValue.intellij_idea,
+        ktlintOfficialCodeStyleDefaultValue = CodeStyleValue.ktlint_official,
     )

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty.kt
@@ -13,15 +13,28 @@ public data class EditorConfigProperty<T>(
     public val type: PropertyType<T>,
 
     /**
-     * Default value for property if it does not exist in loaded properties and codestyle 'official'.
+     * Default value for property if it does not exist in loaded properties. This default applies to all code styles
+     * unless the code style specific default value is set.
      */
     public val defaultValue: T,
 
     /**
-     * Default value for property if it does not exist in loaded properties and codestyle 'android'. This property
-     * is to be set only when its value does not equal [defaultValue].
+     * Default value for property if it does not exist in loaded properties and codestyle 'ktlint_official'. When not
+     * set, it is defaulted to [defaultValue].
      */
-    public val defaultAndroidValue: T = defaultValue,
+    public val ktlintOfficialCodeStyleDefaultValue: T = defaultValue,
+
+    /**
+     * Default value for property if it does not exist in loaded properties and codestyle 'intellij_idea'. When not
+     * set, it is defaulted to [defaultValue].
+     */
+    public val intellijIdeaCodeStyleDefaultValue: T = defaultValue,
+
+    /**
+     * Default value for property if it does not exist in loaded properties and codestyle 'android_studio'. When not
+     * set, it is defaulted to [defaultValue].
+     */
+    public val androidStudioCodeStyleDefaultValue: T = defaultValue,
 
     /**
      * If set, it maps the actual value set for the property, to another valid value for that property. See example
@@ -42,8 +55,8 @@ public data class EditorConfigProperty<T>(
      *     }
      * }
      * ```
-     * In case the lambda returns a null value then, the [defaultValue] or [defaultAndroidValue] will be set as
-     * value of the property. The
+     * In case the lambda returns a null value then, the code style specific default value or the generic [defaultValue]
+     * is used.
      */
     public val propertyMapper: ((Property?, CodeStyleValue) -> T?)? = null,
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/MaxLineLengthEditorConfigProperty.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/api/editorconfig/MaxLineLengthEditorConfigProperty.kt
@@ -2,24 +2,35 @@ package com.pinterest.ktlint.core.api.editorconfig
 
 import org.ec4j.core.model.PropertyType
 
+private const val MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE = 100 // https://developer.android.com/kotlin/style-guide#line_wrapping
+private const val MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE = 120
+private const val MAX_LINE_LENGTH_PROPERTY_NONE = -1
+
 public val MAX_LINE_LENGTH_PROPERTY: EditorConfigProperty<Int> =
     EditorConfigProperty(
         name = PropertyType.max_line_length.name,
         type = PropertyType.max_line_length,
-        defaultValue = -1,
-        defaultAndroidValue = 100,
+        defaultValue = MAX_LINE_LENGTH_PROPERTY_NONE,
+        androidStudioCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE,
+        intellijIdeaCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_NONE,
+        ktlintOfficialCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE,
         propertyMapper = { property, codeStyleValue ->
             when {
                 property == null || property.isUnset -> {
-                    if (codeStyleValue == CodeStyleValue.android) {
-                        // https://developer.android.com/kotlin/style-guide#line_wrapping
-                        100
-                    } else {
-                        property?.getValueAs()
+                    when (codeStyleValue) {
+                        CodeStyleValue.android_studio -> {
+                            MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE
+                        }
+                        CodeStyleValue.ktlint_official -> {
+                            MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE
+                        }
+                        else -> {
+                            property?.getValueAs()
+                        }
                     }
                 }
 
-                property.sourceValue == "off" -> -1
+                property.sourceValue == "off" -> MAX_LINE_LENGTH_PROPERTY_NONE
                 else -> PropertyType.max_line_length.parse(property.sourceValue).parsed
             }
         },

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/internal/EditorConfigGeneratorTest.kt
@@ -29,14 +29,14 @@ internal class EditorConfigGeneratorTest {
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = emptySet(),
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).containsExactly(
             "indent_size = 4",
             "indent_style = space",
             "insert_final_newline = true",
-            "ktlint_code_style = official",
+            "ktlint_code_style = intellij_idea",
             "max_line_length = -1",
         ).doesNotContain(
             "${DISABLED_RULES_PROPERTY.name} = ",
@@ -56,7 +56,7 @@ internal class EditorConfigGeneratorTest {
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
@@ -71,7 +71,7 @@ internal class EditorConfigGeneratorTest {
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,
-            codeStyle = CodeStyleValue.android,
+            codeStyle = CodeStyleValue.android_studio,
         )
 
         assertThat(generatedEditorConfig.lines()).contains(
@@ -100,7 +100,7 @@ internal class EditorConfigGeneratorTest {
                     )
                 },
             ),
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).contains(
@@ -125,7 +125,7 @@ internal class EditorConfigGeneratorTest {
                     )
                 },
             ),
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).contains(
@@ -150,7 +150,7 @@ internal class EditorConfigGeneratorTest {
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
@@ -174,7 +174,7 @@ internal class EditorConfigGeneratorTest {
         val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
             filePath = tempFileSystem.normalizedPath(rootDir).resolve("test.kt"),
             rules = rules,
-            codeStyle = CodeStyleValue.official,
+            codeStyle = CodeStyleValue.intellij_idea,
         )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
@@ -235,7 +235,7 @@ internal class EditorConfigGeneratorTest {
                 setOf("true", "false"),
             ),
             defaultValue = PROPERTY_1_DEFAULT_VALUE,
-            defaultAndroidValue = PROPERTY_1_DEFAULT_VALUE_ANDROID,
+            androidStudioCodeStyleDefaultValue = PROPERTY_1_DEFAULT_VALUE_ANDROID,
         )
         val EDITOR_CONFIG_PROPERTY_2 = EditorConfigProperty(
             name = PROPERTY_2_NAME,
@@ -246,7 +246,7 @@ internal class EditorConfigGeneratorTest {
                 setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"),
             ),
             defaultValue = PROPERTY_2_DEFAULT_VALUE,
-            defaultAndroidValue = PROPERTY_2_DEFAULT_VALUE_ANDROID,
+            androidStudioCodeStyleDefaultValue = PROPERTY_2_DEFAULT_VALUE_ANDROID,
         )
         val EDITOR_CONFIG_PROPERTY_3_WITH_DEFAULT_VALUE_A = EditorConfigProperty(
             name = PROPERTY_3_NAME,

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -699,6 +699,7 @@ public class FunctionSignatureRule :
                     setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
                 ),
                 defaultValue = -1,
+                ktlintOfficialCodeStyleDefaultValue = 2,
             )
 
         @Deprecated(
@@ -721,6 +722,7 @@ public class FunctionSignatureRule :
                     FunctionBodyExpressionWrapping.values().map { it.name }.toSet(),
                 ),
                 defaultValue = default,
+                ktlintOfficialCodeStyleDefaultValue = multiline,
             )
 
         @Deprecated(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
@@ -249,7 +249,7 @@ public class ImportOrderingRule :
                     EDITOR_CONFIG_PROPERTY_PARSER,
                 ),
                 defaultValue = IDEA_PATTERN,
-                defaultAndroidValue = ASCII_PATTERN,
+                androidStudioCodeStyleDefaultValue = ASCII_PATTERN,
                 propertyWriter = { it.joinToString(separator = ",") },
             )
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/MaxLineLengthRule.kt
@@ -126,6 +126,7 @@ public class MaxLineLengthRule :
                     setOf(true.toString(), false.toString()),
                 ),
                 defaultValue = false,
+                ktlintOfficialCodeStyleDefaultValue = true,
             )
 
         @Deprecated(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnCallSiteRule.kt
@@ -256,7 +256,7 @@ public class TrailingCommaOnCallSiteRule :
                     BOOLEAN_VALUES_SET,
                 ),
                 defaultValue = true,
-                defaultAndroidValue = false,
+                androidStudioCodeStyleDefaultValue = false,
             )
 
         @Deprecated(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -433,7 +433,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                     BOOLEAN_VALUES_SET,
                 ),
                 defaultValue = true,
-                defaultAndroidValue = false,
+                androidStudioCodeStyleDefaultValue = false,
             )
 
         @Deprecated(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingEditorconfigTest.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.ruleset.standard.importordering
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
+import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule.Companion.IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -12,7 +13,7 @@ class ImportOrderingEditorconfigTest {
         val properties: EditorConfigProperties = emptyMap()
         val rule = ImportOrderingRule()
         with(rule) {
-            val actual = properties.writeEditorConfigProperty(ImportOrderingRule.IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY, CodeStyleValue.official)
+            val actual = properties.writeEditorConfigProperty(IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY, CodeStyleValue.intellij_idea)
 
             assertThat(actual).isEqualTo("*,java.**,javax.**,kotlin.**,^")
         }

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -28,6 +28,11 @@ internal class GenerateEditorConfigSubCommand : Runnable {
     override fun run() {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
+        if (ktlintCommand.codeStyle == null) {
+            System.err.println("Option --code-style must be set as to generate the '.editorconfig' correctly")
+            exitKtLintProcess(1)
+        }
+
         val ktLintRuleEngine = KtLintRuleEngine(
             ruleProviders = ktlintCommand.ruleProviders(),
             editorConfigOverride = EditorConfigOverride.from(CODE_STYLE_PROPERTY to ktlintCommand.codeStyle),

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GenerateEditorConfigSubCommand.kt
@@ -3,7 +3,6 @@ package com.pinterest.ktlint.internal
 import com.pinterest.ktlint.core.KtLintRuleEngine
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import com.pinterest.ktlint.core.api.editorconfig.CODE_STYLE_PROPERTY
-import com.pinterest.ktlint.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.core.initKtLintKLogger
 import java.nio.file.Paths
 import mu.KotlinLogging
@@ -13,8 +12,8 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
 @CommandLine.Command(
     description = [
-        "EXPERIMENTAL!!! Generate kotlin style section for '.editorconfig' file.",
-        "Add output content into '.editorconfig' file",
+        "Generate kotlin style section for '.editorconfig' file.",
+        "Output should be copied manually to the '.editorconfig' file.",
     ],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class,
@@ -31,7 +30,7 @@ internal class GenerateEditorConfigSubCommand : Runnable {
 
         val ktLintRuleEngine = KtLintRuleEngine(
             ruleProviders = ktlintCommand.ruleProviders(),
-            editorConfigOverride = EditorConfigOverride.from(CODE_STYLE_PROPERTY to codeStyle()),
+            editorConfigOverride = EditorConfigOverride.from(CODE_STYLE_PROPERTY to ktlintCommand.codeStyle),
             isInvokedFromCli = true,
         )
         val generatedEditorConfig = ktLintRuleEngine.generateKotlinEditorConfigSection(Paths.get("."))
@@ -44,13 +43,6 @@ internal class GenerateEditorConfigSubCommand : Runnable {
             LOGGER.info { "Nothing to add to .editorconfig file" }
         }
     }
-
-    private fun codeStyle() =
-        if (ktlintCommand.android) {
-            CodeStyleValue.android
-        } else {
-            CodeStyleValue.official
-        }
 
     internal companion object {
         internal const val COMMAND_NAME = "generateEditorConfig"

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitHookInstaller.kt
@@ -14,17 +14,17 @@ private const val DEFAULT_GIT_HOOKS_DIR = "hooks"
 internal object GitHookInstaller {
     fun installGitHook(
         gitHookName: String,
-        gitHookLoader: () -> ByteArray,
+        hookContentProvider: () -> ByteArray,
     ) {
         val gitHooksDir = try {
             resolveGitHooksDir()
         } catch (e: IOException) {
-            LOGGER.error { e.message }
+            System.err.println(e.message)
             exitKtLintProcess(1)
         }
 
         val gitHookFile = gitHooksDir.resolve(gitHookName)
-        val hookContent = gitHookLoader()
+        val hookContent = hookContentProvider()
 
         if (gitHookFile.exists()) {
             backupExistingHook(gitHooksDir, gitHookFile, hookContent, gitHookName)
@@ -33,10 +33,9 @@ internal object GitHookInstaller {
         gitHookFile.writeBytes(hookContent)
         gitHookFile.setExecutable(true)
         LOGGER.info {
-            """
-            ${gitHookFile.path} is installed. Be aware that this hook assumes to find ktlint on the PATH. Either
-            ensure that ktlint is actually added to the path or expand the ktlint command in the hook with the path.
-            """.trimIndent()
+            "${gitHookFile.path} is installed. Be aware that this hook assumes to find ktlint on the PATH. Either " +
+                "ensure that ktlint is actually added to the path or expand the ktlint command in the hook with the " +
+                "path."
         }
     }
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
@@ -5,9 +5,7 @@ import picocli.CommandLine
 @CommandLine.Command(
     description = [
         "Install git hook to automatically check files for style violations on commit",
-        "Usage of \"--install-git-pre-commit-hook\" command line option is deprecated!",
     ],
-    aliases = ["--install-git-pre-commit-hook"],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class,
 )
@@ -22,15 +20,15 @@ internal class GitPreCommitHookSubCommand : Runnable {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         GitHookInstaller.installGitHook("pre-commit") {
-            loadHookContent()
+            """
+            #!/bin/sh
+
+            # <https://github.com/pinterest/ktlint> pre-commit hook
+
+            git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --code-style=${ktlintCommand.codeStyle} --relative --patterns-from-stdin=''
+            """.trimIndent().toByteArray()
         }
     }
-
-    private fun loadHookContent(): ByteArray = ClassLoader
-        .getSystemClassLoader()
-        .getResourceAsStream(
-            "ktlint-git-pre-commit-hook${if (ktlintCommand.android) "-android" else ""}.sh",
-        ).use { it.readBytes() }
 
     internal companion object {
         internal const val COMMAND_NAME = "installGitPreCommitHook"

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPreCommitHookSubCommand.kt
@@ -19,6 +19,11 @@ internal class GitPreCommitHookSubCommand : Runnable {
     override fun run() {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
+        if (ktlintCommand.codeStyle == null) {
+            System.err.println("Option --code-style must be set as to generate the git pre commit hook correctly")
+            exitKtLintProcess(1)
+        }
+
         GitHookInstaller.installGitHook("pre-commit") {
             """
             #!/bin/sh

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
@@ -5,9 +5,7 @@ import picocli.CommandLine
 @CommandLine.Command(
     description = [
         "Install git hook to automatically check files for style violations before push",
-        "Usage of \"--install-git-pre-push-hook\" command line option is deprecated!",
     ],
-    aliases = ["--install-git-pre-push-hook"],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class,
 )
@@ -22,16 +20,15 @@ internal class GitPrePushHookSubCommand : Runnable {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
         GitHookInstaller.installGitHook("pre-push") {
-            loadHookContent()
+            """
+            #!/bin/sh
+
+            # <https://github.com/pinterest/ktlint> pre-push hook
+
+            git diff --name-only -z HEAD "origin/${'$'}(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --code-style=${ktlintCommand.codeStyle} --relative --patterns-from-stdin=''
+            """.trimIndent().toByteArray()
         }
     }
-
-    private fun loadHookContent() = ClassLoader
-        .getSystemClassLoader()
-        .getResourceAsStream(
-            "ktlint-git-pre-push-hook${if (ktlintCommand.android) "-android" else ""}.sh",
-        )
-        .readBytes()
 
     internal companion object {
         internal const val COMMAND_NAME = "installGitPrePushHook"

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/GitPrePushHookSubCommand.kt
@@ -19,6 +19,11 @@ internal class GitPrePushHookSubCommand : Runnable {
     override fun run() {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
 
+        if (ktlintCommand.codeStyle == null) {
+            System.err.println("Option --code-style must be set as to generate the git pre push hook correctly")
+            exitKtLintProcess(1)
+        }
+
         GitHookInstaller.installGitHook("pre-push") {
             """
             #!/bin/sh

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -102,15 +102,18 @@ internal class KtlintCommandLine {
     @Option(
         names = ["--android", "-a"],
         description = ["Turn on Android Kotlin Style Guide compatibility"],
+        hidden = true,
     )
     var android: Boolean = false
 
     @Option(
+        // Ensure that the code-style can be set on sub commands and is visible in the help documentation
+        scope = CommandLine.ScopeType.INHERIT,
         names = ["--code-style"],
         description = ["Defines the code style (ktlint_official, intellij_idea or android_studio) to be used for formatting the code. It is advised to define '.editorconfig' property 'ktlint_code_style'."],
         converter = [CodeStyleValueConverter::class],
     )
-    var codeStyle: CodeStyleValue = CodeStyleValue.ktlint_official
+    var codeStyle: CodeStyleValue? = null
 
     @Option(
         names = ["--color"],
@@ -296,9 +299,9 @@ internal class KtlintCommandLine {
     }
 
     fun run() {
-        if (android != null) {
+        if (android) {
             logger.error {
-                "Option '--android' / '-a' is deprecated and replace with option '--code-style=android_studio'. Setting '.editorconfig' property 'ktlint_code_style=android_studio' might be a better idea for a project that is always to formatted with this code style."
+                "Option '--android' / '-a' is deprecated and replaced with option '--code-style=android_studio'. Setting '.editorconfig' property 'ktlint_code_style=android_studio' might be a better idea for a project that is always to formatted with this code style."
             }
         }
         assertStdinAndPatternsFromStdinOptionsMutuallyExclusive()

--- a/ktlint/src/main/resources/ktlint-git-pre-commit-hook-android.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-commit-hook-android.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# <https://github.com/pinterest/ktlint> pre-commit hook
-
-git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --android --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# <https://github.com/pinterest/ktlint> pre-commit hook
-
-git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-push-hook-android.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-push-hook-android.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# <https://github.com/pinterest/ktlint> pre-push hook
-
-git diff --name-only -z HEAD "origin/$(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --android --relative --patterns-from-stdin=''

--- a/ktlint/src/main/resources/ktlint-git-pre-push-hook.sh
+++ b/ktlint/src/main/resources/ktlint-git-pre-push-hook.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# <https://github.com/pinterest/ktlint> pre-push hook
-
-git diff --name-only -z HEAD "origin/$(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
 import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -167,5 +168,175 @@ class SimpleCLITest {
                     assertThat(errorOutput).doesNotContainLineMatching("Exception in thread \"main\" java.lang.IllegalArgumentException: this and base files have different roots:")
                 }.assertAll()
             }
+    }
+
+    @Nested
+    inner class `Generate git pre commit hook` {
+        @Test
+        fun `Given that the code-style option is specified before the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("--code-style=ktlint_official", "installGitPreCommitHook"),
+                ) {
+                    SoftAssertions().apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("git directory not found. Are you sure you are inside project directory?")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that the code-style option is specified after the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("installGitPreCommitHook", "--code-style=ktlint_official"),
+                ) {
+                    SoftAssertions().apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("git directory not found. Are you sure you are inside project directory?")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that no code-style option is specified then the command should fail`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("installGitPreCommitHook"),
+                ) {
+                    SoftAssertions().apply {
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("Option --code-style must be set as to generate the git pre commit hook correctly")
+                    }.assertAll()
+                }
+        }
+    }
+
+    @Nested
+    inner class `Generate git pre push hook` {
+        @Test
+        fun `Given that the code-style option is specified before the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("--code-style=ktlint_official", "installGitPrePushHook"),
+                ) {
+                    SoftAssertions().apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("git directory not found. Are you sure you are inside project directory?")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that the code-style option is specified after the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("installGitPrePushHook", "--code-style=ktlint_official"),
+                ) {
+                    SoftAssertions().apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("git directory not found. Are you sure you are inside project directory?")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that no code-style option is specified then the command should fail`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("installGitPrePushHook"),
+                ) {
+                    SoftAssertions().apply {
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("Option --code-style must be set as to generate the git pre push hook correctly")
+                    }.assertAll()
+                }
+        }
+    }
+
+    @Nested
+    inner class `Generate 'editorconfig' file` {
+        @Test
+        fun `Given that the code-style option is specified before the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("--code-style=ktlint_official", "generateEditorConfig"),
+                ) {
+                    SoftAssertions().apply {
+                        assertNormalExitCode()
+                        assertThat(normalOutput).containsLineMatching("ktlint_code_style = ktlint_official")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that the code-style option is specified after the command`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("generateEditorConfig", "--code-style=ktlint_official"),
+                ) {
+                    SoftAssertions().apply {
+                        assertNormalExitCode()
+                        assertThat(normalOutput).containsLineMatching("ktlint_code_style = ktlint_official")
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given that no code-style option is specified then the command should fail`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "too-many-empty-lines",
+                    listOf("generateEditorConfig"),
+                ) {
+                    SoftAssertions().apply {
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching("Option --code-style must be set as to generate the '.editorconfig' correctly")
+                    }.assertAll()
+                }
+        }
     }
 }


### PR DESCRIPTION
## Description

Add code style `ktlint_official` (functionally equivalent with old `official` code style), `intellij_idea` (replacement for old `official` code style) and `android_studio` (replacement for old `android` code style).

Closes #1699

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
