### PR TITLE
Fix false positive in import ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix false positive when multiple KDOCs exists between a declaration and another annotated declaration `spacing-between-declarations-with-annotations` ([#1802](https://github.com/pinterest/ktlint/issues/1802))
 * Fix false positive when a single line statement containing a block having exactly the maximum line length is preceded by a blank line `wrapping` ([#1808](https://github.com/pinterest/ktlint/issues/1808))
 * Fix false positive when a single line contains multiple dot qualified expressions and/or safe expressions `indent` ([#1830](https://github.com/pinterest/ktlint/issues/1830))
+* When `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|` then do not report a violation nor insert a blank line `import-ordering` ([#1845](https://github.com/pinterest/ktlint/issues/1845))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
@@ -84,7 +84,7 @@ public class ImportOrderingRule :
                             break
                         }
                     }
-                    if (hasBlankLines) {
+                    if (hasBlankLines && prev != null) {
                         sortedImportsWithSpaces += PsiWhiteSpaceImpl("\n\n")
                     }
                     sortedImportsWithSpaces += current

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleCustomTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleCustomTest.kt
@@ -247,4 +247,24 @@ class ImportOrderingRuleCustomTest {
             .withEditorConfigOverride(IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY to "kotlin.io.Closeable.*,kotlin.**,*")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 1845 - Given a list of pattern entries including a '|' pattern but no import exists that match any pattern before the first '|'`() {
+        val code =
+            """
+            import java.nio.file.Files
+            import java.nio.file.Paths
+            import java.util.Objects
+
+            object TestData {
+                fun loadString(dataset: String): String {
+                    val path = Paths.get(Objects.requireNonNull(TestData::class.java.getResource(dataset)).toURI())
+                    return String(Files.readAllBytes(path))
+                }
+            }
+            """.trimIndent()
+        importOrderingRuleAssertThat(code)
+            .withEditorConfigOverride(IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY to "*, |, javax.**, java.**, |, kotlinx.**, kotlin.**")
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix false positive when `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|`

Closes #1845

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
