### PR TITLE
Move release process to GitHub Actions Workflow

### DIFF
--- a/.announce
+++ b/.announce
@@ -9,7 +9,13 @@ else
   AUTOACCEPT=false
 fi
 
-PREVIOUS_VERSION=$(cat CHANGELOG.md | grep -E "## \[\d+[.]\d+[.]\d+\]" | awk '{gsub(/\[|\]/,"",$2); print $2}' | awk 'NR == 2')
+PREVIOUS_VERSION=$(grep -E "## \[[0-9]+\.[0-9]+\.[0-9]+\]" CHANGELOG.md | awk '{gsub(/\[|\]/,"",$2); print $2}' | awk 'NR == 2')
+
+if [ -z "$PREVIOUS_VERSION" ]; then
+  echo "Cannot find PREVIOUS_VERSION."
+  exit 1
+fi
+
 if [ "$VERSION" == "$PREVIOUS_VERSION" ]; then
   echo "VERSION $VERSION equal to PREVIOUS_VERSION $PREVIOUS_VERSION"
   exit 1
@@ -30,12 +36,12 @@ if [ "$(git status --porcelain=v1 docs/install/cli.md docs/install/integrations.
   fi
 fi
 
-escape_for_sed() { echo $1 | sed -e 's/[]\/$*.^|[]/\\&/g'; }
+escape_for_sed() { echo "$1" | sed -e 's/[]\/$*.^|[]/\\&/g'; }
 
 # update Docs
 
-sed -i "" "s/$(escape_for_sed $PREVIOUS_VERSION)/$(escape_for_sed $VERSION)/g" docs/install/cli.md
-sed -i "" "s/$(escape_for_sed $PREVIOUS_VERSION)/$(escape_for_sed $VERSION)/g" docs/install/integrations.md
+sed -i -e "s/$PREVIOUS_VERSION/$VERSION/g" docs/install/cli.md
+sed -i -e "s/$PREVIOUS_VERSION/$VERSION/g" docs/install/integrations.md
 git --no-pager diff docs/install/cli.md docs/install/integrations.md
 
 # ask for user confirmation
@@ -57,6 +63,3 @@ fi
 
 # Make a separate branch because master branch is protected
 git checkout --track origin/master -b $BRANCH && git commit -m "$COMMIT_MESSAGE" docs/install/cli.md docs/install/integrations.md && git push origin $BRANCH
-
-open "https://github.com/pinterest/ktlint/compare/$BRANCH?expand=1"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release (WIP)
+
+on :
+  push :
+    tags :
+      - '*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'shashachu/ktlint'
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'master'
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 19
+      - uses: gradle/gradle-build-action@v2
+      - name: Build executable
+        if: false
+        run: ./gradlew clean shadowJarExecutable
+        env:
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingKeyPassword : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+      
+      - name : Extract release notes
+        if: false
+        id : release_notes
+        uses : ffurrer2/extract-release-notes@v1
+
+      - name : Create release
+        if: false
+        id: github_release
+        uses : softprops/action-gh-release@v1
+        with :
+          draft: false
+          prerelease: true
+          body : ${{ steps.release_notes.outputs.release_notes }}
+          files: |
+            ktlint/build/run/*
+          
+        env :
+          GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Get version
+        id: get_version
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        
+      - name: Announce Release
+        run: | 
+          git config --global user.name "Ktlint Release Workflow" |
+          ./.announce -y
+        env:
+          VERSION: ${{ env.version }}
+          
+      - name: Bump Homebrew Formula
+        if: false
+        uses: mislav/bump-homebrew-formula-action@v1
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+        with:
+          formula-name: ktlint
+          download-url: https://github.com/shashachu/ktlint/releases/download/${{ env.version }}/ktlint
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release (WIP)
+name: Publish Release
 
 on :
   push :
@@ -37,7 +37,7 @@ jobs:
         uses : softprops/action-gh-release@v1
         with :
           draft: false
-          prerelease: true
+          prerelease: true # Remove this after testing
           body : ${{ steps.release_notes.outputs.release_notes }}
           files: |
             ktlint/build/run/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Announce Release
         run: |
-          git config --global user.name "Ktlint Release Workflow" |
+          git config user.email "<>>" |
+          git config user.name "Ktlint Release Workflow" |
           ./.announce -y
         env:
           VERSION: ${{ env.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Announce Release
         run: |
-          git config user.email "<>>" |
+          git config user.email "<>" |
           git config user.name "Ktlint Release Workflow" |
           ./.announce -y
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,22 +1,11 @@
 # How to make new project release
 
-### Required configuration
-
-Add following information to your `$HOME/.gradle/gradle.properties` file:
-```properties
-# You Github access token
-servers.github.privKey=github_token
-# Signing GPG key id
-signing.keyId=12345678
-# Signing GPG key password
-signing.password=some_password
-# Path to GPG file to sync artifcats
-signing.secretKeyRingFile=~/.gnupg/secring.gpg
-```
-
 ### Publishing new release
 
-1. Update `VERSION_NAME` with new release version in project root `gradle.properties`
-2. Fill in `CHANGELOG.md` with related to new version changes.
-3. Run `./gradlew publishNewRelease` to build, upload new artifacts, update KtLint version number on [CLI documentation](docs/install/cli.md) and [integrations documentation](docs/install/integrations.md) and [https://ktlint.github.io](https://ktlint.github.io) site.
-4. Update Github release notes with info from `CHANGELOG.md`
+1. Update `VERSION_NAME` with new release version in project root `gradle.properties`. Be sure to remove `-SNAPSHOT`
+2. Update `CHANGELOG.md` to rename the `Unreleased` section to the new release name, following the `## [x.x.x] - YYYY-MM-DD` format.
+3. Add the new release to the bottom of the `CHANGELOG.md` file.
+4. Commit `gradle.properties` and `CHANGELOG.md`.
+5. Add a tag with the new release version, and push it to remote. This will kick off the Release workflow.
+6. Close and release the repo on Sonatype.
+7. Update `gradle.properties` with the new `SNAPSHOT` version, and add a new empty `Unreleased` section to the top of `CHANGELOG.md` and commit.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,4 +8,5 @@
 4. Commit `gradle.properties` and `CHANGELOG.md`.
 5. Add a tag with the new release version, and push it to remote. This will kick off the Release workflow.
 6. Close and release the repo on Sonatype.
-7. Update `gradle.properties` with the new `SNAPSHOT` version, and add a new empty `Unreleased` section to the top of `CHANGELOG.md` and commit.
+7. Find the `<release>-update-refs` branch in the repo (created by the `.announce` script) and merge it.
+8. Update `gradle.properties` with the new `SNAPSHOT` version, and add a new empty `Unreleased` section to the top of `CHANGELOG.md` and commit.

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -92,6 +92,11 @@ signing {
     // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent how to configure it
     // useGpgCmd()
 
+    val signingKeyId = System.getenv("ORG_GRADLE_PROJECT_signingKeyId")
+    val signingKey = System.getenv("ORG_GRADLE_PROJECT_signingKey")
+    val signingPassword = System.getenv("ORG_GRADLE_PROJECT_signingKeyPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+
     sign(publishing.publications["maven"])
     isRequired = !version.toString().endsWith("SNAPSHOT")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,9 @@
 import java.net.URL
-import org.gradle.crypto.checksum.Checksum
 
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.checksum)
     alias(libs.plugins.shadow)
-    alias(libs.plugins.githubRelease)
 }
 
 val isKotlinDev: Boolean = project.hasProperty("isKotlinDev")
@@ -52,67 +50,6 @@ tasks.register<JavaExec>("ktlint") {
         // Do not run with option "--verbose" or "-v" as the lint violations are difficult to spot between the amount of
         // debug output lines.
     )
-}
-
-// Deployment tasks
-val githubToken: String = if (project.hasProperty("servers.github.privKey")) {
-    project.property("servers.github.privKey").toString()
-} else {
-    logger.warn("No github token specified")
-    ""
-}
-
-tasks.githubRelease {
-    setReleaseAssets(
-        provider {
-            projects.ktlint.dependencyProject.tasks.named<Checksum>("shadowJarExecutableChecksum")
-                .map { it.outputDirectory.asFileTree.files.toTypedArray() }
-        },
-    )
-}
-
-githubRelease {
-    token(githubToken)
-    owner("pinterest")
-    repo("ktlint")
-    tagName(project.property("VERSION_NAME").toString())
-    releaseName(project.property("VERSION_NAME").toString())
-    targetCommitish("master")
-    overwrite(true)
-    dryRun(false)
-    body {
-        var changelog = project.file("CHANGELOG.md").readText()
-        changelog = changelog.substring(changelog.indexOf("## "))
-        // 1 in indexOf here to skip first "## [" occurence
-        changelog.substring(0, changelog.indexOf("## [", 1))
-    }
-}
-
-// Put "servers.github.privKey" in "$HOME/.gradle/gradle.properties".
-val announceRelease by tasks.registering(Exec::class) {
-    group = "Help"
-    description = "Runs .announce script"
-    subprojects.filter { !it.name.contains("ktlint-ruleset-template") }.forEach { subproject ->
-        dependsOn(subproject.tasks.named("publishMavenPublicationToMavenCentralRepository"))
-    }
-
-    commandLine("./.announce", "-y")
-    environment("VERSION" to "${project.property("VERSION_NAME")}")
-    environment("GITHUB_TOKEN" to githubToken)
-}
-
-val homebrewBumpFormula by tasks.registering(Exec::class) {
-    group = "Help"
-    description = "Runs brew bump-forumula-pr"
-    commandLine("./.homebrew")
-    environment("VERSION" to "${project.property("VERSION_NAME")}")
-    dependsOn(tasks.githubRelease)
-}
-
-tasks.register<DefaultTask>("publishNewRelease") {
-    group = "Help"
-    description = "Triggers uploading new archives and publish announcements"
-    dependsOn(announceRelease, homebrewBumpFormula, tasks.githubRelease)
 }
 
 tasks.wrapper {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ kotlinDev = "1.8.0-RC"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-githubRelease = "com.github.breadmoirai.github-release:2.4.1"
 checksum = "org.gradle.crypto.checksum:1.4.0"
 shadow = "com.github.johnrengelman.shadow:7.1.2"
 


### PR DESCRIPTION
## Description

Moving releases to GH Actions so that @shashachu isn't as much of a release bottleneck.

A test release on my fork:
https://github.com/shashachu/ktlint/releases/tag/0.49.3

A Homebrew PR:
https://github.com/Homebrew/homebrew-core/pull/118545

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ x ] PR description added
