### PR TITLE
Fix bug in parseImportsLayout: trim spaces in entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Trim spaces in the `.editorconfig` property `ij_kotlin_imports_layout`'s entries ([#1770](https://github.com/pinterest/ktlint/pull/1770))
+
 ### Changed
 
 ## [0.48.1] - 2023-01-03

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportLayoutParser.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/internal/importordering/ImportLayoutParser.kt
@@ -8,7 +8,7 @@ internal const val ALIAS_CHAR = "^"
  * Adapted from https://github.com/JetBrains/intellij-kotlin/blob/73b5a484198f02518c9ece2fb453d27cead680fb/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPackageEntryTableAccessor.kt#L27-L43
  */
 internal fun parseImportsLayout(importsLayout: String): List<PatternEntry> {
-    val importsList = importsLayout.split(",").onEach { it.trim() }
+    val importsList = importsLayout.split(",").map { it.trim() }
 
     if (importsList.first() == BLANK_LINE_CHAR || importsList.last() == BLANK_LINE_CHAR) {
         throw IllegalArgumentException("Blank lines are not supported in the beginning or end of import list")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
@@ -5,6 +5,8 @@ import com.pinterest.ktlint.ruleset.standard.internal.importordering.parseImport
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class ImportLayoutParserTest {
     @Test
@@ -21,9 +23,17 @@ class ImportLayoutParserTest {
         }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
-    @Test
-    fun `parses correctly`() {
-        val expected = listOf(
+    @ParameterizedTest(name = "Imports layout: {0}")
+    @ValueSource(
+        strings = [
+            "android.**,|,org.junit.**,|,^android.**,*,kotlin.io.Closeable.*,^",
+            "android.**, |, org.junit.**, |, ^android.**, *, kotlin.io.Closeable.*, ^",
+        ],
+    )
+    fun `Given some imports layout then parse it correctly`(importsLayout: String) {
+        val actual = parseImportsLayout(importsLayout)
+
+        assertThat(actual).containsExactly(
             PatternEntry("android.*", withSubpackages = true, hasAlias = false),
             PatternEntry.BLANK_LINE_ENTRY,
             PatternEntry("org.junit.*", withSubpackages = true, hasAlias = false),
@@ -33,14 +43,5 @@ class ImportLayoutParserTest {
             PatternEntry("kotlin.io.Closeable.*", withSubpackages = false, hasAlias = false),
             PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY,
         )
-        val actual = parseImportsLayout("android.**,|,org.junit.**,|,^android.**,*,kotlin.io.Closeable.*,^")
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `trims spaces in entries`() {
-        assertThat(parseImportsLayout("android.**,|,org.junit.**,|,^android.**,*,kotlin.io.Closeable.*,^"))
-            .isEqualTo(parseImportsLayout("android.**, |, org.junit.**, |, ^android.**, *, kotlin.io.Closeable.*, ^"))
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportLayoutParserTest.kt
@@ -37,4 +37,10 @@ class ImportLayoutParserTest {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `trims spaces in entries`() {
+        assertThat(parseImportsLayout("android.**,|,org.junit.**,|,^android.**,*,kotlin.io.Closeable.*,^"))
+            .isEqualTo(parseImportsLayout("android.**, |, org.junit.**, |, ^android.**, *, kotlin.io.Closeable.*, ^"))
+    }
 }


### PR DESCRIPTION
## Description

This MR fixes a typo in `parseImportsLayout(String)` that causes the `.editorconfig` property `ij_kotlin_imports_layout` to be parsed incorrectly when it contains spaces after commas (e.g. `*, ^`). This issue is particularly annoying given IntelliJ adds spaces by default when its "Reformat Code" action is used.

## Checklist

- [x] PR description added
- [x] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] `CHANGELOG.md` is updated
