### PR TITLE
Indent multiline expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,9 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Enforce spacing around rangeUntil operator `..<` similar to the range operator `..` in `range-spacing`  ([#1858](https://github.com/pinterest/ktlint/issues/1858))
 * When `.editorconfig` property `ij_kotlin_imports_layout` contains a `|` but no import exists that match any pattern before the first `|` then do not report a violation nor insert a blank line `import-ordering` ([#1845](https://github.com/pinterest/ktlint/issues/1845))
 * When negate-patterns only are specified in Ktlint CLI then automatically add the default include patterns (`**/*.kt` and `**/*.kts`) so that all Kotlin files excluding the files matching the negate-patterns will be processed ([#1847](https://github.com/pinterest/ktlint/issues/1847))
+* Do not remove newlines from multiline type parameter lists `type-parameter-list-spacing` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
+* Wrap each type parameter in a multiline type parameter list `wrapping` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
+* Allow value arguments with a multiline expression to be indented on a separate line `indent` ([#1217](https://github.com/pinterest/ktlint/issues/1217))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Wrap the type or value of a property in case the maximum line length is exceeded `property-wrapping` ([#1846](https://github.com/pinterest/ktlint/pull/1846))
 * Recognize Kotlin Script when linting and formatting code from `stdin` with KtLint CLI ([#1832](https://github.com/pinterest/ktlint/issues/1832))
 * Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style. This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#1224](https://github.com/pinterest/ktlint/issues/1224))
+* Add new experimental rule `multiline-expression-wrapping` for `ktlint_official` code style. This forces a multiline expression as value in an assignment to start on a separate line. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#1217](https://github.com/pinterest/ktlint/issues/1217))
 
 ### Removed
 

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -482,3 +482,34 @@ Rule id: `context-receiver-wrapping`
 A KDoc comment should start and end on a line that does not contain any other element.
 
 Rule id: `kdoc-wrapping`
+
+### Multiline expression wrapping
+
+Multiline expression on the right hand side of an expression are forced to start on a separate line. Expressions in return statement are excluded as that would result in a compilation error. 
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val foo =
+        foo(
+            parameterName =
+                "The quick brown fox "
+                    .plus("jumps ")
+                    .plus("over the lazy dog"),
+        )
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val foo = foo(
+        parameterName = "The quick brown fox "
+            .plus("jumps ")
+            .plus("over the lazy dog"),
+    )
+    ```
+
+Rule id: `multiline-expression-wrapping`
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
@@ -11,17 +11,19 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
 public class KtlintApiConsumer {
     // The KtLint RuleEngine only needs to be instantiated once and can be reused in multiple invocations
-    private val ktLintRuleEngine = KtLintRuleEngine(
-        ruleProviders = KTLINT_API_CONSUMER_RULE_PROVIDERS,
-    )
+    private val ktLintRuleEngine =
+        KtLintRuleEngine(
+            ruleProviders = KTLINT_API_CONSUMER_RULE_PROVIDERS,
+        )
 
     public fun run(
         command: String,
         fileName: String,
     ) {
-        val codeFile = Code.fromFile(
-            File(fileName),
-        )
+        val codeFile =
+            Code.fromFile(
+                File(fileName),
+            )
 
         when (command) {
             "lint" -> {

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/CustomRuleSetProvider.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/CustomRuleSetProvider.kt
@@ -5,9 +5,10 @@ import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 
 internal val CUSTOM_RULE_SET_ID = "custom-rule-set-id"
 
-internal val KTLINT_API_CONSUMER_RULE_PROVIDERS = setOf(
-    // Can provide custom rules
-    RuleProvider { NoVarRule() },
-    // but also reuse rules from KtLint rulesets
-    RuleProvider { IndentationRule() },
-)
+internal val KTLINT_API_CONSUMER_RULE_PROVIDERS =
+    setOf(
+        // Can provide custom rules
+        RuleProvider { NoVarRule() },
+        // but also reuse rules from KtLint rulesets
+        RuleProvider { IndentationRule() },
+    )

--- a/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/KtLintRuleEngineTest.kt
+++ b/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/KtLintRuleEngineTest.kt
@@ -50,12 +50,14 @@ class KtLintRuleEngineTest {
         ) {
             val dir = ApiTestRunner(tempDir).prepareTestProject("no-code-style-error")
 
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
             val lintErrors = mutableListOf<LintError>()
             ktLintRuleEngine.lint(
@@ -68,22 +70,25 @@ class KtLintRuleEngineTest {
 
         @Test
         fun `Given a kotlin code snippet that does not contain an error`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
             val lintErrors = mutableListOf<LintError>()
             ktLintRuleEngine.lint(
-                code = Code.fromSnippet(
-                    """
-                    fun main() {
-                        println("Hello world!")
-                    }
-                    """.trimIndent(),
-                ),
+                code =
+                    Code.fromSnippet(
+                        """
+                        fun main() {
+                            println("Hello world!")
+                        }
+                        """.trimIndent(),
+                    ),
                 callback = { lintErrors.add(it) },
             )
 
@@ -92,24 +97,27 @@ class KtLintRuleEngineTest {
 
         @Test
         fun `Given a kotlin script code snippet that does not contain an error`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
             val lintErrors = mutableListOf<LintError>()
             ktLintRuleEngine.lint(
-                code = Code.fromSnippet(
-                    """
-                    plugins {
-                        id("foo")
-                        id("bar")
-                    }
-                    """.trimIndent(),
-                    script = true,
-                ),
+                code =
+                    Code.fromSnippet(
+                        """
+                        plugins {
+                            id("foo")
+                            id("bar")
+                        }
+                        """.trimIndent(),
+                        script = true,
+                    ),
                 callback = { lintErrors.add(it) },
             )
 
@@ -118,23 +126,27 @@ class KtLintRuleEngineTest {
 
         @Test
         fun `Given a code snippet that violates a custom rule prefixed by a rule set id`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { NoVarRule() },
-                ),
-                editorConfigOverride = EditorConfigOverride.from(
-                    NoVarRule.NO_VAR_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { NoVarRule() },
+                        ),
+                    editorConfigOverride =
+                        EditorConfigOverride.from(
+                            NoVarRule.NO_VAR_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
             val lintErrors = mutableListOf<LintError>()
             ktLintRuleEngine.lint(
-                code = Code.fromSnippet(
-                    """
-                    var foo = "foo"
-                    """.trimIndent(),
-                ),
+                code =
+                    Code.fromSnippet(
+                        """
+                        var foo = "foo"
+                        """.trimIndent(),
+                    ),
                 callback = { lintErrors.add(it) },
             )
 
@@ -143,19 +155,22 @@ class KtLintRuleEngineTest {
 
         @Test
         fun `Given a code snippet then the file name rule may not result in a Lint violation`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { FilenameRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { FilenameRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
             val lintErrors = mutableListOf<LintError>()
             ktLintRuleEngine.lint(
-                code = Code.fromSnippet(
-                    """
-                    var foo = "foo"
-                    """.trimIndent(),
-                ),
+                code =
+                    Code.fromSnippet(
+                        """
+                        var foo = "foo"
+                        """.trimIndent(),
+                    ),
                 callback = { lintErrors.add(it) },
             )
 
@@ -172,40 +187,47 @@ class KtLintRuleEngineTest {
         ) {
             val dir = ApiTestRunner(tempDir).prepareTestProject("no-code-style-error")
 
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
             val original = File("$dir/Main.kt").readText()
 
-            val actual = ktLintRuleEngine.format(
-                code = Code.fromFile(File("$dir/Main.kt")),
-            )
+            val actual =
+                ktLintRuleEngine.format(
+                    code = Code.fromFile(File("$dir/Main.kt")),
+                )
 
             assertThat(actual).isEqualTo(original)
         }
 
         @Test
         fun `Given a kotlin code snippet that does contain an indentation error`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
-            val actual = ktLintRuleEngine.format(
-                code = Code.fromSnippet(
-                    """
-                    fun main() {
-                    println("Hello world!")
-                    }
-                    """.trimIndent(),
-                ),
-            )
+            val actual =
+                ktLintRuleEngine.format(
+                    code =
+                        Code.fromSnippet(
+                            """
+                            fun main() {
+                            println("Hello world!")
+                            }
+                            """.trimIndent(),
+                        ),
+                )
 
             assertThat(actual).isEqualTo(
                 """
@@ -218,24 +240,28 @@ class KtLintRuleEngineTest {
 
         @Test
         fun `Given a kotlin script code snippet that does contain an indentation error`() {
-            val ktLintRuleEngine = KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { IndentationRule() },
-                ),
-                fileSystem = ktlintTestFileSystem.fileSystem,
-            )
+            val ktLintRuleEngine =
+                KtLintRuleEngine(
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { IndentationRule() },
+                        ),
+                    fileSystem = ktlintTestFileSystem.fileSystem,
+                )
 
-            val actual = ktLintRuleEngine.format(
-                code = Code.fromSnippet(
-                    """
-                    plugins {
-                    id("foo")
-                    id("bar")
-                    }
-                    """.trimIndent(),
-                    script = true,
-                ),
-            )
+            val actual =
+                ktLintRuleEngine.format(
+                    code =
+                        Code.fromSnippet(
+                            """
+                            plugins {
+                            id("foo")
+                            id("bar")
+                            }
+                            """.trimIndent(),
+                            script = true,
+                        ),
+                )
 
             assertThat(actual).isEqualTo(
                 """
@@ -250,32 +276,36 @@ class KtLintRuleEngineTest {
 
     @Test
     fun `Given that all experimental rules are enabled`() {
-        val ktLintEngine = KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider { NoVarRule() },
-            ),
-            editorConfigDefaults = EditorConfigDefaults(
-                EditorConfig
-                    .builder()
-                    .section(
-                        Section
+        val ktLintEngine =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        RuleProvider { NoVarRule() },
+                    ),
+                editorConfigDefaults =
+                    EditorConfigDefaults(
+                        EditorConfig
                             .builder()
-                            .glob(Glob("*.{kt,kts}"))
-                            .properties(
-                                EXPERIMENTAL_RULES_EXECUTION_PROPERTY.toPropertyBuilderWithValue("enabled"),
-                            ),
-                    )
-                    .build(),
-            ),
-            fileSystem = ktlintTestFileSystem.fileSystem,
-        )
+                            .section(
+                                Section
+                                    .builder()
+                                    .glob(Glob("*.{kt,kts}"))
+                                    .properties(
+                                        EXPERIMENTAL_RULES_EXECUTION_PROPERTY.toPropertyBuilderWithValue("enabled"),
+                                    ),
+                            )
+                            .build(),
+                    ),
+                fileSystem = ktlintTestFileSystem.fileSystem,
+            )
         val errors = mutableListOf<LintError>()
         ktLintEngine.lint(
-            code = Code.fromSnippet(
-                """
-                var foo = "foo"
-                """.trimIndent(),
-            ),
+            code =
+                Code.fromSnippet(
+                    """
+                    var foo = "foo"
+                    """.trimIndent(),
+                ),
             callback = errors::add,
         )
 

--- a/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProvider.kt
+++ b/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProvider.kt
@@ -12,9 +12,10 @@ public class FormatReporterProvider : ReporterProviderV2<FormatReporter> {
     ): FormatReporter =
         FormatReporter(
             out,
-            format = opt
-                .getOrElse("format") { throw IllegalArgumentException("Format is not specified in config options") }
-                .toBooleanStrict(),
+            format =
+                opt
+                    .getOrElse("format") { throw IllegalArgumentException("Format is not specified in config options") }
+                    .toBooleanStrict(),
             shouldColorOutput = opt["color"]?.emptyOrTrue() ?: false,
             outputColor = getColor(opt["color_name"]),
         )

--- a/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProviderTest.kt
+++ b/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProviderTest.kt
@@ -21,13 +21,15 @@ class FormatReporterProviderTest {
 
     @Test
     fun `Given that the format configuration and a valid color name is provided then the format reporter provider is created without exception`() {
-        val formatReporter = FormatReporterProvider().get(
-            out = PrintStream(out, true),
-            opt = mapOf(
-                "format" to "true",
-                "color_name" to "RED",
-            ),
-        )
+        val formatReporter =
+            FormatReporterProvider().get(
+                out = PrintStream(out, true),
+                opt =
+                    mapOf(
+                        "format" to "true",
+                        "color_name" to "RED",
+                    ),
+            )
 
         assertThat(formatReporter).isNotNull
     }
@@ -39,10 +41,11 @@ class FormatReporterProviderTest {
                 FormatReporterProvider()
                     .get(
                         out = PrintStream(out, true),
-                        opt = mapOf(
-                            "format" to "invalid",
-                            "color_name" to "RED",
-                        ),
+                        opt =
+                            mapOf(
+                                "format" to "invalid",
+                                "color_name" to "RED",
+                            ),
                     )
             }.withMessage("The string doesn't represent a boolean value: invalid")
     }
@@ -66,10 +69,11 @@ class FormatReporterProviderTest {
                 FormatReporterProvider()
                     .get(
                         out = PrintStream(out, true),
-                        opt = mapOf(
-                            "format" to "true",
-                            "color_name" to "",
-                        ),
+                        opt =
+                            mapOf(
+                                "format" to "true",
+                                "color_name" to "",
+                            ),
                     )
             }.withMessage("Invalid color parameter.")
     }
@@ -81,10 +85,11 @@ class FormatReporterProviderTest {
                 FormatReporterProvider()
                     .get(
                         out = PrintStream(out, true),
-                        opt = mapOf(
-                            "format" to "true",
-                            "color_name" to "GARBAGE_INPUT",
-                        ),
+                        opt =
+                            mapOf(
+                                "format" to "true",
+                                "color_name" to "GARBAGE_INPUT",
+                            ),
                     )
             }.withMessage("Invalid color parameter.")
     }

--- a/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
+++ b/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
@@ -14,10 +14,11 @@ class FormatReporterTest {
     @Test
     fun `Given some lint violations from which at least one is autocorrected and format is running`() {
         val out = ByteArrayOutputStream()
-        val reporter = FormatReporter(
-            out = PrintStream(out, true),
-            format = true,
-        )
+        val reporter =
+            FormatReporter(
+                out = PrintStream(out, true),
+                format = true,
+            )
 
         // File 1: 1 violation not autocorrected
         reporter.onLintError(
@@ -62,10 +63,11 @@ class FormatReporterTest {
     @Test
     fun `Given some lint violations from which none is autocorrected and lint is running`() {
         val out = ByteArrayOutputStream()
-        val reporter = FormatReporter(
-            out = PrintStream(out, true),
-            format = false,
-        )
+        val reporter =
+            FormatReporter(
+                out = PrintStream(out, true),
+                format = false,
+            )
 
         // File 1: At least 1 violation can be autocorrected but is not (e.g. lint is running)
         reporter.onLintError(
@@ -91,12 +93,13 @@ class FormatReporterTest {
     fun `Given that the output has to be colored`() {
         val out = ByteArrayOutputStream()
         val outputColor = Color.DARK_GRAY
-        val reporter = FormatReporter(
-            PrintStream(out, true),
-            format = true,
-            shouldColorOutput = true,
-            outputColor = outputColor,
-        )
+        val reporter =
+            FormatReporter(
+                PrintStream(out, true),
+                format = true,
+                shouldColorOutput = true,
+                outputColor = outputColor,
+            )
 
         reporter.onLintError(
             File.separator.plus(SOME_FILE_NAME),

--- a/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterProviderTest.kt
+++ b/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterProviderTest.kt
@@ -9,10 +9,11 @@ import java.lang.System.out
 class PlainSummaryReporterProviderTest {
     @Test
     fun `Get a plain summary reporter then create it without exception`() {
-        val plainSummaryReporter = PlainSummaryReporterProvider().get(
-            out = PrintStream(out, true),
-            opt = emptyMap(),
-        )
+        val plainSummaryReporter =
+            PlainSummaryReporterProvider().get(
+                out = PrintStream(out, true),
+                opt = emptyMap(),
+            )
 
         assertThat(plainSummaryReporter).isNotNull
     }

--- a/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterProviderTest.kt
+++ b/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterProviderTest.kt
@@ -9,10 +9,11 @@ import java.lang.System.out
 class PlainReporterProviderTest {
     @Test
     fun `Given that a valid color name is provided then the plain reporter provider is created without exception`() {
-        val plainReporter = PlainReporterProvider().get(
-            out = PrintStream(out, true),
-            opt = mapOf("color_name" to "RED"),
-        )
+        val plainReporter =
+            PlainReporterProvider().get(
+                out = PrintStream(out, true),
+                opt = mapOf("color_name" to "RED"),
+            )
 
         assertThat(plainReporter).isNotNull
     }

--- a/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
@@ -98,11 +98,12 @@ class PlainReporterTest {
     fun testColoredOutput() {
         val out = ByteArrayOutputStream()
         val outputColor = Color.DARK_GRAY
-        val reporter = PlainReporter(
-            PrintStream(out, true),
-            shouldColorOutput = true,
-            outputColor = outputColor,
-        )
+        val reporter =
+            PlainReporter(
+                PrintStream(out, true),
+                shouldColorOutput = true,
+                outputColor = outputColor,
+            )
         reporter.onLintError(
             File.separator + "one-fixed-and-one-not.kt",
             @Suppress("ktlint:argument-list-wrapping")

--- a/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
+++ b/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
@@ -45,24 +45,28 @@ public class SarifReporter(private val out: PrintStream) : ReporterV2 {
             Result(
                 ruleID = ktlintCliError.ruleId,
                 level = Level.Error,
-                locations = listOf(
-                    Location(
-                        physicalLocation = PhysicalLocation(
-                            region = Region(
-                                startLine = ktlintCliError.line.toLong(),
-                                startColumn = ktlintCliError.col.toLong(),
-                            ),
-                            artifactLocation = workingDirectory?.let { workingDirectory ->
-                                ArtifactLocation(
-                                    uri = Path(file).relativeToOrSelf(workingDirectory.toPath()).pathString,
-                                    uriBaseID = SRCROOT,
-                                )
-                            } ?: ArtifactLocation(
-                                uri = file,
-                            ),
+                locations =
+                    listOf(
+                        Location(
+                            physicalLocation =
+                                PhysicalLocation(
+                                    region =
+                                        Region(
+                                            startLine = ktlintCliError.line.toLong(),
+                                            startColumn = ktlintCliError.col.toLong(),
+                                        ),
+                                    artifactLocation =
+                                        workingDirectory?.let { workingDirectory ->
+                                            ArtifactLocation(
+                                                uri = Path(file).relativeToOrSelf(workingDirectory.toPath()).pathString,
+                                                uriBaseID = SRCROOT,
+                                            )
+                                        } ?: ArtifactLocation(
+                                            uri = file,
+                                        ),
+                                ),
                         ),
                     ),
-                ),
                 message = Message(text = ktlintCliError.detail),
             ),
         )
@@ -70,31 +74,36 @@ public class SarifReporter(private val out: PrintStream) : ReporterV2 {
 
     override fun afterAll() {
         val version = ktlintVersion(SarifReporter::class.java)
-        val sarifSchema210 = SarifSchema210(
-            schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-            version = Version.The210,
-            runs = listOf(
-                Run(
-                    tool = Tool(
-                        driver = ToolComponent(
-                            downloadURI = "https://github.com/pinterest/ktlint/releases/tag/$version",
-                            fullName = "ktlint",
-                            informationURI = "https://github.com/pinterest/ktlint/",
-                            language = "en",
-                            name = "ktlint",
-                            rules = listOf(),
-                            organization = "pinterest",
-                            semanticVersion = version,
-                            version = version,
+        val sarifSchema210 =
+            SarifSchema210(
+                schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+                version = Version.The210,
+                runs =
+                    listOf(
+                        Run(
+                            tool =
+                                Tool(
+                                    driver =
+                                        ToolComponent(
+                                            downloadURI = "https://github.com/pinterest/ktlint/releases/tag/$version",
+                                            fullName = "ktlint",
+                                            informationURI = "https://github.com/pinterest/ktlint/",
+                                            language = "en",
+                                            name = "ktlint",
+                                            rules = listOf(),
+                                            organization = "pinterest",
+                                            semanticVersion = version,
+                                            version = version,
+                                        ),
+                                ),
+                            originalURIBaseIDS =
+                                workingDirectory?.let {
+                                    mapOf(SRCROOT to ArtifactLocation(uri = "file://${it.path.sanitize()}"))
+                                },
+                            results = results,
                         ),
                     ),
-                    originalURIBaseIDS = workingDirectory?.let {
-                        mapOf(SRCROOT to ArtifactLocation(uri = "file://${it.path.sanitize()}"))
-                    },
-                    results = results,
-                ),
-            ),
-        )
+            )
         out.println(SarifSerializer.toJson(sarifSchema210))
     }
 }

--- a/ktlint-cli-reporter-sarif/src/test/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporterTest.kt
+++ b/ktlint-cli-reporter-sarif/src/test/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporterTest.kt
@@ -39,10 +39,11 @@ class SarifReporterTest {
         reporter.afterAll()
 
         val actual = String(out.toByteArray()).replace("\\s".toRegex(), "")
-        val expected = File(javaClass.getResource("/relative-path.sarif").path)
-            .readText()
-            .replace("{WORKINDG_DIR}", workingDirectory)
-            .replace("\\s".toRegex(), "")
+        val expected =
+            File(javaClass.getResource("/relative-path.sarif").path)
+                .readText()
+                .replace("{WORKINDG_DIR}", workingDirectory)
+                .replace("\\s".toRegex(), "")
         assertThat(actual).isEqualTo(expected)
     }
 }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/Main.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/Main.kt
@@ -15,13 +15,14 @@ import picocli.CommandLine
 // issues. So the class is to be kept at the old location.
 public fun main(args: Array<String>) {
     val ktlintCommand = KtlintCommandLine()
-    val commandLine = CommandLine(ktlintCommand)
-        .addSubcommand(GitPreCommitHookSubCommand.COMMAND_NAME, GitPreCommitHookSubCommand())
-        .addSubcommand(GitPrePushHookSubCommand.COMMAND_NAME, GitPrePushHookSubCommand())
-        .addSubcommand(PrintASTSubCommand.COMMAND_NAME, PrintASTSubCommand())
-        .addSubcommand(GenerateEditorConfigSubCommand.COMMAND_NAME, GenerateEditorConfigSubCommand())
-        // Keep setUsageHelpAutoWidth after all addSubcommands
-        .setUsageHelpAutoWidth(true)
+    val commandLine =
+        CommandLine(ktlintCommand)
+            .addSubcommand(GitPreCommitHookSubCommand.COMMAND_NAME, GitPreCommitHookSubCommand())
+            .addSubcommand(GitPrePushHookSubCommand.COMMAND_NAME, GitPrePushHookSubCommand())
+            .addSubcommand(PrintASTSubCommand.COMMAND_NAME, PrintASTSubCommand())
+            .addSubcommand(GenerateEditorConfigSubCommand.COMMAND_NAME, GenerateEditorConfigSubCommand())
+            // Keep setUsageHelpAutoWidth after all addSubcommands
+            .setUsageHelpAutoWidth(true)
     val parseResult = commandLine.parseArgs(*args)
 
     // The logger needs to be configured for the ktlintCommand and all subcommands. The logger can however not be configured before the

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
@@ -162,12 +162,13 @@ private class BaselineLoader(private val path: String) {
         KtlintCliError(
             line = getAttribute("line").toInt(),
             col = getAttribute("column").toInt(),
-            ruleId = getAttribute("source")
-                .let {
-                    // Ensure backwards compatibility with baseline files in which the rule set id for standard rules is not saved
-                    RuleId.prefixWithStandardRuleSetIdWhenMissing(it)
-                        .also { ruleReferenceWithoutRuleSetIdPrefix++ }
-                },
+            ruleId =
+                getAttribute("source")
+                    .let {
+                        // Ensure backwards compatibility with baseline files in which the rule set id for standard rules is not saved
+                        RuleId.prefixWithStandardRuleSetIdWhenMissing(it)
+                            .also { ruleReferenceWithoutRuleSetIdPrefix++ }
+                    },
             detail = "", // Not available in the baseline
             status = BASELINE_IGNORED,
         )

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GenerateEditorConfigSubCommand.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GenerateEditorConfigSubCommand.kt
@@ -33,11 +33,12 @@ internal class GenerateEditorConfigSubCommand : Runnable {
             exitKtLintProcess(1)
         }
 
-        val ktLintRuleEngine = KtLintRuleEngine(
-            ruleProviders = ktlintCommand.ruleProviders(),
-            editorConfigOverride = EditorConfigOverride.from(CODE_STYLE_PROPERTY to ktlintCommand.codeStyle),
-            isInvokedFromCli = true,
-        )
+        val ktLintRuleEngine =
+            KtLintRuleEngine(
+                ruleProviders = ktlintCommand.ruleProviders(),
+                editorConfigOverride = EditorConfigOverride.from(CODE_STYLE_PROPERTY to ktlintCommand.codeStyle),
+                isInvokedFromCli = true,
+            )
         val generatedEditorConfig = ktLintRuleEngine.generateKotlinEditorConfigSection(Paths.get("."))
 
         if (generatedEditorConfig.isNotBlank()) {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitHookInstaller.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitHookInstaller.kt
@@ -55,11 +55,12 @@ internal object GitHookInstaller {
     // Try to find the .git directory automatically, falling back to `./.git`
     private fun getGitDir(): File {
         val gitDir = try {
-            val root = Runtime.getRuntime().exec("git rev-parse --show-toplevel")
-                .inputStream
-                .bufferedReader()
-                .readText()
-                .trim()
+            val root =
+                Runtime.getRuntime().exec("git rev-parse --show-toplevel")
+                    .inputStream
+                    .bufferedReader()
+                    .readText()
+                    .trim()
 
             File(root).resolve(".git")
         } catch (_: IOException) {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -63,7 +63,7 @@ private lateinit var logger: KLogger
 
 @Command(
     headerHeading =
-    """
+        """
 An anti-bikeshedding Kotlin linter with built-in formatter.
 (https://github.com/pinterest/ktlint).
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintServiceLoader.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintServiceLoader.kt
@@ -36,9 +36,10 @@ internal fun <T> Class<T>.loadFromJarFiles(
             // Remove JAR files which were provided multiple times
             .distinct()
             .map { url ->
-                val providers = this
-                    .loadProvidersFromJars(url)
-                    .filterNot { providerIdsFromKtlintJars.contains(providerId(it)) }
+                val providers =
+                    this
+                        .loadProvidersFromJars(url)
+                        .filterNot { providerIdsFromKtlintJars.contains(providerId(it)) }
                 if (providers.isEmpty()) {
                     if (customJarProviderCheck == ERROR_WHEN_REQUIRED_PROVIDER_IS_MISSING) {
                         if (LOGGER.isDebugEnabled) {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/PrintASTSubCommand.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/PrintASTSubCommand.kt
@@ -64,9 +64,10 @@ internal class PrintASTSubCommand : Runnable {
 
         try {
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { DumpASTRule(System.out, ktlintCommand.color) },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider { DumpASTRule(System.out, ktlintCommand.color) },
+                    ),
             ).lint(code)
         } catch (e: Exception) {
             if (e is KtLintParseException) {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
@@ -68,13 +68,14 @@ internal class ReporterAggregator(
         parseReporterConfigurationString(configuration)
             .let { config ->
                 config.copy(
-                    additionalConfig = config.additionalConfig.plus(
-                        mapOf(
-                            "color" to color.toString(),
-                            "color_name" to colorName,
-                            "format" to format.toString(),
+                    additionalConfig =
+                        config.additionalConfig.plus(
+                            mapOf(
+                                "color" to color.toString(),
+                                "color_name" to colorName,
+                                "format" to format.toString(),
+                            ),
                         ),
-                    ),
                 )
             }
 

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -168,14 +168,16 @@ class CommandLineTestRunner(private val tempDir: Path) {
             return null
         }
 
-        val matchResult = JAVA_VERSION_REGEX.matchEntire(this)
-        /*
-         * Java 9+: no more leading `1.`.
-         */
-            ?: return toIntOrNull()
+        val matchResult =
+            JAVA_VERSION_REGEX
+                .matchEntire(this)
+                ?: // Java 9+ has no leading `1.` as prefix in the version number
+                return toIntOrNull()
 
-        val matchGroup = matchResult.groups["version"]
-            ?: return null
+        val matchGroup =
+            matchResult
+                .groups["version"]
+                ?: return null
 
         return matchGroup.value.toIntOrNull()
     }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/EditorConfigDefaultsLoaderCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/EditorConfigDefaultsLoaderCLITest.kt
@@ -48,10 +48,11 @@ class EditorConfigDefaultsLoaderCLITest {
         CommandLineTestRunner(tempDir)
             .run(
                 testProjectName = "editorconfig-path",
-                arguments = listOf(
-                    "**/*.test",
-                    "--editorconfig=$tempDir/editorconfig-path/project/$editorconfigPath",
-                ),
+                arguments =
+                    listOf(
+                        "**/*.test",
+                        "--editorconfig=$tempDir/editorconfig-path/project/$editorconfigPath",
+                    ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()
@@ -73,10 +74,11 @@ class EditorConfigDefaultsLoaderCLITest {
         CommandLineTestRunner(tempDir)
             .run(
                 testProjectName = "editorconfig-path",
-                arguments = listOf(
-                    "**/*.test",
-                    "--editorconfig=$tempDir/editorconfig-path/project/.editorconfig-default-max-line-length-on-tests-only",
-                ),
+                arguments =
+                    listOf(
+                        "**/*.test",
+                        "--editorconfig=$tempDir/editorconfig-path/project/.editorconfig-default-max-line-length-on-tests-only",
+                    ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()
@@ -97,10 +99,11 @@ class EditorConfigDefaultsLoaderCLITest {
         CommandLineTestRunner(tempDir)
             .run(
                 testProjectName = "editorconfig-path",
-                arguments = listOf(
-                    "**/*.test",
-                    "--editorconfig=$tempDir/editorconfig-path/project/.editorconfig-disable-no-wildcard-imports-rule",
-                ),
+                arguments =
+                    listOf(
+                        "**/*.test",
+                        "--editorconfig=$tempDir/editorconfig-path/project/.editorconfig-disable-no-wildcard-imports-rule",
+                    ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()
@@ -119,10 +122,11 @@ class EditorConfigDefaultsLoaderCLITest {
         CommandLineTestRunner(tempDir)
             .run(
                 testProjectName = "editorconfig-path",
-                arguments = listOf(
-                    "**/*.test",
-                    "--editorconfig=$tempDir/editorconfig-path/project/editorconfig-boolean-setting",
-                ),
+                arguments =
+                    listOf(
+                        "**/*.test",
+                        "--editorconfig=$tempDir/editorconfig-path/project/editorconfig-boolean-setting",
+                    ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -422,19 +422,20 @@ class SimpleCLITest {
             .run(
                 testProjectName = "too-many-empty-lines",
                 arguments = listOf("--stdin"),
-                stdin = ByteArrayInputStream(
-                    """
-                    pluginManagement {
-                        repositories {
-                            mavenCentral()
-                            gradlePluginPortal()
+                stdin =
+                    ByteArrayInputStream(
+                        """
+                        pluginManagement {
+                            repositories {
+                                mavenCentral()
+                                gradlePluginPortal()
+                            }
+
+
+                            includeBuild("build-logic")
                         }
-
-
-                        includeBuild("build-logic")
-                    }
-                    """.trimIndent().toByteArray(),
-                ),
+                        """.trimIndent().toByteArray(),
+                    ),
             ) {
                 assertThat(normalOutput)
                     .containsLineMatching(Regex(".*Not a valid Kotlin file.*"))
@@ -453,19 +454,20 @@ class SimpleCLITest {
             .run(
                 testProjectName = "too-many-empty-lines",
                 arguments = listOf("--stdin", "--format"),
-                stdin = ByteArrayInputStream(
-                    """
-                    pluginManagement {
-                        repositories {
-                            mavenCentral()
-                            gradlePluginPortal()
+                stdin =
+                    ByteArrayInputStream(
+                        """
+                        pluginManagement {
+                            repositories {
+                                mavenCentral()
+                                gradlePluginPortal()
+                            }
+
+
+                            includeBuild("build-logic")
                         }
-
-
-                        includeBuild("build-logic")
-                    }
-                    """.trimIndent().toByteArray(),
-                ),
+                        """.trimIndent().toByteArray(),
+                    ),
             ) {
                 assertThat(normalOutput)
                     .containsLineMatching(Regex(".*Not a valid Kotlin file.*"))

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -82,12 +82,14 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given some patterns and no workdir then ignore all files in hidden directories`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "project1/**/*.kt",
-                "project1/*.kt",
-            ),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "project1/**/*.kt",
+                        "project1/*.kt",
+                    ),
+            )
 
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(
@@ -103,12 +105,14 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given some patterns including a negate pattern and no workdir then select all files except files in the negate pattern`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "project1/src/**/*.kt",
-                "!project1/src/**/example/*.kt",
-            ),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "project1/src/**/*.kt",
+                        "!project1/src/**/example/*.kt",
+                    ),
+            )
 
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(ktFile1InProjectSubDirectory)
@@ -117,12 +121,14 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given a pattern and a workdir then find all files in that workdir and all its sub directories that match the pattern`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "**/main/**/*.kt",
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "**/main/**/*.kt",
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -147,10 +153,11 @@ internal class FileUtilsTest {
     fun `Given a pattern containing redundant elements then find all files in that workdir and all its sub directories that match the pattern without the redundant items`(
         pattern: String,
     ) {
-        val foundFiles = getFiles(
-            patterns = listOf(pattern),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf(pattern),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -160,10 +167,11 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given an (relative) file path from the workdir then find all files in that workdir and all its sub directories that match the pattern`() {
-        val foundFiles = getFiles(
-            patterns = listOf("src/main/kotlin/One.kt"),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf("src/main/kotlin/One.kt"),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -172,13 +180,15 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given an (absolute) file path and a workdir then find that absolute path and all files in the workdir and all its sub directories that match the pattern`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "src/main/kotlin/One.kt",
-                "${ktlintTestFileSystem.resolve(ktFile2InProjectSubDirectory).toAbsolutePath()}",
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "src/main/kotlin/One.kt",
+                        "${ktlintTestFileSystem.resolve(ktFile2InProjectSubDirectory).toAbsolutePath()}",
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -207,22 +217,25 @@ internal class FileUtilsTest {
             writeFile(filePath, SOME_CONTENT)
         }
 
-        val foundFiles = getFiles(
-            patterns = listOf(pattern),
-            rootDir = ktlintTestFileSystem.fileSystem.rootDirectories.first(),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf(pattern),
+                rootDir = ktlintTestFileSystem.fileSystem.rootDirectories.first(),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(filePath)
     }
 
     @Test
     fun `Given a pattern containing a double star and a workdir without subdirectories then find all files in that workdir`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "**/*.kt",
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1/src/main/kotlin/"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "**/*.kt",
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1/src/main/kotlin/"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -232,12 +245,14 @@ internal class FileUtilsTest {
 
     @Test
     fun `Given a pattern containing multiple double star patters and a workdir without subdirectories then find all files in that workdir`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "src/**/kotlin/**/*.kt",
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "src/**/kotlin/**/*.kt",
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -254,10 +269,11 @@ internal class FileUtilsTest {
                 "\tpatterns = $patterns\n" +
                 "\trootDir = $dir"
         }
-        val foundFiles = getFiles(
-            patterns = listOf("src/main/kotlin"),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf("src/main/kotlin"),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).containsExactlyInAnyOrder(
             ktFile1InProjectSubDirectory,
@@ -270,12 +286,14 @@ internal class FileUtilsTest {
     @EnabledOnOs(OS.WINDOWS)
     @Test
     fun `Given the Windows OS and some globs using backslash as file separator the convert the globs to using a forward slash`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "project1\\src\\**\\*.kt",
-                "!project1\\src\\**\\example\\*.kt",
-            ),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "project1\\src\\**\\*.kt",
+                        "!project1\\src\\**\\example\\*.kt",
+                    ),
+            )
 
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(ktFile1InProjectSubDirectory)
@@ -295,10 +313,11 @@ internal class FileUtilsTest {
     fun `On non-WindowsOS, a pattern containing a double-dot (parent directory) reference may leave the current directory`(
         pattern: String,
     ) {
-        val foundFiles = getFiles(
-            patterns = listOf(pattern),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf(pattern),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).contains(ktFile1InProjectSubDirectory)
     }
@@ -316,13 +335,15 @@ internal class FileUtilsTest {
     fun `On WindowsOS, a pattern containing a double-dot (parent directory) reference may not leave the current directory`(
         pattern: String,
     ) {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                pattern,
-                "/some/non/existing/file", // This prevents the default patterns to be added
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        pattern,
+                        "/some/non/existing/file", // This prevents the default patterns to be added
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).isEmpty()
     }
@@ -337,10 +358,11 @@ internal class FileUtilsTest {
         ],
     )
     fun `On non-WindowsOS, a pattern containing a wildcard may followed by a double-dot (parent directory) reference`(pattern: String) {
-        val foundFiles = getFiles(
-            patterns = listOf(pattern),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns = listOf(pattern),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).contains(ktFile1InProjectSubDirectory)
     }
@@ -355,24 +377,28 @@ internal class FileUtilsTest {
         ],
     )
     fun `On WindowsOS, a pattern containing a wildcard may followed by a double-dot (parent directory) reference`(pattern: String) {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                pattern,
-                "/some/non/existing/file", // This prevents the default patterns to be added
-            ),
-            rootDir = ktlintTestFileSystem.resolve("project1"),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        pattern,
+                        "/some/non/existing/file", // This prevents the default patterns to be added
+                    ),
+                rootDir = ktlintTestFileSystem.resolve("project1"),
+            )
 
         assertThat(foundFiles).isEmpty()
     }
 
     @Test
     fun `Issue 1847 - Given a negate pattern only then include the default patters and select all files except files in the negate pattern`() {
-        val foundFiles = getFiles(
-            patterns = listOf(
-                "!project1/**/*.kt",
-            ),
-        )
+        val foundFiles =
+            getFiles(
+                patterns =
+                    listOf(
+                        "!project1/**/*.kt",
+                    ),
+            )
 
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/RuleSetProviderV2.kt
@@ -76,12 +76,13 @@ public abstract class RuleSetProviderV2(
     }
 
     public companion object {
-        public val NO_ABOUT: About = About(
-            maintainer = "Not specified",
-            description = "Not specified",
-            license = "Not specified",
-            repositoryUrl = "Not specified",
-            issueTrackerUrl = "Not specified",
-        )
+        public val NO_ABOUT: About =
+            About(
+                maintainer = "Not specified",
+                description = "Not specified",
+                license = "Not specified",
+                repositoryUrl = "Not specified",
+                issueTrackerUrl = "Not specified",
+            )
     }
 }

--- a/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/ElementType.kt
+++ b/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/ast/ElementType.kt
@@ -9,8 +9,9 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 @Deprecated(
-    message = "Marked for removal in KtLint 0.50. For now kept for backward compatibility with custom rulesets compiled with Ktlint " +
-        "0.48 or before",
+    message =
+        "Marked for removal in KtLint 0.50. For now kept for backward compatibility with custom rulesets compiled with Ktlint 0.48 or " +
+            "before",
     replaceWith = ReplaceWith("ElementType", "com.pinterest.ktlint.ruleset.core.api"),
 )
 public object ElementType {

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -320,8 +320,9 @@ public val ASTNode.column: Int
     }
 
 @Deprecated(
-    message = "Marked for removal in Ktlint 0.50. Replace with 'indent' but do note that it automatically includes a newline character " +
-        "as prefix.",
+    message =
+        "Marked for removal in Ktlint 0.50. Replace with 'indent' but do note that it automatically includes a newline character as " +
+            "prefix.",
     replaceWith = ReplaceWith("indent"),
 )
 public fun ASTNode.lineIndent(): String {

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
@@ -141,9 +141,10 @@ public data class IndentConfig(
     public companion object {
         private val TABS_AND_SPACES = Regex("[ \t]*")
 
-        public val DEFAULT_INDENT_CONFIG: IndentConfig = IndentConfig(
-            indentStyle = INDENT_STYLE_PROPERTY.defaultValue,
-            tabWidth = INDENT_SIZE_PROPERTY.defaultValue,
-        )
+        public val DEFAULT_INDENT_CONFIG: IndentConfig =
+            IndentConfig(
+                indentStyle = INDENT_STYLE_PROPERTY.defaultValue,
+                tabWidth = INDENT_SIZE_PROPERTY.defaultValue,
+            )
     }
 }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleProvider.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleProvider.kt
@@ -45,13 +45,15 @@ public class RuleProvider private constructor(
                     RuleProvider(
                         provider = provider,
                         ruleId = rule.ruleId,
-                        runAsLateAsPossible = rule
-                            .visitorModifiers
-                            .filterIsInstance<Rule.VisitorModifier.RunAsLateAsPossible>()
-                            .any(),
-                        runAfterRules = rule
-                            .visitorModifiers
-                            .filterIsInstance<Rule.VisitorModifier.RunAfterRule>(),
+                        runAsLateAsPossible =
+                            rule
+                                .visitorModifiers
+                                .filterIsInstance<Rule.VisitorModifier.RunAsLateAsPossible>()
+                                .any(),
+                        runAfterRules =
+                            rule
+                                .visitorModifiers
+                                .filterIsInstance<Rule.VisitorModifier.RunAfterRule>(),
                     )
                 }
     }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig.kt
@@ -44,13 +44,14 @@ public data class EditorConfig(
             editorConfigProperty.deprecationWarning != null ->
                 LOGGER.warn { "Property '${editorConfigProperty.name}' is deprecated: ${editorConfigProperty.deprecationWarning}" }
         }
-        val property = properties.getOrElse(editorConfigProperty.name) {
-            throw IllegalStateException(
-                "Property '${editorConfigProperty.name}' can not be retrieved from this EditorConfig. Note that the EditorConfig which " +
-                    "is provided to class '${Rule::class.qualifiedName}' only contains the properties which are defined in the property " +
-                    "'${Rule::usesEditorConfigProperties.name}'.",
-            )
-        }
+        val property =
+            properties.getOrElse(editorConfigProperty.name) {
+                throw IllegalStateException(
+                    "Property '${editorConfigProperty.name}' can not be retrieved from this EditorConfig. Note that the EditorConfig " +
+                        "which is provided to class '${Rule::class.qualifiedName}' only contains the properties which are defined in the " +
+                        "property '${Rule::usesEditorConfigProperties.name}'.",
+                )
+            }
 
         editorConfigProperty
             .propertyMapper

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -470,9 +470,10 @@ class ASTNodeExtensionTest {
 
     private fun transformCodeToAST(code: String) =
         KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider { DummyRule() },
-            ),
+            ruleProviders =
+                setOf(
+                    RuleProvider { DummyRule() },
+                ),
         ).transformToAst(
             Code.fromSnippet(code),
         )

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
@@ -215,9 +215,10 @@ class EditorConfigTest {
 
     @Test
     fun `Given an editorconfig containing a property for which the value is unset then return its default value`() {
-        val editorConfig = EditorConfig(
-            SOME_EDITOR_CONFIG_PROPERTY.toPropertyWithValue("unset"),
-        )
+        val editorConfig =
+            EditorConfig(
+                SOME_EDITOR_CONFIG_PROPERTY.toPropertyWithValue("unset"),
+            )
 
         val actual = editorConfig[SOME_EDITOR_CONFIG_PROPERTY]
 
@@ -227,9 +228,10 @@ class EditorConfigTest {
     @Test
     fun `Given an editorconfig containing a property with an invalid source value then return its default value`() {
         val someEditorConfigProperty = editorConfigProperty("some-editor-config-property")
-        val editorConfig = EditorConfig(
-            someEditorConfigProperty.toPropertyWithValue("some-invalid-value"),
-        )
+        val editorConfig =
+            EditorConfig(
+                someEditorConfigProperty.toPropertyWithValue("some-invalid-value"),
+            )
 
         val actual = editorConfig[someEditorConfigProperty]
 
@@ -255,25 +257,27 @@ class EditorConfigTest {
         val ktlintTestRuleExecutionProperty2 = "ktlint_test_rule-2"
         val ktlintTestRuleExecutionPropertyType2 = editorConfigProperty(ktlintTestRuleExecutionProperty2)
 
-        val ktlintTestFileSystem = KtlintTestFileSystem().apply {
-            writeRootEditorConfigFile(
-                //language=EditorConfig
-                """
+        val ktlintTestFileSystem =
+            KtlintTestFileSystem().apply {
+                writeRootEditorConfigFile(
+                    //language=EditorConfig
+                    """
                 [*.{kt,kts}]
                 $ktlintTestRuleExecutionProperty1 = disabled
                 $ktlintTestRuleExecutionProperty2 = disabled
-                """.trimIndent(),
-            )
-        }
+                    """.trimIndent(),
+                )
+            }
 
         val ktlintTestRuleProperties =
             EditorConfigDefaults
                 .load(
                     path = ktlintTestFileSystem.resolve(""),
-                    propertyTypes = setOf(
-                        // Note that ktlintTestRuleEditorConfigPropertyType1 has been left out on purpose
-                        ktlintTestRuleExecutionPropertyType2.type,
-                    ),
+                    propertyTypes =
+                        setOf(
+                            // Note that ktlintTestRuleEditorConfigPropertyType1 has been left out on purpose
+                            ktlintTestRuleExecutionPropertyType2.type,
+                        ),
                 ).value
                 .sections
                 .flatMap { it.properties.values }
@@ -306,12 +310,13 @@ class EditorConfigTest {
     private fun editorConfigProperty(name: String) =
         EditorConfigProperty(
             name = name,
-            type = PropertyType.LowerCasingPropertyType(
-                name,
-                "",
-                SafeEnumValueParser(RuleExecution::class.java),
-                RuleExecution.values().map { it.name }.toSet(),
-            ),
+            type =
+                PropertyType.LowerCasingPropertyType(
+                    name,
+                    "",
+                    SafeEnumValueParser(RuleExecution::class.java),
+                    RuleExecution.values().map { it.name }.toSet(),
+                ),
             defaultValue = RuleExecution.enabled,
         )
 
@@ -322,18 +327,20 @@ class EditorConfigTest {
         const val SOME_PROPERTY_VALUE_DEFAULT = "some-property-value-default"
         const val SOME_PROPERTY_VALUE_INTELLIJ_IDEA = "some-property-value-intellij-idea"
         const val SOME_PROPERTY_VALUE_OFFICIAL = "some-property-value-official"
-        val SOME_EDITOR_CONFIG_PROPERTY = EditorConfigProperty(
-            name = SOME_PROPERTY_NAME,
-            type = PropertyType(
-                SOME_PROPERTY_NAME,
-                "",
-                PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
-                setOf(SOME_PROPERTY_VALUE_ANDROID, SOME_PROPERTY_VALUE_INTELLIJ_IDEA),
-            ),
-            defaultValue = SOME_PROPERTY_VALUE_DEFAULT,
-            androidStudioCodeStyleDefaultValue = SOME_PROPERTY_VALUE_ANDROID,
-            ktlintOfficialCodeStyleDefaultValue = SOME_PROPERTY_VALUE_OFFICIAL,
-            intellijIdeaCodeStyleDefaultValue = SOME_PROPERTY_VALUE_INTELLIJ_IDEA,
-        )
+        val SOME_EDITOR_CONFIG_PROPERTY =
+            EditorConfigProperty(
+                name = SOME_PROPERTY_NAME,
+                type =
+                    PropertyType(
+                        SOME_PROPERTY_NAME,
+                        "",
+                        PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                        setOf(SOME_PROPERTY_VALUE_ANDROID, SOME_PROPERTY_VALUE_INTELLIJ_IDEA),
+                    ),
+                defaultValue = SOME_PROPERTY_VALUE_DEFAULT,
+                androidStudioCodeStyleDefaultValue = SOME_PROPERTY_VALUE_ANDROID,
+                ktlintOfficialCodeStyleDefaultValue = SOME_PROPERTY_VALUE_OFFICIAL,
+                intellijIdeaCodeStyleDefaultValue = SOME_PROPERTY_VALUE_INTELLIJ_IDEA,
+            )
     }
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigDefaults.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigDefaults.kt
@@ -29,8 +29,9 @@ public data class EditorConfigDefaults(
          * ".editorconfig" is ignored entirely.
          */
         @Deprecated(
-            message = "Marked for removal in Ktlint 0.50. This method causes class cast exceptions in case the '.editorconfig' file " +
-                "contains properties having an EditorConfigProperty with a custom type (e.g. a type not defined in the ec4j library)",
+            message =
+                "Marked for removal in Ktlint 0.50. This method causes class cast exceptions in case the '.editorconfig' file contains " +
+                    "properties having an EditorConfigProperty with a custom type (e.g. a type not defined in the ec4j library)",
             replaceWith = ReplaceWith("load(path, propertyTypes)"),
         )
         public fun load(path: Path?): EditorConfigDefaults =

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -70,12 +70,13 @@ public class KtLintRuleEngine(
 
     internal val editorConfigLoaderEc4j = EditorConfigLoaderEc4j(ruleProviders.propertyTypes())
 
-    internal val editorConfigLoader = EditorConfigLoader(
-        fileSystem,
-        editorConfigLoaderEc4j,
-        editorConfigDefaults,
-        editorConfigOverride,
-    )
+    internal val editorConfigLoader =
+        EditorConfigLoader(
+            fileSystem,
+            editorConfigLoaderEc4j,
+            editorConfigDefaults,
+            editorConfigOverride,
+        )
 
     /**
      * Check the [code] for lint errors. If [code] is path as file reference then the '.editorconfig' files on the path to file are taken
@@ -182,10 +183,11 @@ public class KtLintRuleEngine(
             return code.content
         }
 
-        val formattedCode = ruleExecutionContext
-            .rootNode
-            .text
-            .replace("\n", ruleExecutionContext.determineLineSeparator(code.content))
+        val formattedCode =
+            ruleExecutionContext
+                .rootNode
+                .text
+                .replace("\n", ruleExecutionContext.determineLineSeparator(code.content))
         return if (hasUTF8BOM) {
             UTF8_BOM + formattedCode
         } else {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
@@ -25,10 +25,11 @@ internal class EditorConfigFinder(private val editorConfigLoaderEc4j: EditorConf
      */
     fun findEditorConfigs(path: Path): List<Path> {
         READ_WRITE_LOCK.read {
-            val cacheValue = IN_MEMORY_CACHE[path]
-                ?.also {
-                    LOGGER.info { "Retrieving EditorConfig cache entry for path $path" }
-                }
+            val cacheValue =
+                IN_MEMORY_CACHE[path]
+                    ?.also {
+                        LOGGER.info { "Retrieving EditorConfig cache entry for path $path" }
+                    }
             return cacheValue
                 ?: READ_WRITE_LOCK.write {
                     cacheEditorConfigs(path)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -139,10 +139,11 @@ internal class EditorConfigLoader(
         /**
          * List of file extensions, editorconfig lookup will be performed.
          */
-        internal val SUPPORTED_FILES = arrayOf(
-            ".kt",
-            ".kts",
-        )
+        internal val SUPPORTED_FILES =
+            arrayOf(
+                ".kt",
+                ".kts",
+            )
 
         private const val TAB_WIDTH_PROPERTY_NAME = "tab_width"
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
@@ -81,9 +81,10 @@ private fun extractCompilerExtension(): Path {
         val tempDir = Files.createTempDirectory("ktlint")
         tempDir.toFile().deleteOnExit()
 
-        val extensionsDir = tempDir.resolve("META-INF/extensions").also {
-            Files.createDirectories(it)
-        }
+        val extensionsDir =
+            tempDir.resolve("META-INF/extensions").also {
+                Files.createDirectories(it)
+            }
         extensionsDir.resolve("compiler.xml").toFile().outputStream().buffered().use {
             input!!.copyTo(it)
         }
@@ -135,12 +136,13 @@ private class FormatPomModel : UserDataHolderBase(), PomModel {
             // using approach described in https://git.io/vKQTo due to the magical bytecode of TreeAspect
             // (check constructor signature and compare it to the source)
             // (org.jetbrains.kotlin:kotlin-compiler-embeddable:1.0.3)
-            val constructor = ReflectionFactory
-                .getReflectionFactory()
-                .newConstructorForSerialization(
-                    aspect,
-                    Any::class.java.getDeclaredConstructor(*arrayOfNulls<Class<*>>(0)),
-                )
+            val constructor =
+                ReflectionFactory
+                    .getReflectionFactory()
+                    .newConstructorForSerialization(
+                        aspect,
+                        Any::class.java.getDeclaredConstructor(*arrayOfNulls<Class<*>>(0)),
+                    )
             return constructor.newInstance() as T
         }
         return null

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/PositionInTextLocator.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/PositionInTextLocator.kt
@@ -41,11 +41,12 @@ private class SegmentTree(
         }
     }
 
-    private val segments: List<Segment> = sortedArray
-        .dropLast(1)
-        .mapIndexed { index: Int, element: Int ->
-            Segment(element, sortedArray[index + 1] - 1)
-        }
+    private val segments: List<Segment> =
+        sortedArray
+            .dropLast(1)
+            .mapIndexed { index: Int, element: Int ->
+                Segment(element, sortedArray[index + 1] - 1)
+            }
 
     fun get(i: Int): Segment = segments[i]
     fun indexOf(v: Int): Int = binarySearch(v, 0, segments.size - 1)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
@@ -73,16 +73,17 @@ internal class RuleProviderSorter {
             }
         unprocessedRuleProviders.removeAll(sortedRuleProviders)
         while (unprocessedRuleProviders.isNotEmpty()) {
-            val ruleProvider = unprocessedRuleProviders
-                .firstOrNull { ruleProvider ->
-                    ruleProvider
-                        .runAfterRules
-                        .filter { it.ruleId in ruleIdsToBeSorted }
-                        .all { it.ruleId in ruleIdsSortedRuleProviders }
-                }
-                ?: throw IllegalStateException(
-                    "Can not complete sorting of rule providers as next item can not be determined.",
-                )
+            val ruleProvider =
+                unprocessedRuleProviders
+                    .firstOrNull { ruleProvider ->
+                        ruleProvider
+                            .runAfterRules
+                            .filter { it.ruleId in ruleIdsToBeSorted }
+                            .all { it.ruleId in ruleIdsSortedRuleProviders }
+                    }
+                    ?: throw IllegalStateException(
+                        "Can not complete sorting of rule providers as next item can not be determined.",
+                    )
             sortedRuleProviders.add(ruleProvider)
             ruleIdsSortedRuleProviders.add(ruleProvider.ruleId)
             unprocessedRuleProviders.remove(ruleProvider)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressHandler.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressHandler.kt
@@ -13,10 +13,11 @@ internal class SuppressHandler(
         ruleId: RuleId,
         function: (Boolean, (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) -> Unit,
     ) {
-        val suppress = suppressionLocator(
-            node.startOffset,
-            ruleId,
-        )
+        val suppress =
+            suppressionLocator(
+                node.startOffset,
+                ruleId,
+            )
         val autoCorrect = this.autoCorrect && !suppress
         val emit = if (suppress) {
             SUPPRESS_EMIT

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
@@ -28,16 +28,17 @@ internal object SuppressionLocatorBuilder {
      * when specific non-ktlint annotations are found. The prevents that developers have to specify multiple annotations
      * for the same violation.
      */
-    private val SUPPRESS_ANNOTATION_RULE_MAP = mapOf(
-        // It would have been nice if the official rule id's as defined in the Rules themselves could have been used here. But that would
-        // introduce a circular dependency between the ktlint-rule-engine and the ktlint-ruleset-standard modules.
-        "EnumEntryName" to RuleId("standard:enum-entry-name-case"),
-        "RemoveCurlyBracesFromTemplate" to RuleId("standard:string-template"),
-        "ClassName" to RuleId("standard:class-naming"),
-        "FunctionName" to RuleId("standard:function-naming"),
-        "PackageName" to RuleId("standard:package-name"),
-        "PropertyName" to RuleId("standard:property-naming"),
-    )
+    private val SUPPRESS_ANNOTATION_RULE_MAP =
+        mapOf(
+            // It would have been nice if the official rule id's as defined in the Rules themselves could have been used here. But that would
+            // introduce a circular dependency between the ktlint-rule-engine and the ktlint-ruleset-standard modules.
+            "EnumEntryName" to RuleId("standard:enum-entry-name-case"),
+            "RemoveCurlyBracesFromTemplate" to RuleId("standard:string-template"),
+            "ClassName" to RuleId("standard:class-naming"),
+            "FunctionName" to RuleId("standard:function-naming"),
+            "PackageName" to RuleId("standard:package-name"),
+            "PropertyName" to RuleId("standard:property-naming"),
+        )
     private val SUPPRESS_ANNOTATIONS = setOf("Suppress", "SuppressWarnings")
     private val SUPPRESS_ALL_KTLINT_RULES_RULE_ID = RuleId("ktlint:suppress-all-rules")
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCache.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCache.kt
@@ -29,10 +29,11 @@ internal class ThreadSafeEditorConfigCache : Cache {
         editorConfigLoader: EditorConfigLoader,
     ): EditorConfig {
         readWriteLock.read {
-            val cachedEditConfig = inMemoryMap[resource]
-                ?.also {
-                    LOGGER.trace { "Retrieving EditorConfig cache entry for path ${resource.path}" }
-                }?.editConfig
+            val cachedEditConfig =
+                inMemoryMap[resource]
+                    ?.also {
+                        LOGGER.trace { "Retrieving EditorConfig cache entry for path ${resource.path}" }
+                    }?.editConfig
             return cachedEditConfig
                 ?: readWriteLock.write {
                     CacheValue(resource, editorConfigLoader)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
@@ -179,8 +179,9 @@ internal class RunAfterRuleFilter : RuleFilter {
         val separator = "\n  - "
         return requiredButMissingRuleIds
             .joinToString(
-                prefix = "Skipping rule(s) which are depending on a rule which is not loaded. Please check if " +
-                    "you need to add additional rule sets before creating an issue.$separator",
+                prefix =
+                    "Skipping rule(s) which are depending on a rule which is not loaded. Please check if you need to add additional " +
+                        "rule sets before creating an issue.$separator",
                 separator = separator,
             ) {
                 "Rule with id '${it.ruleId}' requires rule with id '${it.runAfterRuleId}' to be loaded"

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/DisabledRulesTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/DisabledRulesTest.kt
@@ -17,9 +17,10 @@ class DisabledRulesTest {
         assertThat(
             ArrayList<LintError>().apply {
                 KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider { NoVarRule(SOME_RULE_ID) },
-                    ),
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { NoVarRule(SOME_RULE_ID) },
+                        ),
                 ).lint(Code.fromSnippet("var foo")) { e -> add(e) }
             },
         ).contains(
@@ -42,12 +43,14 @@ class DisabledRulesTest {
         assertThat(
             ArrayList<LintError>().apply {
                 KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider { NoVarRule(someRuleId) },
-                    ),
-                    editorConfigOverride = EditorConfigOverride.from(
-                        RuleId(disabledRuleId).createRuleExecutionEditorConfigProperty() to RuleExecution.disabled,
-                    ),
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { NoVarRule(someRuleId) },
+                        ),
+                    editorConfigOverride =
+                        EditorConfigOverride.from(
+                            RuleId(disabledRuleId).createRuleExecutionEditorConfigProperty() to RuleExecution.disabled,
+                        ),
                 ).lint(Code.fromSnippet("var foo")) { e -> add(e) }
             },
         ).isEmpty()

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -44,15 +44,16 @@ class KtLintTest {
             fun `Given a non empty rule providers and empty userData then do not throw an error`() {
                 var numberOfRootNodesVisited = 0
                 KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider {
-                            DummyRule { node ->
-                                if (node.isRoot()) {
-                                    numberOfRootNodesVisited++
+                    ruleProviders =
+                        setOf(
+                            RuleProvider {
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
                                 }
-                            }
-                        },
-                    ),
+                            },
+                        ),
                 ).lint(Code.fromSnippet("fun main() {}"))
                 assertThat(numberOfRootNodesVisited).isEqualTo(1)
             }
@@ -66,9 +67,10 @@ class KtLintTest {
                     """.trimIndent()
                 val callbacks = mutableListOf<CallbackResult>()
                 KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider { AutoCorrectErrorRule() },
-                    ),
+                    ruleProviders =
+                        setOf(
+                            RuleProvider { AutoCorrectErrorRule() },
+                        ),
                 ).lint(Code.fromSnippet(code)) { e ->
                     callbacks.add(
                         CallbackResult(
@@ -108,15 +110,16 @@ class KtLintTest {
             fun `Given a non empty rule providers and empty userData then do not throw an error`() {
                 var numberOfRootNodesVisited = 0
                 KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider {
-                            DummyRule { node ->
-                                if (node.isRoot()) {
-                                    numberOfRootNodesVisited++
+                    ruleProviders =
+                        setOf(
+                            RuleProvider {
+                                DummyRule { node ->
+                                    if (node.isRoot()) {
+                                        numberOfRootNodesVisited++
+                                    }
                                 }
-                            }
-                        },
-                    ),
+                            },
+                        ),
                 ).format(Code.fromSnippet("fun main() {}"))
                 assertThat(numberOfRootNodesVisited).isEqualTo(1)
             }
@@ -134,22 +137,24 @@ class KtLintTest {
                     val bar = "$STRING_VALUE_AFTER_AUTOCORRECT"
                     """.trimIndent()
                 val callbacks = mutableListOf<CallbackResult>()
-                val actualFormattedCode = KtLintRuleEngine(
-                    ruleProviders = setOf(
-                        RuleProvider { AutoCorrectErrorRule() },
-                    ),
-                ).format(Code.fromSnippet(code)) { e, corrected ->
-                    callbacks.add(
-                        CallbackResult(
-                            line = e.line,
-                            col = e.col,
-                            ruleId = e.ruleId,
-                            detail = e.detail,
-                            canBeAutoCorrected = e.canBeAutoCorrected,
-                            corrected = corrected,
-                        ),
-                    )
-                }
+                val actualFormattedCode =
+                    KtLintRuleEngine(
+                        ruleProviders =
+                            setOf(
+                                RuleProvider { AutoCorrectErrorRule() },
+                            ),
+                    ).format(Code.fromSnippet(code)) { e, corrected ->
+                        callbacks.add(
+                            CallbackResult(
+                                line = e.line,
+                                col = e.col,
+                                ruleId = e.ruleId,
+                                detail = e.detail,
+                                canBeAutoCorrected = e.canBeAutoCorrected,
+                                corrected = corrected,
+                            ),
+                        )
+                    }
                 assertThat(actualFormattedCode).isEqualTo(formattedCode)
                 assertThat(callbacks).containsExactly(
                     CallbackResult(
@@ -177,22 +182,23 @@ class KtLintTest {
     fun `Given a normal rule then execute on root node and child nodes`() {
         val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
         KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider {
-                    SimpleTestRule(
-                        ruleExecutionCalls = ruleExecutionCalls,
-                        ruleId = SimpleTestRule.RULE_ID_A,
-                        visitorModifiers = setOf(),
-                    )
-                },
-                RuleProvider {
-                    SimpleTestRule(
-                        ruleExecutionCalls = ruleExecutionCalls,
-                        ruleId = SimpleTestRule.RULE_ID_B,
-                        visitorModifiers = setOf(RunAsLateAsPossible),
-                    )
-                },
-            ),
+            ruleProviders =
+                setOf(
+                    RuleProvider {
+                        SimpleTestRule(
+                            ruleExecutionCalls = ruleExecutionCalls,
+                            ruleId = SimpleTestRule.RULE_ID_A,
+                            visitorModifiers = setOf(),
+                        )
+                    },
+                    RuleProvider {
+                        SimpleTestRule(
+                            ruleExecutionCalls = ruleExecutionCalls,
+                            ruleId = SimpleTestRule.RULE_ID_B,
+                            visitorModifiers = setOf(RunAsLateAsPossible),
+                        )
+                    },
+                ),
         ).lint(EMPTY_CODE_SNIPPET)
         assertThat(ruleExecutionCalls).containsExactly(
             // File a
@@ -220,27 +226,28 @@ class KtLintTest {
     fun `Given multiple rules which have to run in a certain order`() {
         val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
         KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider {
-                    SimpleTestRule(
-                        ruleExecutionCalls = ruleExecutionCalls,
-                        ruleId = SimpleTestRule.RULE_ID_D,
-                        visitorModifiers = setOf(RunAsLateAsPossible),
-                    )
-                },
-                RuleProvider {
-                    SimpleTestRule(
-                        ruleExecutionCalls = ruleExecutionCalls,
-                        ruleId = SimpleTestRule.RULE_ID_B,
-                    )
-                },
-                RuleProvider {
-                    SimpleTestRule(
-                        ruleExecutionCalls = ruleExecutionCalls,
-                        ruleId = SimpleTestRule.RULE_ID_C,
-                    )
-                },
-            ),
+            ruleProviders =
+                setOf(
+                    RuleProvider {
+                        SimpleTestRule(
+                            ruleExecutionCalls = ruleExecutionCalls,
+                            ruleId = SimpleTestRule.RULE_ID_D,
+                            visitorModifiers = setOf(RunAsLateAsPossible),
+                        )
+                    },
+                    RuleProvider {
+                        SimpleTestRule(
+                            ruleExecutionCalls = ruleExecutionCalls,
+                            ruleId = SimpleTestRule.RULE_ID_B,
+                        )
+                    },
+                    RuleProvider {
+                        SimpleTestRule(
+                            ruleExecutionCalls = ruleExecutionCalls,
+                            ruleId = SimpleTestRule.RULE_ID_C,
+                        )
+                    },
+                ),
         ).lint(EMPTY_CODE_SNIPPET)
 
         assertThat(ruleExecutionCalls).containsExactly(
@@ -278,11 +285,13 @@ class KtLintTest {
     fun testFormatUnicodeBom() {
         val code = getResourceAsText("spec/format-unicode-bom.kt.spec")
 
-        val actual = KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider { DummyRule() },
-            ),
-        ).format(Code.fromSnippet(code))
+        val actual =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        RuleProvider { DummyRule() },
+                    ),
+            ).format(Code.fromSnippet(code))
 
         assertThat(actual).isEqualTo(code)
     }
@@ -293,15 +302,16 @@ class KtLintTest {
         fun `Given that the traversal is stopped in the beforeFirstNode hook then do no traverse the AST but do call the afterLastNode hook`() {
             val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider {
-                        SimpleTestRule(
-                            ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
-                            ruleExecutionCalls = ruleExecutionCalls,
-                            stopTraversalInBeforeFirstNode = true,
-                        )
-                    },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider {
+                            SimpleTestRule(
+                                ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                stopTraversalInBeforeFirstNode = true,
+                            )
+                        },
+                    ),
             ).format(Code.fromSnippet("class Foo"))
 
             assertThat(ruleExecutionCalls).containsExactly(
@@ -324,18 +334,19 @@ class KtLintTest {
                 }
                 """.trimIndent()
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider {
-                        SimpleTestRule(
-                            ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
-                            ruleExecutionCalls = ruleExecutionCalls,
-                            stopTraversalInBeforeVisitChildNodes = { node ->
-                                // Stop when Class Foo has been entered
-                                node.elementType == CLASS && node.findChildByType(IDENTIFIER)?.text == "Foo"
-                            },
-                        )
-                    },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider {
+                            SimpleTestRule(
+                                ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                stopTraversalInBeforeVisitChildNodes = { node ->
+                                    // Stop when Class Foo has been entered
+                                    node.elementType == CLASS && node.findChildByType(IDENTIFIER)?.text == "Foo"
+                                },
+                            )
+                        },
+                    ),
             ).format(Code.fromSnippet(code))
 
             assertThat(ruleExecutionCalls)
@@ -364,18 +375,19 @@ class KtLintTest {
                 }
                 """.trimIndent()
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider {
-                        SimpleTestRule(
-                            ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
-                            ruleExecutionCalls = ruleExecutionCalls,
-                            stopTraversalInAfterVisitChildNodes = { node ->
-                                // Stop when Class Foo has been visited
-                                node.elementType == CLASS && node.findChildByType(IDENTIFIER)?.text == "Foo"
-                            },
-                        )
-                    },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider {
+                            SimpleTestRule(
+                                ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                stopTraversalInAfterVisitChildNodes = { node ->
+                                    // Stop when Class Foo has been visited
+                                    node.elementType == CLASS && node.findChildByType(IDENTIFIER)?.text == "Foo"
+                                },
+                            )
+                        },
+                    ),
             ).format(Code.fromSnippet(code))
 
             assertThat(ruleExecutionCalls)
@@ -396,15 +408,16 @@ class KtLintTest {
         fun `Given that the traversal is stopped in the afterLastNode hook then do nothing special as traversal is already stopped`() {
             val ruleExecutionCalls = mutableListOf<RuleExecutionCall>()
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider {
-                        SimpleTestRule(
-                            ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
-                            ruleExecutionCalls = ruleExecutionCalls,
-                            stopTraversalInBeforeFirstNode = true,
-                        )
-                    },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider {
+                            SimpleTestRule(
+                                ruleId = SimpleTestRule.RULE_ID_STOP_TRAVERSAL,
+                                ruleExecutionCalls = ruleExecutionCalls,
+                                stopTraversalInBeforeFirstNode = true,
+                            )
+                        },
+                    ),
             ).format(Code.fromSnippet("class Foo"))
 
             assertThat(ruleExecutionCalls).containsExactly(
@@ -421,9 +434,10 @@ class KtLintTest {
          * able to request a new instance of the rule whenever the instance has been used before to traverse the AST.
          */
         KtLintRuleEngine(
-            ruleProviders = setOf(
-                RuleProvider { WithStateRule() },
-            ),
+            ruleProviders =
+                setOf(
+                    RuleProvider { WithStateRule() },
+                ),
         ).format(EMPTY_CODE_SNIPPET)
     }
 
@@ -437,9 +451,10 @@ class KtLintTest {
             """.trimIndent()
         val actualFormattedCode =
             KtLintRuleEngine(
-                ruleProviders = setOf(
-                    RuleProvider { AutoCorrectErrorRule() },
-                ),
+                ruleProviders =
+                    setOf(
+                        RuleProvider { AutoCorrectErrorRule() },
+                    ),
             ).format(Code.fromSnippet(code))
         assertThat(actualFormattedCode).isEqualTo(code)
     }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoaderTest.kt
@@ -18,9 +18,10 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class EditorConfigDefaultsLoaderTest {
     private val ktlintTestFileSystem = KtlintTestFileSystem()
-    private val editorConfigDefaultsLoader = EditorConfigDefaultsLoader(
-        EditorConfigLoaderEc4j(EC4J_PROPERTY_TYPES_USED_BY_KTLINT),
-    )
+    private val editorConfigDefaultsLoader =
+        EditorConfigDefaultsLoader(
+            EditorConfigLoaderEc4j(EC4J_PROPERTY_TYPES_USED_BY_KTLINT),
+        )
 
     @AfterEach
     internal fun tearDown() {
@@ -36,9 +37,10 @@ class EditorConfigDefaultsLoaderTest {
 
     @Test
     fun `Given an empty path then return empty editor config default`() {
-        val actual = editorConfigDefaultsLoader.load(
-            ktlintTestFileSystem.resolve(""),
-        )
+        val actual =
+            editorConfigDefaultsLoader.load(
+                ktlintTestFileSystem.resolve(""),
+            )
 
         assertThat(actual).isEqualTo(EMPTY_EDITOR_CONFIG_DEFAULTS)
     }
@@ -46,18 +48,20 @@ class EditorConfigDefaultsLoaderTest {
     @Test
     @DisabledOnOs(OS.WINDOWS) // Filename can not start or end with space
     fun `Given a blank path then return empty editor config default`() {
-        val actual = editorConfigDefaultsLoader.load(
-            ktlintTestFileSystem.resolve("  "),
-        )
+        val actual =
+            editorConfigDefaultsLoader.load(
+                ktlintTestFileSystem.resolve("  "),
+            )
 
         assertThat(actual).isEqualTo(EMPTY_EDITOR_CONFIG_DEFAULTS)
     }
 
     @Test
     fun `Given an non existing path then return empty editor config default`() {
-        val actual = editorConfigDefaultsLoader.load(
-            ktlintTestFileSystem.resolve("/path/to/non/existing/file.kt"),
-        )
+        val actual =
+            editorConfigDefaultsLoader.load(
+                ktlintTestFileSystem.resolve("/path/to/non/existing/file.kt"),
+            )
 
         assertThat(actual).isEqualTo(EMPTY_EDITOR_CONFIG_DEFAULTS)
     }
@@ -79,9 +83,10 @@ class EditorConfigDefaultsLoaderTest {
             )
         }
 
-        val actual = editorConfigDefaultsLoader.load(
-            ktlintTestFileSystem.resolve("$somePathToDirectory/$fileName"),
-        )
+        val actual =
+            editorConfigDefaultsLoader.load(
+                ktlintTestFileSystem.resolve("$somePathToDirectory/$fileName"),
+            )
 
         assertThat(actual).isEqualTo(
             EditorConfigDefaults(SOME_EDITOR_CONFIG),
@@ -95,9 +100,10 @@ class EditorConfigDefaultsLoaderTest {
             writeEditorConfigFile(somePathToDirectory, SOME_EDITOR_CONFIG.toString())
         }
 
-        val actual = editorConfigDefaultsLoader.load(
-            ktlintTestFileSystem.resolve(somePathToDirectory),
-        )
+        val actual =
+            editorConfigDefaultsLoader.load(
+                ktlintTestFileSystem.resolve(somePathToDirectory),
+            )
 
         assertThat(actual).isEqualTo(
             EditorConfigDefaults(SOME_EDITOR_CONFIG),
@@ -105,27 +111,29 @@ class EditorConfigDefaultsLoaderTest {
     }
 
     private companion object {
-        val SOME_EDITOR_CONFIG: EditorConfig = EditorConfig
-            .builder()
-            .section(
-                Section
-                    .builder()
-                    .glob(Glob("*.kt"))
-                    .properties(
-                        Property
-                            .builder()
-                            .name("some-property")
-                            .value("some-property-value"),
-                    ),
+        val SOME_EDITOR_CONFIG: EditorConfig =
+            EditorConfig
+                .builder()
+                .section(
+                    Section
+                        .builder()
+                        .glob(Glob("*.kt"))
+                        .properties(
+                            Property
+                                .builder()
+                                .name("some-property")
+                                .value("some-property-value"),
+                        ),
+                )
+                .build()
+        val EC4J_PROPERTY_TYPES_USED_BY_KTLINT =
+            setOf(
+                PropertyType.end_of_line,
+                PropertyType.indent_size,
+                PropertyType.indent_style,
+                PropertyType.insert_final_newline,
+                PropertyType.max_line_length,
+                PropertyType.tab_width,
             )
-            .build()
-        val EC4J_PROPERTY_TYPES_USED_BY_KTLINT = setOf(
-            PropertyType.end_of_line,
-            PropertyType.indent_size,
-            PropertyType.indent_style,
-            PropertyType.insert_final_newline,
-            PropertyType.max_line_length,
-            PropertyType.tab_width,
-        )
     }
 }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigGeneratorTest.kt
@@ -13,18 +13,20 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
 internal class EditorConfigGeneratorTest {
-    private val ruleProviders = setOf(
-        RuleProvider { TestRule() },
-    )
+    private val ruleProviders =
+        setOf(
+            RuleProvider { TestRule() },
+        )
     private val rules =
         ruleProviders
             .map { it.createNewRuleInstance() }
             .toSet()
     private val ktlintTestFileSystem = KtlintTestFileSystem()
-    private val editorConfigGenerator = EditorConfigGenerator(
-        fileSystem = ktlintTestFileSystem.fileSystem,
-        EditorConfigLoaderEc4j(ruleProviders.propertyTypes()),
-    )
+    private val editorConfigGenerator =
+        EditorConfigGenerator(
+            fileSystem = ktlintTestFileSystem.fileSystem,
+            EditorConfigLoaderEc4j(ruleProviders.propertyTypes()),
+        )
 
     @AfterEach
     fun tearDown() {
@@ -42,11 +44,12 @@ internal class EditorConfigGeneratorTest {
             )
         }
 
-        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
-            rules = rules,
-            codeStyle = CodeStyleValue.intellij_idea,
-            filePath = ktlintTestFileSystem.resolve("test.kt"),
-        )
+        val generatedEditorConfig =
+            editorConfigGenerator.generateEditorconfig(
+                rules = rules,
+                codeStyle = CodeStyleValue.intellij_idea,
+                filePath = ktlintTestFileSystem.resolve("test.kt"),
+            )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
         assertThat(generatedEditorConfig.lines()).contains(
@@ -57,11 +60,12 @@ internal class EditorConfigGeneratorTest {
 
     @Test
     fun `Should use default Android code style value if value is missing and android code style is active`() {
-        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
-            rules = rules,
-            codeStyle = CodeStyleValue.android_studio,
-            filePath = ktlintTestFileSystem.resolve("test.kt"),
-        )
+        val generatedEditorConfig =
+            editorConfigGenerator.generateEditorconfig(
+                rules = rules,
+                codeStyle = CodeStyleValue.android_studio,
+                filePath = ktlintTestFileSystem.resolve("test.kt"),
+            )
 
         assertThat(generatedEditorConfig.lines()).contains(
             "$PROPERTY_1_NAME = $PROPERTY_1_DEFAULT_VALUE_ANDROID",
@@ -74,25 +78,28 @@ internal class EditorConfigGeneratorTest {
 
     @Test
     fun `Given distinct rules that use the same property with the same default value then is should be written only once to the editorconfig file`() {
-        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
-            rules = setOf(
-                object : Rule(
-                    ruleId = RuleId("test:rule-one"),
-                    about = About(),
-                    usesEditorConfigProperties = setOf(
-                        EDITOR_CONFIG_PROPERTY_2,
-                        EDITOR_CONFIG_PROPERTY_1,
+        val generatedEditorConfig =
+            editorConfigGenerator.generateEditorconfig(
+                rules =
+                    setOf(
+                        object : Rule(
+                            ruleId = RuleId("test:rule-one"),
+                            about = About(),
+                            usesEditorConfigProperties =
+                                setOf(
+                                    EDITOR_CONFIG_PROPERTY_2,
+                                    EDITOR_CONFIG_PROPERTY_1,
+                                ),
+                        ) {},
+                        object : Rule(
+                            ruleId = RuleId("test:rule-two"),
+                            about = About(),
+                            usesEditorConfigProperties = setOf(EDITOR_CONFIG_PROPERTY_1),
+                        ) {},
                     ),
-                ) {},
-                object : Rule(
-                    ruleId = RuleId("test:rule-two"),
-                    about = About(),
-                    usesEditorConfigProperties = setOf(EDITOR_CONFIG_PROPERTY_1),
-                ) {},
-            ),
-            codeStyle = CodeStyleValue.intellij_idea,
-            filePath = ktlintTestFileSystem.resolve("test.kt"),
-        )
+                codeStyle = CodeStyleValue.intellij_idea,
+                filePath = ktlintTestFileSystem.resolve("test.kt"),
+            )
 
         assertThat(generatedEditorConfig.lines()).contains(
             "$PROPERTY_1_NAME = $PROPERTY_1_DEFAULT_VALUE",
@@ -115,11 +122,12 @@ internal class EditorConfigGeneratorTest {
             )
         }
 
-        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
-            rules = rules,
-            codeStyle = CodeStyleValue.intellij_idea,
-            filePath = ktlintTestFileSystem.resolve("test.kt"),
-        )
+        val generatedEditorConfig =
+            editorConfigGenerator.generateEditorconfig(
+                rules = rules,
+                codeStyle = CodeStyleValue.intellij_idea,
+                filePath = ktlintTestFileSystem.resolve("test.kt"),
+            )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
         assertThat(generatedEditorConfig.lines()).contains(
@@ -144,11 +152,12 @@ internal class EditorConfigGeneratorTest {
             )
         }
 
-        val generatedEditorConfig = editorConfigGenerator.generateEditorconfig(
-            rules = rules,
-            codeStyle = CodeStyleValue.intellij_idea,
-            filePath = ktlintTestFileSystem.resolve("test.kt"),
-        )
+        val generatedEditorConfig =
+            editorConfigGenerator.generateEditorconfig(
+                rules = rules,
+                codeStyle = CodeStyleValue.intellij_idea,
+                filePath = ktlintTestFileSystem.resolve("test.kt"),
+            )
 
         assertThat(generatedEditorConfig.lines()).doesNotContainAnyElementsOf(listOf("root = true"))
         assertThat(generatedEditorConfig.lines()).contains(
@@ -162,10 +171,11 @@ internal class EditorConfigGeneratorTest {
     private class TestRule : Rule(
         ruleId = RuleId("test:test-rule"),
         about = About(),
-        usesEditorConfigProperties = setOf(
-            EDITOR_CONFIG_PROPERTY_2,
-            EDITOR_CONFIG_PROPERTY_1,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                EDITOR_CONFIG_PROPERTY_2,
+                EDITOR_CONFIG_PROPERTY_1,
+            ),
     )
 
     private companion object {
@@ -176,27 +186,31 @@ internal class EditorConfigGeneratorTest {
         const val PROPERTY_2_NAME = "property-2"
         const val PROPERTY_2_DEFAULT_VALUE = 10
         const val PROPERTY_2_DEFAULT_VALUE_ANDROID = 11
-        val EDITOR_CONFIG_PROPERTY_1 = EditorConfigProperty(
-            name = PROPERTY_1_NAME,
-            type = PropertyType(
-                PROPERTY_1_NAME,
-                "",
-                PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                setOf("true", "false"),
-            ),
-            defaultValue = PROPERTY_1_DEFAULT_VALUE,
-            androidStudioCodeStyleDefaultValue = PROPERTY_1_DEFAULT_VALUE_ANDROID,
-        )
-        val EDITOR_CONFIG_PROPERTY_2 = EditorConfigProperty(
-            name = PROPERTY_2_NAME,
-            type = PropertyType(
-                PROPERTY_2_NAME,
-                "",
-                PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
-                setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"),
-            ),
-            defaultValue = PROPERTY_2_DEFAULT_VALUE,
-            androidStudioCodeStyleDefaultValue = PROPERTY_2_DEFAULT_VALUE_ANDROID,
-        )
+        val EDITOR_CONFIG_PROPERTY_1 =
+            EditorConfigProperty(
+                name = PROPERTY_1_NAME,
+                type =
+                    PropertyType(
+                        PROPERTY_1_NAME,
+                        "",
+                        PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                        setOf("true", "false"),
+                    ),
+                defaultValue = PROPERTY_1_DEFAULT_VALUE,
+                androidStudioCodeStyleDefaultValue = PROPERTY_1_DEFAULT_VALUE_ANDROID,
+            )
+        val EDITOR_CONFIG_PROPERTY_2 =
+            EditorConfigProperty(
+                name = PROPERTY_2_NAME,
+                type =
+                    PropertyType(
+                        PROPERTY_2_NAME,
+                        "",
+                        PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+                        setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"),
+                    ),
+                defaultValue = PROPERTY_2_DEFAULT_VALUE,
+                androidStudioCodeStyleDefaultValue = PROPERTY_2_DEFAULT_VALUE_ANDROID,
+            )
     }
 }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -560,15 +560,17 @@ internal class EditorConfigLoaderTest {
         //language=
         const val SOME_PROPERTY_VALUE_1 = "some-property-value-1"
         const val SOME_PROPERTY_VALUE_2 = "some-property-value-2"
-        val SOME_EDITOR_CONFIG_PROPERTY = EditorConfigProperty(
-            name = SOME_PROPERTY_NAME,
-            type = PropertyType(
-                SOME_PROPERTY_NAME,
-                "",
-                PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
-                setOf(SOME_PROPERTY_VALUE_1, SOME_PROPERTY_VALUE_2),
-            ),
-            defaultValue = SOME_PROPERTY_VALUE_1,
-        )
+        val SOME_EDITOR_CONFIG_PROPERTY =
+            EditorConfigProperty(
+                name = SOME_PROPERTY_NAME,
+                type =
+                    PropertyType(
+                        SOME_PROPERTY_NAME,
+                        "",
+                        PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                        setOf(SOME_PROPERTY_VALUE_1, SOME_PROPERTY_VALUE_2),
+                    ),
+                defaultValue = SOME_PROPERTY_VALUE_1,
+            )
     }
 }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
@@ -26,10 +26,11 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        NormalRule(STANDARD_RULE_B),
-                        NormalRule(STANDARD_RULE_A),
-                    ),
+                    ruleProviders =
+                        createRuleProviders(
+                            NormalRule(STANDARD_RULE_B),
+                            NormalRule(STANDARD_RULE_A),
+                        ),
                 )
                 .map { it.ruleId }
 
@@ -44,16 +45,17 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        ExperimentalRule(STANDARD_RULE_B),
-                        ExperimentalRule(STANDARD_RULE_A),
-                        NormalRule(CUSTOM_RULE_SET_A_RULE_B),
-                        NormalRule(CUSTOM_RULE_SET_A_RULE_A),
-                        NormalRule(STANDARD_RULE_D),
-                        NormalRule(STANDARD_RULE_C),
-                        NormalRule(CUSTOM_RULE_SET_B_RULE_B),
-                        NormalRule(CUSTOM_RULE_SET_B_RULE_A),
-                    ),
+                    ruleProviders =
+                        createRuleProviders(
+                            ExperimentalRule(STANDARD_RULE_B),
+                            ExperimentalRule(STANDARD_RULE_A),
+                            NormalRule(CUSTOM_RULE_SET_A_RULE_B),
+                            NormalRule(CUSTOM_RULE_SET_A_RULE_A),
+                            NormalRule(STANDARD_RULE_D),
+                            NormalRule(STANDARD_RULE_C),
+                            NormalRule(CUSTOM_RULE_SET_B_RULE_B),
+                            NormalRule(CUSTOM_RULE_SET_B_RULE_A),
+                        ),
                 ).map { it.ruleId }
 
         assertThat(actual).containsExactly(
@@ -74,11 +76,12 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        NormalRule(STANDARD_RULE_C),
-                        RunAsLateAsPossibleRule(STANDARD_RULE_A),
-                        NormalRule(STANDARD_RULE_B),
-                    ),
+                    ruleProviders =
+                        createRuleProviders(
+                            NormalRule(STANDARD_RULE_C),
+                            RunAsLateAsPossibleRule(STANDARD_RULE_A),
+                            NormalRule(STANDARD_RULE_B),
+                        ),
                 )
                 .map { it.ruleId }
 
@@ -94,16 +97,17 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_B),
-                        RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_A),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_B),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_A),
-                        RunAsLateAsPossibleRule(STANDARD_RULE_D),
-                        RunAsLateAsPossibleRule(STANDARD_RULE_C),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_B),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_A),
-                    ),
+                    ruleProviders =
+                        createRuleProviders(
+                            RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_B),
+                            RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_A),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_B),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_A),
+                            RunAsLateAsPossibleRule(STANDARD_RULE_D),
+                            RunAsLateAsPossibleRule(STANDARD_RULE_C),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_B),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_A),
+                        ),
                 ).map { it.ruleId }
 
         assertThat(actual).containsExactly(
@@ -124,16 +128,17 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_B),
-                        RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_A),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_B),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_A),
-                        RunAsLateAsPossibleRule(STANDARD_RULE_D),
-                        RunAsLateAsPossibleRule(STANDARD_RULE_C),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_B),
-                        RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_A),
-                    ),
+                    ruleProviders =
+                        createRuleProviders(
+                            RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_B),
+                            RunAsLateAsPossibleExperimentalRule(STANDARD_RULE_A),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_B),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_A_RULE_A),
+                            RunAsLateAsPossibleRule(STANDARD_RULE_D),
+                            RunAsLateAsPossibleRule(STANDARD_RULE_C),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_B),
+                            RunAsLateAsPossibleRule(CUSTOM_RULE_SET_B_RULE_A),
+                        ),
                 ).map { it.ruleId }
 
         assertThat(actual).containsExactly(
@@ -154,30 +159,34 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        object : R(
-                            ruleId = STANDARD_RULE_A,
-                            visitorModifier = VisitorModifier.RunAfterRule(
+                    ruleProviders =
+                        createRuleProviders(
+                            object : R(
+                                ruleId = STANDARD_RULE_A,
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_C,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                            ) {},
+                            NormalRule(STANDARD_RULE_B),
+                            object : R(
+                                ruleId = STANDARD_RULE_D,
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                            ) {},
+                            object : R(
                                 ruleId = STANDARD_RULE_C,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
-                        ) {},
-                        NormalRule(STANDARD_RULE_B),
-                        object : R(
-                            ruleId = STANDARD_RULE_D,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
-                        ) {},
-                        object : R(
-                            ruleId = STANDARD_RULE_C,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
-                        ) {},
-                    ),
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                            ) {},
+                        ),
                 ).map { it.ruleId }
 
         assertThat(actual).containsExactly(
@@ -193,32 +202,36 @@ class RuleProviderSorterTest {
         val actual =
             RuleProviderSorter()
                 .getSortedRuleProviders(
-                    ruleProviders = createRuleProviders(
-                        NormalRule(STANDARD_RULE_B),
-                        object : R(
-                            ruleId = STANDARD_RULE_D,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
-                        ) {},
-                        object : R(
-                            ruleId = STANDARD_RULE_C,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
-                        ) {},
-                        object :
-                            R(
-                                ruleId = CUSTOM_RULE_SET_A_RULE_A,
-                                visitorModifier = VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_C,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                    ruleProviders =
+                        createRuleProviders(
+                            NormalRule(STANDARD_RULE_B),
+                            object : R(
+                                ruleId = STANDARD_RULE_D,
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                            ) {},
+                            object : R(
+                                ruleId = STANDARD_RULE_C,
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                            ) {},
+                            object :
+                                R(
+                                    ruleId = CUSTOM_RULE_SET_A_RULE_A,
+                                    visitorModifier =
+                                        VisitorModifier.RunAfterRule(
+                                            ruleId = STANDARD_RULE_C,
+                                            mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                        ),
                                 ),
-                            ),
-                            Rule.Experimental {},
-                    ),
+                                Rule.Experimental {},
+                        ),
                 ).map { it.ruleId }
 
         assertThat(actual).containsExactly(
@@ -236,11 +249,12 @@ class RuleProviderSorterTest {
             val actual =
                 RuleProviderSorter()
                     .getSortedRuleProviders(
-                        ruleProviders = createRuleProviders(
-                            IndentationRule(),
-                            TrailingCommaOnCallSiteRule(),
-                            WrappingRule(),
-                        ),
+                        ruleProviders =
+                            createRuleProviders(
+                                IndentationRule(),
+                                TrailingCommaOnCallSiteRule(),
+                                WrappingRule(),
+                            ),
                     ).map { it.ruleId }
 
             assertThat(actual).containsExactly(
@@ -255,12 +269,13 @@ class RuleProviderSorterTest {
             val actual =
                 RuleProviderSorter()
                     .getSortedRuleProviders(
-                        ruleProviders = createRuleProviders(
-                            IndentationRule(),
-                            TrailingCommaOnCallSiteRule(),
-                            WrappingRule(),
-                            FunctionSignatureRule(),
-                        ),
+                        ruleProviders =
+                            createRuleProviders(
+                                IndentationRule(),
+                                TrailingCommaOnCallSiteRule(),
+                                WrappingRule(),
+                                FunctionSignatureRule(),
+                            ),
                     ).map { it.ruleId }
 
             assertThat(actual).containsExactly(
@@ -279,15 +294,17 @@ class RuleProviderSorterTest {
             val actual =
                 RuleProviderSorter()
                     .getSortedRuleProviders(
-                        ruleProviders = createRuleProviders(
-                            object : R(
-                                ruleId = STANDARD_RULE_A,
-                                visitorModifier = VisitorModifier.RunAfterRule(
-                                    ruleId = RuleId("test:not-loaded-rule"),
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ) {},
-                        ),
+                        ruleProviders =
+                            createRuleProviders(
+                                object : R(
+                                    ruleId = STANDARD_RULE_A,
+                                    visitorModifier =
+                                        VisitorModifier.RunAfterRule(
+                                            ruleId = RuleId("test:not-loaded-rule"),
+                                            mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                        ),
+                                ) {},
+                            ),
                     ).map { it.ruleId }
 
             assertThat(actual).containsExactly(
@@ -300,22 +317,24 @@ class RuleProviderSorterTest {
             val actual =
                 RuleProviderSorter()
                     .getSortedRuleProviders(
-                        ruleProviders = createRuleProviders(
-                            object : R(STANDARD_RULE_A) {},
-                            object : R(
-                                ruleId = STANDARD_RULE_B,
-                                visitorModifiers = setOf(
-                                    VisitorModifier.RunAfterRule(
-                                        ruleId = STANDARD_RULE_A,
-                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                    ),
-                                    VisitorModifier.RunAfterRule(
-                                        ruleId = RuleId("test:not-loaded-rule"),
-                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                    ),
-                                ),
-                            ) {},
-                        ),
+                        ruleProviders =
+                            createRuleProviders(
+                                object : R(STANDARD_RULE_A) {},
+                                object : R(
+                                    ruleId = STANDARD_RULE_B,
+                                    visitorModifiers =
+                                        setOf(
+                                            VisitorModifier.RunAfterRule(
+                                                ruleId = STANDARD_RULE_A,
+                                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                            ),
+                                            VisitorModifier.RunAfterRule(
+                                                ruleId = RuleId("test:not-loaded-rule"),
+                                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                            ),
+                                        ),
+                                ) {},
+                            ),
                     ).map { it.ruleId }
 
             assertThat(actual).containsExactly(
@@ -333,17 +352,19 @@ class RuleProviderSorterTest {
                 .isThrownBy {
                     RuleProviderSorter()
                         .getSortedRuleProviders(
-                            ruleProviders = createRuleProviders(
-                                object : R(
-                                    ruleId = STANDARD_RULE_A,
-                                    visitorModifiers = setOf(
-                                        VisitorModifier.RunAfterRule(
-                                            ruleId = STANDARD_RULE_A,
-                                            mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
-                                        ),
-                                    ),
-                                ) {},
-                            ),
+                            ruleProviders =
+                                createRuleProviders(
+                                    object : R(
+                                        ruleId = STANDARD_RULE_A,
+                                        visitorModifiers =
+                                            setOf(
+                                                VisitorModifier.RunAfterRule(
+                                                    ruleId = STANDARD_RULE_A,
+                                                    mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                                                ),
+                                            ),
+                                    ) {},
+                                ),
                         ).map { it.ruleId }
                 }.withMessage(
                     "Rule with id '${STANDARD_RULE_A.value}' has a visitor modifier of type 'RunAfterRule' which may not refer to the " +
@@ -357,21 +378,23 @@ class RuleProviderSorterTest {
                 .isThrownBy {
                     RuleProviderSorter()
                         .getSortedRuleProviders(
-                            ruleProviders = createRuleProviders(
-                                object : R(
-                                    ruleId = STANDARD_RULE_A,
-                                    visitorModifiers = setOf(
-                                        VisitorModifier.RunAfterRule(
-                                            ruleId = STANDARD_RULE_A,
-                                            mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                        ),
-                                        VisitorModifier.RunAfterRule(
-                                            ruleId = STANDARD_RULE_B,
-                                            mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                        ),
-                                    ),
-                                ) {},
-                            ),
+                            ruleProviders =
+                                createRuleProviders(
+                                    object : R(
+                                        ruleId = STANDARD_RULE_A,
+                                        visitorModifiers =
+                                            setOf(
+                                                VisitorModifier.RunAfterRule(
+                                                    ruleId = STANDARD_RULE_A,
+                                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                                ),
+                                                VisitorModifier.RunAfterRule(
+                                                    ruleId = STANDARD_RULE_B,
+                                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                                ),
+                                            ),
+                                    ) {},
+                                ),
                         ).map { it.ruleId }
                 }.withMessage(
                     "Rule with id '${STANDARD_RULE_A.value}' has a visitor modifier of type 'RunAfterRule' which may not refer to the " +
@@ -407,17 +430,19 @@ class RuleProviderSorterTest {
 
     private class RunAsLateAsPossibleRule(ruleId: RuleId) : R(
         ruleId = ruleId,
-        visitorModifiers = setOf(
-            VisitorModifier.RunAsLateAsPossible,
-        ),
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAsLateAsPossible,
+            ),
     )
 
     private class RunAsLateAsPossibleExperimentalRule(ruleId: RuleId) :
         R(
             ruleId = ruleId,
-            visitorModifiers = setOf(
-                VisitorModifier.RunAsLateAsPossible,
-            ),
+            visitorModifiers =
+                setOf(
+                    VisitorModifier.RunAsLateAsPossible,
+                ),
         ),
         Rule.Experimental
 

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
@@ -241,17 +241,20 @@ class SuppressionLocatorBuilderTest {
 
         val STANDARD_NO_FOO_IDENTIFIER_RULE_ID = RuleId("standard:no-foo-identifier-standard")
         val NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID = RuleId("$NON_STANDARD_RULE_SET_ID:no-foo-identifier")
-        val KTLINT_RULE_ENGINE = KtLintRuleEngine(
-            ruleProviders = setOf(
-                // The same rule is supplied once a standard rule and once as non-standard rule. Note that the
-                // ruleIds are different.
-                RuleProvider { NoFooIdentifierRule(STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
-                RuleProvider { NoFooIdentifierRule(NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
-            ),
-            editorConfigOverride = EditorConfigOverride.from(
-                STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
-                NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
-            ),
-        )
+        val KTLINT_RULE_ENGINE =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        // The same rule is supplied once a standard rule and once as non-standard rule. Note that the
+                        // ruleIds are different.
+                        RuleProvider { NoFooIdentifierRule(STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
+                        RuleProvider { NoFooIdentifierRule(NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
+                    ),
+                editorConfigOverride =
+                    EditorConfigOverride.from(
+                        STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
+                        NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
+                    ),
+            )
     }
 }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
@@ -32,11 +32,12 @@ class ThreadSafeEditorConfigCacheTest {
         val threadSafeEditorConfigCache = ThreadSafeEditorConfigCache()
 
         val editorConfigLoader = EditorConfigLoaderMock(EDIT_CONFIG_1)
-        val actual = listOf(
-            threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
-            threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
-            threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
-        )
+        val actual =
+            listOf(
+                threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
+                threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
+                threadSafeEditorConfigCache.get(FILE_1, editorConfigLoader),
+            )
 
         // In logs, it can also be seen that the EditConfig entry is created only once and retrieved multiple times
         assertThat(editorConfigLoader.loadCount).isEqualTo(1)
@@ -53,11 +54,12 @@ class ThreadSafeEditorConfigCacheTest {
         val editorConfigLoaderFile1 = EditorConfigLoaderMock(EDIT_CONFIG_1)
         val editorConfigLoaderFile2 = EditorConfigLoaderMock(EDIT_CONFIG_2)
 
-        val actual = listOf(
-            threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1),
-            threadSafeEditorConfigCache.get(FILE_2, editorConfigLoaderFile2),
-            threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1),
-        )
+        val actual =
+            listOf(
+                threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1),
+                threadSafeEditorConfigCache.get(FILE_2, editorConfigLoaderFile2),
+                threadSafeEditorConfigCache.get(FILE_1, editorConfigLoaderFile1),
+            )
 
         // In logs, it can also be seen that the EditConfig entry for FILE_1 and FILE_2 are created only once and
         // retrieved once more for FILE_1

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
@@ -21,10 +21,11 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { NormalRule(STANDARD_RULE_A) },
                 RuleProvider { NormalRule(STANDARD_RULE_B) },
                 RuleProvider { NormalRule(STANDARD_RULE_C) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_$STANDARD", RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_$STANDARD", RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -41,9 +42,10 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { ExperimentalRule(STANDARD_RULE_B) },
                 RuleProvider { NormalRule(STANDARD_RULE_C) },
                 RuleProvider { NormalRule(STANDARD_RULE_D) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -59,11 +61,12 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { NormalRule(STANDARD_RULE_A) },
                 RuleProvider { NormalRule(STANDARD_RULE_B) },
                 RuleProvider { NormalRule(STANDARD_RULE_C) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_$STANDARD", RuleExecution.disabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_A, RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_$STANDARD", RuleExecution.disabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_A, RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -80,10 +83,11 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { ExperimentalRule(STANDARD_RULE_C) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_B) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_C) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_B, RuleExecution.enabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_B, RuleExecution.enabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -100,12 +104,13 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { ExperimentalRule(STANDARD_RULE_C) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_B) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_C) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_experimental", RuleExecution.disabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_$CUSTOM", RuleExecution.disabled),
-                    ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_B, RuleExecution.enabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_experimental", RuleExecution.disabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_$CUSTOM", RuleExecution.disabled),
+                        ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_B, RuleExecution.enabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -122,12 +127,13 @@ class RuleExecutionRuleFilterTest {
                 RuleProvider { ExperimentalRule(STANDARD_RULE_C) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_B) },
                 RuleProvider { ExperimentalRule(CUSTOM_RULE_C) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_experimental", RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
-                    ktLintRuleExecutionEditorConfigProperty("ktlint_$CUSTOM", RuleExecution.enabled),
-                    ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_C, RuleExecution.disabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_experimental", RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_C, RuleExecution.disabled),
+                        ktLintRuleExecutionEditorConfigProperty("ktlint_$CUSTOM", RuleExecution.enabled),
+                        ktLintRuleExecutionEditorConfigProperty(CUSTOM_RULE_C, RuleExecution.disabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).containsExactly(
@@ -142,10 +148,11 @@ class RuleExecutionRuleFilterTest {
             runWithRuleExecutionRuleFilter(
                 RuleProvider { NormalRule(STANDARD_RULE_A) },
                 RuleProvider { NormalRule(STANDARD_RULE_B) },
-                editorConfig = EditorConfig(
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_A, RuleExecution.disabled),
-                    ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.disabled),
-                ),
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_A, RuleExecution.disabled),
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_B, RuleExecution.disabled),
+                    ),
             ).toRuleIds()
 
         assertThat(actual).isEmpty()

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
@@ -42,26 +42,28 @@ class RunAfterRuleFilterTest {
                         createRuleProviders(
                             object : R(
                                 ruleId = STANDARD_RULE_A,
-                                visitorModifiers = setOf(
-                                    VisitorModifier.RunAfterRule(
-                                        ruleId = STANDARD_RULE_B,
-                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                visitorModifiers =
+                                    setOf(
+                                        VisitorModifier.RunAfterRule(
+                                            ruleId = STANDARD_RULE_B,
+                                            mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                        ),
+                                        VisitorModifier.RunAfterRule(
+                                            ruleId = STANDARD_RULE_C,
+                                            mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                                        ),
                                     ),
-                                    VisitorModifier.RunAfterRule(
-                                        ruleId = STANDARD_RULE_C,
-                                        mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
-                                    ),
-                                ),
                             ) {},
                             object :
                                 R(
                                     ruleId = EXPERIMENTAL_RULE_B,
-                                    visitorModifiers = setOf(
-                                        VisitorModifier.RunAfterRule(
-                                            ruleId = EXPERIMENTAL_RULE_C,
-                                            mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                                    visitorModifiers =
+                                        setOf(
+                                            VisitorModifier.RunAfterRule(
+                                                ruleId = EXPERIMENTAL_RULE_C,
+                                                mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                                            ),
                                         ),
-                                    ),
                                 ),
                                 Rule.Experimental {},
                         ),
@@ -85,10 +87,11 @@ class RunAfterRuleFilterTest {
                     createRuleProviders(
                         object : R(
                             ruleId = STANDARD_RULE_A,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = RuleId("test:not-loaded-rule"),
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = RuleId("test:not-loaded-rule"),
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                     ),
                 ).toRuleId()
@@ -106,16 +109,17 @@ class RunAfterRuleFilterTest {
                         object : R(STANDARD_RULE_A) {},
                         object : R(
                             ruleId = STANDARD_RULE_B,
-                            visitorModifiers = setOf(
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_A,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                            visitorModifiers =
+                                setOf(
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_A,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = RuleId("test:not-loaded-rule"),
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                                 ),
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = RuleId("test:not-loaded-rule"),
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ),
                         ) {},
                     ),
                 ).toRuleId()
@@ -136,25 +140,28 @@ class RunAfterRuleFilterTest {
                     createRuleProviders(
                         object : R(
                             ruleId = STANDARD_RULE_A,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = STANDARD_RULE_B,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                         object : R(
                             ruleId = STANDARD_RULE_B,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_C,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = STANDARD_RULE_C,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                         object :
                             R(
                                 ruleId = STANDARD_RULE_C,
-                                visitorModifier = VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_A,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_A,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                             ),
                             Rule.Experimental {},
                     ),
@@ -176,37 +183,40 @@ class RunAfterRuleFilterTest {
                     createRuleProviders(
                         object : R(
                             ruleId = STANDARD_RULE_A,
-                            visitorModifiers = setOf(
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = CUSTOM_RULE_SET_A_RULE_B,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                            visitorModifiers =
+                                setOf(
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = CUSTOM_RULE_SET_A_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                                 ),
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_B,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ),
                         ) {},
                         object : R(
                             ruleId = STANDARD_RULE_B,
-                            visitorModifiers = setOf(
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_C,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                            visitorModifiers =
+                                setOf(
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_C,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = CUSTOM_RULE_SET_A_RULE_C,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                                 ),
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = CUSTOM_RULE_SET_A_RULE_C,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ),
                         ) {},
                         object :
                             R(
                                 ruleId = CUSTOM_RULE_SET_A_RULE_C,
-                                visitorModifier = VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_A,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
+                                visitorModifier =
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_A,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                             ),
                             Rule.Experimental {},
                     ),
@@ -231,24 +241,27 @@ class RunAfterRuleFilterTest {
                     createRuleProviders(
                         object : R(
                             ruleId = STANDARD_RULE_C,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = CUSTOM_RULE_SET_B_RULE_B,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = CUSTOM_RULE_SET_B_RULE_B,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                         object : R(
                             ruleId = CUSTOM_RULE_SET_B_RULE_B,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = CUSTOM_RULE_SET_A_RULE_A,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = CUSTOM_RULE_SET_A_RULE_A,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                         object : R(
                             ruleId = CUSTOM_RULE_SET_A_RULE_A,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_C,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = STANDARD_RULE_C,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                     ),
                 )
@@ -269,36 +282,39 @@ class RunAfterRuleFilterTest {
                     createRuleProviders(
                         object : R(
                             ruleId = STANDARD_RULE_C,
-                            visitorModifiers = setOf(
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = CUSTOM_RULE_SET_B_RULE_B,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                            visitorModifiers =
+                                setOf(
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = CUSTOM_RULE_SET_B_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_B,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                                 ),
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_B,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ),
                         ) {},
                         object : R(
                             ruleId = CUSTOM_RULE_SET_B_RULE_B,
-                            visitorModifiers = setOf(
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = STANDARD_RULE_A,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                            visitorModifiers =
+                                setOf(
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = STANDARD_RULE_A,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
+                                    VisitorModifier.RunAfterRule(
+                                        ruleId = CUSTOM_RULE_SET_A_RULE_A,
+                                        mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                    ),
                                 ),
-                                VisitorModifier.RunAfterRule(
-                                    ruleId = CUSTOM_RULE_SET_A_RULE_A,
-                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                                ),
-                            ),
                         ) {},
                         object : R(
                             ruleId = CUSTOM_RULE_SET_A_RULE_A,
-                            visitorModifier = VisitorModifier.RunAfterRule(
-                                ruleId = STANDARD_RULE_C,
-                                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-                            ),
+                            visitorModifier =
+                                VisitorModifier.RunAfterRule(
+                                    ruleId = STANDARD_RULE_C,
+                                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                                ),
                         ) {},
                     ),
                 )
@@ -336,10 +352,11 @@ class RunAfterRuleFilterTest {
     ): Rule =
         object : R(
             ruleId = beforeRule,
-            visitorModifier = VisitorModifier.RunAfterRule(
-                ruleId = afterRule,
-                mode = mode,
-            ),
+            visitorModifier =
+                VisitorModifier.RunAfterRule(
+                    ruleId = afterRule,
+                    mode = mode,
+                ),
         ) {}
 
     private open class R(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRule.kt
@@ -5,11 +5,12 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 
-internal val STANDARD_RULE_ABOUT = Rule.About(
-    maintainer = "KtLint",
-    repositoryUrl = "https://github.com/pinterest/ktlint",
-    issueTrackerUrl = "https://github.com/pinterest/ktlint/issues",
-)
+internal val STANDARD_RULE_ABOUT =
+    Rule.About(
+        maintainer = "KtLint",
+        repositoryUrl = "https://github.com/pinterest/ktlint",
+        issueTrackerUrl = "https://github.com/pinterest/ktlint/issues",
+    )
 
 /**
  * Standard rules can only be declared and instantiated in the 'ktlint-ruleset-standard'. Custom rule set providers or API consumers have

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -30,6 +30,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.MaxLineLengthRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierOrderRule
 import com.pinterest.ktlint.ruleset.standard.rules.MultiLineIfElseRule
+import com.pinterest.ktlint.ruleset.standard.rules.MultilineExpressionWrapping
 import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLineBeforeRbraceRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLineInListRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLinesInChainedMethodCallsRule
@@ -107,6 +108,7 @@ public class StandardRuleSetProvider :
             RuleProvider { ModifierListSpacingRule() },
             RuleProvider { ModifierOrderRule() },
             RuleProvider { MultiLineIfElseRule() },
+            RuleProvider { MultilineExpressionWrapping() },
             RuleProvider { NoBlankLineBeforeRbraceRule() },
             RuleProvider { NoBlankLineInListRule() },
             RuleProvider { NoBlankLinesInChainedMethodCallsRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -75,10 +75,11 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 public class AnnotationRule :
     StandardRule(
         id = "annotation",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ) {
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
@@ -55,29 +55,31 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
         //      @JvmField
         //      val s: Any
         //
-        val whiteSpaces = (annotations.asSequence().map { it.nextSibling } + node.treeNext)
-            .filterIsInstance<PsiWhiteSpace>()
-            .take(annotations.size)
-            .toList()
+        val whiteSpaces =
+            (annotations.asSequence().map { it.nextSibling } + node.treeNext)
+                .filterIsInstance<PsiWhiteSpace>()
+                .take(annotations.size)
+                .toList()
 
-        val next = node.nextSiblingWithAtLeastOneOf(
-            {
-                !it.isWhiteSpace() &&
-                    it.textLength > 0 &&
-                    !it.isPartOf(ElementType.FILE_ANNOTATION_LIST) &&
-                    !it.isCommentOnSameLineAsPrevLeaf()
-            },
-            {
-                // Disallow multiple white spaces as well as comments
-                if (it.psi is PsiWhiteSpace) {
-                    val s = it.text
-                    // Ensure at least one occurrence of two line breaks
-                    s.indexOf("\n") != s.lastIndexOf("\n")
-                } else {
-                    it.isPartOfComment() && !it.isCommentOnSameLineAsPrevLeaf()
-                }
-            },
-        )
+        val next =
+            node.nextSiblingWithAtLeastOneOf(
+                {
+                    !it.isWhiteSpace() &&
+                        it.textLength > 0 &&
+                        !it.isPartOf(ElementType.FILE_ANNOTATION_LIST) &&
+                        !it.isCommentOnSameLineAsPrevLeaf()
+                },
+                {
+                    // Disallow multiple white spaces as well as comments
+                    if (it.psi is PsiWhiteSpace) {
+                        val s = it.text
+                        // Ensure at least one occurrence of two line breaks
+                        s.indexOf("\n") != s.lastIndexOf("\n")
+                    } else {
+                        it.isPartOfComment() && !it.isCommentOnSameLineAsPrevLeaf()
+                    }
+                },
+            )
         if (next != null) {
             if (node.elementType != ElementType.FILE_ANNOTATION_LIST && next.isPartOfComment()) {
                 val psi = node.psi
@@ -156,8 +158,9 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
         // Replace the extra white space with a single break
         val text = leaf.text
         val firstIndex = text.indexOf("\n") + 1
-        val replacementText = text.substring(0, firstIndex) +
-            text.substringAfter("\n").replace("\n", "")
+        val replacementText =
+            text.substring(0, firstIndex) +
+                text.substringAfter("\n").replace("\n", "")
 
         leaf.rawReplaceWithText(replacementText)
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -40,19 +40,21 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 public class ArgumentListWrappingRule :
     StandardRule(
         id = "argument-list-wrapping",
-        visitorModifiers = setOf(
-            VisitorModifier.RunAfterRule(
-                // ArgumentListWrapping should only be used in case after normal wrapping the max_line_length is still
-                // violated
-                ruleId = WRAPPING_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAfterRule(
+                    // ArgumentListWrapping should only be used in case after normal wrapping the max_line_length is still
+                    // violated
+                    ruleId = WRAPPING_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
             ),
-        ),
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ) {
     private var editorConfigIndent = IndentConfig.DEFAULT_INDENT_CONFIG
 
@@ -248,12 +250,13 @@ public class ArgumentListWrappingRule :
     private fun ASTNode.isOnSameLineAsControlFlowKeyword(): Boolean {
         val containerNode = psi.getStrictParentOfType<KtContainerNode>() ?: return false
         if (containerNode.node.elementType == ELSE) return false
-        val controlFlowKeyword = when (val parent = containerNode.parent) {
-            is KtIfExpression -> parent.ifKeyword.node
-            is KtWhileExpression -> parent.firstChild.node
-            is KtDoWhileExpression -> parent.whileKeyword?.node
-            else -> null
-        } ?: return false
+        val controlFlowKeyword =
+            when (val parent = containerNode.parent) {
+                is KtIfExpression -> parent.ifKeyword.node
+                is KtWhileExpression -> parent.firstChild.node
+                is KtDoWhileExpression -> parent.whileKeyword?.node
+                else -> null
+            } ?: return false
 
         var prevLeaf = prevLeaf() ?: return false
         while (prevLeaf != controlFlowKeyword) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
@@ -15,15 +15,16 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 public class BlockCommentInitialStarAlignmentRule :
     StandardRule(
         "block-comment-initial-star-alignment",
-        visitorModifiers = setOf(
-            // The block comment is a node which can contain multiple lines. The indent of the second and later line
-            // should be determined based on the indent of the block comment node. This indent is determined by the
-            // indentation rule.
-            VisitorModifier.RunAfterRule(
-                ruleId = INDENTATION_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        visitorModifiers =
+            setOf(
+                // The block comment is a node which can contain multiple lines. The indent of the second and later line
+                // should be determined based on the indent of the block comment node. This indent is determined by the
+                // indentation rule.
+                VisitorModifier.RunAfterRule(
+                    ruleId = INDENTATION_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
             ),
-        ),
     ),
     Rule.Experimental {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
@@ -44,10 +44,11 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 public class ChainWrappingRule :
     StandardRule(
         id = "chain-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ) {
     private val sameLineTokens = TokenSet.create(MUL, DIV, PERC, ANDAND, OROR)
     private val prefixTokens = TokenSet.create(PLUS, MINUS)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRule.kt
@@ -24,10 +24,11 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
 public class CommentWrappingRule :
     StandardRule(
         id = "comment-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -36,11 +36,12 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 public class ContextReceiverWrappingRule :
     StandardRule(
         id = "context-receiver-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ),
     Rule.Experimental {
     private var indentConfig = DEFAULT_INDENT_CONFIG

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -51,17 +51,19 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 public class FunctionSignatureRule :
     StandardRule(
         id = "function-signature",
-        visitorModifiers = setOf(
-            // Run after wrapping and spacing rules
-            VisitorModifier.RunAsLateAsPossible,
-        ),
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-            FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY,
-            FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY,
-        ),
+        visitorModifiers =
+            setOf(
+                // Run after wrapping and spacing rules
+                VisitorModifier.RunAsLateAsPossible,
+            ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+                FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY,
+                FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY,
+            ),
     ),
     Rule.Experimental {
     private var indentConfig = DEFAULT_INDENT_CONFIG
@@ -183,9 +185,10 @@ public class FunctionSignatureRule :
             // When max line length is not set then keep it as single line function signature only when the original
             // signature already was a single line signature. Otherwise, rewrite the entire signature as a multiline
             // signature.
-            val rewriteToSingleLineFunctionSignature = node
-                .functionSignatureNodes()
-                .none { it.textContains('\n') }
+            val rewriteToSingleLineFunctionSignature =
+                node
+                    .functionSignatureNodes()
+                    .none { it.textContains('\n') }
             if (!forceMultilineSignature && rewriteToSingleLineFunctionSignature) {
                 fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
             } else {
@@ -199,12 +202,13 @@ public class FunctionSignatureRule :
             node
                 .findChildByType(VALUE_PARAMETER_LIST)
                 ?.findChildByType(RPAR)
-        val tailNodesOfFunctionSignature = node
-            .functionSignatureNodes()
-            .childrenBetween(
-                startASTNodePredicate = { it == closingParenthesis },
-                endASTNodePredicate = { false },
-            )
+        val tailNodesOfFunctionSignature =
+            node
+                .functionSignatureNodes()
+                .childrenBetween(
+                    startASTNodePredicate = { it == closingParenthesis },
+                    endASTNodePredicate = { false },
+                )
 
         return node.indent(false).length +
             tailNodesOfFunctionSignature.sumOf { it.text.length }
@@ -513,9 +517,10 @@ public class FunctionSignatureRule :
         val whiteSpaceBeforeFunctionBodyExpression = bodyNodes.getStartingWhitespaceOrNull()
         val functionBodyExpressionNodes = bodyNodes.dropWhile { it.isWhiteSpace() }
 
-        val functionBodyExpressionLines = functionBodyExpressionNodes
-            .joinTextToString()
-            .split("\n")
+        val functionBodyExpressionLines =
+            functionBodyExpressionNodes
+                .joinTextToString()
+                .split("\n")
         functionBodyExpressionLines
             .firstOrNull()
             ?.also { firstLineOfBodyExpression ->
@@ -699,29 +704,31 @@ public class FunctionSignatureRule :
     public companion object {
         public val FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY: EditorConfigProperty<Int> =
             EditorConfigProperty(
-                type = PropertyType.LowerCasingPropertyType(
-                    "ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than",
-                    "Force wrapping the parameters of the function signature in case it contains at least the specified " +
-                        "number of parameters even in case the entire function signature would fit on a single line. " +
-                        "By default this parameter is not enabled.",
-                    PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
-                    setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
-                ),
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than",
+                        "Force wrapping the parameters of the function signature in case it contains at least the specified " +
+                            "number of parameters even in case the entire function signature would fit on a single line. " +
+                            "By default this parameter is not enabled.",
+                        PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+                        setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
+                    ),
                 defaultValue = Int.MAX_VALUE,
                 ktlintOfficialCodeStyleDefaultValue = 2,
             )
 
         public val FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY: EditorConfigProperty<FunctionBodyExpressionWrapping> =
             EditorConfigProperty(
-                type = PropertyType.LowerCasingPropertyType(
-                    "ktlint_function_signature_body_expression_wrapping",
-                    "Determines how to wrap the body of function in case it is an expression. Use 'default' " +
-                        "to wrap the body expression only when the first line of the expression does not fit on the same " +
-                        "line as the function signature. Use 'multiline' to force wrapping of body expressions that " +
-                        "consists of multiple line. Use 'always' to force wrapping of body expression always.",
-                    EnumValueParser(FunctionBodyExpressionWrapping::class.java),
-                    FunctionBodyExpressionWrapping.values().map { it.name }.toSet(),
-                ),
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ktlint_function_signature_body_expression_wrapping",
+                        "Determines how to wrap the body of function in case it is an expression. Use 'default' " +
+                            "to wrap the body expression only when the first line of the expression does not fit on the same " +
+                            "line as the function signature. Use 'multiline' to force wrapping of body expressions that " +
+                            "consists of multiple line. Use 'always' to force wrapping of body expression always.",
+                        EnumValueParser(FunctionBodyExpressionWrapping::class.java),
+                        FunctionBodyExpressionWrapping.values().map { it.name }.toSet(),
+                    ),
                 defaultValue = default,
                 ktlintOfficialCodeStyleDefaultValue = multiline,
             )

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
@@ -33,10 +33,11 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 public class IfElseBracingRule :
     StandardRule(
         id = "if-else-bracing",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental,
     Rule.OfficialCodeStyle {
@@ -64,9 +65,10 @@ public class IfElseBracingRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val thenNode = requireNotNull(node.findChildByType(THEN)) {
-            "Can not find THEN branch in IF"
-        }
+        val thenNode =
+            requireNotNull(node.findChildByType(THEN)) {
+                "Can not find THEN branch in IF"
+            }
         val elseNode = node.findChildByType(ELSE) ?: return
         val parentIfBracing =
             node

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
@@ -63,11 +63,12 @@ public class ImportOrderingRule :
                     getUniqueImportsAndBlankLines(children, emit)
 
                 val hasComments = children.any { it.elementType == ElementType.BLOCK_COMMENT || it.elementType == ElementType.EOL_COMMENT }
-                val sortedImports = imports
-                    .asSequence()
-                    .mapNotNull { it.psi as? KtImportDirective } // sorter expects KtImportDirective, whitespaces are inserted afterwards
-                    .sortedWith(importSorter)
-                    .map { it.node } // transform back to ASTNode in order to operate over its method (addChild)
+                val sortedImports =
+                    imports
+                        .asSequence()
+                        .mapNotNull { it.psi as? KtImportDirective } // sorter expects KtImportDirective, whitespaces are inserted afterwards
+                        .sortedWith(importSorter)
+                        .map { it.node } // transform back to ASTNode in order to operate over its method (addChild)
 
                 // insert blank lines wherever needed
                 // traverse the list using fold to have previous and current element and decide if the blank line is needed in between
@@ -196,15 +197,17 @@ public class ImportOrderingRule :
          */
         private val IDEA_PATTERN = parseImportsLayout("*,java.**,javax.**,kotlin.**,^")
 
-        private const val IDEA_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between " +
-            "with \"java\", \"javax\", \"kotlin\" and aliases in the end"
+        private const val IDEA_ERROR_MESSAGE =
+            "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and " +
+                "aliases in the end"
         private const val ASCII_ERROR_MESSAGE = "Imports must be ordered in lexicographic order without any empty lines in-between"
         private const val CUSTOM_ERROR_MESSAGE = "Imports must be ordered according to the pattern specified in .editorconfig"
 
-        private val ERROR_MESSAGES = mapOf(
-            IDEA_PATTERN to IDEA_ERROR_MESSAGE,
-            ASCII_PATTERN to ASCII_ERROR_MESSAGE,
-        )
+        private val ERROR_MESSAGES =
+            mapOf(
+                IDEA_PATTERN to IDEA_ERROR_MESSAGE,
+                ASCII_PATTERN to ASCII_ERROR_MESSAGE,
+            )
 
         private val EDITOR_CONFIG_PROPERTY_PARSER: (String, String?) -> PropertyType.PropertyValue<List<PatternEntry>> =
             { _, value ->
@@ -248,11 +251,12 @@ public class ImportOrderingRule :
 
         public val IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY: EditorConfigProperty<List<PatternEntry>> =
             EditorConfigProperty<List<PatternEntry>>(
-                type = PropertyType(
-                    "ij_kotlin_imports_layout",
-                    "Defines imports order layout for Kotlin files",
-                    EDITOR_CONFIG_PROPERTY_PARSER,
-                ),
+                type =
+                    PropertyType(
+                        "ij_kotlin_imports_layout",
+                        "Defines imports order layout for Kotlin files",
+                        EDITOR_CONFIG_PROPERTY_PARSER,
+                    ),
                 defaultValue = IDEA_PATTERN,
                 androidStudioCodeStyleDefaultValue = ASCII_PATTERN,
                 propertyWriter = { it.joinToString(separator = ",") },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -71,6 +71,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT_LIS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.USER_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
@@ -204,6 +205,9 @@ public class IndentationRule :
                     lastChildIndent = "",
                 )
 
+            node.elementType == VALUE_ARGUMENT ->
+                visitValueArgument(node)
+
             node.elementType == SECONDARY_CONSTRUCTOR ->
                 visitSecondaryConstructor(node)
 
@@ -324,6 +328,22 @@ public class IndentationRule :
             else -> {
                 LOGGER.trace { "No processing for ${node.elementType}: ${node.textWithEscapedTabAndNewline()}" }
             }
+        }
+    }
+
+    private fun visitValueArgument(node: ASTNode) {
+        if (codeStyle == ktlint_official) {
+            // Deviate from standard IntelliJ IDEA formatting to allow formatting below:
+            //     val foo = foo(
+            //         parameterName =
+            //             "The quick brown fox "
+            //                .plus("jumps ")
+            //                .plus("over the lazy dog"),
+            //     )
+            startIndentContext(
+                fromAstNode = node,
+                lastChildIndent = "",
+            )
         }
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -122,26 +122,28 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 public class IndentationRule :
     StandardRule(
         id = "indent",
-        visitorModifiers = setOf(
-            VisitorModifier.RunAsLateAsPossible,
-            VisitorModifier.RunAfterRule(
-                ruleId = FUNCTION_SIGNATURE_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAsLateAsPossible,
+                VisitorModifier.RunAfterRule(
+                    ruleId = FUNCTION_SIGNATURE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAfterRule(
+                    ruleId = TRAILING_COMMA_ON_CALL_SITE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAfterRule(
+                    ruleId = TRAILING_COMMA_ON_DECLARATION_SITE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
             ),
-            VisitorModifier.RunAfterRule(
-                ruleId = TRAILING_COMMA_ON_CALL_SITE_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        usesEditorConfigProperties =
+            setOf(
+                CODE_STYLE_PROPERTY,
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
             ),
-            VisitorModifier.RunAfterRule(
-                ruleId = TRAILING_COMMA_ON_DECLARATION_SITE_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
-            ),
-        ),
-        usesEditorConfigProperties = setOf(
-            CODE_STYLE_PROPERTY,
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
     ) {
     private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
@@ -352,9 +354,10 @@ public class IndentationRule :
             .findChildByType(CONSTRUCTOR_DELEGATION_CALL)
             ?.let { constructorDelegationCall ->
                 val fromAstNode = node.skipLeadingWhitespaceCommentsAndAnnotations()
-                val nextToAstNode = startIndentContext(
-                    fromAstNode = constructorDelegationCall,
-                ).prevCodeLeaf()
+                val nextToAstNode =
+                    startIndentContext(
+                        fromAstNode = constructorDelegationCall,
+                    ).prevCodeLeaf()
 
                 // Leading annotations and comments should be indented at same level as constructor itself
                 if (fromAstNode != node.nextLeaf()) {
@@ -407,9 +410,10 @@ public class IndentationRule :
 
     private fun visitLbrace(node: ASTNode) {
         // Outer indent context
-        val rbrace = requireNotNull(
-            node.nextSibling { it.elementType == RBRACE },
-        ) { "Can not find matching rbrace" }
+        val rbrace =
+            requireNotNull(
+                node.nextSibling { it.elementType == RBRACE },
+            ) { "Can not find matching rbrace" }
         startIndentContext(
             fromAstNode = node,
             toAstNode = rbrace,
@@ -1271,8 +1275,9 @@ private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
             .filter { it.prevLeaf()?.text == "\n" }
             .filterNot { it.text == "\n" }
             .let { indents ->
-                val indentsExceptBlankIndentBeforeClosingQuote = indents
-                    .filterNot { it.isIndentBeforeClosingQuote() }
+                val indentsExceptBlankIndentBeforeClosingQuote =
+                    indents
+                        .filterNot { it.isIndentBeforeClosingQuote() }
                 if (indentsExceptBlankIndentBeforeClosingQuote.count() > 0) {
                     indentsExceptBlankIndentBeforeClosingQuote
                 } else {
@@ -1305,20 +1310,22 @@ private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
 
     private fun ASTNode.containsMixedIndentationCharacters(): Boolean {
         assert((this.psi as KtStringTemplateExpression).isMultiLine())
-        val nonBlankLines = this
-            .text
-            .split("\n")
-            .filterNot { it.startsWith("\"\"\"") }
-            .filterNot { it.endsWith("\"\"\"") }
-            .filterNot { it.isBlank() }
+        val nonBlankLines =
+            this
+                .text
+                .split("\n")
+                .filterNot { it.startsWith("\"\"\"") }
+                .filterNot { it.endsWith("\"\"\"") }
+                .filterNot { it.isBlank() }
         val prefixLength = nonBlankLines.minOfOrNull { it.indentLength() } ?: 0
-        val distinctIndentCharacters = nonBlankLines
-            .joinToString(separator = "") {
-                it.splitIndentAt(prefixLength).first
-            }
-            .toCharArray()
-            .distinct()
-            .count()
+        val distinctIndentCharacters =
+            nonBlankLines
+                .joinToString(separator = "") {
+                    it.splitIndentAt(prefixLength).first
+                }
+                .toCharArray()
+                .distinct()
+                .count()
         return distinctIndentCharacters > 1
     }
 
@@ -1342,13 +1349,14 @@ private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
      */
     private fun String.splitIndentAt(index: Int): Pair<String, String> {
         assert(index >= 0)
-        val firstNonWhitespaceIndex = indexOfFirst { !it.isWhitespace() }.let {
-            if (it == -1) {
-                this.length
-            } else {
-                it
+        val firstNonWhitespaceIndex =
+            indexOfFirst { !it.isWhitespace() }.let {
+                if (it == -1) {
+                    this.length
+                } else {
+                    it
+                }
             }
-        }
         val safeIndex = kotlin.math.min(firstNonWhitespaceIndex, index)
         return Pair(
             first = this.take(safeIndex),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRule.kt
@@ -22,10 +22,11 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 public class KdocWrappingRule :
     StandardRule(
         id = "kdoc-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -25,27 +25,29 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 public class MaxLineLengthRule :
     StandardRule(
         id = "max-line-length",
-        visitorModifiers = setOf(
-            VisitorModifier.RunAfterRule(
-                // This rule should run after all other rules. Each time a rule visitor is modified with
-                // RunAsLateAsPossible, it needs to be checked that this rule still runs after that new rule or that it
-                // won't be affected by that rule.
-                ruleId = TRAILING_COMMA_ON_CALL_SITE_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAfterRule(
+                    // This rule should run after all other rules. Each time a rule visitor is modified with
+                    // RunAsLateAsPossible, it needs to be checked that this rule still runs after that new rule or that it
+                    // won't be affected by that rule.
+                    ruleId = TRAILING_COMMA_ON_CALL_SITE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAfterRule(
+                    // This rule should run after all other rules. Each time a rule visitor is modified with
+                    // RunAsLateAsPossible, it needs to be checked that this rule still runs after that new rule or that it
+                    // won't be affected by that rule.
+                    ruleId = TRAILING_COMMA_ON_DECLARATION_SITE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAsLateAsPossible,
             ),
-            VisitorModifier.RunAfterRule(
-                // This rule should run after all other rules. Each time a rule visitor is modified with
-                // RunAsLateAsPossible, it needs to be checked that this rule still runs after that new rule or that it
-                // won't be affected by that rule.
-                ruleId = TRAILING_COMMA_ON_DECLARATION_SITE_RULE_ID,
-                mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+        usesEditorConfigProperties =
+            setOf(
+                MAX_LINE_LENGTH_PROPERTY,
+                IGNORE_BACKTICKED_IDENTIFIER_PROPERTY,
             ),
-            VisitorModifier.RunAsLateAsPossible,
-        ),
-        usesEditorConfigProperties = setOf(
-            MAX_LINE_LENGTH_PROPERTY,
-            IGNORE_BACKTICKED_IDENTIFIER_PROPERTY,
-        ),
     ) {
     private var maxLineLength: Int = MAX_LINE_LENGTH_PROPERTY.defaultValue
     private var rangeTree = RangeTree()
@@ -115,12 +117,13 @@ public class MaxLineLengthRule :
     public companion object {
         public val IGNORE_BACKTICKED_IDENTIFIER_PROPERTY: EditorConfigProperty<Boolean> =
             EditorConfigProperty(
-                type = PropertyType.LowerCasingPropertyType(
-                    "ktlint_ignore_back_ticked_identifier",
-                    "Defines whether the backticked identifier (``) should be ignored",
-                    PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                    setOf(true.toString(), false.toString()),
-                ),
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ktlint_ignore_back_ticked_identifier",
+                        "Defines whether the backticked identifier (``) should be ignored",
+                        PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                        setOf(true.toString(), false.toString()),
+                    ),
                 defaultValue = false,
             )
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -36,27 +36,28 @@ import java.util.Arrays
 
 public class ModifierOrderRule : StandardRule("modifier-order") {
     // subset of ElementType.MODIFIER_KEYWORDS_ARRAY (+ annotations entries)
-    private val order = arrayOf(
-        ANNOTATION_ENTRY,
-        PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
-        EXPECT_KEYWORD, ACTUAL_KEYWORD,
-        FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
-        EXTERNAL_KEYWORD,
-        OVERRIDE_KEYWORD,
-        LATEINIT_KEYWORD,
-        TAILREC_KEYWORD,
-        VARARG_KEYWORD,
-        SUSPEND_KEYWORD,
-        INNER_KEYWORD,
-        ENUM_KEYWORD, ANNOTATION_KEYWORD,
-        COMPANION_KEYWORD,
-        INLINE_KEYWORD,
-        INFIX_KEYWORD,
-        OPERATOR_KEYWORD,
-        DATA_KEYWORD,
-        // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
-        // HEADER_KEYWORD, IMPL_KEYWORD
-    )
+    private val order =
+        arrayOf(
+            ANNOTATION_ENTRY,
+            PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
+            EXPECT_KEYWORD, ACTUAL_KEYWORD,
+            FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
+            EXTERNAL_KEYWORD,
+            OVERRIDE_KEYWORD,
+            LATEINIT_KEYWORD,
+            TAILREC_KEYWORD,
+            VARARG_KEYWORD,
+            SUSPEND_KEYWORD,
+            INNER_KEYWORD,
+            ENUM_KEYWORD, ANNOTATION_KEYWORD,
+            COMPANION_KEYWORD,
+            INLINE_KEYWORD,
+            INFIX_KEYWORD,
+            OPERATOR_KEYWORD,
+            DATA_KEYWORD,
+            // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
+            // HEADER_KEYWORD, IMPL_KEYWORD
+        )
     private val tokenSet = TokenSet.create(*order)
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
@@ -32,10 +32,11 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 public class MultiLineIfElseRule :
     StandardRule(
         id = "multiline-if-else",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ) {
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
@@ -34,10 +34,11 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 public class MultilineExpressionWrapping :
     StandardRule(
         id = "multiline-expression-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental,
     Rule.OfficialCodeStyle {
@@ -115,12 +116,13 @@ public class MultilineExpressionWrapping :
             ?.takeIf { it.elementType == RPAR }
 
     private companion object {
-        val CHAINABLE_EXPRESSION = setOf(
-            CALL_EXPRESSION,
-            DOT_QUALIFIED_EXPRESSION,
-            REFERENCE_EXPRESSION,
-            SAFE_ACCESS_EXPRESSION,
-        )
+        val CHAINABLE_EXPRESSION =
+            setOf(
+                CALL_EXPRESSION,
+                DOT_QUALIFIED_EXPRESSION,
+                REFERENCE_EXPRESSION,
+                SAFE_ACCESS_EXPRESSION,
+            )
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
@@ -1,0 +1,127 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EQ
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * This rule wraps each multiline expression to a newline.
+ */
+public class MultilineExpressionWrapping :
+    StandardRule(
+        id = "multiline-expression-wrapping",
+        usesEditorConfigProperties = setOf(
+            INDENT_SIZE_PROPERTY,
+            INDENT_STYLE_PROPERTY,
+        ),
+    ),
+    Rule.Experimental,
+    Rule.OfficialCodeStyle {
+    private var indentConfig = DEFAULT_INDENT_CONFIG
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig = IndentConfig(
+            indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+            tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+        )
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType in CHAINABLE_EXPRESSION &&
+            node.treeParent.elementType !in CHAINABLE_EXPRESSION
+        ) {
+            visitExpression(node, emit, autoCorrect)
+        }
+        if (node.elementType == BINARY_EXPRESSION &&
+            node.treeParent.elementType != BINARY_EXPRESSION
+        ) {
+            visitExpression(node, emit, autoCorrect)
+        }
+    }
+
+    private fun visitExpression(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        if (node.containsWhitespaceWithNewline() && node.isValueInAnAssignment()) {
+            node
+                .prevLeaf { !it.isPartOfComment() }
+                .let { prevLeaf ->
+                    val expectedIndent =
+                        node
+                            .treeParent
+                            .indent()
+                            .plus(indentConfig.indent)
+                    if (prevLeaf != null && prevLeaf.text != expectedIndent) {
+                        emit(node.startOffset, "A multiline expression should start on a new line", true)
+                        if (autoCorrect) {
+                            node.upsertWhitespaceBeforeMe(expectedIndent)
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun ASTNode.containsWhitespaceWithNewline(): Boolean {
+        val lastLeaf = lastChildLeafOrSelf()
+        return firstChildLeafOrSelf()
+            .leavesIncludingSelf()
+            .takeWhile { it != lastLeaf }
+            .any { it.isWhiteSpaceWithNewline() }
+    }
+
+    private fun ASTNode.isValueInAnAssignment() =
+        null !=
+            prevCodeSibling()
+                ?.takeIf { it.elementType == EQ }
+                ?.takeUnless {
+                    it.closingParenthesisOfFunctionOrNull()
+                        ?.prevLeaf()
+                        .isWhiteSpaceWithNewline()
+                }
+
+    private fun ASTNode.closingParenthesisOfFunctionOrNull() =
+        takeIf { treeParent.elementType == FUN }
+            ?.prevCodeLeaf()
+            ?.takeIf { it.elementType == RPAR }
+
+    private companion object {
+        val CHAINABLE_EXPRESSION = setOf(
+            CALL_EXPRESSION,
+            DOT_QUALIFIED_EXPRESSION,
+            REFERENCE_EXPRESSION,
+            SAFE_ACCESS_EXPRESSION,
+        )
+    }
+}
+
+public val MULTILINE_EXPRESSION_WRAPPING_RULE_ID: RuleId = MultilineExpressionWrapping().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInList.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInList.kt
@@ -112,14 +112,15 @@ public class NoBlankLineInListRule :
 
     private companion object {
         // The MODIFIER_LIST is handled by separate rule ModifierListSpacingRule
-        val LIST_TYPES = listOf(
-            SUPER_TYPE_LIST,
-            TYPE_ARGUMENT_LIST,
-            TYPE_CONSTRAINT_LIST,
-            TYPE_PARAMETER_LIST,
-            VALUE_ARGUMENT_LIST,
-            VALUE_PARAMETER_LIST,
-        )
+        val LIST_TYPES =
+            listOf(
+                SUPER_TYPE_LIST,
+                TYPE_ARGUMENT_LIST,
+                TYPE_CONSTRAINT_LIST,
+                TYPE_PARAMETER_LIST,
+                VALUE_ARGUMENT_LIST,
+                VALUE_PARAMETER_LIST,
+            )
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRule.kt
@@ -42,12 +42,15 @@ public class NoConsecutiveBlankLinesRule : StandardRule("no-consecutive-blank-li
                         }
                 emit(offset, "Needless blank line(s)", true)
                 if (autoCorrect) {
-                    val newText = buildString {
-                        append(split.first())
-                        append("\n")
-                        if (!eof && !betweenClassAndPrimaryConstructor) append("\n")
-                        append(split.last())
-                    }
+                    val newText =
+                        buildString {
+                            append(split.first())
+                            append("\n")
+                            if (!eof && !betweenClassAndPrimaryConstructor) {
+                                append("\n")
+                            }
+                            append(split.last())
+                        }
                     (node as LeafPsiElement).rawReplaceWithText(newText)
                 }
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFirstLineInClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFirstLineInClassBodyRule.kt
@@ -17,10 +17,11 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 public class NoEmptyFirstLineInClassBodyRule :
     StandardRule(
         id = "no-empty-first-line-in-class-body",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental,
     Rule.OfficialCodeStyle {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
@@ -61,11 +61,14 @@ public class NoSemicolonsRule : StandardRule("no-semi") {
             return true
         }
         if (this is PsiWhiteSpace) {
-            val nextLeaf = nextLeaf {
-                val psi = it.psi
-                it !is PsiWhiteSpace && it !is PsiComment && psi.getStrictParentOfType<KDoc>() == null &&
-                    psi.getStrictParentOfType<KtAnnotationEntry>() == null
-            }
+            val nextLeaf =
+                nextLeaf {
+                    val psi = it.psi
+                    it !is PsiWhiteSpace &&
+                        it !is PsiComment &&
+                        psi.getStrictParentOfType<KDoc>() == null &&
+                        psi.getStrictParentOfType<KtAnnotationEntry>() == null
+                }
             return (
                 nextLeaf == null || // \s+ and then eof
                     textContains('\n') && nextLeaf.elementType != KtTokens.LBRACE

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
@@ -67,10 +67,11 @@ public class NoTrailingSpacesRule : StandardRule("no-trailing-spaces") {
     private fun ASTNode.hasTrailingSpacesBeforeNewline() = text.contains(SPACE_OR_TAB_BEFORE_NEWLINE_REGEX)
 
     private fun ASTNode.removeTrailingSpacesBeforeNewline() {
-        val newText = text.replace(
-            regex = SPACE_OR_TAB_BEFORE_NEWLINE_REGEX,
-            replacement = "\n",
-        )
+        val newText =
+            text.replace(
+                regex = SPACE_OR_TAB_BEFORE_NEWLINE_REGEX,
+                replacement = "\n",
+            )
         (this as LeafPsiElement).replaceWithText(newText)
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -32,9 +32,10 @@ import org.jetbrains.kotlin.resolve.ImportPath
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
-    private val ref = mutableSetOf(
-        Reference("*", false),
-    )
+    private val ref =
+        mutableSetOf(
+            Reference("*", false),
+        )
     private val parentExpressions = mutableSetOf<String>()
     private val imports = mutableMapOf<ImportPath, ASTNode>()
     private var packageName = ""
@@ -215,9 +216,7 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
             return false
         }
 
-        val methodCallExpression = text.substringBeforeLast(
-            "(",
-        )
+        val methodCallExpression = text.substringBeforeLast("(")
 
         // Only check static imports; identified if they start with a capital letter indicating a
         // class name rather than a sub-package
@@ -228,11 +227,12 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
         imports
             .filterKeys { it.pathStr.removeBackticksAndTrim().endsWith(".$methodCallExpression") }
             .forEach { import ->
-                val count = imports.count {
-                    it.key.pathStr.removeBackticksAndTrim().startsWith(
-                        import.key.pathStr.removeBackticksAndTrim().substringBefore(methodCallExpression),
-                    )
-                }
+                val count =
+                    imports.count {
+                        it.key.pathStr.removeBackticksAndTrim().startsWith(
+                            import.key.pathStr.removeBackticksAndTrim().substringBefore(methodCallExpression),
+                        )
+                    }
                 // Parent import and static import both are present
                 if (count > 1) {
                     return true
@@ -263,30 +263,31 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
     private companion object {
         val COMPONENT_N_REGEX = Regex("^component\\d+$")
 
-        val OPERATOR_SET = setOf(
-            // unary
-            "unaryPlus", "unaryMinus", "not",
-            // inc/dec
-            "inc", "dec",
-            // arithmetic
-            "plus", "minus", "times", "div", "rem", "mod", "rangeTo",
-            // in
-            "contains",
-            // indexed access
-            "get", "set",
-            // invoke
-            "invoke",
-            // augmented assignments
-            "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
-            // (in)equality
-            "equals",
-            // comparison
-            "compareTo",
-            // iteration (https://github.com/shyiko/ktlint/issues/40)
-            "iterator",
-            // by (https://github.com/shyiko/ktlint/issues/54)
-            "getValue", "setValue",
-        )
+        val OPERATOR_SET =
+            setOf(
+                // unary
+                "unaryPlus", "unaryMinus", "not",
+                // inc/dec
+                "inc", "dec",
+                // arithmetic
+                "plus", "minus", "times", "div", "rem", "mod", "rangeTo",
+                // in
+                "contains",
+                // indexed access
+                "get", "set",
+                // invoke
+                "invoke",
+                // augmented assignments
+                "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
+                // (in)equality
+                "equals",
+                // comparison
+                "compareTo",
+                // iteration (https://github.com/shyiko/ktlint/issues/40)
+                "iterator",
+                // by (https://github.com/shyiko/ktlint/issues/54)
+                "getValue", "setValue",
+            )
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
@@ -13,9 +13,10 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 public class NoWildcardImportsRule :
     StandardRule(
         id = "no-wildcard-imports",
-        usesEditorConfigProperties = setOf(
-            IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND,
+            ),
     ) {
     private lateinit var allowedWildcardImports: List<PatternEntry>
 
@@ -81,11 +82,12 @@ public class NoWildcardImportsRule :
 
         public val IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND: EditorConfigProperty<List<PatternEntry>> =
             EditorConfigProperty(
-                type = PropertyType(
-                    "ij_kotlin_packages_to_use_import_on_demand",
-                    "Defines allowed wildcard imports",
-                    PACKAGES_TO_USE_ON_DEMAND_IMPORT_PROPERTY_PARSER,
-                ),
+                type =
+                    PropertyType(
+                        "ij_kotlin_packages_to_use_import_on_demand",
+                        "Defines allowed wildcard imports",
+                        PACKAGES_TO_USE_ON_DEMAND_IMPORT_PROPERTY_PARSER,
+                    ),
                 /**
                  * Default IntelliJ IDEA style: Use wildcard imports for packages in "java.util", "kotlin.android.synthetic" and
                  * it's subpackages.

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -36,12 +36,13 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 public class ParameterListWrappingRule :
     StandardRule(
         id = "parameter-list-wrapping",
-        usesEditorConfigProperties = setOf(
-            CODE_STYLE_PROPERTY,
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                CODE_STYLE_PROPERTY,
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ) {
     private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
@@ -254,9 +255,10 @@ public class ParameterListWrappingRule :
         } else {
             parent.children().firstOrNull { it.elementType == TYPE_PARAMETER_LIST }
         }
-        val typeListNode = typeParameterList
-            ?: parent.psi.collectDescendantsOfType<KtTypeArgumentList>().firstOrNull()?.node
-            ?: return false
+        val typeListNode =
+            typeParameterList
+                ?: parent.psi.collectDescendantsOfType<KtTypeArgumentList>().firstOrNull()?.node
+                ?: return false
         return typeListNode.children().any { it.isWhiteSpaceWithNewline() }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
@@ -42,11 +42,12 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 public class ParameterWrappingRule :
     StandardRule(
         id = "parameter-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ) {
     private var line = 1
     private var indentConfig = DEFAULT_INDENT_CONFIG

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
@@ -40,11 +40,12 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 public class PropertyWrappingRule :
     StandardRule(
         id = "property-wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ) {
     private var line = 1
     private var indentConfig = DEFAULT_INDENT_CONFIG

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
@@ -48,18 +48,24 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                 emit(prevLeaf.startOffset, "Unexpected newline before \":\"", true)
                 if (autoCorrect) {
                     val parent = node.parent
-                    val prevNonCodeElements = node.siblings(forward = false, withItself = false)
-                        .takeWhile { it.node.isWhiteSpace() || it.node.isPartOfComment() }.toList()
+                    val prevNonCodeElements =
+                        node
+                            .siblings(forward = false, withItself = false)
+                            .takeWhile { it.node.isWhiteSpace() || it.node.isPartOfComment() }.toList()
                     when {
                         parent is KtProperty || parent is KtNamedFunction -> {
-                            val equalsSignElement = node.siblings(forward = true, withItself = false)
-                                .firstOrNull { it.node.elementType == EQ }
+                            val equalsSignElement =
+                                node
+                                    .siblings(forward = true, withItself = false)
+                                    .firstOrNull { it.node.elementType == EQ }
                             if (equalsSignElement != null) {
                                 equalsSignElement.nextSibling?.takeIf { it.node.isWhiteSpace() }?.delete()
                                 prevNonCodeElements.forEach { parent.addAfter(it, equalsSignElement) }
                             }
-                            val blockElement = node.siblings(forward = true, withItself = false)
-                                .firstIsInstanceOrNull<KtBlockExpression>()
+                            val blockElement =
+                                node
+                                    .siblings(forward = true, withItself = false)
+                                    .firstIsInstanceOrNull<KtBlockExpression>()
                             if (blockElement != null) {
                                 prevNonCodeElements
                                     .let { if (it.first().node.isWhiteSpace()) it.drop(1) else it }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
@@ -73,9 +73,11 @@ public class SpacingAroundCurlyRule : StandardRule("curly-spacing") {
                 ) {
                     emit(node.startOffset, "Unexpected newline before \"${node.text}\"", true)
                     if (autoCorrect) {
-                        val eolCommentExists = prevLeaf.prevLeaf()?.let {
-                            it is PsiComment && it.elementType == EOL_COMMENT
-                        } ?: false
+                        val eolCommentExists =
+                            prevLeaf
+                                .prevLeaf()
+                                ?.let { it is PsiComment && it.elementType == EOL_COMMENT }
+                                ?: false
                         if (eolCommentExists) {
                             val commentLeaf = prevLeaf.prevLeaf()!!
                             if (commentLeaf.prevLeaf() is PsiWhiteSpace) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundKeywordRule.kt
@@ -30,10 +30,11 @@ import org.jetbrains.kotlin.psi.KtWhenEntry
 
 public class SpacingAroundKeywordRule : StandardRule("keyword-spacing") {
     private val noLFBeforeSet = create(ELSE_KEYWORD, CATCH_KEYWORD, FINALLY_KEYWORD)
-    private val tokenSet = create(
-        FOR_KEYWORD, IF_KEYWORD, ELSE_KEYWORD, WHILE_KEYWORD, DO_KEYWORD,
-        TRY_KEYWORD, CATCH_KEYWORD, FINALLY_KEYWORD, WHEN_KEYWORD,
-    )
+    private val tokenSet =
+        create(
+            FOR_KEYWORD, IF_KEYWORD, ELSE_KEYWORD, WHILE_KEYWORD, DO_KEYWORD,
+            TRY_KEYWORD, CATCH_KEYWORD, FINALLY_KEYWORD, WHEN_KEYWORD,
+        )
 
     private val keywordsWithoutSpaces = create(GET_KEYWORD, SET_KEYWORD)
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
@@ -39,10 +39,11 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 
 public class SpacingAroundOperatorsRule : StandardRule("op-spacing") {
-    private val tokenSet = TokenSet.create(
-        MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
-        EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW,
-    )
+    private val tokenSet =
+        TokenSet.create(
+            MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
+            EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW,
+        )
 
     override fun beforeVisitChildNodes(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
@@ -32,13 +32,14 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 public class TrailingCommaOnCallSiteRule :
     StandardRule(
         id = "trailing-comma-on-call-site",
-        visitorModifiers = setOf(
-            VisitorModifier.RunAfterRule(
-                ruleId = WRAPPING_RULE_ID,
-                mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAfterRule(
+                    ruleId = WRAPPING_RULE_ID,
+                    mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                ),
+                VisitorModifier.RunAsLateAsPossible,
             ),
-            VisitorModifier.RunAsLateAsPossible,
-        ),
         usesEditorConfigProperties = setOf(TRAILING_COMMA_ON_CALL_SITE_PROPERTY),
     ) {
     private var allowTrailingCommaOnCallSite = TRAILING_COMMA_ON_CALL_SITE_PROPERTY.defaultValue
@@ -68,9 +69,10 @@ public class TrailingCommaOnCallSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .last { it.elementType == ElementType.RBRACKET }
+        val inspectNode =
+            node
+                .children()
+                .last { it.elementType == ElementType.RBRACKET }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             emit = emit,
@@ -86,9 +88,10 @@ public class TrailingCommaOnCallSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .last { it.elementType == ElementType.RBRACKET }
+        val inspectNode =
+            node
+                .children()
+                .last { it.elementType == ElementType.RBRACKET }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             emit = emit,
@@ -122,9 +125,10 @@ public class TrailingCommaOnCallSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .first { it.elementType == ElementType.GT }
+        val inspectNode =
+            node
+                .children()
+                .first { it.elementType == ElementType.GT }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             emit = emit,
@@ -237,26 +241,28 @@ public class TrailingCommaOnCallSiteRule :
 
         public val TRAILING_COMMA_ON_CALL_SITE_PROPERTY: EditorConfigProperty<Boolean> =
             EditorConfigProperty(
-                type = PropertyType.LowerCasingPropertyType(
-                    "ij_kotlin_allow_trailing_comma_on_call_site",
-                    "Defines whether a trailing comma (or no trailing comma) should be enforced on the calling side," +
-                        "e.g. argument-list, when-entries, lambda-arguments, indices, etc." +
-                        "When set, IntelliJ IDEA uses this property to allow usage of a trailing comma by discretion " +
-                        "of the developer. KtLint however uses this setting to enforce consistent usage of the " +
-                        "trailing comma when set.",
-                    PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                    BOOLEAN_VALUES_SET,
-                ),
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ij_kotlin_allow_trailing_comma_on_call_site",
+                        "Defines whether a trailing comma (or no trailing comma) should be enforced on the calling side," +
+                            "e.g. argument-list, when-entries, lambda-arguments, indices, etc." +
+                            "When set, IntelliJ IDEA uses this property to allow usage of a trailing comma by discretion " +
+                            "of the developer. KtLint however uses this setting to enforce consistent usage of the " +
+                            "trailing comma when set.",
+                        PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                        BOOLEAN_VALUES_SET,
+                    ),
                 defaultValue = true,
                 androidStudioCodeStyleDefaultValue = false,
             )
 
-        private val TYPES_ON_CALL_SITE = TokenSet.create(
-            COLLECTION_LITERAL_EXPRESSION,
-            INDICES,
-            TYPE_ARGUMENT_LIST,
-            VALUE_ARGUMENT_LIST,
-        )
+        private val TYPES_ON_CALL_SITE =
+            TokenSet.create(
+                COLLECTION_LITERAL_EXPRESSION,
+                INDICES,
+                TYPE_ARGUMENT_LIST,
+                VALUE_ARGUMENT_LIST,
+            )
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -52,13 +52,14 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 public class TrailingCommaOnDeclarationSiteRule :
     StandardRule(
         id = "trailing-comma-on-declaration-site",
-        visitorModifiers = setOf(
-            VisitorModifier.RunAfterRule(
-                ruleId = WRAPPING_RULE_ID,
-                mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAfterRule(
+                    ruleId = WRAPPING_RULE_ID,
+                    mode = ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED,
+                ),
+                VisitorModifier.RunAsLateAsPossible,
             ),
-            VisitorModifier.RunAsLateAsPossible,
-        ),
         usesEditorConfigProperties = setOf(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY),
     ) {
     private var allowTrailingComma = TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY.defaultValue
@@ -90,9 +91,10 @@ public class TrailingCommaOnDeclarationSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .last { it.elementType == ElementType.RPAR }
+        val inspectNode =
+            node
+                .children()
+                .last { it.elementType == ElementType.RPAR }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             isTrailingCommaAllowed = node.isTrailingCommaAllowed(),
@@ -108,11 +110,12 @@ public class TrailingCommaOnDeclarationSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .lastOrNull { it.elementType == ARROW }
-            ?: // lambda w/o an arrow -> no arguments -> no commas
-            return
+        val inspectNode =
+            node
+                .children()
+                .lastOrNull { it.elementType == ARROW }
+                ?: // lambda w/o an arrow -> no arguments -> no commas
+                return
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             isTrailingCommaAllowed = node.isTrailingCommaAllowed(),
@@ -146,9 +149,10 @@ public class TrailingCommaOnDeclarationSiteRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val inspectNode = node
-            .children()
-            .first { it.elementType == ElementType.GT }
+        val inspectNode =
+            node
+                .children()
+                .first { it.elementType == ElementType.GT }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             isTrailingCommaAllowed = node.isTrailingCommaAllowed(),
@@ -169,9 +173,10 @@ public class TrailingCommaOnDeclarationSiteRule :
             return
         }
 
-        val inspectNode = node
-            .children()
-            .first { it.elementType == ARROW }
+        val inspectNode =
+            node
+                .children()
+                .first { it.elementType == ARROW }
         node.reportAndCorrectTrailingCommaNodeBefore(
             inspectNode = inspectNode,
             isTrailingCommaAllowed = node.isTrailingCommaAllowed(),
@@ -292,11 +297,12 @@ public class TrailingCommaOnDeclarationSiteRule :
                     }
                     if (autoCorrect) {
                         if (addNewLineBeforeArrowInWhenEntry) {
-                            val newLine = KtPsiFactory(prevNode.psi).createWhiteSpace(
-                                prevNode
-                                    .treeParent
-                                    .indent(),
-                            )
+                            val newLine =
+                                KtPsiFactory(prevNode.psi).createWhiteSpace(
+                                    prevNode
+                                        .treeParent
+                                        .indent(),
+                                )
                             val leafBeforeArrow = (psi as KtWhenEntry).arrow?.prevLeaf()
                             if (leafBeforeArrow != null && leafBeforeArrow is PsiWhiteSpace) {
                                 leafBeforeArrow.replace(newLine)
@@ -429,29 +435,31 @@ public class TrailingCommaOnDeclarationSiteRule :
 
         public val TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY: EditorConfigProperty<Boolean> =
             EditorConfigProperty(
-                type = PropertyType.LowerCasingPropertyType(
-                    "ij_kotlin_allow_trailing_comma",
-                    "Defines whether a trailing comma (or no trailing comma) should be enforced on the defining " +
-                        "side, e.g. parameter-list, type-argument-list, lambda-value-parameters, enum-entries, etc." +
-                        "When set, IntelliJ IDEA uses this property to allow usage of a trailing comma by discretion " +
-                        "of the developer. KtLint however uses this setting to enforce consistent usage of the " +
-                        "trailing comma when set.",
-                    PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                    BOOLEAN_VALUES_SET,
-                ),
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ij_kotlin_allow_trailing_comma",
+                        "Defines whether a trailing comma (or no trailing comma) should be enforced on the defining " +
+                            "side, e.g. parameter-list, type-argument-list, lambda-value-parameters, enum-entries, etc." +
+                            "When set, IntelliJ IDEA uses this property to allow usage of a trailing comma by discretion " +
+                            "of the developer. KtLint however uses this setting to enforce consistent usage of the " +
+                            "trailing comma when set.",
+                        PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                        BOOLEAN_VALUES_SET,
+                    ),
                 defaultValue = true,
                 androidStudioCodeStyleDefaultValue = false,
             )
 
-        private val TYPES_ON_DECLARATION_SITE = TokenSet.create(
-            CLASS,
-            DESTRUCTURING_DECLARATION,
-            FUNCTION_LITERAL,
-            FUNCTION_TYPE,
-            TYPE_PARAMETER_LIST,
-            VALUE_PARAMETER_LIST,
-            WHEN_ENTRY,
-        )
+        private val TYPES_ON_DECLARATION_SITE =
+            TokenSet.create(
+                CLASS,
+                DESTRUCTURING_DECLARATION,
+                FUNCTION_LITERAL,
+                FUNCTION_TYPE,
+                TYPE_PARAMETER_LIST,
+                VALUE_PARAMETER_LIST,
+                WHEN_ENTRY,
+            )
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
@@ -29,10 +29,11 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 public class TryCatchFinallySpacingRule :
     StandardRule(
         id = "try-catch-finally-spacing",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental,
     Rule.OfficialCodeStyle {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -34,10 +34,11 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 public class TypeParameterListSpacingRule :
     StandardRule(
         id = "type-parameter-list-spacing",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
     ),
     Rule.Experimental {
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -90,11 +90,12 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 public class WrappingRule :
     StandardRule(
         id = "wrapping",
-        usesEditorConfigProperties = setOf(
-            INDENT_SIZE_PROPERTY,
-            INDENT_STYLE_PROPERTY,
-            MAX_LINE_LENGTH_PROPERTY,
-        ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
     ) {
     private var line = 1
     private var indentConfig = DEFAULT_INDENT_CONFIG

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -4850,7 +4850,7 @@ internal class IndentationRuleTest {
         }
 
         @Test
-        fun `Given ktlint_official code style then indent the type when it does not fit on the same line as the variable name`() {
+        fun `Given a type which does not fit on the same line as the variable name`() {
             val code =
                 """
                 // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
@@ -4873,6 +4873,35 @@ internal class IndentationRuleTest {
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .setMaxLineLength()
                 .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Issue 1217 - Given a function parameter with a multiline expression starting on a new line`() {
+            val code =
+                """
+                val foo = foo(
+                    parameterName =
+                    "The quick brown fox "
+                        .plus("jumps ")
+                        .plus("over the lazy dog"),
+                )
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = foo(
+                    parameterName =
+                        "The quick brown fox "
+                            .plus("jumps ")
+                            .plus("over the lazy dog"),
+                )
+                """.trimIndent()
+            indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolations(
+                    LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(4, 1, "Unexpected indentation (8) (should be 12)"),
+                    LintViolation(5, 1, "Unexpected indentation (8) (should be 12)"),
+                ).isFormattedAs(formattedCode)
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingTest.kt
@@ -1,0 +1,238 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Test
+
+class MultilineExpressionWrappingTest {
+    private val multilineExpressionWrappingAssertThat = KtLintAssertThat.assertThatRule { MultilineExpressionWrapping() }
+
+    @Test
+    fun `Given value argument in a function with a multiline dot qualified expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = "The quick brown fox "
+                    .plus("jumps ")
+                    .plus("over the lazy dog"),
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        "The quick brown fox "
+                            .plus("jumps ")
+                            .plus("over the lazy dog"),
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given value argument in a function with a multiline binary expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = "The quick brown fox " +
+                    "jumps " +
+                    "over the lazy dog",
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        "The quick brown fox " +
+                            "jumps " +
+                            "over the lazy dog",
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given value argument in a function with a multiline safe access expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = theQuickBrownFoxOrNull
+                    ?.plus("jumps ")
+                    ?.plus("over the lazy dog"),
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        theQuickBrownFoxOrNull
+                            ?.plus("jumps ")
+                            ?.plus("over the lazy dog"),
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given value argument in a function with a multiline combination of a safe access expression and a call expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = theQuickBrownFoxOrNull()
+                    ?.plus("jumps ")
+                    ?.plus("over the lazy dog"),
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        theQuickBrownFoxOrNull()
+                            ?.plus("jumps ")
+                            ?.plus("over the lazy dog"),
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given value argument in a function with a multiline combination of a dot qualified and a safe access expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = "The quick brown fox "
+                    .takeIf { it.jumps }
+                    ?.plus("jumps over the lazy dog"),
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        "The quick brown fox "
+                            .takeIf { it.jumps }
+                            ?.plus("jumps over the lazy dog"),
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given value argument in a function with a multiline call expression on the same line as the assignment`() {
+        val code =
+            """
+            val foo = foo(
+                parameterName = bar(
+                    "bar"
+                )
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo(
+                    parameterName =
+                        bar(
+                            "bar"
+                        )
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(2, 21, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a return statement with a multiline expression then do not reformat as it would result in a compilation error`() {
+        val code =
+            """
+            fun foo() {
+                return bar(
+                    "bar"
+                )
+            }
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a function with a multiline body expression`() {
+        val code =
+            """
+            fun foo() = bar(
+                "bar"
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() =
+                bar(
+                    "bar"
+                )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolation(1, 13, "A multiline expression should start on a new line")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with a multiline signature without a return type but with a multiline expression body starting on same line as closing parenthesis of function`() {
+        val code =
+            """
+            fun foo(
+                foobar: String
+            ) = bar(
+                foobar
+            )
+            """.trimIndent()
+        multilineExpressionWrappingAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasNoLintViolations()
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -16,11 +16,12 @@ class ParameterListWrappingRuleTest {
     private val parameterListWrappingRuleAssertThat =
         assertThatRule(
             provider = { ParameterListWrappingRule() },
-            additionalRuleProviders = setOf(
-                // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
-                // correct.
-                RuleProvider { IndentationRule() },
-            ),
+            additionalRuleProviders =
+                setOf(
+                    // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                    // correct.
+                    RuleProvider { IndentationRule() },
+                ),
         )
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRuleTest.kt
@@ -11,13 +11,14 @@ class TrailingCommaOnCallSiteRuleTest {
     private val trailingCommaOnCallSiteRuleAssertThat =
         assertThatRule(
             provider = { TrailingCommaOnCallSiteRule() },
-            additionalRuleProviders = setOf(
-                // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
-                RuleProvider { WrappingRule() },
-                // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
-                // correct.
-                RuleProvider { IndentationRule() },
-            ),
+            additionalRuleProviders =
+                setOf(
+                    // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
+                    RuleProvider { WrappingRule() },
+                    // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                    // correct.
+                    RuleProvider { IndentationRule() },
+                ),
         )
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -11,13 +11,14 @@ class TrailingCommaOnDeclarationSiteRuleTest {
     private val trailingCommaOnDeclarationSiteRuleAssertThat =
         KtLintAssertThat.assertThatRule(
             provider = { TrailingCommaOnDeclarationSiteRule() },
-            additionalRuleProviders = setOf(
-                // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
-                RuleProvider { WrappingRule() },
-                // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
-                // correct.
-                RuleProvider { IndentationRule() },
-            ),
+            additionalRuleProviders =
+                setOf(
+                    // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
+                    RuleProvider { WrappingRule() },
+                    // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                    // correct.
+                    RuleProvider { IndentationRule() },
+                ),
         )
 
     @Test
@@ -930,10 +931,11 @@ class TrailingCommaOnDeclarationSiteRuleTest {
         val multiLineIfElseRuleAssertThat =
             KtLintAssertThat.assertThatRule(
                 provider = { MultiLineIfElseRule() },
-                additionalRuleProviders = setOf(
-                    RuleProvider { TrailingCommaOnDeclarationSiteRule() },
-                    RuleProvider { WrappingRule() }, // Required for TrailingCommaOnDeclarationSiteRule
-                ),
+                additionalRuleProviders =
+                    setOf(
+                        RuleProvider { TrailingCommaOnDeclarationSiteRule() },
+                        RuleProvider { WrappingRule() }, // Required for TrailingCommaOnDeclarationSiteRule
+                    ),
             )
 
         multiLineIfElseRuleAssertThat(code)
@@ -1019,14 +1021,15 @@ class TrailingCommaOnDeclarationSiteRuleTest {
         val noSemicolonsRuleAssertThat =
             KtLintAssertThat.assertThatRule(
                 provider = { NoSemicolonsRule() },
-                additionalRuleProviders = setOf(
-                    // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
-                    RuleProvider { WrappingRule() },
-                    // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
-                    // correct.
-                    RuleProvider { IndentationRule() },
-                    RuleProvider { TrailingCommaOnDeclarationSiteRule() },
-                ),
+                additionalRuleProviders =
+                    setOf(
+                        // WrappingRule must be loaded in order to run TrailingCommaOnCallSiteRule
+                        RuleProvider { WrappingRule() },
+                        // Apply the IndentationRule always as additional rule, so that the formattedCode in the unit test looks
+                        // correct.
+                        RuleProvider { IndentationRule() },
+                        RuleProvider { TrailingCommaOnDeclarationSiteRule() },
+                    ),
             )
         noSemicolonsRuleAssertThat(code)
             .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleTest.kt
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.Test
 class ImportOrderingRuleTest {
     @Test
     fun `Given a list of pattern entries then write the patters as comma separated string`() {
-        val actual = ImportOrderingRule.IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY.propertyWriter(
-            listOf(
-                PatternEntry.ALL_OTHER_IMPORTS_ENTRY,
-                PatternEntry(packageName = "java", withSubpackages = true, hasAlias = false),
-                PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY,
-            ),
-        )
+        val actual =
+            ImportOrderingRule.IJ_KOTLIN_IMPORTS_LAYOUT_PROPERTY.propertyWriter(
+                listOf(
+                    PatternEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    PatternEntry(packageName = "java", withSubpackages = true, hasAlias = false),
+                    PatternEntry.ALL_OTHER_ALIAS_IMPORTS_ENTRY,
+                ),
+            )
         assertThat(actual).isEqualTo("*,java.**,^")
     }
 }

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -7,11 +7,12 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 public class NoVarRule : Rule(
     ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
-    about = About(
-        maintainer = "Your name",
-        repositoryUrl = "https://github.com/your/project/",
-        issueTrackerUrl = "https://github.com/your/project/issues",
-    ),
+    about =
+        About(
+            maintainer = "Your name",
+            repositoryUrl = "https://github.com/your/project/",
+            issueTrackerUrl = "https://github.com/your/project/issues",
+        ),
 ) {
     override fun beforeVisitChildNodes(
         node: ASTNode,

--- a/ktlint-ruleset-test-tooling/src/main/kotlin/com/pinterest/ruleset/testtooling/DumpASTRule.kt
+++ b/ktlint-ruleset-test-tooling/src/main/kotlin/com/pinterest/ruleset/testtooling/DumpASTRule.kt
@@ -18,11 +18,12 @@ public class DumpASTRule @JvmOverloads constructor(
     private val color: Boolean = false,
 ) : Rule(
     ruleId = RuleId("$TEST_TOOLING_RULESET_ID:dump-ast"),
-    about = About(
-        maintainer = "Ktlint",
-        repositoryUrl = "https://github.com/pinterest/ktlint",
-        issueTrackerUrl = "https://github.com/pinterest/ktlint/issues",
-    ),
+    about =
+        About(
+            maintainer = "Ktlint",
+            repositoryUrl = "https://github.com/pinterest/ktlint",
+            issueTrackerUrl = "https://github.com/pinterest/ktlint/issues",
+        ),
 ) {
     private companion object {
         val ELEMENT_TYPE_SET = ElementType::class.members.map { it.name }.toSet()

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -613,9 +613,10 @@ public class KtLintAssertThatAssertable(
                 // the additional rules to be loaded and enabled as well.
                 .plus(additionalRuleProviders)
                 .plus(DUMP_AST_RULE_PROVIDER)
-        val editorConfigOverride = editorConfigOverride
-            .enableExperimentalRules()
-            .extendWithRuleSetRuleExecutionsFor(ruleProviders)
+        val editorConfigOverride =
+            editorConfigOverride
+                .enableExperimentalRules()
+                .extendWithRuleSetRuleExecutionsFor(ruleProviders)
         return KtLintRuleEngine(
             ruleProviders = ruleProviders,
             editorConfigOverride = editorConfigOverride,
@@ -669,19 +670,20 @@ public data class LintViolation(
  * provided.
  */
 private fun EditorConfigOverride.extendWithRuleSetRuleExecutionsFor(ruleProviders: Set<RuleProvider>): EditorConfigOverride {
-    val ruleSetRuleExecutions = ruleProviders
-        .asSequence()
-        .map { ruleProvider ->
-            ruleProvider
-                .createNewRuleInstance()
-                .ruleId
-                .ruleSetId
-                .createRuleSetExecutionEditorConfigProperty()
-        }.distinct()
-        .filter { editorConfigProperty -> this.properties[editorConfigProperty] == null }
-        .map { it to RuleExecution.enabled }
-        .toList()
-        .toTypedArray()
+    val ruleSetRuleExecutions =
+        ruleProviders
+            .asSequence()
+            .map { ruleProvider ->
+                ruleProvider
+                    .createNewRuleInstance()
+                    .ruleId
+                    .ruleSetId
+                    .createRuleSetExecutionEditorConfigProperty()
+            }.distinct()
+            .filter { editorConfigProperty -> this.properties[editorConfigProperty] == null }
+            .map { it to RuleExecution.enabled }
+            .toList()
+            .toTypedArray()
     return this.plus(*ruleSetRuleExecutions)
 }
 

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleExtension.kt
@@ -47,20 +47,23 @@ private const val KTLINT_UNIT_TEST_DUMP_AST = "KTLINT_UNIT_TEST_DUMP_AST"
 private const val KTLINT_UNIT_TEST_ON_PROPERTY = "ON"
 
 private fun Set<RuleProvider>.toRuleProviders(): Set<RuleProvider> {
-    val dumpAstRuleProvider = System
-        .getenv(KTLINT_UNIT_TEST_DUMP_AST)
-        .orEmpty()
-        .equals(KTLINT_UNIT_TEST_ON_PROPERTY, ignoreCase = true)
-        .ifTrue {
-            LOGGER.info { "Dump AST of code before processing as System environment variable $KTLINT_UNIT_TEST_DUMP_AST is set to 'on'" }
-            RuleProvider {
-                DumpASTRule(
-                    // Write to STDOUT. The focus in a failed unit test should first go to the error in the rule that is
-                    // to be tested and not to the AST,
-                    out = System.out,
-                )
+    val dumpAstRuleProvider =
+        System
+            .getenv(KTLINT_UNIT_TEST_DUMP_AST)
+            .orEmpty()
+            .equals(KTLINT_UNIT_TEST_ON_PROPERTY, ignoreCase = true)
+            .ifTrue {
+                LOGGER.info {
+                    "Dump AST of code before processing as System environment variable $KTLINT_UNIT_TEST_DUMP_AST is set to 'on'"
+                }
+                RuleProvider {
+                    DumpASTRule(
+                        // Write to STDOUT. The focus in a failed unit test should first go to the error in the rule that is
+                        // to be tested and not to the AST,
+                        out = System.out,
+                    )
+                }
             }
-        }
     return this.plus(setOfNotNull(dumpAstRuleProvider))
 }
 
@@ -87,9 +90,10 @@ public fun Set<RuleProvider>.lint(
     }
     KtLintRuleEngine(
         ruleProviders = ruleProviders,
-        editorConfigOverride = editorConfigOverride
-            .enableExperimentalRules()
-            .extendWithRuleSetRuleExecutionsFor(ruleProviders),
+        editorConfigOverride =
+            editorConfigOverride
+                .enableExperimentalRules()
+                .extendWithRuleSetRuleExecutionsFor(ruleProviders),
         fileSystem = KTLINT_TEST_FILE_SYSTEM.fileSystem,
     ).lint(code) { lintError -> lintErrors.add(lintError) }
     return lintErrors
@@ -100,19 +104,20 @@ public fun Set<RuleProvider>.lint(
  * provided.
  */
 private fun EditorConfigOverride.extendWithRuleSetRuleExecutionsFor(ruleProviders: Set<RuleProvider>): EditorConfigOverride {
-    val ruleSetRuleExecutions = ruleProviders
-        .asSequence()
-        .map { ruleProvider ->
-            ruleProvider
-                .createNewRuleInstance()
-                .ruleId
-                .ruleSetId
-                .createRuleSetExecutionEditorConfigProperty()
-        }.distinct()
-        .filter { editorConfigProperty -> this.properties[editorConfigProperty] == null }
-        .map { it to RuleExecution.enabled }
-        .toList()
-        .toTypedArray()
+    val ruleSetRuleExecutions =
+        ruleProviders
+            .asSequence()
+            .map { ruleProvider ->
+                ruleProvider
+                    .createNewRuleInstance()
+                    .ruleId
+                    .ruleSetId
+                    .createRuleSetExecutionEditorConfigProperty()
+            }.distinct()
+            .filter { editorConfigProperty -> this.properties[editorConfigProperty] == null }
+            .map { it to RuleExecution.enabled }
+            .toList()
+            .toTypedArray()
     return this.plus(*ruleSetRuleExecutions)
 }
 
@@ -143,9 +148,10 @@ public fun Set<RuleProvider>.format(
     val formattedCode =
         KtLintRuleEngine(
             ruleProviders = ruleProviders,
-            editorConfigOverride = editorConfigOverride
-                .enableExperimentalRules()
-                .extendWithRuleSetRuleExecutionsFor(ruleProviders),
+            editorConfigOverride =
+                editorConfigOverride
+                    .enableExperimentalRules()
+                    .extendWithRuleSetRuleExecutionsFor(ruleProviders),
             fileSystem = KTLINT_TEST_FILE_SYSTEM.fileSystem,
         ).format(code) { lintError, _ -> lintErrors.add(lintError) }
     return Pair(formattedCode, lintErrors)

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/RuleSetProviderTest.kt
@@ -22,10 +22,12 @@ public open class RuleSetProviderTest(
     public fun checkAllRulesInPackageAreProvidedByRuleSetProvider() {
         val srcLocation = rulesetClass.protectionDomain.codeSource.location.path
         val rulesDir = File(srcLocation + packageName.replace(".", "/"))
-        val packageRules = rulesDir.listFiles()
-            ?.map { it.name.removeSuffix(".class") }
-            ?.filter { it.endsWith("Rule") }
-            ?: arrayListOf()
+        val packageRules =
+            rulesDir
+                .listFiles()
+                ?.map { it.name.removeSuffix(".class") }
+                ?.filter { it.endsWith("Rule") }
+                ?: arrayListOf()
         assertThat(packageRules)
             .withFailMessage("No rules were found in package '$rulesDir'. Is the packagname '$packageName' correct?")
             .isNotEmpty


### PR DESCRIPTION
## Description

Allow value arguments with a multiline expression to be indented on a separate line.
Closes #1217 

Add experimental rule `multiline-expression-wrapping` for `ktlint_official` code style which forces multiline expressions to start on a separate line.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [X] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
