### PR TITLE
Fix documentation trailing comma's

### DIFF
--- a/docs/rules/configuration-ktlint.md
+++ b/docs/rules/configuration-ktlint.md
@@ -204,7 +204,16 @@ This setting is used by multiple rules of which rule `max-line-length` is the mo
 
 ## Trailing comma on call site
 
-By default, trailing comma's on call site are not allowed. When enabling the property, the trailing comma becomes mandatory where applicable.
+KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma_on_call_site` to *enforce* the usage of the trailing comma at call site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
+
+!!! note
+    In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
+
+    Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) leaves it to the developer's discretion to use trailing comma's on the call site, it also states that usage of trailing commas has several benefits:
+    
+     * It makes version-control diffs cleaner – as all the focus is on the changed value.
+     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
+     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
 Example:
 ```ini
@@ -216,7 +225,16 @@ This setting only takes effect when rule `trailing-comma-on-call-site` is enable
 
 ## Trailing comma on declaration site
 
-By default, trailing comma's on declaration site are not allowed. When enabling the property, the trailing comma becomes mandatory where applicable.
+KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to *enforce* the usage of the trailing comma at declaration site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
+
+!!! note
+    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
+
+    The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) encourages the usage of trailing comma's on the declaration site, but leaves it to the developer's discretion to use trailing comma's on the call site. But next to this, it also states that usage of trailing commas has several benefits:
+    
+     * It makes version-control diffs cleaner – as all the focus is on the changed value.
+     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
+     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
 Example:
 ```ini


### PR DESCRIPTION
## Description

Fix documentation - trailing comma's are enabled by default except for android codestyle

fixes https://github.com/pinterest/ktlint/issues/1810#issuecomment-1419866153

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
