### PR TITLE
Do not allow any wildcard import in code style `ktlint_official`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,9 @@ ktlint_standard = enabled
 # we are not pleased ourselves with the results on the ktlint code base.
 ktlint_experimental = enabled
 
+# Don't allow any wildcard imports
+ij_kotlin_packages_to_use_import_on_demand = unset
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Disable the default patterns if the option `--patterns-from-stdin` is specified ([#1793](https://github.com/pinterest/ktlint/issues/1793))
 * Update Kotlin development version to `1.8.20-Beta` and Kotlin version to `1.8.10`.
 * Revert to matrix build to speed up build, especially for the Windows related build ([#1787](https://github.com/pinterest/ktlint/pull/1787))
+* For the new code style `ktlint_official`, do not allow wildcard imports `java.util` and `kotlinx.android.synthetic` by default. Important: `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand` needs to be set to value `unset` in order to enforce IntelliJ IDEA default formatter to not generate wildcard imports. `no-wildcard-imports` ([#1797](https://github.com/pinterest/ktlint/issues/1797))
 
 ## [0.48.2] - 2023-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Disable the default patterns if the option `--patterns-from-stdin` is specified ([#1793](https://github.com/pinterest/ktlint/issues/1793))
 * Update Kotlin development version to `1.8.20-Beta` and Kotlin version to `1.8.10`.
 * Revert to matrix build to speed up build, especially for the Windows related build ([#1787](https://github.com/pinterest/ktlint/pull/1787))
-* For the new code style `ktlint_official`, do not allow wildcard imports `java.util` and `kotlinx.android.synthetic` by default. Important: `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand` needs to be set to value `unset` in order to enforce IntelliJ IDEA default formatter to not generate wildcard imports. `no-wildcard-imports` ([#1797](https://github.com/pinterest/ktlint/issues/1797))
+* For the new code style `ktlint_official`, do not allow wildcard imports `java.util` and `kotlinx.android.synthetic` by default. Important: `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand` needs to be set to value `unset` in order to enforce IntelliJ IDEA default formatter to not generate wildcard imports `no-wildcard-imports` ([#1797](https://github.com/pinterest/ktlint/issues/1797))
 
 ## [0.48.2] - 2023-01-21
 

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -153,7 +153,7 @@ No wildcard imports except imports listed in `.editorconfig` property `ij_kotlin
     In case property `ij_kotlin_packages_to_use_import_on_demand` is not explicitly set, it allows wildcards imports like `java.util.*` by default to keep in sync with IntelliJ IDEA behavior. To disallow *all* wildcard imports, add property below to your `.editorconfig`:
     ```editorconfig
     [*.{kt,kts}]
-    ij_kotlin_packages_to_use_import_on_demand = nothing
+    ij_kotlin_packages_to_use_import_on_demand = unset
     ```
 
 Rule id: `no-wildcard-imports`

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -43,7 +43,7 @@ import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
@@ -51,6 +51,8 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.ArrayList
+import kotlin.collections.LinkedHashSet
 import kotlin.concurrent.thread
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine.Companion.UTF8_BOM
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleException
 import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.internal.rulefilter.RuleExecutionRuleFilter
 import com.pinterest.ktlint.rule.engine.internal.rulefilter.RunAfterRuleFilter
@@ -52,7 +53,9 @@ internal class RuleExecutionContext private constructor(
                 // The rule get access to an EditConfig which is filtered by the properties which are actually registered as being used by
                 // the rule. In this way it can be forced that the rule actually registers the properties that it uses and the field becomes
                 // reliable to be used by for example the ".editorconfig" file generator.
-                editorConfig.filterBy(rule.usesEditorConfigProperties),
+                // Note that also the CODE_STYLE_PROPERTY is provided because that property is needed to determine the default value of an
+                // EditorConfigProperty that is not explicitly defined.
+                editorConfig.filterBy(rule.usesEditorConfigProperties.plus(CODE_STYLE_PROPERTY)),
             )
             this.executeRuleOnNodeRecursively(rootNode, rule, fqRuleId, autoCorrect, emit)
             rule.afterLastNode()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -113,7 +113,8 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.psiUtil.parents
-import java.util.*
+import java.util.Deque
+import java.util.LinkedList
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
@@ -93,7 +93,14 @@ public class NoWildcardImportsRule :
                  * https://github.com/JetBrains/kotlin/blob/ffdab473e28d0d872136b910eb2e0f4beea2e19c/idea/formatter/src/org/jetbrains/kotlin/idea/core/formatter/KotlinCodeStyleSettings.java#L81-L82
                  */
                 defaultValue = parseAllowedWildcardImports("java.util.*,kotlinx.android.synthetic.**"),
-                propertyWriter = { it.joinToString(separator = ",") },
+                propertyWriter = {
+                    if (it.isEmpty()) {
+                        "unset"
+                    } else {
+                        it.joinToString(separator = ",")
+                    }
+                },
+                ktlintOfficialCodeStyleDefaultValue = emptyList(),
             )
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
@@ -1,5 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.ruleset.standard.rules.NoWildcardImportsRule.Companion.IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
@@ -97,5 +99,20 @@ class NoWildcardImportsRuleTest {
                 .withEditorConfigOverride(IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND to "")
                 .hasLintViolationWithoutAutoCorrect(2, 1, "Wildcard import")
         }
+    }
+
+    @Test
+    fun `Given the ktlint_official codestyle then the default wildcard imports allowed in other code styles are no longer allowed`() {
+        val code =
+            """
+            import java.util.*
+            import kotlinx.android.synthetic.*
+            """.trimIndent()
+        noWildcardImportsRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(1, 1, "Wildcard import"),
+                LintViolation(2, 1, "Wildcard import"),
+            )
     }
 }


### PR DESCRIPTION
## Description

For the new code style `ktlint_official`, do not allow wildcard imports `java.util` and `kotlinx.android.synthetic` by default.

When generating the `.editorconfig` file generate value `unset` for property `ij_kotlin_packages_to_use_import_on_demand` in case the list of on demand imports is empty.

Also, set `ij_kotlin_packages_to_use_import_on_demand` to `unset` in the KtLint project `.editorconfig` itself to comply with this new default and resolve lint violation.

Closes #1797

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
