### PR TITLE
Fix PR builds when version is non-SNAPSHOT

### DIFF
--- a/.github/workflows/gradle-pr-build.yml
+++ b/.github/workflows/gradle-pr-build.yml
@@ -18,8 +18,16 @@ jobs:
       - uses: gradle/gradle-build-action@v2
       - name: Build with release Kotlin version
         run: ./gradlew clean build ktlint --no-daemon
+        env:
+          ORG_GRADLE_PROJECT_signingKey : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingKeyPassword : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
       - name: Build with dev Kotlin version
         run: ./gradlew -PkotlinDev clean build ktlint --no-daemon
+        env:
+          ORG_GRADLE_PROJECT_signingKey : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingKeyPassword : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
non-snapshot builds sign the release, so we need to pass the proper signing key env variables.