### PR TITLE
Try catch finally rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,9 +224,10 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 
 ### Added
 
-* Add new experimental rule for `ktlint_official` code style that disallows a class to start with a blank line `no-empty-first-line-in-class-body`.
-* Add new experimental rule for `ktlint_official` code style that enforces consistent usage of braces in all branches of a singe if or if-else-if statement `if-else-bracing`.
-* Add new experimental rule for `ktlint_official` code style that disallows consecutive comments except EOL comments `no-consecutive-comments`
+* Add new experimental rule `no-empty-first-line-in-class-body` for `ktlint_official` code style. This rule disallows a class to start with a blank line. This rule can also be run for other code styles but then its needs to be explicitly enabled.
+* Add new experimental rule `if-else-bracing` for `ktlint_official` code style. This rules enforces consistent usage of braces in all branches of a singe if or if-else-if statement. This rule can also be run for other code styles but then its needs to be explicitly enabled.
+* Add new experimental rule `no-consecutive-comments` for `ktlint_official` code style. This rule disallows consecutive comments except EOL comments. This rule can also be run for other code styles but then its needs to be explicitly enabled.
+* Add new experimental rule `try-catch-finally-spacing` for `ktlint_official` code style. This rule enforces consistent spacing in try-catch, try-finally and try-catch-finally statement. This rule can also be run for other code styles but then its needs to be explicitly enabled.
 * Wrap the type or value of a function or class parameter in case the maximum line length is exceeded `parameter-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Wrap the type or value of a property in case the maximum line length is exceeded `property-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -19,7 +19,7 @@ Detect blank lines at start of a class body.
 Rule id: `no-empty-first-line-in-class-body`
 
 !!! Note
-    This rule is only run when `ktlint_code_style` is set to `ktlint_official`. 
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ## Disallow consecutive comments
 
@@ -55,7 +55,7 @@ Disallow consecutive comments (EOL comments, block comments or KDoc) except EOL 
 Rule id: `no-consecutive-comments`
 
 !!! Note
-    This rule is only run when `ktlint_code_style` is set to `ktlint_official`. 
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ## Unnecessary parenthesis before trailing lambda
 
@@ -210,6 +210,43 @@ Rule id: `parameter-list-spacing`
 Consistent spacing between function name and opening parenthesis.
 
 Rule id: `spacing-between-function-name-and-opening-parenthesis`
+
+### Try catch finally spacing
+
+Enforce consistent spacing in `try { .. } catch { .. } finally { .. }`.
+
+=== "[:material-heart:](#) Ktlint (ktlint_official code style)"
+
+    ```kotlin
+    fun foo() =
+        try {
+            // do something
+        } catch (exception: Exception) {
+            // handle exception
+        } finally {
+            // clean up
+        }
+    ```
+=== "[:material-heart:](#) Ktlint (non ktlint_official code style)"
+
+    ```kotlin
+    fun foo1() = try { /* ... */ } catch (exception: Exception) { /* ... */ } finally { /* ... */ }
+    fun foo2() = 
+        try {
+            // do something
+        }
+        catch (exception: Exception) {
+            // handle exception
+        }
+        finally {
+            // clean up
+        }
+    ```
+
+Rule id: `try-catch-finally-spacing`
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ### Type argument list spacing
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -69,6 +69,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.SpacingBetweenFunctionNameAnd
 import com.pinterest.ktlint.ruleset.standard.rules.StringTemplateRule
 import com.pinterest.ktlint.ruleset.standard.rules.TrailingCommaOnCallSiteRule
 import com.pinterest.ktlint.ruleset.standard.rules.TrailingCommaOnDeclarationSiteRule
+import com.pinterest.ktlint.ruleset.standard.rules.TryCatchFinallySpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.TypeArgumentListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.TypeParameterListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.UnnecessaryParenthesesBeforeTrailingLambdaRule
@@ -146,6 +147,7 @@ public class StandardRuleSetProvider :
             RuleProvider { StringTemplateRule() },
             RuleProvider { TrailingCommaOnCallSiteRule() },
             RuleProvider { TrailingCommaOnDeclarationSiteRule() },
