### PR TITLE
Add check for presence of parameters before assuming multilinemode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+* A function signature not having any parameters which exceeds the `max-line-length` should be ignored by rule `function-signature` ([#1773](https://github.com/pinterest/ktlint/issues/1773))
 
 ### Changed
 

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -158,10 +158,17 @@ public class FunctionSignatureRule :
                 node.containsParameterPrecededByAnnotationOnSeparateLine()
         if (isMaxLineLengthSet()) {
             val singleLineFunctionSignatureLength = calculateFunctionSignatureLengthAsSingleLineSignature(node, emit, autoCorrect)
-            if (forceMultilineSignature ||
-                (singleLineFunctionSignatureLength > maxLineLength && node.countParameters() > 0) ||
-                node.hasMinimumNumberOfParameters()
-            ) {
+            // Function signatures not having parameters, should not be reformatted automatically. It would result in function signatures
+            // like below, which are not acceptable:
+            //     fun aVeryLongFunctionName(
+            //     ) = "some-value"
+            //
+            //     fun aVeryLongFunctionName(
+            //     ): SomeVeryLongTypeName =
+            //         SomeVeryLongTypeName(...)
+            // Leave it up to the max-line-length rule to detect those violations so that the developer can handle it manually.
+            val rewriteFunctionSignatureWithParameters = node.countParameters() > 0 && singleLineFunctionSignatureLength > maxLineLength
+            if (forceMultilineSignature || rewriteFunctionSignatureWithParameters) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
                 // Due to rewriting the function signature, the remaining length on the last line of the multiline
                 // signature needs to be recalculated

--- a/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRule.kt
@@ -159,7 +159,7 @@ public class FunctionSignatureRule :
         if (isMaxLineLengthSet()) {
             val singleLineFunctionSignatureLength = calculateFunctionSignatureLengthAsSingleLineSignature(node, emit, autoCorrect)
             if (forceMultilineSignature ||
-                singleLineFunctionSignatureLength > maxLineLength ||
+                (singleLineFunctionSignatureLength > maxLineLength && node.countParameters() > 0) ||
                 node.hasMinimumNumberOfParameters()
             ) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -1075,6 +1075,19 @@ class FunctionSignatureRuleTest {
             .hasNoLintViolations()
     }
 
+    @Test
+    fun `Issue 1773 - Given a back ticked function signature with an expression body which does not fit on the same line as the signature then do not reformat`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun `a very long function name as found in a test case`() =
+                "some-result"
+            """.trimIndent()
+        functionSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""

--- a/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/FunctionSignatureRuleTest.kt
@@ -1075,17 +1075,47 @@ class FunctionSignatureRuleTest {
             .hasNoLintViolations()
     }
 
-    @Test
-    fun `Issue 1773 - Given a back ticked function signature with an expression body which does not fit on the same line as the signature then do not reformat`() {
-        val code =
-            """
-            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
-            fun `a very long function name as found in a test case`() =
-                "some-result"
-            """.trimIndent()
-        functionSignatureWrappingRuleAssertThat(code)
-            .setMaxLineLength()
-            .hasNoLintViolations()
+    @Nested
+    inner class `Issue 1773 - Given a unction signature without parameters exceeding the max line length` {
+        @Test
+        fun `Given a function name between backticks and expression body`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+                fun `a very long function name as found in a test case`() =
+                    "some-result"
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function name not between backticks and expression body`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+                fun aVeryLongFunctionNameAsFoundInATestCase() =
+                    "some-result"
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function name not between backticks and a return type and body block`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+                fun aVeryLongFunctionNameAsFoundInATestCase(): String {
+                    return "some-result"
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue than provide a link to that issue. -->

The FunctionSignature rule would assume multiline mode when exceeding the maxLineLength, but this isn't always the case.

Given a long function name (as found in test cases for example) with an expression body and no parameters:
```kotlin
fun `a very long function name as found in a test case`() =
                "some-result"
```

The function name here exceeds the maxLineLength of the FunctionSignatureRule but not the overal MaxLineLength.

The ktlint error would suggest to put the expression body on the same line:
`First line of body expression fits on same line as function signature [FunctionSignature]`

Which obviously won't fit. The code would calculate the remaining space based on multiline mode (assuming the line length is just `) =`). This fix checks if there are parameters on the function and if not used the full line for space calculation, not the last 3 nodes.

Fixes: #1773

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
