### PR TITLE
Type parameter list spacing and wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,8 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * When `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|` then do not report a violation nor insert a blank line `import-ordering` ([#1845](https://github.com/pinterest/ktlint/issues/1845))
 * When negate-patterns only are specified in Ktlint CLI then automatically add the default include patterns (`**/*.kt` and `**/*.kts`) so that all Kotlin files excluding the files matching the negate-patterns will be processed ([#1847](https://github.com/pinterest/ktlint/issues/1847))
 * Do not remove newlines from multiline type parameter lists `type-parameter-list-spacing` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
-* 
+* Wrap each type parameter in a multiline type parameter list `wrapping` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
+
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).
   Changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,8 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Enforce spacing around rangeUntil operator `..<` similar to the range operator `..` in `range-spacing`  ([#1858](https://github.com/pinterest/ktlint/issues/1858))
 * When `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|` then do not report a violation nor insert a blank line `import-ordering` ([#1845](https://github.com/pinterest/ktlint/issues/1845))
 * When negate-patterns only are specified in Ktlint CLI then automatically add the default include patterns (`**/*.kt` and `**/*.kts`) so that all Kotlin files excluding the files matching the negate-patterns will be processed ([#1847](https://github.com/pinterest/ktlint/issues/1847))
-
+* Do not remove newlines from multiline type parameter lists `type-parameter-list-spacing` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
+* 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).
   Changelog:

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -31,6 +31,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_ENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
@@ -119,7 +121,8 @@ public class WrappingRule :
             LPAR, LBRACKET -> rearrangeBlock(node, autoCorrect, emit) // TODO: LT
             SUPER_TYPE_LIST -> rearrangeSuperTypeList(node, autoCorrect, emit)
             VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(node, autoCorrect, emit)
-            TYPE_ARGUMENT_LIST -> rearrangeTypeArgumentList(node, autoCorrect, emit)
+            TYPE_ARGUMENT_LIST, TYPE_PARAMETER_LIST -> rearrangeTypeArgumentList(node, autoCorrect, emit)
+//            TYPE_PARAMETER_LIST -> rearrangeTypeParameterList(node, autoCorrect, emit)
             ARROW -> rearrangeArrow(node, autoCorrect, emit)
             WHITE_SPACE -> line += node.text.count { it == '\n' }
             CLOSING_QUOTE -> rearrangeClosingQuote(node, autoCorrect, emit)
@@ -381,7 +384,7 @@ public class WrappingRule :
             // Each type projection must be preceded with a whitespace containing a newline
             node
                 .children()
-                .filter { it.elementType == TYPE_PROJECTION }
+                .filter { it.elementType == TYPE_PROJECTION || it.elementType == TYPE_PARAMETER }
                 .forEach { typeProjection ->
                     typeProjection
                         .prevSibling { !it.isPartOfComment() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
@@ -259,8 +259,8 @@ class TypeParameterListSpacingRuleTest {
             """.trimIndent()
         typeParameterListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 10, "No whitespace expected at this position"),
-                LintViolation(1, 14, "No whitespace expected at this position"),
+                LintViolation(1, 10, "No whitespace expected"),
+                LintViolation(1, 14, "No whitespace expected"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -278,8 +278,8 @@ class TypeParameterListSpacingRuleTest {
             """.trimIndent()
         typeParameterListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 6, "No whitespace expected at this position"),
-                LintViolation(2, 11, "No whitespace expected at this position"),
+                LintViolation(1, 6, "No whitespace expected"),
+                LintViolation(2, 11, "No whitespace expected"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -297,8 +297,8 @@ class TypeParameterListSpacingRuleTest {
             """.trimIndent()
         typeParameterListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 7, "No whitespace expected at this position"),
-                LintViolation(2, 12, "No whitespace expected at this position"),
+                LintViolation(1, 7, "No whitespace expected"),
+                LintViolation(2, 12, "No whitespace expected"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -314,8 +314,21 @@ class TypeParameterListSpacingRuleTest {
             """.trimIndent()
         typeParameterListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 14, "No whitespace expected at this position"),
+                LintViolation(1, 14, "No whitespace expected"),
                 LintViolation(1, 19, "Expected a single space"),
             ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 1867 - Given a multiline type parameter list which is correctly formatted then do not report a violation`() {
+        val code =
+            """
+            fun <
+                Foo,
+                Bar,
+                > foobar()
+            """.trimIndent()
+        typeParameterListSpacingRuleAssertThat(code)
+            .hasNoLintViolations()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -1849,6 +1849,28 @@ internal class WrappingRuleTest {
                 .hasNoLintViolations()
         }
     }
+
+    @Test
+    fun `Issue 1867 - Given a multiline type parameter list then wrap each type parameter to a new line`() {
+        val code =
+            """
+            fun <
+                Foo, Bar,
+                FooBar,
+                > foobar()
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun <
+                Foo,
+                Bar,
+                FooBar,
+                > foobar()
+            """.trimIndent()
+        wrappingRuleAssertThat(code)
+            .hasLintViolation(2, 10, "A newline was expected before 'Bar'")
+            .isFormattedAs(formattedCode)
+    }
 }
 
 // Replace the "$." placeholder with an actual "$" so that string "$.{expression}" is transformed to a String template


### PR DESCRIPTION
## Description

Do not remove newlines from multiline type parameter lists and wrap each type parameter in a multiline type parameter list.

Closes #1867

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
