### PR TITLE
Change 'max_line_length' value '-1' to 'Int.MAX_VALUE'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,10 @@ Fields `loadOnlyWhenOtherRuleIsLoaded` and `runOnlyWhenOtherRuleIsEnabled` have 
 
 Like before, the API Consumer can still offer a mix of rules originating from `ktlint-ruleset-standard` as well as custom rules.
 
+#### `.editorconfig` property `max_line_length` default value
+
+Previously the default value for `.editorconfig` property `max_line_length` was set to `-1` in ktlint unless the property was defined explicitly in the `.editorconfig` or when `ktlint_code_style` was set to Android. As a result of that rules have to check that max_line_length contains a positive value before checking that the actual line length is exceeding the maximum. Now the value `Int.MAX_VALUE` (use constant `MAX_LINE_LENGTH_PROPERTY_OFF` to refer to that value) is used instead. 
+
 ### Added
 
 * Add new experimental rule for `ktlint_official` code style that disallows a class to start with a blank line `no-empty-first-line-in-class-body`.

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
@@ -17,8 +17,8 @@ class MaxLineLengthEditorConfigPropertyTest {
             value = [
                 "android, 100",
                 "android_studio, 100",
-                "intellij_idea, -1",
-                "official, -1",
+                "intellij_idea, ${Int.MAX_VALUE}",
+                "official, ${Int.MAX_VALUE}",
                 "ktlint_official, 140",
             ],
         )
@@ -36,8 +36,8 @@ class MaxLineLengthEditorConfigPropertyTest {
             value = [
                 "android, 100",
                 "android_studio, 100",
-                "intellij_idea, -1",
-                "official, -1",
+                "intellij_idea, ${Int.MAX_VALUE}",
+                "official, ${Int.MAX_VALUE}",
                 "ktlint_official, 140",
             ],
         )
