### PR TITLE
experimental:function-return-type-spacing should not violate max-line rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix continuation indent for a dot qualified array access expression in `ktlint_official` code style only `indent` ([#1540](https://github.com/pinterest/ktlint/issues/1540)).
 * When generating the `.editorconfig` use value `off` for the `max_line_length` property instead of value `-1` to denote that lines are not restricted to a maximum length ([#1824](https://github.com/pinterest/ktlint/issues/1824)).
 * Do not report an "unnecessary semicolon" after adding a trailing comma to an enum class containing a code element after the last enum entry `trailing-comma-on-declaration-site` ([#1786](https://github.com/pinterest/ktlint/issues/1786))
+* A newline before a function return type should not be removed in case that leads to exceeding the maximum line length `function-return-type-spacing` ([#1764](https://github.com/pinterest/ktlint/issues/1764))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRule.kt
@@ -5,15 +5,28 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.psiUtil.leaves
 
 public class FunctionReturnTypeSpacingRule :
-    StandardRule("function-return-type-spacing"),
+    StandardRule(
+        id = "function-return-type-spacing",
+        usesEditorConfigProperties = setOf(MAX_LINE_LENGTH_PROPERTY),
+    ),
     Rule.Experimental {
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+    }
+
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -57,13 +70,38 @@ public class FunctionReturnTypeSpacingRule :
             ?.takeIf { it.elementType == WHITE_SPACE }
             .let { whiteSpaceAfterColon ->
                 if (whiteSpaceAfterColon?.text != " ") {
-                    emit(node.startOffset, "Single space expected between colon and return type", true)
-                    if (autoCorrect) {
-                        node.upsertWhitespaceAfterMe(" ")
+                    // In case the whitespace contains a newline than replacing it with a single space results in merging the lines to a
+                    // single line. This rule allows this only when the merged lines entirely fit on a single line. Suppose that code below
+                    // does not fit on a single line:
+                    //    fun foo():
+                    //        String = "some-looooooooooooooooong-string"
+                    // This rule does *not* attempt to reformat the code as follows:
+                    //    fun foo(): String =
+                    //        "some-looooooooooooooooong-string"
+                    // See FunctionSignatureRule for such reformatting.
+                    val newLineLength =
+                        node.lengthUntilNewline(false) + // Length of line before but excluding the colon
+                            node.textLength + // Length of the colon itself
+                            1 + // Length of the fixed whitespace
+                            whiteSpaceAfterColon.lengthUntilNewline(true) // Length of the line after but excluding the whitespace
+                    if (newLineLength <= maxLineLength) {
+                        emit(node.startOffset, "Single space expected between colon and return type", true)
+                        if (autoCorrect) {
+                            node.upsertWhitespaceAfterMe(" ")
+                        }
                     }
                 }
             }
     }
+
+    private fun ASTNode?.lengthUntilNewline(forward: Boolean) =
+        if (this == null) {
+            0
+        } else {
+            leaves(forward = forward)
+                .takeWhile { !it.isWhiteSpaceWithNewline() }
+                .sumOf { it.textLength }
+        }
 }
 
 public val FUNCTION_RETURN_TYPE_SPACING_RULE_ID: RuleId = FunctionReturnTypeSpacingRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRuleTest.kt
@@ -1,5 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import org.junit.jupiter.api.Test
 
@@ -90,5 +92,42 @@ class FunctionReturnTypeSpacingRuleTest {
         functionReturnTypeSpacingRuleAssertThat(code)
             .hasLintViolation(1, 10, "Single space expected between colon and return type")
             .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function signature with a new line between the colon and the return type which when concatenated does not exceed the maximum line length then do reformat`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun foo():
+                String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun foo(): String = "some-result"
+            """.trimIndent()
+        functionReturnTypeSpacingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 10, "Single space expected between colon and return type")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function signature with a new line between the colon and the return type which when concatenated does exceed the maximum line length then do not reformat`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            fun foo():
+                String = "some-result"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            fun foo(): String = "some-result"
+            """.trimIndent()
+        functionReturnTypeSpacingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
     }
 }


### PR DESCRIPTION
## Description

Replacing a whitespace containing a newline after the return type may not result in a max-line-length violation

In case the whitespace contains a newline than replacing it with a single space results in merging the lines to a single line. This rule allows this only when the merged lines entirely fit on a single line.

Suppose that code below does not fit on a single line than this rule no longer emits a violation:
    fun foo():
        String = "some-looooooooooooooooong-string"

See FunctionSignatureRule for reformatting the function like below:
    fun foo(): String =
        "some-looooooooooooooooong-string"

Closes #1764

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
