### PR TITLE
Add documents about trailing comma is disabled when wrapping is enabled

### DIFF
--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -202,7 +202,7 @@ Consistent removal (default) or adding of trailing comma's on call site.
     ```
 
 !!! note
-    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
+    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.48.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
 
 
 Rule id: `trailing-comma-on-call-site`
@@ -241,7 +241,7 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
     ```
 
 !!! note
-    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
+    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.48.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
 
 Rule id: `trailing-comma-on-declaration-site`
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -187,7 +187,7 @@ Consistent removal (default) or adding of trailing comma's on call site.
 !!! note
     Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped calls. (see [dependencies](./dependencies.md)).
 
-    === "[:material-heart:](#) Trailing comma with wrapping"
+    === "[:material-heart:](#) Ktlint"
 
         ```kotlin
         FooWrapper(
@@ -197,7 +197,7 @@ Consistent removal (default) or adding of trailing comma's on call site.
             ),
         )
         ```
-    === "[:material-heart-off-outline:](#) Trailing comma without wrapping"
+    === "[:material-heart-off-outline:](#) Disallowed"
 
         ```kotlin
         FooWrapper(Foo(
@@ -228,7 +228,7 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
 !!! note
     Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped declarations. (see [dependencies](./dependencies.md)).
 
-    === "[:material-heart:](#) Trailing comma with wrapping"
+    === "[:material-heart:](#) Ktlint"
 
         ```kotlin
         class FooWrapper(
@@ -238,7 +238,7 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
             ),
         )
         ```
-    === "[:material-heart-off-outline:](#) Trailing comma without wrapping"
+    === "[:material-heart-off-outline:](#) Disallowed"
 
         ```kotlin
         class FooWrapper(val foo = Foo(

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -184,6 +184,16 @@ Consistent removal (default) or adding of trailing comma's on call site.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
+!!! note
+    Trailing comma on call site is automatically disabled if [Wrapping](#wrapping) rule (before 0.48.0, [Indentation](#indentation) rule) is disabled. Because it cannot provide proper formatting with unwrapped calls. (see [Dependencies](./dependencies.md))
+
+    ```kotlin
+    processFoo(Foo(
+        a = 3,
+        b = 4,
+    ),) // it's weird to insert "," between unwrapped (continuated) parenthesis
+    ```
+
 Rule id: `trailing-comma-on-call-site`
 
 ## Trailing comma on declaration site
@@ -191,16 +201,26 @@ Rule id: `trailing-comma-on-call-site`
 Consistent removal (default) or adding of trailing comma's on declaration site.
 
 !!! important
-KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at declaration site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
+    KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at declaration site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
 
 !!! note
-In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
+    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
 
     The Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) encourages the usage of trailing comma's on the declaration site, but leaves it to the developer's discretion to use trailing comma's on the call site. But next to this, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
+
+!!! note
+    Trailing comma on declaration site is automatically disabled if [Wrapping](#wrapping) rule (before 0.48.0, [Indentation](#indentation) rule) is disabled. Because it cannot provide proper formatting with unwrapped declarations. (see [Dependencies](./dependencies.md))
+
+    ```kotlin
+    class FooWrapper(val foo: Foo = Foo(
+        a = 3,
+        b = 4,
+    ),) // it's weird to insert "," between unwrapped (continuated) parenthesis
+    ```
 
 Rule id: `trailing-comma-on-declaration-site`
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -178,21 +178,32 @@ Consistent removal (default) or adding of trailing comma's on call site.
 !!! note
     In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
     
-    Although the Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) leaves it to the developer's discretion to use trailing comma's on the call site, it also states that usage of trailing commas has several benefits:
+    Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) leaves it to the developer's discretion to use trailing comma's on the call site, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on call site is automatically disabled if [Wrapping](#wrapping) rule (before 0.48.0, [Indentation](#indentation) rule) is disabled. Because it cannot provide proper formatting with unwrapped calls. (see [Dependencies](./dependencies.md))
+=== "[:material-heart:](#) Ktlint"
 
     ```kotlin
-    processFoo(Foo(
+    class FooWrapper(Foo(
         a = 3,
-        b = 4,
-    ),) // it's weird to insert "," between unwrapped (continuated) parenthesis
+        b = 4, // Trailing comma enforced
+    )) // No trailing comma enforced because of continuated parenthesis
     ```
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    class FooWrapper(Foo(
+        a = 3,
+        b = 4 // Trailing comma is missing
+    ),) // No trailing comma expected
+    ```
+
+!!! note
+    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
+
 
 Rule id: `trailing-comma-on-call-site`
 
@@ -206,21 +217,31 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
 !!! note
     In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
 
-    The Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) encourages the usage of trailing comma's on the declaration site, but leaves it to the developer's discretion to use trailing comma's on the call site. But next to this, it also states that usage of trailing commas has several benefits:
+    The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) encourages the usage of trailing comma's on the declaration site, but leaves it to the developer's discretion to use trailing comma's on the call site. But next to this, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on declaration site is automatically disabled if [Wrapping](#wrapping) rule (before 0.48.0, [Indentation](#indentation) rule) is disabled. Because it cannot provide proper formatting with unwrapped declarations. (see [Dependencies](./dependencies.md))
+=== "[:material-heart:](#) Ktlint"
 
     ```kotlin
     class FooWrapper(val foo: Foo = Foo(
         a = 3,
-        b = 4,
-    ),) // it's weird to insert "," between unwrapped (continuated) parenthesis
+        b = 4, // Trailing comma enforced
+    )) // No trailing comma enforced because of continuated parenthesis
     ```
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    class FooWrapper(val foo: Foo = Foo(
+        a = 3,
+        b = 4 // Trailing comma is missing
+    ),) // No trailing comma expected
+    ```
+
+!!! note
+    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
 
 Rule id: `trailing-comma-on-declaration-site`
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -184,25 +184,27 @@ Consistent removal (default) or adding of trailing comma's on call site.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-=== "[:material-heart:](#) Ktlint"
-
-    ```kotlin
-    class FooWrapper(Foo(
-        a = 3,
-        b = 4, // Trailing comma enforced
-    )) // No trailing comma enforced because of continuated parenthesis
-    ```
-=== "[:material-heart-off-outline:](#) Disallowed"
-
-    ```kotlin
-    class FooWrapper(Foo(
-        a = 3,
-        b = 4 // Trailing comma is missing
-    ),) // No trailing comma expected
-    ```
-
 !!! note
