### PR TITLE
Fix typos in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Report ktlint bug
 
 ---
 
-<!-- The bug you're experiencing might have already be reported!
+<!-- The bug you're experiencing might have already been reported!
 Please search in the [issues](https://github.com/pinterest/ktlint/issues) before creating one. -->
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -4,7 +4,7 @@ about: Propose new enhancement to the Ktlint API
 
 ---
 
-<!-- The enhancement you want to propose might have already be reported!
+<!-- The enhancement you want to propose might have already been reported!
 Please search in the [issues](https://github.com/pinterest/ktlint/issues) before creating one. -->
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/new_rule_proposal.md
+++ b/.github/ISSUE_TEMPLATE/new_rule_proposal.md
@@ -4,7 +4,7 @@ about: Propose new rule
 
 ---
 
-<!-- New rule you want to propose might have already be reported!
+<!-- New rule you want to propose might have already been reported!
 Please search in the [issues](https://github.com/pinterest/ktlint/issues) before creating one. -->
 
 ## Expected Rule behavior

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,11 @@
 
 <!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.
 
-If the PR solves an issue than provide a link to that issue. -->
+If the PR solves an issue then provide a link to that issue. -->
 
 ## Checklist
 
-<!-- Following checklist maybe skipped in some cases -->
+<!-- Following checklist may be skipped in some cases -->
 - [ ] PR description added
 - [ ] tests are added
 - [ ] KtLint has been applied on source code itself and violations are fixed


### PR DESCRIPTION
## Description

This PR fixes typos in GitHub templates.

## Checklist

<!-- Following checklist maybe skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
