### PR TITLE
Fix another issue with annotations incorrectly being forced to be multi-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Issue with the `annotation` rule which would sometimes incorrectly force an array of annotations to be multi-line
+
 ### Changed
 
 ## [0.48.1] - 2023-01-03

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRule.kt
@@ -61,26 +61,27 @@ public class AnnotationRule : Rule("annotation") {
     ) {
         require(node.elementType == ANNOTATION_ENTRY)
 
-        if (node.isAnnotationEntryWithValueArgumentList() &&
-            node.treeParent.treeParent.elementType != VALUE_PARAMETER && // fun fn(@Ann("blah") a: String)
-            node.treeParent.treeParent.elementType != VALUE_ARGUMENT && // fn(@Ann("blah") "42")
-            !node.isPartOf(TYPE_ARGUMENT_LIST) && // val property: Map<@Ann("blah") String, Int>
-            node.isNotReceiverTargetAnnotation()
-        ) {
-            checkForAnnotationWithParameterToBePlacedOnSeparateLine(node, emit, autoCorrect)
-        }
+        if (node.treeParent.elementType != ANNOTATION) {
+            if (node.isAnnotationEntryWithValueArgumentList() &&
+                node.treeParent.treeParent.elementType != VALUE_PARAMETER && // fun fn(@Ann("blah") a: String)
+                node.treeParent.treeParent.elementType != VALUE_ARGUMENT && // fn(@Ann("blah") "42")
+                !node.isPartOf(TYPE_ARGUMENT_LIST) && // val property: Map<@Ann("blah") String, Int>
+                node.isNotReceiverTargetAnnotation()
+            ) {
+                checkForAnnotationWithParameterToBePlacedOnSeparateLine(node, emit, autoCorrect)
+            }
 
-        if ((node.isFollowedByOtherAnnotationEntry() && node.isOnSameLineAsNextAnnotationEntry()) ||
-            (node.isPrecededByOtherAnnotationEntry() && node.isOnSameLineAsAnnotatedConstruct())
-        ) {
-            checkForAnnotationToBePlacedOnSeparateLine(node, emit, autoCorrect)
-        }
+            if ((node.isFollowedByOtherAnnotationEntry() && node.isOnSameLineAsNextAnnotationEntry()) ||
+                (node.isPrecededByOtherAnnotationEntry() && node.isOnSameLineAsAnnotatedConstruct())
+            ) {
+                checkForAnnotationToBePlacedOnSeparateLine(node, emit, autoCorrect)
+            }
 
-        if (node.treeParent.elementType != ANNOTATION &&
-            node.isPrecededByOtherAnnotationEntry() &&
-            node.isOnSameLineAsAnnotatedConstruct()
-        ) {
-            checkForMultipleAnnotationsOnSameLineAsAnnotatedConstruct(node, emit, autoCorrect)
+            if (node.isPrecededByOtherAnnotationEntry() &&
+                node.isOnSameLineAsAnnotatedConstruct()
+            ) {
+                checkForMultipleAnnotationsOnSameLineAsAnnotatedConstruct(node, emit, autoCorrect)
+            }
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/AnnotationRuleTest.kt
@@ -548,4 +548,14 @@ class AnnotationRuleTest {
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Given an annotation with multiple annotation entries including with parameters then do not force wrapping of the entries`() {
+        val code =
+            """
+            @[JvmStatic Provides Foo("bar")]
+            fun foo() = 42
+            """.trimIndent()
+        annotationRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Similar to #1688, an array of annotations would be forced to be multi-line if any of the entries had a parameter.

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] `CHANGELOG.md` is updated
