### PR TITLE
Allow disabling signing

### DIFF
--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -97,6 +97,8 @@ signing {
     val signingPassword = System.getenv("ORG_GRADLE_PROJECT_signingKeyPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
 
+    // This property allows OS package maintainers to disable signing
+    val enableSigning = project.findProperty("ktlint.publication.signing.enable") != "false"
     sign(publishing.publications["maven"])
-    isRequired = !version.toString().endsWith("SNAPSHOT")
+    isRequired = enableSigning && !version.toString().endsWith("SNAPSHOT")
 }


### PR DESCRIPTION
## Description

This PR makes it possible to disable code signing for release builds. This is primarily useful for package maintainers building the project from source. In this scenario, ktlint's own signing is not necessary, since the resulting package will be signed anyway. The property `ktlint.disable-signing` (name open for discussion) is introduced, which when set during release builds, skips the signing.

Fixes #1817

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
