### PR TITLE
Add default include patterns when only negate patterns are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Fix false positive when a single line contains multiple dot qualified expressions and/or safe expressions `indent` ([#1830](https://github.com/pinterest/ktlint/issues/1830))
 * Enforce spacing around rangeUntil operator `..<` similar to the range operator `..` in `range-spacing`  ([#1858](https://github.com/pinterest/ktlint/issues/1858))
 * When `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|` then do not report a violation nor insert a blank line `import-ordering` ([#1845](https://github.com/pinterest/ktlint/issues/1845))
+* When negate-patterns only are specified in Ktlint CLI then automatically add the default include patterns (`**/*.kt` and `**/*.kts`) so that all Kotlin files excluding the files matching the negate-patterns will be processed ([#1847](https://github.com/pinterest/ktlint/issues/1847))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -75,7 +75,7 @@ internal fun FileSystem.fileSequence(
                             "are used."
                     }
                     includeMatchers.plus(
-                        expand(DEFAULT_PATTERNS, rootDir)
+                        expand(DEFAULT_PATTERNS, rootDir),
                     )
                 } else {
                     includeMatchers

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -60,15 +60,27 @@ internal fun FileSystem.fileSequence(
 
     val globs = expand(patternsExclusiveExistingFiles, rootDir)
 
-    val pathMatchers =
-        globs
-            .filterNot { it.startsWith(NEGATION_PREFIX) }
-            .map { getPathMatcher(it) }
-
     val negatedPathMatchers =
         globs
             .filter { it.startsWith(NEGATION_PREFIX) }
             .map { getPathMatcher(it.removePrefix(NEGATION_PREFIX)) }
+
+    val pathMatchers =
+        globs
+            .filterNot { it.startsWith(NEGATION_PREFIX) }
+            .let { includeMatchers ->
+                if (negatedPathMatchers.isNotEmpty() && includeMatchers.isEmpty()) {
+                    LOGGER.info {
+                        "A negate pattern is specified without an include pattern. As default, the include patterns '$DEFAULT_PATTERNS' " +
+                            "are used."
+                    }
+                    includeMatchers.plus(
+                        expand(DEFAULT_PATTERNS, rootDir)
+                    )
+                } else {
+                    includeMatchers
+                }
+            }.map { getPathMatcher(it) }
 
     LOGGER.debug {
         """

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -366,6 +366,28 @@ internal class FileUtilsTest {
         assertThat(foundFiles).isEmpty()
     }
 
+    @Test
+    fun `Issue 1847 - Given a negate pattern only then include the default patters and select all files except files in the negate pattern`() {
+        val foundFiles = getFiles(
+            patterns = listOf(
+                "!project1/**/*.kt",
+            ),
+        )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(
+                ktFileRootDirectory,
+                ktsFileRootDirectory,
+                ktsFileInProjectRootDirectory,
+                ktsFileInProjectSubDirectory,
+            )
+            .doesNotContain(
+                ktFileInProjectRootDirectory,
+                ktFile1InProjectSubDirectory,
+                ktFile2InProjectSubDirectory,
+            )
+    }
+
     private fun KtlintTestFileSystem.createFile(fileName: String) =
         writeFile(
             relativeDirectoryToRoot = fileName.substringBeforeLast("/", ""),


### PR DESCRIPTION
## Description

Add the default include patterns when only negate patterns are specified in Ktlint CLI

Closes #1847

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
