### PR TITLE
Fix false positive when multiple KDOCs exists between declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Wrap annotations on type arguments in same way as with other constructs `annotation`, `wrapping` ([#1725](https://github.com/pinterest/ktlint/issues/1725))
 * Fix indentation of try-catch-finally when catch or finally starts on a newline `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix indentation of a multiline typealias `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
+* Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
@@ -133,7 +133,7 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
             }
             """.trimIndent()
         spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code)
-            .hasLintViolation(5, 5, "Declarations and declarations with annotations should have an empty space between.")
+            .hasLintViolation(5, 1, "Declarations and declarations with annotations should have an empty space between.")
             .isFormattedAs(formattedCode)
     }
 
@@ -201,6 +201,22 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
                 }
                 // end::testQuery[]
             }
+            """.trimIndent()
+        spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1802 - Given a declaration followed by multiple kdocs and an annotated declaration`() {
+        val code =
+            """
+            public var foo = "foo"
+
+            /**
+             * Kdoc1
+             */
+            /** Kdoc2 */
+            @Bar
+            public var bar = "bar"
             """.trimIndent()
         spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
## Description

Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration

Closes #1802

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
