### PR TITLE
Fix false positive when a single line contains multiple dot qualified expressions and/or safe expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix indentation of a multiline typealias `indent` ([#1788](https://github.com/pinterest/ktlint/issues/1788))
 * Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
 * Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping` ([#1808](https://github.com/pinterest/ktlint/issues/1808))
+* Fix false positive when a single line contains multiple dot qualified expressions and/or safe expressions `indent` ([#1830](https://github.com/pinterest/ktlint/issues/1830))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -214,7 +214,8 @@ public class IndentationRule :
             node.elementType == BINARY_WITH_TYPE ||
                 node.elementType == SUPER_TYPE_ENTRY ||
                 node.elementType == TYPE_ARGUMENT_LIST ||
-                node.elementType == TYPE_PARAMETER_LIST ->
+                node.elementType == TYPE_PARAMETER_LIST ||
+                node.elementType == USER_TYPE ->
                 startIndentContext(node)
 
             node.elementType == DELEGATED_SUPER_TYPE_ENTRY ||
@@ -257,9 +258,7 @@ public class IndentationRule :
             node.elementType == BINARY_EXPRESSION ->
                 visitBinaryExpression(node)
 
-            node.elementType == DOT_QUALIFIED_EXPRESSION ||
-                node.elementType == SAFE_ACCESS_EXPRESSION ||
-                node.elementType == USER_TYPE -> {
+            node.elementType in CHAINABLE_EXPRESSION -> {
                 if (codeStyle == ktlint_official &&
                     node.elementType == DOT_QUALIFIED_EXPRESSION &&
                     node.treeParent?.elementType == ARRAY_ACCESS_EXPRESSION &&
@@ -274,7 +273,9 @@ public class IndentationRule :
                         fromAstNode = node.treeParent,
                         toAstNode = node.treeParent.treeParent.lastChildLeafOrSelf(),
                     )
-                } else if (node.treeParent?.elementType != node.elementType) {
+                } else if (node.treeParent.elementType in CHAINABLE_EXPRESSION) {
+                    // Multiple dot qualified expressions and/or safe expression on the same line should not increase the indent level
+                } else {
                     startIndentContext(node)
                 }
             }
@@ -1068,6 +1069,7 @@ public class IndentationRule :
     private companion object {
         const val KDOC_CONTINUATION_INDENT = " "
         const val TYPE_CONSTRAINT_CONTINUATION_INDENT = "      " // Length of keyword "where" plus separating space
+        val CHAINABLE_EXPRESSION = setOf(DOT_QUALIFIED_EXPRESSION, SAFE_ACCESS_EXPRESSION)
     }
 
     private data class IndentContext(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -3974,7 +3974,7 @@ internal class IndentationRuleTest {
             ).isFormattedAs(formattedCode)
     }
 
-    @Test
+    @Test // user_type
     fun `Issue 1210 - Given a supertype delegate`() {
         val code =
             """
@@ -4917,6 +4917,19 @@ internal class IndentationRuleTest {
             """
             typealias FooBar =
                 HashMap<Foo, Bar>
+            """.trimIndent()
+        indentationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 1830 - Given a dot qualified expression followed by an safe access expression on the same line`() {
+        val code =
+            """
+            private fun test(): Boolean? =
+                runCatching { true }
+                    .getOrNull()?.let { result ->
+                        !result
+                    }
             """.trimIndent()
         indentationRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
## Description

Fix false positive when a single line contains multiple dot qualified expressions and/or safe expressions

Closes #1830

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
