### PR TITLE
Map property max_line_length to "off" instead of "-1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ Like before, the API Consumer can still offer a mix of rules originating from `k
 * Do not add the first line of a multiline body expression on the same line as the function signature in case function body expression wrapping property is set to `multiline`. `function-signature`. 
 * Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin` ([#1742](https://github.com/pinterest/ktlint/issues/1742))
 * The parameters of a function literal containing a multiline parameter list are aligned with first parameter whenever the first parameter is on the same line as the start of that function literal (not allowed in `ktlint_official` code style) `indent` ([#1756](https://github.com/pinterest/ktlint/issues/1756)).
-* Fix continuation indent for a dot qualified array access expression in `ktlint_official` code style only `indent`  ([#1740](https://github.com/pinterest/ktlint/issues/1540)).
+* Fix continuation indent for a dot qualified array access expression in `ktlint_official` code style only `indent` ([#1540](https://github.com/pinterest/ktlint/issues/1540)).
 * When generating the `.editorconfig` use value `off` for the `max_line_length` property instead of value `-1` to denote that lines are not restricted to a maximum length ([#1824](https://github.com/pinterest/ktlint/issues/1824)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ Like before, the API Consumer can still offer a mix of rules originating from `k
 * Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin` ([#1742](https://github.com/pinterest/ktlint/issues/1742))
 * The parameters of a function literal containing a multiline parameter list are aligned with first parameter whenever the first parameter is on the same line as the start of that function literal (not allowed in `ktlint_official` code style) `indent` ([#1756](https://github.com/pinterest/ktlint/issues/1756)).
 * Fix continuation indent for a dot qualified array access expression in `ktlint_official` code style only `indent`  ([#1740](https://github.com/pinterest/ktlint/issues/1540)).
+* When generating the `.editorconfig` use value `off` for the `max_line_length` property instead of value `-1` to denote that lines are not restricted to a maximum length ([#1824](https://github.com/pinterest/ktlint/issues/1824)).
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/docs/rules/configuration-ktlint.md
+++ b/docs/rules/configuration-ktlint.md
@@ -191,7 +191,7 @@ By default, the maximum line length is not set. The `android` code style sets th
 
 ```ini
 [*.{kt,kts}]