-    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.48.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
+    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped calls. (see [dependencies](./dependencies.md)).
+
+    === "[:material-heart:](#) Trailing comma with wrapping"
+
+        ```kotlin
+        FooWrapper(
+            Foo(
+                a = 3,
+                b = 4,
+            ),
+        )
+        ```
+    === "[:material-heart-off-outline:](#) Trailing comma without wrapping"
+
+        ```kotlin
+        FooWrapper(Foo(
+            a = 3,
+            b = 4,
+        ),) // it's weird to insert "," between unwrapped (continued) parenthesis
+        ```
 
 
 Rule id: `trailing-comma-on-call-site`
@@ -223,25 +225,28 @@ Consistent removal (default) or adding of trailing comma's on declaration site.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-=== "[:material-heart:](#) Ktlint"
-
-    ```kotlin
-    class FooWrapper(val foo: Foo = Foo(
-        a = 3,
-        b = 4, // Trailing comma enforced
-    )) // No trailing comma enforced because of continuated parenthesis
-    ```
-=== "[:material-heart-off-outline:](#) Disallowed"
-
-    ```kotlin
-    class FooWrapper(val foo: Foo = Foo(
-        a = 3,
-        b = 4 // Trailing comma is missing
-    ),) // No trailing comma expected
-    ```
-
 !!! note
-    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.48.0`, the [Indentation](#indentation) rule) is disabled or not loaded (see [dependencies](./dependencies.md)).
+    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped declarations. (see [dependencies](./dependencies.md)).
+
+    === "[:material-heart:](#) Trailing comma with wrapping"
+
+        ```kotlin
+        class FooWrapper(
+            val foo = Foo(
+                a = 3,
+                b = 4,
+            ),
+        )
+        ```
+    === "[:material-heart-off-outline:](#) Trailing comma without wrapping"
+
+        ```kotlin
+        class FooWrapper(val foo = Foo(
+            a = 3,
+            b = 4,
+        ),) // it's weird to insert "," between unwrapped (continued) parenthesis
+        ```
+
 
 Rule id: `trailing-comma-on-declaration-site`
 


### PR DESCRIPTION
## Description

[From Kotlin Slack](https://kotlinlang.slack.com/archives/CKS3XG0LS/p1674804306134669)

If wrapping rule is disabled then trailing comma on call site & trailing comma on declaration site is disabled, because w/o wrapping trailing commas can produce weird formattings. (see 10cb29caf2c36bf5a8aac8d3cce38314c6671f71)

But there are no descriptions in rule documents about existence of this dependency and why exists. It may confuse users, so I added it.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
