### PR TITLE
Fix EditorConfig property names for custom rule set in docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -146,7 +146,7 @@ All rules in a rule set can be enabled or disabled with a rule set property. The
 ```editorconfig
 ktlint_standard = disabled # Disable all rules from the `standard` rule set provided by KtLint
 ktlint_experimental = enabled # Enable all rules from the `experimental` rule set provided by KtLint
-ktlint_your-custom-rule-set_custom-rule = enabled # Enable all rules in the `custom-rule-set` rule set (not provided by KtLint)
+ktlint_custom-rule-set = enabled # Enable all rules in the `custom-rule-set` rule set (not provided by KtLint)
 ```
 
 !!! note

--- a/docs/rules/configuration-ktlint.md
+++ b/docs/rules/configuration-ktlint.md
@@ -32,7 +32,7 @@ All rules in a rule set can be enabled or disabled with a rule set property. The
 ```editorconfig
 ktlint_standard = disabled # Disable all rules from the `standard` rule set provided by KtLint
 ktlint_experimental = enabled # Enable all rules from the `experimental` rule set provided by KtLint
-ktlint_your-custom-rule-set_custom-rule = enabled # Enable all rules in the `custom-rule-set` rule set (not provided by KtLint)
+ktlint_custom-rule-set = enabled # Enable all rules in the `custom-rule-set` rule set (not provided by KtLint)
 ```
 
 !!! note


### PR DESCRIPTION
## Description

This PR fixes EditorConfig property names for custom rule set in docs as they seem to be wrong considering their description.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)