-max_line_length = -1 # Use "off" (or -1) to ignore max line length or a positive number to set max line length
+max_line_length = off # Use "off" to ignore max line length or a positive number to set max line length
 ```
 
 This setting is used by multiple rules of which rule `max-line-length` is the most important.

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigProperty.kt
@@ -1,37 +1,71 @@
 package com.pinterest.ktlint.rule.engine.core.api.editorconfig
 
+import com.pinterest.ktlint.logger.api.initKtLintKLogger
+import mu.KotlinLogging
 import org.ec4j.core.model.PropertyType
 
 private const val MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE = 100 // https://developer.android.com/kotlin/style-guide#line_wrapping
 private const val MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE = 140
-private const val MAX_LINE_LENGTH_PROPERTY_NONE = -1
+private const val MAX_LINE_LENGTH_PROPERTY_OFF = "off"
+private const val MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY = -1
+
+private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
+private var isInvalidValueLoggedBefore = false
 
 public val MAX_LINE_LENGTH_PROPERTY: EditorConfigProperty<Int> =
     EditorConfigProperty(
         name = PropertyType.max_line_length.name,
         type = PropertyType.max_line_length,
-        defaultValue = MAX_LINE_LENGTH_PROPERTY_NONE,
+        defaultValue = MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY,
         androidStudioCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE,
-        intellijIdeaCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_NONE,
+        intellijIdeaCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY,
         ktlintOfficialCodeStyleDefaultValue = MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE,
         propertyMapper = { property, codeStyleValue ->
             when {
                 property == null || property.isUnset -> {
                     when (codeStyleValue) {
-                        CodeStyleValue.android_studio -> {
+                        CodeStyleValue.android,
+                        CodeStyleValue.android_studio,
+                        -> {
                             MAX_LINE_LENGTH_PROPERTY_ANDROID_STUDIO_CODE_STYLE
                         }
                         CodeStyleValue.ktlint_official -> {
                             MAX_LINE_LENGTH_PROPERTY_KTLINT_OFFICIAL_CODE_STYLE
                         }
                         else -> {
-                            property?.getValueAs()
+                            MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY
                         }
                     }
                 }
 
-                property.sourceValue == "off" -> MAX_LINE_LENGTH_PROPERTY_NONE
-                else -> PropertyType.max_line_length.parse(property.sourceValue).parsed
+                /**
+                 * Internally, Ktlint uses value '-1' to indicate that the max line length has to be ignored as this is easier in
+                 * comparisons to check whether the maximum length of a line is exceeded.
+                 */
+                property.sourceValue == MAX_LINE_LENGTH_PROPERTY_OFF -> MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY
+
+                else ->
+                    PropertyType
+                        .max_line_length
+                        .parse(property.sourceValue)
+                        .let {
+                            if (!it.isValid) {
+                                if (!isInvalidValueLoggedBefore) {
+                                    isInvalidValueLoggedBefore = true
+                                    LOGGER.warn { "Found invalid '.editorconfig' property value: ${it.errorMessage}" }
+                                }
+                                MAX_LINE_LENGTH_PROPERTY_OFF_INTERNALLY
+                            } else {
+                                it.parsed
+                            }
+                        }
+            }
+        },
+        propertyWriter = { property ->
+            if (property <= 0) {
+                MAX_LINE_LENGTH_PROPERTY_OFF
+            } else {
+                property.toString()
             }
         },
     )

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/IndentSizeEditorConfigPropertyTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/IndentSizeEditorConfigPropertyTest.kt
@@ -1,0 +1,58 @@
+package com.pinterest.ktlint.rule.engine.core.api.editorconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class IndentSizeEditorConfigPropertyTest {
+    val indentSizePropertyMapper = INDENT_SIZE_PROPERTY.propertyMapper!!
+
+    @ParameterizedTest(name = "Code style: {0}, default value: {1}")
+    @EnumSource(CodeStyleValue::class)
+    fun `Given a null property then the property mapper returns 4 which is set as the default value`(codeStyleValue: CodeStyleValue) {
+        val actual = indentSizePropertyMapper(null, codeStyleValue)
+
+        assertThat(actual).isEqualTo(4)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}, default value: {1}")
+    @EnumSource(CodeStyleValue::class)
+    fun `Given a property which is unset then the property mapper returns -1 as default value`(codeStyleValue: CodeStyleValue) {
+        val property = indentSizeProperty("unset")
+
+        val actual = indentSizePropertyMapper(property, codeStyleValue)
+
+        assertThat(actual).isEqualTo(-1)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class)
+    fun `Given a valid string value then the property mapper returns the integer value`(codeStyleValue: CodeStyleValue) {
+        val someValue = 123
+        val property = indentSizeProperty(someValue.toString())
+
+        val actual = indentSizePropertyMapper(property, codeStyleValue)
+
+        assertThat(actual).isEqualTo(someValue)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class)
+    fun `Given value 'tab' then the property mapper returns 4 which is set as the default value`(codeStyleValue: CodeStyleValue) {
+        val property = indentSizeProperty("tab")
+
+        val actual = indentSizePropertyMapper(property, codeStyleValue)
+
+        assertThat(actual).isEqualTo(4)
+    }
+
+    private fun indentSizeProperty(value: String?): Property? =
+        Property
+            .builder()
+            .name("indent_size")
+            .type(PropertyType.indent_size)
+            .value(value)
+            .build()
+}

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
@@ -1,0 +1,116 @@
+package com.pinterest.ktlint.rule.engine.core.api.editorconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+
+class MaxLineLengthEditorConfigPropertyTest {
+    @Nested
+    inner class PropertyMapper {
+        val maxLineLengthPropertyMapper = MAX_LINE_LENGTH_PROPERTY.propertyMapper!!
+
+        @ParameterizedTest(name = "Code style: {0}, default value: {1}")
+        @CsvSource(
+            value = [
+                "android, 100",
+                "android_studio, 100",
+                "intellij_idea, -1",
+                "official, -1",
+                "ktlint_official, 140",
+            ],
+        )
+        fun `Given a null property then the property mapper returns the default value of the code style`(
+            codeStyleValue: CodeStyleValue,
+            expectedDefaultValue: Int,
+        ) {
+            val actual = maxLineLengthPropertyMapper(null, codeStyleValue)
+
+            assertThat(actual).isEqualTo(expectedDefaultValue)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}, default value: {1}")
+        @CsvSource(
+            value = [
+                "android, 100",
+                "android_studio, 100",
+                "intellij_idea, -1",
+                "official, -1",
+                "ktlint_official, 140",
+            ],
+        )
+        fun `Given a property which is unset then the property mapper returns the default value of the code style`(
+            codeStyleValue: CodeStyleValue,
+            expectedDefaultValue: Int,
+        ) {
+            val property = maxLineLengthProperty("unset")
+
+            val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(expectedDefaultValue)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a valid string value then the property mapper returns the integer value`(codeStyleValue: CodeStyleValue) {
+            val someValue = 123
+            val property = maxLineLengthProperty(someValue.toString())
+
+            val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(someValue)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given the value 'off' then the property mapper returns -1 which is internally used to disable the max line length`(
+            codeStyleValue: CodeStyleValue,
+        ) {
+            val property = maxLineLengthProperty("off")
+
+            val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(-1)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given an invalid value then the property mapper returns -1 which is internally used to disable the max line length`(
+            codeStyleValue: CodeStyleValue,
+        ) {
+            val property = maxLineLengthProperty("some-invalid-value")
+
+            val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(-1)
+        }
+    }
+
+    @ParameterizedTest(name = "Input value: {0}, output value: {1}")
+    @CsvSource(
+        value = [
+            "-1, off",
+            "0, off",
+            "1, 1",
+        ],
+    )
+    fun `Given a property with an integer value than write that property`(
+        inputValue: Int,
+        expectedOutputValue: String,
+    ) {
+        val actual = MAX_LINE_LENGTH_PROPERTY.propertyWriter(inputValue)
+
+        assertThat(actual).isEqualTo(expectedOutputValue)
+    }
+
+    private fun maxLineLengthProperty(value: String?): Property? =
+        Property
+            .builder()
+            .name("max_line_length")
+            .type(PropertyType.max_line_length)
+            .value(value)
+            .build()
+}


### PR DESCRIPTION
## Description

When generating the `.editorconfig` the default value of property `max_line_length` is set to `-1` for code style `official`. This value is not recognized by IntelliJ IDEA and has negative effect on code formatting in IntelliJ. The value `off` has to be generated instead to disable the maximum line length check.

Closes #1824 

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
