### PR TITLE
Add rule no-blank-line-in-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Wrap the type or value of a function or class parameter in case the maximum line length is exceeded `parameter-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Wrap the type or value of a property in case the maximum line length is exceeded `property-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Recognize Kotlin Script when linting and formatting code from `stdin` with KtLint CLI ([#1832](https://github.com/pinterest/ktlint/issues/1832))
+* Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style. This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists. This rule can also be run for other code styles but then its needs to be explicitly enabled.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Wrap the type or value of a function or class parameter in case the maximum line length is exceeded `parameter-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Wrap the type or value of a property in case the maximum line length is exceeded `property-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Recognize Kotlin Script when linting and formatting code from `stdin` with KtLint CLI ([#1832](https://github.com/pinterest/ktlint/issues/1832))
-* Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style. This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists. This rule can also be run for other code styles but then its needs to be explicitly enabled.
+* Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style. This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#1224](https://github.com/pinterest/ktlint/issues/1224))
 
 ### Removed
 

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -193,6 +193,161 @@ Consistent spacing between modifiers in and after the last modifier in a modifie
 
 Rule id: `modifier-list-spacing`
 
+### No blank lines in list
+
+Disallow blank lines to be used in lists before the first element, between elements, and after the last element.
+
+*Super type*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    class FooBar:
+        Foo,
+        Bar {
+        // body
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    class FooBar:
+
+        Foo,
+
+        Bar
+
+    {
+        // body
+    }
+    ```
+
+*Type argument list*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val foobar: FooBar<
+        Foo,
+        Bar,
+        > = FooBar(Foo(), Bar())
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val foobar: FooBar<
+
+        Foo,
+
+        Bar,
+
+        > = FooBar(Foo(), Bar())
+    ```
+
+*Type constraint list*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+        val adapter1: A1,
+        val adapter2: A2
+    ) : RecyclerView.Adapter<C>()
+        where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+              A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider {
+        // body
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+        val adapter1: A1,
+        val adapter2: A2
+    ) : RecyclerView.Adapter<C>()
+        where
+              A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+
+              A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider
+    {
+        // body
+    }
+    ```
+
+*Type parameter list*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    fun <
+        Foo,
+        Bar,
+        > foobar()
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    fun <
+
+        Foo,
+
+        Bar,
+
+        > foobar()
+    ```
+
+*Value argument list*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val foobar = foobar(
+        "foo",
+        "bar",
+    )
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val foobar = foobar(
+
+        "foo",
+
+        "bar",
+
+    )
+    ```
+
+*Value parameter list*
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    fun foobar(
+        foo: String,
+        bar: String,
+    )
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    fun foobar(
+
+        foo: String,
+
+        bar: String,
+
+    )
+    ```
+
+Rule id: `no-blank-line-in-list`
+
 ### Nullable type spacing
 
 No spaces in a nullable type.

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
@@ -31,12 +31,10 @@ public class Baseline(
      * Path to the baseline file.
      */
     public val path: String? = null,
-
     /**
      * Status of the baseline file.
      */
     public val status: Status,
-
     /**
      * Lint errors grouped by (relative) file path.
      */

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
@@ -75,7 +75,6 @@ internal class ReporterAggregator(
                             "format" to format.toString(),
                         ),
                     ),
-
                 )
             }
 

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/Rule.kt
@@ -26,7 +26,6 @@ public open class Rule(
      *   - qualifiedRuleId: the guaranteed fully qualified rule id containing the rule set id as prefix.
      */
     public val id: String,
-
     /**
      * Set of modifiers of the visitor. Preferably a rule has no modifiers at all, meaning that it is completely
      * independent of all other rules.

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt
@@ -48,7 +48,6 @@ public abstract class RuleSetProviderV2(
          * Name of person, organisation or group maintaining the rule set.
          */
         val maintainer: String?,
-
         /**
          * Short description of the rule set.
          */

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -127,10 +127,10 @@ public fun ASTNode.nextCodeLeaf(
 
 public fun ASTNode.prevCodeSibling(): ASTNode? = prevSibling { it.elementType != WHITE_SPACE && !it.isPartOfComment() }
 
-public inline fun ASTNode.prevSibling(p: (ASTNode) -> Boolean): ASTNode? {
+public inline fun ASTNode.prevSibling(predicate: (ASTNode) -> Boolean = { true }): ASTNode? {
     var n = this.treePrev
     while (n != null) {
-        if (p(n)) {
+        if (predicate(n)) {
             return n
         }
         n = n.treePrev
@@ -140,10 +140,10 @@ public inline fun ASTNode.prevSibling(p: (ASTNode) -> Boolean): ASTNode? {
 
 public fun ASTNode.nextCodeSibling(): ASTNode? = nextSibling { it.elementType != WHITE_SPACE && !it.isPartOfComment() }
 
-public inline fun ASTNode.nextSibling(p: (ASTNode) -> Boolean): ASTNode? {
+public inline fun ASTNode.nextSibling(predicate: (ASTNode) -> Boolean = { true }): ASTNode? {
     var n = this.treeNext
     while (n != null) {
-        if (p(n)) {
+        if (predicate(n)) {
             return n
         }
         n = n.treeNext

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
@@ -8,7 +8,6 @@ import org.ec4j.core.model.PropertyType
 
 public data class IndentConfig(
     val indentStyle: IndentStyle,
-
     /**
      * The number of spaces that is equivalent to one tab
      */
@@ -32,7 +31,6 @@ public data class IndentConfig(
      */
     public constructor(
         indentStyle: PropertyType.IndentStyleValue,
-
         /**
          * The number of spaces that is equivalent to one tab
          */

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -60,19 +60,16 @@ public open class Rule(
      * Consumers should use a prefix other than 'standard' to mark the origin of rules which are not maintained by the KtLint project.
      */
     public open val ruleId: RuleId,
-
     /**
      * About the rule. Background information about the rule and its maintainer. About information is meant to be used in stack traces or
      * API consumers to provide more detailed information about the rule.
      */
     public open val about: About,
-
     /**
      * Set of modifiers of the visitor. Preferably a rule has no modifiers at all, meaning that it is completely
      * independent of all other rules.
      */
     public open val visitorModifiers: Set<VisitorModifier> = emptySet(),
-
     /**
      * Set of [EditorConfigProperty]'s that are to provided to the rule. Only specify the properties that are actually used by the rule.
      */
@@ -185,12 +182,10 @@ public open class Rule(
          * Name of person, organisation or group maintaining the rule.
          */
         val maintainer: String = "Not specified (and not maintained by the Ktlint project)",
-
         /**
          * Url to the repository containing the rule.
          */
         val repositoryUrl: String = "Not specified",
-
         /**
          * Url to the issue tracker of the project which provides the rule.
          */
@@ -207,13 +202,11 @@ public open class Rule(
              * The [RuleId] of the [Rule] which should run before the [Rule] that declares the [VisitorModifier.RunAfterRule].
              */
             val ruleId: RuleId,
-
             /**
              * The [Mode] determines whether the [Rule] that declares this [VisitorModifier] can be run in case the [Rule] with rule id
              * [VisitorModifier.RunAfterRule.ruleId] is not loaded or enabled.
              */
             val mode: Mode,
-
         ) : VisitorModifier() {
             public enum class Mode {
                 /**

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleProvider.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleProvider.kt
@@ -12,17 +12,14 @@ public class RuleProvider private constructor(
      * Lambda which creates a new instance of the rule.
      */
     private val provider: () -> Rule,
-
     /**
      * The rule id of the [Rule] created by the provider.
      */
     public val ruleId: RuleId,
-
     /**
      * Flag whether the [Rule] created by the provider has to run as late as possible.
      */
     public val runAsLateAsPossible: Boolean,
-
     /**
      * The list of rules which have to run before the [Rule] created by the provider can be run.
      */

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty.kt
@@ -19,31 +19,26 @@ public data class EditorConfigProperty<T>(
      * Type of property. Could be one of default ones (see [PropertyType.STANDARD_TYPES]) or custom one.
      */
     public val type: PropertyType<T>,
-
     /**
      * Default value for property if it does not exist in loaded properties. This default applies to all code styles
      * unless the code style specific default value is set.
      */
     public val defaultValue: T,
-
     /**
      * Default value for property if it does not exist in loaded properties and codestyle 'ktlint_official'. When not
      * set, it is defaulted to [defaultValue].
      */
     public val ktlintOfficialCodeStyleDefaultValue: T = defaultValue,
-
     /**
      * Default value for property if it does not exist in loaded properties and codestyle 'intellij_idea'. When not
      * set, it is defaulted to [defaultValue].
      */
     public val intellijIdeaCodeStyleDefaultValue: T = defaultValue,
-
     /**
      * Default value for property if it does not exist in loaded properties and codestyle 'android_studio'. When not
      * set, it is defaulted to [defaultValue].
      */
     public val androidStudioCodeStyleDefaultValue: T = defaultValue,
-
     /**
      * If set, it maps the actual value set for the property, to another valid value for that property. See example
      * below where
@@ -67,24 +62,20 @@ public data class EditorConfigProperty<T>(
      * is used.
      */
     public val propertyMapper: ((Property?, CodeStyleValue) -> T?)? = null,
-
     /**
      * Custom function that represents [T] as String. Defaults to the standard `toString()` call. Override the
      * default implementation in case you need a different behavior than the standard `toString()` (e.g. for
      * collections joinToString() is more applicable).
      */
     public val propertyWriter: (T) -> String = { it.toString() },
-
     /**
      * Optional message to be displayed whenever the value of the property is being retrieved while it has been deprecated.
      */
     val deprecationWarning: String? = null,
-
     /**
      * Optional message to be displayed whenever the value of the property is being retrieved while it has been deprecated.
      */
     val deprecationError: String? = null,
-
     /**
      * Name of the property. A property must be named in case multiple properties are defined for the same type.
      * Defaults to the name of the type when not set.

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -38,26 +38,22 @@ public class KtLintRuleEngine(
      * that it can keep internal state and be called thread-safe manner
      */
     public val ruleProviders: Set<RuleProvider> = emptySet(),
-
     /**
      * The default values for `.editorconfig` properties which are not set explicitly in any '.editorconfig' file located on the path of the
      * file which is processed with the [KtLintRuleEngine]. If a property is set in [editorConfigDefaults] this takes precedence above the
      * default values defined in the KtLint project.
      */
     public val editorConfigDefaults: EditorConfigDefaults = EMPTY_EDITOR_CONFIG_DEFAULTS,
-
     /**
      * Override values for `.editorconfig` properties. If a property is set in [editorConfigOverride] it takes precedence above the same
      * property being set in any other way.
      */
     public val editorConfigOverride: EditorConfigOverride = EMPTY_EDITOR_CONFIG_OVERRIDE,
-
     /**
      * **For internal use only**: indicates that linting was invoked from KtLint CLI tool. It enables some internals workarounds for Kotlin
      * Compiler initialization. This property is likely to be removed in any of next versions without further notice.
      */
     public val isInvokedFromCli: Boolean = false,
-
     /**
      * The [FileSystem] to be used. This property is primarily intended to be used in unit tests. By specifying an alternative [FileSystem]
      * the unit test gains control on whether the [EditorConfigLoader] should or should not read specific ".editorconfig" files. For

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -31,6 +31,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.ModifierListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierOrderRule
 import com.pinterest.ktlint.ruleset.standard.rules.MultiLineIfElseRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLineBeforeRbraceRule
+import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLineInListRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLinesInChainedMethodCallsRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoConsecutiveBlankLinesRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoConsecutiveCommentsRule
@@ -107,6 +108,7 @@ public class StandardRuleSetProvider :
             RuleProvider { ModifierOrderRule() },
             RuleProvider { MultiLineIfElseRule() },
             RuleProvider { NoBlankLineBeforeRbraceRule() },
+            RuleProvider { NoBlankLineInListRule() },
             RuleProvider { NoBlankLinesInChainedMethodCallsRule() },
             RuleProvider { NoConsecutiveBlankLinesRule() },
             RuleProvider { NoConsecutiveCommentsRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -217,7 +217,7 @@ public class FunctionSignatureRule :
             .filter { it.elementType == VALUE_PARAMETER }
             .mapNotNull {
                 // If the value parameter contains a modifier then this list is followed by a white space
-                it.findChildByType(MODIFIER_LIST)?.nextSibling { true }
+                it.findChildByType(MODIFIER_LIST)?.nextSibling()
             }.any { it.textContains('\n') }
 
     private fun calculateFunctionSignatureLengthAsSingleLineSignature(
@@ -443,7 +443,7 @@ public class FunctionSignatureRule :
 
         val closingParenthesis = valueParameterList.findChildByType(RPAR)
         closingParenthesis
-            ?.prevSibling { true }
+            ?.prevSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             .let { whiteSpaceBeforeClosingParenthesis ->
                 if (multiline) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
@@ -44,7 +44,7 @@ public class FunctionTypeReferenceSpacingRule :
             if (currentNode.elementType == TYPE_REFERENCE) {
                 return currentNode
             }
-            currentNode = currentNode.nextSibling { true }
+            currentNode = currentNode.nextSibling()
         }
         return null
     }
@@ -56,7 +56,7 @@ public class FunctionTypeReferenceSpacingRule :
     ) {
         var currentNode: ASTNode? = node
         while (currentNode != null && currentNode.elementType != VALUE_PARAMETER_LIST) {
-            val nextNode = currentNode.nextSibling { true }
+            val nextNode = currentNode.nextSibling()
             removeIfNonEmptyWhiteSpace(currentNode, emit, autoCorrect)
             currentNode = nextNode
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1077,40 +1077,34 @@ public class IndentationRule :
          * The node on which the indent context starts.
          */
         val fromASTNode: ASTNode,
-
         /**
          * The node at which the indent context ends. If null, then the context ends at the last child leaf of the node
          * on which the indent context starts.
          */
         val toASTNode: ASTNode = fromASTNode.lastChildLeafOrSelf(),
-
         /**
          * Cumulative indentation for the node. Normally this should be equal to a multiple of the
          * 'indentConfig.indentStyle' to ensure a consistent indentation style.
          */
         val nodeIndent: String,
-
         /**
          * Additional indentation for first child node. Normally this should be equal to the 'indentConfig.indent' to
          * ensure a consistent indentation style. In very limited cases when the default indentation is set to 'tab' it
          * is still needed to adjust the last indentation using spaces.
          */
         val firstChildIndent: String,
-
         /**
          * Additional indentation for child nodes. Normally this should be equal to the 'indentConfig.indent' to ensure
          * a consistent indentation style. In very limited cases when the default indentation is set to 'tab' it is
          * still needed to adjust the last indentation using spaces.
          */
         val childIndent: String,
-
         /**
          * Additional indentation for last child node. Normally this should be equal to the 'indentConfig.indent' to
          * ensure a consistent indentation style. In very limited cases when the default indentation is set to 'tab' it
          * is still needed to adjust the last indentation using spaces.
          */
         val lastChildIndent: String,
-
         /**
          * True when the indentation level of this context is activated
          */

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInList.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInList.kt
@@ -1,0 +1,126 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+
+public class NoBlankLineInListRule :
+    StandardRule("no-blank-line-in-list"),
+    Rule.Experimental,
+    Rule.OfficialCodeStyle {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType != WHITE_SPACE) {
+            return
+        }
+
+        node
+            .treeParent
+            .elementType
+            .takeIf { it in LIST_TYPES }
+            ?.let { treeParentElementType ->
+                visitWhiteSpace(node, emit, autoCorrect, treeParentElementType)
+            }
+
+        // Note: depending on the implementation of the list type in the Kotlin language, the whitespace before the first and after the last
+        // element in the list might be or not be part of the list.
+        // In a VALUE_ARGUMENT_LIST the whitespaces before the first and after the last element are included in the VALUE_ARGUMENT_LIST. In
+        // the SUPER_TYPE_LIST of a CLASS the whitespaces before the first super type is a child of the CLASS. The whitespace after the last
+        // SUPER_TYPE is part of the class only when the class has a body.
+        node
+            .nextSibling()
+            ?.elementType
+            ?.takeIf { it in LIST_TYPES }
+            ?.let { treeParentElementType ->
+                visitWhiteSpace(
+                    node = node,
+                    emit = emit,
+                    autoCorrect = autoCorrect,
+                    partOfElementType = treeParentElementType,
+                    replaceWithSingeSpace = treeParentElementType == TYPE_CONSTRAINT_LIST,
+                )
+            }
+
+        // Note: depending on the implementation of the list type in the Kotlin language, the whitespace before the first and after the last
+        // element in the list might be or not be part of the list.
+        // In a VALUE_ARGUMENT_LIST the whitespaces before the first and after the last element are included in the VALUE_ARGUMENT_LIST. In
+        // the SUPER_TYPE_LIST of a CLASS the whitespaces before the first super type is a child of the CLASS. The whitespace after the last
+        // SUPER_TYPE is part of the class only when the class has a body.
+        node
+            .prevSibling()
+            ?.elementType
+            ?.takeIf { it in LIST_TYPES }
+            ?.let { treeParentElementType ->
+                visitWhiteSpace(
+                    node = node,
+                    emit = emit,
+                    autoCorrect = autoCorrect,
+                    partOfElementType = treeParentElementType,
+                    replaceWithSingeSpace = node.nextSibling()?.elementType == CLASS_BODY,
+                )
+            }
+    }
+
+    private fun visitWhiteSpace(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        partOfElementType: IElementType,
+        replaceWithSingeSpace: Boolean = false,
+    ) {
+        node
+            .text
+            .split("\n")
+            .let { lines ->
+                if (lines.size > 2) {
+                    emit(
+                        node.startOffset + 1,
+                        "Unexpected blank line(s) in ${partOfElementType.elementTypeDescription()}",
+                        true,
+                    )
+                    if (autoCorrect) {
+                        if (replaceWithSingeSpace) {
+                            (node as LeafPsiElement).rawReplaceWithText(" ")
+                        } else {
+                            (node as LeafPsiElement).rawReplaceWithText("${lines.first()}\n${lines.last()}")
+                        }
+                    }
+                }
+            }
+    }
+
+    private fun IElementType.elementTypeDescription() =
+        toString()
+            .lowercase()
+            .replace('_', ' ')
+
+    private companion object {
+        // The MODIFIER_LIST is handled by separate rule ModifierListSpacingRule
+        val LIST_TYPES = listOf(
+            SUPER_TYPE_LIST,
+            TYPE_ARGUMENT_LIST,
+            TYPE_CONSTRAINT_LIST,
+            TYPE_PARAMETER_LIST,
+            VALUE_ARGUMENT_LIST,
+            VALUE_PARAMETER_LIST,
+        )
+    }
+}
+
+public val NO_BLANK_LINE_IN_LIST_RULE_ID: RuleId = NoBlankLineInListRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -145,7 +145,7 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
                 ) {
                     emit(node.startOffset, "Unused import", true)
                     if (autoCorrect) {
-                        val nextSibling = node.nextSibling { true }
+                        val nextSibling = node.nextSibling()
                         if (nextSibling == null) {
                             // Last import
                             node
@@ -192,12 +192,12 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
         require(this.elementType == IMPORT_DIRECTIVE)
         when {
             treeParent.firstChildNode == this -> {
-                nextSibling { true }
+                nextSibling()
                     ?.takeIf { it.isWhiteSpaceWithNewline() }
                     ?.let { it.treeParent.removeChild(it) }
             }
             treeParent.lastChildNode == this -> {
-                prevSibling { true }
+                prevSibling()
                     ?.takeIf { it.isWhiteSpaceWithNewline() }
                     ?.let { it.treeParent.removeChild(it) }
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -91,7 +91,7 @@ public class ParameterListSpacingRule :
                     // Comma must be followed by whitespace
                     val nextSibling =
                         el
-                            .nextSibling { true }
+                            .nextSibling()
                             ?.elementType
                     if (nextSibling != WHITE_SPACE) {
                         addMissingWhiteSpaceAfterMe(el, emit, autoCorrect)
@@ -162,7 +162,7 @@ public class ParameterListSpacingRule :
     ) {
         require(node.elementType == MODIFIER_LIST)
         node
-            .nextSibling { true }
+            .nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { visitWhiteSpaceAfterModifier(it, emit, autoCorrect) }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCommaRule.kt
@@ -36,7 +36,7 @@ public class SpacingAroundCommaRule : StandardRule("comma-spacing") {
                         // If comma is on new line and preceded by a comment, it should be moved before this comment
                         // https://github.com/pinterest/ktlint/issues/367
                         val previousStatement = node.prevCodeLeaf()!!
-                        previousStatement.treeParent.addChild(node.clone(), previousStatement.nextSibling { true })
+                        previousStatement.treeParent.addChild(node.clone(), previousStatement.nextSibling())
                         val nextLeaf = node.nextLeaf()
                         if (nextLeaf is PsiWhiteSpace) {
                             nextLeaf.treeParent.removeChild(nextLeaf)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenFunctionNameAndOpeningParenthesisRule.kt
@@ -19,7 +19,7 @@ public class SpacingBetweenFunctionNameAndOpeningParenthesisRule :
         node
             .takeIf { node.elementType == ElementType.FUN }
             ?.findChildByType(ElementType.IDENTIFIER)
-            ?.nextSibling { true }
+            ?.nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { whiteSpace ->
                 emit(whiteSpace.startOffset, "Unexpected whitespace", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentListSpacingRule.kt
@@ -74,7 +74,7 @@ public class TypeArgumentListSpacingRule :
         //    val list = listOf< String>()
         node
             .findChildByType(ElementType.LT)
-            ?.nextSibling { true }
+            ?.nextSibling()
             ?.takeIf { it.elementType == ElementType.WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
 
@@ -82,7 +82,7 @@ public class TypeArgumentListSpacingRule :
         //    val list = listOf<String >()
         node
             .findChildByType(ElementType.GT)
-            ?.prevSibling { true }
+            ?.prevSibling()
             ?.takeIf { it.elementType == ElementType.WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -54,7 +54,7 @@ public class TypeParameterListSpacingRule :
         // No white space expected between class name and parameter list
         //     class Bar <T>
         node
-            .prevSibling { true }
+            .prevSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
 
@@ -62,7 +62,7 @@ public class TypeParameterListSpacingRule :
         // constructor
         //     class Bar<T> (...)
         node
-            .nextSibling { true }
+            .nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE && it.nextCodeSibling()?.elementType == PRIMARY_CONSTRUCTOR }
             ?.let { whiteSpace ->
                 if (whiteSpace.nextCodeSibling()?.findChildByType(CONSTRUCTOR_KEYWORD) != null) {
@@ -79,7 +79,7 @@ public class TypeParameterListSpacingRule :
         // No white space expected between parameter type list and class body when constructor is missing
         //    class Bar<T> {
         node
-            .nextSibling { true }
+            .nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE && it.nextCodeSibling()?.elementType == CLASS_BODY }
             ?.let { singleSpaceExpected(it, autoCorrect, emit) }
     }
@@ -92,14 +92,14 @@ public class TypeParameterListSpacingRule :
         // No white space expected between typealias keyword name and parameter list
         //     typealias Bar <T>
         node
-            .prevSibling { true }
+            .prevSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
 
         // No white space expected between parameter type list and equals sign
         //    typealias Bar<T> = ...
         node
-            .nextSibling { true }
+            .nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE && it.nextCodeSibling()?.elementType == EQ }
             ?.let { singleSpaceExpected(it, autoCorrect, emit) }
     }
@@ -139,13 +139,13 @@ public class TypeParameterListSpacingRule :
     ) {
         node
             .findChildByType(LT)
-            ?.nextSibling { true }
+            ?.nextSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
 
         node
             .findChildByType(GT)
-            ?.prevSibling { true }
+            ?.prevSibling()
             ?.takeIf { it.elementType == WHITE_SPACE }
             ?.let { noWhitespaceExpected(it, autoCorrect, emit) }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -616,7 +616,7 @@ public class WrappingRule :
             if (node.isWhiteSpaceWithNewline()) {
                 return false
             }
-            node = node.nextSibling { true }
+            node = node.nextSibling()
         }
         return true
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInListRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInListRuleTest.kt
@@ -1,0 +1,446 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.SPACE
+import com.pinterest.ktlint.test.TAB
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NoBlankLineInListRuleTest {
+    private val noBlankLineInListRuleAssertThat = KtLintAssertThat.assertThatRule { NoBlankLineInListRule() }
+
+    @Nested
+    inner class `Given a super type list` {
+        val formattedCode =
+            """
+            class FooBar:
+                Foo,
+                Bar {}
+            """.trimIndent()
+
+        @Test
+        fun `Given one or more blank lines before the first super type`() {
+            val code =
+                """
+                class FooBar:
+
+                    $SPACE
+                ${TAB}$TAB
+                    Foo,
+                    Bar {}
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(2, 1, "Unexpected blank line(s) in super type list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines between the super type`() {
+            val code =
+                """
+                class FooBar:
+                    Foo,
+
+                    $SPACE
+                ${TAB}$TAB
+                    Bar {}
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in super type list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines after the last super type`() {
+            val code =
+                """
+                class FooBar:
+                    Foo,
+                    Bar
+                    $SPACE
+                ${TAB}$TAB
+                    {}
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "Unexpected blank line(s) in super type list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class without body and one or more blank lines after the last super type then do not report a violation`() {
+            val code =
+                """
+                class FooBar:
+                    Foo,
+                    Bar
+
+                    $SPACE
+                ${TAB}$TAB
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a type constraint list` {
+        val formattedCode =
+            """
+            class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                val adapter1: A1,
+                val adapter2: A2
+            ) : RecyclerView.Adapter<C>()
+                where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+                      A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider {
+            }
+            """.trimIndent()
+
+        @Test
+        fun `Given one or more blank lines before the first type constraint`() {
+            val code =
+                """
+                class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                    val adapter1: A1,
+                    val adapter2: A2
+                ) : RecyclerView.Adapter<C>()
+                    where
+                    $SPACE
+                ${TAB}$TAB
+                          A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+                          A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider {
+                }
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasLintViolation(6, 1, "Unexpected blank line(s) in type constraint list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines between the super type`() {
+            val code =
+                """
+                class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                    val adapter1: A1,
+                    val adapter2: A2
+                ) : RecyclerView.Adapter<C>()
+                    where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+                    $SPACE
+                ${TAB}$TAB
+                          A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider {
+                }
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(6, 1, "Unexpected blank line(s) in type constraint list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines after the last super type`() {
+            val code =
+                """
+                class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                    val adapter1: A1,
+                    val adapter2: A2
+                ) : RecyclerView.Adapter<C>()
+                    where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+                          A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider
+                    $SPACE
+                ${TAB}$TAB
+                    {
+                }
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(7, 1, "Unexpected blank line(s) in type constraint list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class without body and one or more blank lines after the last super type then do not report a violation`() {
+            val code =
+                """
+                class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                    val adapter1: A1,
+                    val adapter2: A2
+                ) : RecyclerView.Adapter<C>()
+                    where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
+                          A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider
+                    $SPACE
+                ${TAB}$TAB
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a type argument list` {
+        val formattedCode =
+            """
+            val foobar: FooBar<
+                Foo,
+                Bar,
+                > = FooBar(Foo(), Bar())
+            """.trimIndent()
+
+        @Test
+        fun `Given one or more blank lines before the first type argument`() {
+            val code =
+                """
+                val foobar: FooBar<
+
+                    $SPACE
+                ${TAB}$TAB
+                    Foo,
+                    Bar,
+                    > = FooBar(Foo(), Bar())
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(2, 1, "Unexpected blank line(s) in type argument list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines between type arguments`() {
+            val code =
+                """
+                val foobar: FooBar<
+                    Foo,
+
+                    $SPACE
+                ${TAB}$TAB
+                    Bar,
+                    > = FooBar(Foo(), Bar())
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in type argument list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines after the last type argument`() {
+            val code =
+                """
+                val foobar: FooBar<
+                    Foo,
+
+                    $SPACE
+                ${TAB}$TAB
+                    Bar,
+                    > = FooBar(Foo(), Bar())
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in type argument list")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a type parameter value list` {
+        val formattedCode =
+            """
+            fun <
+                Foo,
+                Bar,
+                > foobar()
+            """.trimIndent()
+
+        @Test
+        fun `Given one or more blank lines before the first type parameter`() {
+            val code =
+                """
+                fun <
+
+                    $SPACE
+                ${TAB}$TAB
+                    Foo,
+                    Bar,
+                    > foobar()
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(2, 1, "Unexpected blank line(s) in type parameter list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines between type parameters`() {
+            val code =
+                """
+                fun <
+                    Foo,
+
+                    $SPACE
+                ${TAB}$TAB
+                    Bar,
+                    > foobar()
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in type parameter list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given one or more blank lines after the last type parameter`() {
+            val code =
+                """
+                fun <
+                    Foo,
+                    Bar,
+
+                    $SPACE
+                ${TAB}$TAB
+                    > foobar()
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "Unexpected blank line(s) in type parameter list")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a value argument list` {
+        val formattedCode =
+            """
+            val foobar = foobar(
+                "foo",
+                "bar",
+            )
+            """.trimIndent()
+
+        @Test
+        fun `Given a function call containing one or more blank lines before the first argument`() {
+            val code =
+                """
+                val foobar = foobar(
+
+                    $SPACE
+                ${TAB}$TAB
+                    "foo",
+                    "bar",
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(2, 1, "Unexpected blank line(s) in value argument list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function call containing one or more blank lines between the arguments`() {
+            val code =
+                """
+                val foobar = foobar(
+                    "foo",
+
+                    $SPACE
+                ${TAB}$TAB
+                    "bar",
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in value argument list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function call containing one or more blank lines after the last argument`() {
+            val code =
+                """
+                val foobar = foobar(
+                    "foo",
+                    "bar",
+
+                    $SPACE
+                ${TAB}$TAB
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "Unexpected blank line(s) in value argument list")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a value parameter list` {
+        val formattedCode =
+            """
+            fun foobar(
+                foo: String,
+                bar: String,
+            )
+            """.trimIndent()
+
+        @Test
+        fun `Given a function signature containing one or more blank lines before the first parameter`() {
+            val code =
+                """
+                fun foobar(
+
+                    $SPACE
+                ${TAB}$TAB
+                    foo: String,
+                    bar: String,
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(2, 1, "Unexpected blank line(s) in value parameter list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function signature containing one or more blank lines between the parameters`() {
+            val code =
+                """
+                fun foobar(
+                    foo: String,
+
+                    $SPACE
+                ${TAB}$TAB
+                    bar: String,
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(3, 1, "Unexpected blank line(s) in value parameter list")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a function signature containing one or more blank lines after the last parameter`() {
+            val code =
+                """
+                fun foobar(
+                    foo: String,
+                    bar: String,
+
+                    $SPACE
+                ${TAB}$TAB
+
+                )
+                """.trimIndent()
+            noBlankLineInListRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(4, 1, "Unexpected blank line(s) in value parameter list")
+                .isFormattedAs(formattedCode)
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style

This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists.

Closes #1224
Closes #1781

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [X] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
