### PR TITLE
Prevent false-positive "unnecessary semicolon" after adding trailing comma in enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Do not report an "unnecessary semicolon" after adding a trailing comma to an enum class containing a code element after the last enum entry `trailing-comma-on-declaration-site` ([#1786](https://github.com/pinterest/ktlint/issues/1786))
+
 ### Changed
 
 ## [0.48.2] - 2023-01-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+### Removed
+
+### Fixed
+
+### Changed
+
 ## [0.48.2] - 2023-01-21
 
 ### Additional clarification on API Changes in `0.48.0` and `0.48.1`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,4 +13,15 @@ Note: These steps should be done directly in the pinterest/ktlint repository, no
 7. Add a tag with the new release version, and push it directly to remote (e.g. `git tag 0.50.0 && git push origin 0.50.0`). This will kick off the [Release workflow](https://github.com/pinterest/ktlint/actions/workflows/release.yml).
 9. Close and release the repo on Sonatype. (Only Pinterest employees can do this.)
 10. Find the `<release>-update-refs` branch in the repo (created by the `.announce` script) and merge it.
-11. Update `gradle.properties` with the new `SNAPSHOT` version, and add a new empty `Unreleased` section to the top of `CHANGELOG.md` and commit. (This can be done directly in the main repo or in your fork.)
+11. Update `gradle.properties` with the new `SNAPSHOT` version, and add the section below to the top of `CHANGELOG.md` and commit. (This can be done directly in the main repo or in your fork.)
+```markdown
+## Unreleased
+
+### Added
+
+### Removed
+
+### Fixed
+
+### Changed
+```

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/TrailingCommaOnDeclarationSiteRule.kt
@@ -311,6 +311,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                             }
                         }
 
+                        val comma = KtPsiFactory(prevNode.psi).createComma()
                         if (inspectNode.treeParent.elementType == ElementType.ENUM_ENTRY) {
                             with(KtPsiFactory(prevNode.psi)) {
                                 val parentIndent =
@@ -319,15 +320,15 @@ public class TrailingCommaOnDeclarationSiteRule :
                                 val newline = createWhiteSpace(parentIndent)
                                 val enumEntry = inspectNode.treeParent.psi
                                 enumEntry.apply {
+                                    inspectNode.psi.replace(comma)
                                     add(newline)
-                                    removeChild(inspectNode)
-                                    parent.addAfter(createSemicolon(), this)
+                                    add(createSemicolon())
                                 }
                             }
+                            Unit
+                        } else {
+                            prevNode.psi.parent.addAfter(comma, prevNode.psi)
                         }
-
-                        val comma = KtPsiFactory(prevNode.psi).createComma()
-                        prevNode.psi.parent.addAfter(comma, prevNode.psi)
                     }
                 }
             TrailingCommaState.REDUNDANT -> {

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -158,6 +158,12 @@ public class KtLintAssertThat(
     public fun hasNoLintViolations(): Unit = ktLintAssertThatAssertable().hasNoLintViolations()
 
     /**
+     * Asserts that the code does not contain any [LintViolation]s for a given rule id.
+     */
+    public fun hasNoLintViolationsForRuleId(ruleId: String): KtLintAssertThatAssertable =
+        ktLintAssertThatAssertable().hasNoLintViolationsForRuleId(ruleId)
+
+    /**
      * Asserts that the code does not contain any [LintViolation]s except in the additional formatting rules.
      *
      * Note: When linting succeeds without errors, formatting is also checked.
@@ -352,6 +358,19 @@ public class KtLintAssertThatAssertable(
                     .isEqualTo(code)
             },
         )
+    }
+
+    /**
+     * Asserts that the code does not contain any [LintViolation]s for the given rule id.
+     */
+    public fun hasNoLintViolationsForRuleId(ruleId: String): KtLintAssertThatAssertable {
+        val (_, lintErrorsWhenFormatting) = format()
+
+        assertThat(lintErrorsWhenFormatting.filter { it.ruleId == ruleId })
+            .describedAs("At least 1 lint violation was found for rule id '$ruleId' while none were expected")
+            .isEmpty()
+
+        return this
     }
 
     /**


### PR DESCRIPTION
## Description

Do not report an "unnecessary semicolon" after adding a trailing comma to an enum class containing a code element after the last enum entry `trailing-comma-on-declaration-site` 

Closes #1786 

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
