### PR TITLE
Wrapping false positive for line with max line length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,7 +251,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix indentation of try-catch-finally when catch or finally starts on a newline `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix indentation of a multiline typealias `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
-* Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping`  ([#1808](https://github.com/pinterest/ktlint/issues/1808))
+* Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping` ([#1808](https://github.com/pinterest/ktlint/issues/1808))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,7 +251,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix indentation of try-catch-finally when catch or finally starts on a newline `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix indentation of a multiline typealias `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
-* Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping` ([#1808](https://github.com/pinterest/ktlint/issues/1808))
+* Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping`  ([#1808](https://github.com/pinterest/ktlint/issues/1808))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix indentation of try-catch-finally when catch or finally starts on a newline `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix indentation of a multiline typealias `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
+* Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping` ([#1808](https://github.com/pinterest/ktlint/issues/1808))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
@@ -34,7 +34,6 @@ public class NoSemicolonsRule : StandardRule("no-semi") {
             return
         }
         val nextLeaf = node.nextLeaf()
-        val prevCodeLeaf = node.prevCodeLeaf()
         if (nextLeaf.doesNotRequirePreSemi() && isNoSemicolonRequiredAfter(node)) {
             emit(node.startOffset, "Unnecessary semicolon", true)
             if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -1834,6 +1834,20 @@ internal class WrappingRuleTest {
                 .hasLintViolation(2, 8, "A newline was expected before '>'")
                 .isFormattedAs(formattedCode)
         }
+
+        @Test
+        fun `Issue 1808 - Given a line including a block with exact length of line maximum`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER               $EOL_CHAR
+                val foo = "fooooooooooooooo".map { "bar" }
+
+                // Keep blank line above
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line

Closes #1808 

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