@@ -65,26 +65,47 @@ class MaxLineLengthEditorConfigPropertyTest {
 
         @ParameterizedTest(name = "Code style: {0}")
         @EnumSource(CodeStyleValue::class)
-        fun `Given the value 'off' then the property mapper returns -1 which is internally used to disable the max line length`(
+        fun `Given the value 'off' then the property mapper returns integer MAX_VALUE which denotes that no maximum line length is set`(
             codeStyleValue: CodeStyleValue,
         ) {
             val property = MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue("off")
 
             val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
 
-            assertThat(actual).isEqualTo(-1)
+            assertThat(actual).isEqualTo(Int.MAX_VALUE)
         }
 
         @ParameterizedTest(name = "Code style: {0}")
         @EnumSource(CodeStyleValue::class)
-        fun `Given an invalid value then the property mapper returns -1 which is internally used to disable the max line length`(
+        fun `Given the value '-1' then the property mapper returns integer MAX_VALUE which denotes that no maximum line length is set`(
             codeStyleValue: CodeStyleValue,
+        ) {
+            val property = MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue("-1")
+
+            val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(Int.MAX_VALUE)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}, default value: {1}")
+        @CsvSource(
+            value = [
+                "android, 100",
+                "android_studio, 100",
+                "intellij_idea, ${Int.MAX_VALUE}",
+                "official, ${Int.MAX_VALUE}",
+                "ktlint_official, 140",
+            ],
+        )
+        fun `Given an invalid value then the property mapper returns the default value of the code style`(
+            codeStyleValue: CodeStyleValue,
+            expectedDefaultValue: Int,
         ) {
             val property = MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue("some-invalid-value")
 
             val actual = maxLineLengthPropertyMapper(property, codeStyleValue)
 
-            assertThat(actual).isEqualTo(-1)
+            assertThat(actual).isEqualTo(expectedDefaultValue)
         }
     }
 
@@ -94,6 +115,7 @@ class MaxLineLengthEditorConfigPropertyTest {
             "-1, off",
             "0, off",
             "1, 1",
+            "${Int.MAX_VALUE}, off",
         ],
     )
     fun `Given a property with an integer value than write that property`(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -56,7 +56,7 @@ public class ArgumentListWrappingRule :
     ) {
     private var editorConfigIndent = IndentConfig.DEFAULT_INDENT_CONFIG
 
-    private var maxLineLength = -1
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         editorConfigIndent = IndentConfig(
@@ -102,7 +102,7 @@ public class ArgumentListWrappingRule :
             false
         }
 
-    private fun ASTNode.exceedsMaxLineLength() = maxLineLength > -1 && (column - 1 + textLength) > maxLineLength && !textContains('\n')
+    private fun ASTNode.exceedsMaxLineLength() = (column - 1 + textLength) > maxLineLength && !textContains('\n')
 
     private fun ASTNode.getNewIndentLevel(): Int {
         val currentIndentLevel = editorConfigIndent.indentLevelFrom(lineIndent())

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -43,7 +43,7 @@ public class ContextReceiverWrappingRule :
     ),
     Rule.Experimental {
     private lateinit var indent: String
-    private var maxLineLength = -1
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         val indentConfig = IndentConfig(
@@ -88,8 +88,7 @@ public class ContextReceiverWrappingRule :
 
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run
         // before indenting.
-        if (isMaxLineLengthSet() &&
-            !node.textContains('\n') &&
+        if (!node.textContains('\n') &&
             node.lineIndent().length + node.textLength > maxLineLength
         ) {
             node
@@ -130,8 +129,7 @@ public class ContextReceiverWrappingRule :
         val contextReceiver = node.treeParent.text
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run
         // before indenting.
-        if (isMaxLineLengthSet() &&
-            !contextReceiver.contains('\n') &&
+        if (!contextReceiver.contains('\n') &&
             node.lineIndent().length + contextReceiver.length > maxLineLength
         ) {
             node
@@ -165,8 +163,6 @@ public class ContextReceiverWrappingRule :
                 }
         }
     }
-
-    private fun isMaxLineLengthSet() = maxLineLength > -1
 }
 
 public val CONTEXT_RECEIVER_WRAPPING_RULE_ID: RuleId = ContextReceiverWrappingRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRule.kt
@@ -8,14 +8,13 @@ import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
-import kotlin.properties.Delegates
 
 public class FinalNewlineRule :
     StandardRule(
         id = "final-newline",
         usesEditorConfigProperties = setOf(INSERT_FINAL_NEWLINE_PROPERTY),
     ) {
-    private var insertFinalNewline by Delegates.notNull<Boolean>()
+    private var insertFinalNewline = INSERT_FINAL_NEWLINE_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         insertFinalNewline = editorConfig[INSERT_FINAL_NEWLINE_PROPERTY]

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -65,8 +65,9 @@ public class FunctionSignatureRule :
     Rule.Experimental {
     private var indent: String? = null
     private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
-    private var functionSignatureWrappingMinimumParameters = -1
-    private var functionBodyExpressionWrapping = default
+    private var functionSignatureWrappingMinimumParameters =
+        FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.defaultValue
+    private var functionBodyExpressionWrapping = FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         functionSignatureWrappingMinimumParameters = editorConfig[
@@ -680,8 +681,7 @@ public class FunctionSignatureRule :
     private fun List<ASTNode>.joinTextToString(block: (ASTNode) -> String = { it.text }): String =
         collectLeavesRecursively().joinToString(separator = "") { block(it) }
 
-    private fun ASTNode.hasMinimumNumberOfParameters(): Boolean =
-        functionSignatureWrappingMinimumParameters > 0 && countParameters() >= functionSignatureWrappingMinimumParameters
+    private fun ASTNode.hasMinimumNumberOfParameters(): Boolean = countParameters() >= functionSignatureWrappingMinimumParameters
 
     private fun ASTNode.countParameters(): Int {
         val valueParameterList = requireNotNull(findChildByType(VALUE_PARAMETER_LIST))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProper
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.lineIndent
@@ -63,7 +64,7 @@ public class FunctionSignatureRule :
     ),
     Rule.Experimental {
     private var indent: String? = null
-    private var maxLineLength = -1
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
     private var functionSignatureWrappingMinimumParameters = -1
     private var functionBodyExpressionWrapping = default
 
@@ -636,9 +637,7 @@ public class FunctionSignatureRule :
             .firstOrNull()
             ?.takeIf { first -> first.isWhiteSpace() }
 
-    private fun List<ASTNode>.getBody() = this.dropWhile { it.isWhiteSpace() }
-
-    private fun isMaxLineLengthSet() = maxLineLength > -1
+    private fun isMaxLineLengthSet() = maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF
 
     private fun List<ASTNode>.collectLeavesRecursively(): List<ASTNode> = flatMap { it.collectLeavesRecursively() }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
-import kotlin.properties.Delegates
 
 public class MaxLineLengthRule :
     StandardRule(
@@ -50,7 +49,7 @@ public class MaxLineLengthRule :
     ) {
     private var maxLineLength: Int = MAX_LINE_LENGTH_PROPERTY.defaultValue
     private var rangeTree = RangeTree()
-    private var ignoreBackTickedIdentifier by Delegates.notNull<Boolean>()
+    private var ignoreBackTickedIdentifier = IGNORE_BACKTICKED_IDENTIFIER_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         ignoreBackTickedIdentifier = editorConfig[IGNORE_BACKTICKED_IDENTIFIER_PROPERTY]

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isRoot
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
@@ -54,6 +55,9 @@ public class MaxLineLengthRule :
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         ignoreBackTickedIdentifier = editorConfig[IGNORE_BACKTICKED_IDENTIFIER_PROPERTY]
         maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        if (maxLineLength == MAX_LINE_LENGTH_PROPERTY_OFF) {
+            stopTraversalOfAST()
+        }
     }
 
     override fun beforeVisitChildNodes(
@@ -61,9 +65,6 @@ public class MaxLineLengthRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        if (maxLineLength <= 0) {
-            return
-        }
         if (node.isRoot()) {
             val errorOffset = arrayListOf<Int>()
             node

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -45,7 +45,7 @@ public class ParameterListWrappingRule :
     ) {
     private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
-    private var maxLineLength = -1
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         codeStyle = editorConfig[CODE_STYLE_PROPERTY]
@@ -82,8 +82,8 @@ public class ParameterListWrappingRule :
         require(node.elementType == NULLABLE_TYPE)
         node
             .takeUnless {
-                // skip when max line length not set or does not exceed max line length
-                maxLineLength <= 0 || (node.column - 1 + node.textLength) <= maxLineLength
+                // skip when max line length is not exceedd
+                (node.column - 1 + node.textLength) <= maxLineLength
             }?.findChildByType(FUNCTION_TYPE)
             ?.findChildByType(VALUE_PARAMETER_LIST)
             ?.takeIf { it.findChildByType(VALUE_PARAMETER) != null }
@@ -236,7 +236,7 @@ public class ParameterListWrappingRule :
         }
     }
 
-    private fun ASTNode.exceedsMaxLineLength() = maxLineLength > -1 && (column - 1 + textLength) > maxLineLength && !textContains('\n')
+    private fun ASTNode.exceedsMaxLineLength() = (column - 1 + textLength) > maxLineLength && !textContains('\n')
 
     private fun errorMessage(node: ASTNode) =
         when (node.elementType) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
@@ -23,7 +23,6 @@ import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.KtPsiFactory
-import kotlin.properties.Delegates
 
 /**
  * Linting trailing comma for call site.
@@ -42,9 +41,7 @@ public class TrailingCommaOnCallSiteRule :
         ),
         usesEditorConfigProperties = setOf(TRAILING_COMMA_ON_CALL_SITE_PROPERTY),
     ) {
-    private var allowTrailingCommaOnCallSite by Delegates.notNull<Boolean>()
-
-    private fun ASTNode.isTrailingCommaAllowed() = elementType in TYPES_ON_CALL_SITE && allowTrailingCommaOnCallSite
+    private var allowTrailingCommaOnCallSite = TRAILING_COMMA_ON_CALL_SITE_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         allowTrailingCommaOnCallSite = editorConfig[TRAILING_COMMA_ON_CALL_SITE_PROPERTY]
@@ -81,6 +78,8 @@ public class TrailingCommaOnCallSiteRule :
             autoCorrect = autoCorrect,
         )
     }
+
+    private fun ASTNode.isTrailingCommaAllowed() = elementType in TYPES_ON_CALL_SITE && allowTrailingCommaOnCallSite
 
     private fun visitIndices(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -44,7 +44,6 @@ import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 import org.jetbrains.kotlin.utils.addToStdlib.cast
-import kotlin.properties.Delegates
 
 /**
  * Linting trailing comma for declaration site.
@@ -63,9 +62,7 @@ public class TrailingCommaOnDeclarationSiteRule :
         ),
         usesEditorConfigProperties = setOf(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY),
     ) {
-    private var allowTrailingComma by Delegates.notNull<Boolean>()
-
-    private fun ASTNode.isTrailingCommaAllowed() = elementType in TYPES_ON_DECLARATION_SITE && allowTrailingComma
+    private var allowTrailingComma = TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         allowTrailingComma = editorConfig[TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY]
@@ -104,6 +101,8 @@ public class TrailingCommaOnDeclarationSiteRule :
             emit = emit,
         )
     }
+
+    private fun ASTNode.isTrailingCommaAllowed() = elementType in TYPES_ON_DECLARATION_SITE && allowTrailingComma
 
     private fun visitFunctionLiteral(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -43,6 +43,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
@@ -92,7 +93,7 @@ public class WrappingRule :
     ) {
     private var line = 1
     private lateinit var indentConfig: IndentConfig
-    private var maxLineLength: Int = -1
+    private var maxLineLength: Int = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         line = 1
@@ -140,7 +141,7 @@ public class WrappingRule :
                     // A multiline block should always be wrapped unless it starts with an EOL comment
                     node.firstChildLeafOrSelf().elementType != EOL_COMMENT
                 }
-                maxLineLength > 0 -> {
+                maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF -> {
                     val startOfLine = node.prevLeaf {
                         it.isWhiteSpaceWithNewline() || (it.elementType == REGULAR_STRING_PART && it.text == "\n")
                     }


### PR DESCRIPTION
## Description

### Change 'max_line_length' value '-1' to 'Int.MAX_VALUE'

The value '-1' is not a value which is accepted by the property type which only accepts positive integer value or the special value 'off' to denote that no maximum line length is applicable. Also, using value 'Int.MAX_VALUE' results in more readable code.

### Initialize editor config properties in rules

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