+            RuleProvider { TryCatchFinallySpacingRule() },
             RuleProvider { TypeArgumentListSpacingRule() },
             RuleProvider { TypeParameterListSpacingRule() },
             RuleProvider { UnnecessaryParenthesesBeforeTrailingLambdaRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
@@ -1,0 +1,118 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CATCH
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FINALLY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TRY
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * Checks spacing and wrapping of try-catch-finally.
+ */
+public class TryCatchFinallySpacingRule :
+    StandardRule(
+        id = "try-catch-finally-spacing",
+        usesEditorConfigProperties = setOf(
+            INDENT_SIZE_PROPERTY,
+            INDENT_STYLE_PROPERTY,
+        ),
+    ),
+    Rule.Experimental,
+    Rule.OfficialCodeStyle {
+    private var indentConfig = DEFAULT_INDENT_CONFIG
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig = IndentConfig(
+            indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+            tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+        )
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        when (node.elementType) {
+            BLOCK -> {
+                visitBlock(node, emit, autoCorrect)
+            }
+            CATCH, FINALLY -> {
+                visitClause(node, emit, autoCorrect)
+            }
+        }
+    }
+
+    private fun visitBlock(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        if (node.treeParent.elementType !in TRY_CATCH_FINALLY_ELEMENT_TYPES) {
+            return
+        }
+
+        node
+            .findChildByType(LBRACE)!!
+            .let { lbrace ->
+                val nextSibling = lbrace.nextSibling { !it.isPartOfComment() }!!
+                if (!nextSibling.text.startsWith("\n")) {
+                    emit(lbrace.startOffset + 1, "Expected a newline after '{'", true)
+                    if (autoCorrect) {
+                        lbrace.upsertWhitespaceAfterMe(node.treeParent.indent().plus(indentConfig.indent))
+                    }
+                }
+            }
+
+        node
+            .findChildByType(RBRACE)!!
+            .let { rbrace ->
+                val prevSibling = rbrace.prevSibling { !it.isPartOfComment() }!!
+                if (!prevSibling.text.startsWith("\n")) {
+                    emit(rbrace.startOffset, "Expected a newline before '}'", true)
+                    if (autoCorrect) {
+                        rbrace.upsertWhitespaceBeforeMe(node.treeParent.indent())
+                    }
+                }
+            }
+    }
+
+    private fun visitClause(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        val prevLeaf = node.prevLeaf { !it.isPartOfComment() }!!
+        if (prevLeaf.text != " ") {
+            emit(node.startOffset, "A single space is required before '${node.elementTypeName()}'", true)
+            if (autoCorrect) {
+                node.upsertWhitespaceBeforeMe(" ")
+            }
+        }
+    }
+
+    private fun ASTNode.elementTypeName() = elementType.toString().lowercase()
+
+    private companion object {
+        val TRY_CATCH_FINALLY_ELEMENT_TYPES = listOf(TRY, CATCH, FINALLY)
+    }
+}
+
+public val TRY_CATCH_RULE_ID: RuleId = TryCatchFinallySpacingRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRuleTest.kt
@@ -1,0 +1,213 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class TryCatchFinallySpacingRuleTest {
+    private val tryCatchRuleAssertThat = KtLintAssertThat.assertThatRule { TryCatchFinallySpacingRule() }
+
+    @Test
+    fun `Given try - catch which is formatted correctly then do not report violation`() {
+        val code =
+            """
+            val foo = try {
+                // do something
+            } catch (exception: Exception) {
+                "catch"
+            }
+            """.trimIndent()
+        tryCatchRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given try - finally which is formatted correctly then do not report violation`() {
+        val code =
+            """
+            val foo = try {
+                // do something
+            } finally {
+                // do something else
+            }
+            """.trimIndent()
+        tryCatchRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given try - catch - finally which is formatted correctly then do not report violation`() {
+        val code =
+            """
+            val foo = try {
+                // do something
+            } catch (exception: Exception) {
+                "catch"
+            } finally {
+                // do something else
+            }
+            """.trimIndent()
+        tryCatchRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+            .hasNoLintViolations()
+    }
+
+    @Nested
+    inner class `Given a catch not preceded by a single space` {
+        val formattedCode =
+            """
+            val foo = try {
+                "try"
+            } catch (exception: Exception) {
+                "catch"
+            }
+            """.trimIndent()
+
+        @Test
+        fun `Given try - catch without whitespace before catch then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }catch (exception: Exception) {
+                    "catch"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 2, "A single space is required before 'catch'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - catch with multiple spaces before catch then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }  catch (exception: Exception) {
+                    "catch"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 4, "A single space is required before 'catch'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - catch with newline before catch then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }
+                catch (exception: Exception) {
+                    "catch"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "A single space is required before 'catch'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - catch on single line then reformat`() {
+            val code =
+                """
+                val foo = try { "try" } catch (exception: Exception) { "catch" }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolations(
+                    LintViolation(1, 16, "Expected a newline after '{'"),
+                    LintViolation(1, 23, "Expected a newline before '}'"),
+                    LintViolation(1, 55, "Expected a newline after '{'"),
+                    LintViolation(1, 64, "Expected a newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a finally not preceded by a single space` {
+        val formattedCode =
+            """
+            val foo = try {
+                "try"
+            } finally {
+                "finally"
+            }
+            """.trimIndent()
+
+        @Test
+        fun `Given try - finally without whitespace before finally then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }finally {
+                    "finally"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 2, "A single space is required before 'finally'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - finally with multiple spaces before finally then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }  finally {
+                    "finally"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 4, "A single space is required before 'finally'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - finally with newline before finally then reformat`() {
+            val code =
+                """
+                val foo = try {
+                    "try"
+                }
+                finally {
+                    "finally"
+                }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "A single space is required before 'finally'")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given try - finally on single line then reformat`() {
+            val code =
+                """
+                val foo = try { "try" } finally { "finally" }
+                """.trimIndent()
+            tryCatchRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolations(
+                    LintViolation(1, 16, "Expected a newline after '{'"),
+                    LintViolation(1, 23, "Expected a newline before '}'"),
+                    LintViolation(1, 34, "Expected a newline after '{'"),
+                    LintViolation(1, 45, "Expected a newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add new experimental rule `try-catch-finally-spacing` for `ktlint_official` code style. Partly it overlaps with existing rule `keyword-spacing`. Next to this, it reformats single line `try { ... } catch (...) { .. } finally { ... }` to multiline statements.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
