### PR TITLE
Detect new lines inside string template before wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 * Do not enable the experimental rules by default when `.editorconfig` properties `disabled_rules` or `ktlint_disabled_rules` are set. ([#1771](https://github.com/pinterest/ktlint/issues/1771))
 * A function signature not having any parameters which exceeds the `max-line-length` should be ignored by rule `function-signature` ([#1773](https://github.com/pinterest/ktlint/issues/1773))
+* 
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRule.kt
@@ -31,6 +31,7 @@ import com.pinterest.ktlint.core.ast.ElementType.LT
 import com.pinterest.ktlint.core.ast.ElementType.OBJECT_LITERAL
 import com.pinterest.ktlint.core.ast.ElementType.RBRACE
 import com.pinterest.ktlint.core.ast.ElementType.RBRACKET
+import com.pinterest.ktlint.core.ast.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.core.ast.ElementType.RPAR
 import com.pinterest.ktlint.core.ast.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.core.ast.ElementType.SUPER_TYPE_CALL_ENTRY
@@ -142,8 +143,8 @@ public class WrappingRule :
                     node.firstChildLeafOrSelf().elementType != EOL_COMMENT
                 }
                 maxLineLength > 0 -> {
-                    val startOfLine = node.prevLeaf { it.isWhiteSpaceWithNewline() }
-                    val endOfLine = node.nextLeaf { it.isWhiteSpaceWithNewline() }
+                    val startOfLine = node.prevLeaf { it.isWhiteSpaceWithNewline() || (it.elementType == REGULAR_STRING_PART && it.text == "\n") }
+                    val endOfLine = node.nextLeaf { it.isWhiteSpaceWithNewline() || (it.elementType == REGULAR_STRING_PART && it.text == "\n") }
                     val line =
                         startOfLine
                             ?.leaves()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/WrappingRuleTest.kt
@@ -1715,6 +1715,70 @@ internal class WrappingRuleTest {
             """.trimIndent()
         wrappingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Nested
+    inner class `Issue 1776 - Given a string template containing a block` {
+        @Test
+        fun `Given that the string template is on a separate line in the raw string literal`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+                fun getQueryString(query: QueryRequest): String {
+                    val q = $MULTILINE_STRING_QUOTE
+                        SELECT *
+                        FROM table
+                        WHERE 1 = 1
+                        $.{query.gameId?.let { "AND id = ?" } ?: ""}
+                    $MULTILINE_STRING_QUOTE
+                    return q
+                }
+                """.replacePlaceholderWithStringTemplate()
+                    .trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the string template is preceded by some text on the same line in the raw string literal`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
+                fun getQueryString(query: QueryRequest): String {
+                    val q = $MULTILINE_STRING_QUOTE
+                        SELECT *
+                        FROM table
+                        WHERE $.{query.gameId?.let { "id = ?" } ?: "1 = 1"}
+                    $MULTILINE_STRING_QUOTE
+                    return q
+                }
+                """.replacePlaceholderWithStringTemplate()
+                    .trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the string template is followed by some text on the same line in the raw string literal`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                            $EOL_CHAR
+                fun getQueryString(query: QueryRequest): String {
+                    val q = $MULTILINE_STRING_QUOTE
+                        SELECT *
+                        FROM table
+                        WHERE $.{query.gameId?.let { "id = ?" } ?: "1 = 1"} OR level = ?
+                    $MULTILINE_STRING_QUOTE
+                    return q
+                }
+                """.replacePlaceholderWithStringTemplate()
+                    .trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+    }
 }
 
 // Replace the "$." placeholder with an actual "$" so that string "$.{expression}" is transformed to a String template


### PR DESCRIPTION
## Description

Detect new lines inside string template before wrapping

Closes #1776

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
