### PR TITLE
Exception in trailing-comma-on-declaration-site on empty enum class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ Like before, the API Consumer can still offer a mix of rules originating from `k
 * Disable the `standard:filename` rule whenever Ktlint CLI is run with option `--stdin` ([#1742](https://github.com/pinterest/ktlint/issues/1742))
 * The parameters of a function literal containing a multiline parameter list are aligned with first parameter whenever the first parameter is on the same line as the start of that function literal (not allowed in `ktlint_official` code style) `indent` ([#1756](https://github.com/pinterest/ktlint/issues/1756)).
 * Fix continuation indent for a dot qualified array access expression in `ktlint_official` code style only `indent`  ([#1740](https://github.com/pinterest/ktlint/issues/1540)).
+* Do not throw exception when enum class does not contain entries `trailing-comma-on-declaration-site` ([#1711](https://github.com/pinterest/ktlint/issues/1711))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -1033,4 +1033,17 @@ class TrailingCommaOnDeclarationSiteRuleTest {
             .hasNoLintViolationsForRuleId("no-semi")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 1711 - Given an empty enum class then do not throw an exception`() {
+        val code =
+            """
+            enum class Dummy(val type: String) {
+                // empty
+            }
+            """.trimIndent()
+        trailingCommaOnDeclarationSiteRuleAssertThat(code)
+            .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not throw exception when enum class does not contain entries `trailing-comma-on-declaration-site`

Closes #1711

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
