### PR TITLE
Ensure that enabling the ktlint_disabled_rules property doesn't accidentally enable all experimental rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+* Do not enable the experimental rules by default when `.editorconfig` properties `disabled_rules` or `ktlint_disabled_rules` are set. ([#1771](https://github.com/pinterest/ktlint/issues/1771))
 
 ### Changed
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/VisitorProvider.kt
@@ -105,13 +105,13 @@ internal class VisitorProvider(
                 editorConfigProperties.isEnabled(
                     KTLINT_DISABLED_RULES_PROPERTY,
                     qualifiedRuleId,
-                )
+                ) && ruleSetId(qualifiedRuleId) != "experimental"
 
             editorConfigProperties.containsKey(DISABLED_RULES_PROPERTY.name) ->
                 editorConfigProperties.isEnabled(
                     DISABLED_RULES_PROPERTY,
                     qualifiedRuleId,
-                )
+                ) && ruleSetId(qualifiedRuleId) != "experimental"
 
             else ->
                 ruleSetId(qualifiedRuleId) != "experimental"

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -31,7 +31,7 @@ class VisitorProviderTest {
         }
 
         @Test
-        fun `Disabled rules in any type of rule set are not executed`() {
+        fun `Disabled rules in any type of rule set and experimental rules are not executed`() {
             val actual = testVisitorProvider(
                 RuleProvider { NormalRule(RULE_A) },
                 RuleProvider { NormalRule(SOME_DISABLED_RULE_IN_STANDARD_RULE_SET) },
@@ -43,7 +43,6 @@ class VisitorProviderTest {
 
             assertThat(actual).containsExactly(
                 Visit(RULE_A),
-                Visit(EXPERIMENTAL, RULE_B),
                 Visit(CUSTOM_RULE_SET_A, RULE_C),
             )
         }
@@ -135,7 +134,7 @@ class VisitorProviderTest {
         }
 
         @Test
-        fun `Disabled rules in any type of rule set are not executed`() {
+        fun `Disabled rules in any type of rule set and experimental rules are not executed`() {
             val actual = testVisitorProvider(
                 RuleProvider { NormalRule(RULE_A) },
                 RuleProvider { NormalRule(SOME_DISABLED_RULE_IN_STANDARD_RULE_SET) },
@@ -147,7 +146,6 @@ class VisitorProviderTest {
 
             assertThat(actual).containsExactly(
                 Visit(RULE_A),
-                Visit(EXPERIMENTAL, RULE_B),
                 Visit(CUSTOM_RULE_SET_A, RULE_C),
             )
         }
@@ -406,6 +404,31 @@ class VisitorProviderTest {
             )
 
             assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `Given the disabled rule property is set then only run experimental rules if enabled`() {
+            val disabledRuleProperty: Pair<String, Property> = with(KTLINT_DISABLED_RULES_PROPERTY) {
+                name to
+                    Property.builder()
+                        .name(name)
+                        .type(type)
+                        .value(SOME_DISABLED_RULE_IN_STANDARD_RULE_SET)
+                        .build()
+            }
+
+            val actual = testVisitorProvider(
+                RuleProvider { NormalRule("$EXPERIMENTAL:$RULE_B") },
+                RuleProvider { NormalRule("$EXPERIMENTAL:$RULE_C") },
+                editorConfigProperties = mapOf(
+                    disabledRuleProperty,
+                    ktLintRuleExecutionEditorConfigProperty("ktlint_$EXPERIMENTAL:$RULE_B", RuleExecution.enabled),
+                ),
+            )
+
+            assertThat(actual).containsExactly(
+                Visit(EXPERIMENTAL, RULE_B),
+            )
         }
 
         /**

--- a/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
+++ b/ktlint-core/src/test/kotlin/com/pinterest/ktlint/core/VisitorProviderTest.kt
@@ -406,31 +406,6 @@ class VisitorProviderTest {
             assertThat(actual).isEmpty()
         }
 
-        @Test
-        fun `Given the disabled rule property is set then only run experimental rules if enabled`() {
-            val disabledRuleProperty: Pair<String, Property> = with(KTLINT_DISABLED_RULES_PROPERTY) {
-                name to
-                    Property.builder()
-                        .name(name)
-                        .type(type)
-                        .value(SOME_DISABLED_RULE_IN_STANDARD_RULE_SET)
-                        .build()
-            }
-
-            val actual = testVisitorProvider(
-                RuleProvider { NormalRule("$EXPERIMENTAL:$RULE_B") },
-                RuleProvider { NormalRule("$EXPERIMENTAL:$RULE_C") },
-                editorConfigProperties = mapOf(
-                    disabledRuleProperty,
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_$EXPERIMENTAL:$RULE_B", RuleExecution.enabled),
-                ),
-            )
-
-            assertThat(actual).containsExactly(
-                Visit(EXPERIMENTAL, RULE_B),
-            )
-        }
-
         /**
          * Create a visitor provider. It returns a list of visits that the provider made after it was invoked. The tests
          * of the visitor provider should only focus on whether the visit provider has invoked the correct rules in the


### PR DESCRIPTION

## Description

Solving issue: https://github.com/pinterest/ktlint/issues/1771#issue-1528688024

Not sure about how to organise the tests file. It was covered by existing tests but I also added a new test.