### PR TITLE
Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * An enumeration class having a primary constructor and in which the list of enum entries is followed by a semicolon then do not remove the semicolon in case it is followed by code element `no-semi` ([#1733](https://github.com/pinterest/ktlint/issues/1733))
+* Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin` ([#1742](https://github.com/pinterest/ktlint/issues/1742))
 
 ### Changed
 

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -236,6 +236,22 @@ internal class KtlintCommandLine {
     )
     private var minLogLevel: Level = Level.INFO
 
+    init {
+        if (debugOld != null || trace != null || verbose != null) {
+            if (minLogLevel == Level.OFF) {
+                minLogLevel = Level.ERROR
+            }
+            configureLogger().error {
+                "Options '--debug', '--trace', '--verbose' and '-v' are deprecated and replaced with option '--log-level=<level>' or '-l=<level>'."
+            }
+            exitKtLintProcess(1)
+        }
+
+        // Ensure that logger is initialized even when the run method is not executed because a subcommand like (--help)
+        // is executed so that method exitKtLintProcess only prints a log line when the appropriate loglevel is set.
+        logger = configureLogger()
+    }
+
     private val tripped = AtomicBoolean()
     private val fileNumber = AtomicInteger()
     private val errorNumber = AtomicInteger()
@@ -261,6 +277,8 @@ internal class KtlintCommandLine {
                     plus(*disabledRulesEditorConfigOverrides())
                 }.applyIf(android) {
                     plus(CODE_STYLE_PROPERTY to CodeStyleValue.android)
+                }.applyIf(stdin) {
+                    plus(createRuleExecutionEditorConfigProperty("standard:filename") to RuleExecution.disabled)
                 }
 
     private fun disabledRulesEditorConfigOverrides() =
@@ -269,22 +287,6 @@ internal class KtlintCommandLine {
             .filter { it.isNotBlank() }
             .map { ruleId -> createRuleExecutionEditorConfigProperty(ruleId) to RuleExecution.disabled }
             .toTypedArray()
-
-    init {
-        if (debugOld != null || trace != null || verbose != null) {
-            if (minLogLevel == Level.OFF) {
-                minLogLevel = Level.ERROR
-            }
-            configureLogger().error {
-                "Options '--debug', '--trace', '--verbose' and '-v' are deprecated and replaced with option '--log-level=<level>' or '-l=<level>'."
-            }
-            exitKtLintProcess(1)
-        }
-
-        // Ensure that logger is initialized even when the run method is not executed because a subcommand like (--help)
-        // is executed so that method exitKtLintProcess only prints a log line when the appropriate loglevel is set.
-        logger = configureLogger()
-    }
 
     fun run() {
         assertStdinAndPatternsFromStdinOptionsMutuallyExclusive()

--- a/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
+++ b/ktlint/src/main/kotlin/com/pinterest/ktlint/internal/KtlintCommandLine.kt
@@ -236,22 +236,6 @@ internal class KtlintCommandLine {
     )
     private var minLogLevel: Level = Level.INFO
 
-    init {
-        if (debugOld != null || trace != null || verbose != null) {
-            if (minLogLevel == Level.OFF) {
-                minLogLevel = Level.ERROR
-            }
-            configureLogger().error {
-                "Options '--debug', '--trace', '--verbose' and '-v' are deprecated and replaced with option '--log-level=<level>' or '-l=<level>'."
-            }
-            exitKtLintProcess(1)
-        }
-
-        // Ensure that logger is initialized even when the run method is not executed because a subcommand like (--help)
-        // is executed so that method exitKtLintProcess only prints a log line when the appropriate loglevel is set.
-        logger = configureLogger()
-    }
-
     private val tripped = AtomicBoolean()
     private val fileNumber = AtomicInteger()
     private val errorNumber = AtomicInteger()
@@ -287,6 +271,22 @@ internal class KtlintCommandLine {
             .filter { it.isNotBlank() }
             .map { ruleId -> createRuleExecutionEditorConfigProperty(ruleId) to RuleExecution.disabled }
             .toTypedArray()
+
+    init {
+        if (debugOld != null || trace != null || verbose != null) {
+            if (minLogLevel == Level.OFF) {
+                minLogLevel = Level.ERROR
+            }
+            configureLogger().error {
+                "Options '--debug', '--trace', '--verbose' and '-v' are deprecated and replaced with option '--log-level=<level>' or '-l=<level>'."
+            }
+            exitKtLintProcess(1)
+        }
+
+        // Ensure that logger is initialized even when the run method is not executed because a subcommand like (--help)
+        // is executed so that method exitKtLintProcess only prints a log line when the appropriate loglevel is set.
+        logger = configureLogger()
+    }
 
     fun run() {
         assertStdinAndPatternsFromStdinOptionsMutuallyExclusive()

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint
 
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
-import javax.annotation.RegEx
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test

--- a/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
+++ b/ktlint/src/test/kotlin/com/pinterest/ktlint/SimpleCLITest.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint
 
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
+import javax.annotation.RegEx
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -166,6 +168,21 @@ class SimpleCLITest {
                     assertErrorExitCode()
                     assertThat(errorOutput).doesNotContainLineMatching("Exception in thread \"main\" java.lang.IllegalArgumentException: this and base files have different roots:")
                 }.assertAll()
+            }
+    }
+
+    @Test
+    fun `Issue 1742 - Disable the filename rule when --stdin is used`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                testProjectName = "too-many-empty-lines",
+                arguments = listOf("--stdin"),
+                stdin = ByteArrayInputStream("fun foo() = 42".toByteArray()),
+            ) {
+                assertThat(normalOutput).containsLineMatching(Regex(".*ktlint_standard_filename: disabled.*"))
             }
     }
 }


### PR DESCRIPTION
## Description

Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin

Closes #1742 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
