### PR TITLE
Add new experimental rule `string-template-indent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Recognize Kotlin Script when linting and formatting code from `stdin` with KtLint CLI ([#1832](https://github.com/pinterest/ktlint/issues/1832))
 * Add new experimental rule `no-blank-line-in-list` for `ktlint_official` code style. This rule disallows blank lines to be used in super type lists, type argument lists, type constraint lists, type parameter lists, value argument lists, and value parameter lists. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#1224](https://github.com/pinterest/ktlint/issues/1224))
 * Add new experimental rule `multiline-expression-wrapping` for `ktlint_official` code style. This forces a multiline expression as value in an assignment to start on a separate line. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#1217](https://github.com/pinterest/ktlint/issues/1217))
+* Add new experimental rule `string-template-indent` for `ktlint_official` code style. This forces multiline string templates which are post-fixed with `.trimIndent()` to be formatted consistently. The opening and closing `"""` are placed on separate lines and the indentation of the content of the template is aligned with the `"""`. This rule can also be run for other code styles but then its needs to be explicitly enabled. ([#925](https://github.com/pinterest/ktlint/issues/925))
 
 ### Removed
 

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -366,6 +366,46 @@ Consistent spacing between function name and opening parenthesis.
 
 Rule id: `spacing-between-function-name-and-opening-parenthesis`
 
+### String template indent
+
+Enforce consistent string template indentation for multiline string templates which are post-fixed with `.trimIndent()`. The opening and closing `"""` are placed on separate lines and the indentation of the content of the template is aligned with the `"""`.
+
+=== "[:material-heart:](#) Ktlint (ktlint_official code style)"
+
+    ```kotlin
+    val foo =
+        """
+        line1
+        line2
+        """.trimIndent()
+    fun foo() {
+        // The opening """ can not be wrapped to next line as that would result in a compilation error
+        return """
+            line1
+            line2
+            """.trimIndent()
+    }
+    ```
+=== "[:material-heart:](#) Ktlint (non ktlint_official code style)"
+
+    ```kotlin
+    val foo = """
+              line1
+              line2
+              """.trimIndent()
+    fun foo() {
+        return """
+            line1
+            line2
+        """.trimIndent()
+    }
+    ```
+
+Rule id: `string-template-indent`
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+
 ### Try catch finally spacing
 
 Enforce consistent spacing in `try { .. } catch { .. } finally { .. }`.

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -56,7 +56,8 @@ val shadowJarExecutable by tasks.registering(DefaultTask::class) {
     doLast {
         val execFile = outputs.files.files.first()
         execFile.appendText(
-            """#!/bin/sh
+            """
+            #!/bin/sh
 
             # From this SO answer: https://stackoverflow.com/a/56243046
 

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -438,13 +438,13 @@ class ASTNodeExtensionTest {
     fun `Given some identifiers at different indentation levels`() {
         val code =
             """
-                class Foo1 {
-                    val foo2 = "foo2"
+            class Foo1 {
+                val foo2 = "foo2"
 
-                    fun foo3() {
-                        val foo4 = "foo4"
-                    }
+                fun foo3() {
+                    val foo4 = "foo4"
                 }
+            }
             """.trimIndent()
 
         val actual =

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
@@ -262,9 +262,9 @@ class EditorConfigTest {
                 writeRootEditorConfigFile(
                     //language=EditorConfig
                     """
-                [*.{kt,kts}]
-                $ktlintTestRuleExecutionProperty1 = disabled
-                $ktlintTestRuleExecutionProperty2 = disabled
+                    [*.{kt,kts}]
+                    $ktlintTestRuleExecutionProperty1 = disabled
+                    $ktlintTestRuleExecutionProperty2 = disabled
                     """.trimIndent(),
                 )
             }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -105,13 +105,14 @@ internal class EditorConfigLoader(
     private fun MutableMap<String, Property>.prettyPrint(normalizedFilePath: Path?) =
         map { entry -> "${entry.key}: ${entry.value.sourceValue}" }
             .joinToString(
-                prefix = "Effective editorconfig properties${
-                    if (normalizedFilePath == null) {
-                        ""
-                    } else {
-                        " for file '$normalizedFilePath'"
-                    }
-                }:\n\t",
+                prefix =
+                    "Effective editorconfig properties${
+                        if (normalizedFilePath == null) {
+                            ""
+                        } else {
+                            " for file '$normalizedFilePath'"
+                        }
+                    }:\n\t",
                 separator = "\n\t",
             )
 

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -249,8 +249,8 @@ internal class EditorConfigLoaderTest {
                 writeRootEditorConfigFile(
                     //language=EditorConfig
                     """
-                [*.{kt,kts}]
-                some_property = some_value
+                    [*.{kt,kts}]
+                    some_property = some_value
                     """.trimIndent(),
                 )
             }
@@ -297,8 +297,8 @@ internal class EditorConfigLoaderTest {
                 writeRootEditorConfigFile(
                     //language=EditorConfig
                     """
-                [*.{kt,kts}]
-                some_property = some_value
+                    [*.{kt,kts}]
+                    some_property = some_value
                     """.trimIndent(),
                 )
             }
@@ -334,8 +334,8 @@ internal class EditorConfigLoaderTest {
                 writeRootEditorConfigFile(
                     //language=EditorConfig
                     """
-                [*.{kt,kts}]
-                some_property_1 = some_value_1
+                    [*.{kt,kts}]
+                    some_property_1 = some_value_1
                     """.trimIndent(),
                 )
             }
@@ -355,8 +355,8 @@ internal class EditorConfigLoaderTest {
                 writeRootEditorConfigFile(
                     //language=EditorConfig
                     """
-                [*.{kt,kts}]
-                some_property = some_value
+                    [*.{kt,kts}]
+                    some_property = some_value
                     """.trimIndent(),
                 )
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -68,6 +68,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.SpacingAroundUnaryOperatorRul
 import com.pinterest.ktlint.ruleset.standard.rules.SpacingBetweenDeclarationsWithAnnotationsRule
 import com.pinterest.ktlint.ruleset.standard.rules.SpacingBetweenDeclarationsWithCommentsRule
 import com.pinterest.ktlint.ruleset.standard.rules.SpacingBetweenFunctionNameAndOpeningParenthesisRule
+import com.pinterest.ktlint.ruleset.standard.rules.StringTemplateIndentRule
 import com.pinterest.ktlint.ruleset.standard.rules.StringTemplateRule
 import com.pinterest.ktlint.ruleset.standard.rules.TrailingCommaOnCallSiteRule
 import com.pinterest.ktlint.ruleset.standard.rules.TrailingCommaOnDeclarationSiteRule
@@ -147,6 +148,7 @@ public class StandardRuleSetProvider :
             RuleProvider { SpacingBetweenDeclarationsWithCommentsRule() },
             RuleProvider { SpacingBetweenFunctionNameAndOpeningParenthesisRule() },
             RuleProvider { StringTemplateRule() },
+            RuleProvider { StringTemplateIndentRule() },
             RuleProvider { TrailingCommaOnCallSiteRule() },
             RuleProvider { TrailingCommaOnDeclarationSiteRule() },
             RuleProvider { TryCatchFinallySpacingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -1,0 +1,371 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLOSING_QUOTE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LITERAL_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPEN_QUOTE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REGULAR_STRING_PART
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+public class StringTemplateIndentRule :
+    StandardRule(
+        id = "string-template-indent",
+        visitorModifiers =
+            setOf(
+                // Wrap all multiline string templates to a separate line
+                VisitorModifier.RunAfterRule(MULTILINE_EXPRESSION_WRAPPING_RULE_ID, ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED),
+                // The IndentationRule first needs to fix the indentation of the opening quotes of the string template. The indentation inside
+                // the string template is relative to the opening quotes. Running this rule before the IndentationRule results in a wrong
+                // indentation whenever the indent level of the root of the string template is changed.
+                VisitorModifier.RunAfterRule(INDENTATION_RULE_ID, ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED),
+            ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
+    ),
+    Rule.Experimental,
+    Rule.OfficialCodeStyle {
+    private lateinit var nextIndent: String
+    private lateinit var wrongIndentChar: String
+    private lateinit var wrongIndentDescription: String
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        val indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+        if (indentConfig.disabled) {
+            return
+        }
+
+        nextIndent = indentConfig.indent
+        when (indentConfig.indentStyle) {
+            IndentConfig.IndentStyle.SPACE -> {
+                wrongIndentChar = "\t"
+                wrongIndentDescription = "tab"
+            }
+            IndentConfig.IndentStyle.TAB -> {
+                wrongIndentChar = " "
+                wrongIndentDescription = "space"
+            }
+        }
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType == STRING_TEMPLATE) {
+            val psi = node.psi as KtStringTemplateExpression
+            if (psi.isMultiLine() && psi.isFollowedByTrimIndent()) {
+                if (node.containsMixedIndentationCharacters()) {
+                    // It can not be determined with certainty how mixed indentation characters should be interpreted. The trimIndent
+                    // function handles tabs and spaces equally (one tabs equals one space) while the user might expect that the tab size in
+                    // the indentation is more than one space.
+                    emit(node.startOffset, "Indentation of multiline raw string literal should not contain both tab(s) and space(s)", false)
+                    return
+                }
+
+                val indent = node.getIndent()
+//                indentWhiteSpaceBeforeStringTemplate(node, indent, emit, autoCorrect)
+                indentStringTemplate(node, indent, emit, autoCorrect)
+            }
+        }
+    }
+
+    private fun ASTNode.getIndent(): String {
+        // When executing this rule, the indentation rule may not have run yet. The functionality to determine the correct indentation level
+        // is out of scope of this rule as it is owned by the indentation rule. Therefore, the indentation of the line at which the
+        // string template is found, is assumed to be correct and is used to indent all lines of the string template. The indent will be
+        // fixed once the indent rule is run as well.
+        val firstWhiteSpaceLeafOnSameLine = this.prevLeaf { it.elementType == WHITE_SPACE && it.textContains('\n') }
+        return if (this.prevLeaf() == firstWhiteSpaceLeafOnSameLine) {
+            // The string template already is on a separate new line. Keep the current indent.
+            firstWhiteSpaceLeafOnSameLine.getTextAfterLastNewline()
+        } else {
+            // String template is forced to a new line. So indent must be increased
+            firstWhiteSpaceLeafOnSameLine.getTextAfterLastNewline() + nextIndent
+        }
+    }
+
+    private fun ASTNode?.getTextAfterLastNewline() =
+        this
+            ?.text
+            ?.split("\n")
+            ?.last()
+            ?: ""
+
+    private fun ASTNode.containsMixedIndentationCharacters(): Boolean {
+        require((this.psi as KtStringTemplateExpression).isMultiLine())
+        val nonBlankLines = this.getNonBlankLines()
+        val prefixLength =
+            nonBlankLines
+                .minOfOrNull { it.indentLength() }
+                ?: 0
+        val distinctIndentCharacters =
+            nonBlankLines
+                .joinToString(separator = "") {
+                    it.splitIndentAt(prefixLength).first
+                }
+                .toCharArray()
+                .distinct()
+                .count()
+        return distinctIndentCharacters > 1
+    }
+
+    private fun ASTNode.getNonBlankLines(): List<String> {
+        require(elementType == STRING_TEMPLATE)
+        return text
+            .split("\n")
+            .map { it.removePrefix(RAW_STRING_LITERAL_QUOTES) }
+            .map { it.removeSuffix(RAW_STRING_LITERAL_QUOTES) }
+            .filterNot { it.isBlank() }
+    }
+
+    private fun indentWhiteSpaceBeforeStringTemplate(
+        node: ASTNode,
+        indent: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        val prevLeaf = node.prevLeaf()!!
+        if (!prevLeaf.textContains('\n')) {
+            emit(prevLeaf.startOffset + 1, """Missing newline before raw string literal""", true)
+        } else if (prevLeaf.getTextAfterLastNewline() != indent) {
+            emit(prevLeaf.startOffset + 1, "Unexpected indent before opening quotes of raw string literal", true)
+        } else {
+            return
+        }
+
+        if (autoCorrect) {
+            prevLeaf.upsertWhitespaceAfterMe("\n" + indent)
+        }
+    }
+
+    private fun indentStringTemplate(
+        node: ASTNode,
+        newIndent: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        // Get the max prefix length that all lines in the multiline string have in common. All whitespace characters are counted as
+        // one single position. Note that the way of counting should be in sync with the way this is done by the trimIndent
+        // function.
+        val prefixLength =
+            node.text
+                .split("\n")
+                .asSequence()
+                .filterNot {
+                    // For a multiline raw string literal it is very unlikely that text after the opening quotes do contain indentation
+                    // characters (it really looks ugly). In such a case this text should be ignored when calculating the common prefix
+                    // length as otherwise it is probably set to 0.
+                    it.startsWith(RAW_STRING_LITERAL_QUOTES)
+                }
+                .map {
+                    // Indentation before the closing quotes however is relevant to take into account
+                    it.removeSuffix(RAW_STRING_LITERAL_QUOTES)
+                }
+                .filterNot { it.isBlank() }
+                .map { it.indentLength() }
+                .minOrNull() ?: 0
+
+        checkAndFixNewLineAfterOpeningQuotes(node, newIndent, emit, autoCorrect)
+
+        node
+            .children()
+            .filterNot { it.elementType == OPEN_QUOTE }
+            .filterNot {
+                // Blank lines inside the string template should not be indented
+                it.text == "\n"
+            }
+            .forEach {
+                if (it.prevLeaf()?.text == "\n") {
+                    val (currentIndent, currentContent) =
+                        if (it.isIndentBeforeClosingQuote()) {
+                            Pair(it.text, "")
+                        } else {
+                            it.text.splitIndentAt(prefixLength)
+                        }
+                    if (currentIndent.contains(wrongIndentChar)) {
+                        checkAndFixWrongIndentationChar(
+                            it = it,
+                            oldIndent = currentIndent,
+                            newIndent = newIndent,
+                            newContent = currentContent,
+                            emit = emit,
+                            autoCorrect = autoCorrect,
+                        )
+                    } else if (currentIndent != newIndent) {
+                        checkAndFixIndent(
+                            node = it,
+                            oldIndentLength = currentIndent.length,
+                            newIndent = newIndent,
+                            newContent = currentContent,
+                            autoCorrect = autoCorrect,
+                            emit = emit,
+                        )
+                    }
+                }
+            }
+
+        checkAndFixNewLineBeforeClosingQuotes(node, newIndent, emit, autoCorrect)
+    }
+
+    private fun checkAndFixNewLineAfterOpeningQuotes(
+        node: ASTNode,
+        indent: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        val firstNodeAfterOpeningQuotes = node.firstChildNode.nextLeaf() ?: return
+        if (firstNodeAfterOpeningQuotes.text.isNotBlank()) {
+            emit(
+                firstNodeAfterOpeningQuotes.startOffset + firstNodeAfterOpeningQuotes.text.length,
+                "Missing newline after the opening quotes of the raw string literal",
+                true,
+            )
+            if (autoCorrect) {
+                (firstNodeAfterOpeningQuotes as LeafPsiElement).rawReplaceWithText(
+                    "\n" + indent + firstNodeAfterOpeningQuotes.text,
+                )
+            }
+        }
+    }
+
+    private fun checkAndFixWrongIndentationChar(
+        it: ASTNode,
+        oldIndent: String,
+        newIndent: String,
+        newContent: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        emit(
+            it.startOffset + oldIndent.indexOf(wrongIndentChar),
+            "Unexpected '$wrongIndentDescription' character(s) in margin of multiline string",
+            true,
+        )
+        if (autoCorrect) {
+            (it.firstChildNode as LeafPsiElement).rawReplaceWithText(
+                newIndent + newContent,
+            )
+        }
+    }
+
+    private fun checkAndFixIndent(
+        node: ASTNode,
+        oldIndentLength: Int,
+        newIndent: String,
+        newContent: String,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        emit(
+            node.startOffset + oldIndentLength,
+            "Unexpected indent of raw string literal",
+            true,
+        )
+        if (autoCorrect) {
+            if (node.elementType == CLOSING_QUOTE) {
+                (node as LeafPsiElement).rawInsertBeforeMe(
+                    LeafPsiElement(REGULAR_STRING_PART, newIndent),
+                )
+            } else {
+                (node.firstChildLeafOrSelf() as LeafPsiElement).rawReplaceWithText(
+                    newIndent + newContent,
+                )
+            }
+        }
+    }
+
+    private fun checkAndFixNewLineBeforeClosingQuotes(
+        node: ASTNode,
+        indent: String,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        val lastNodeBeforeClosingQuotes = node.lastChildNode.prevLeaf() ?: return
+        if (lastNodeBeforeClosingQuotes.text.isNotBlank()) {
+            emit(
+                lastNodeBeforeClosingQuotes.startOffset + lastNodeBeforeClosingQuotes.text.length,
+                "Missing newline before the closing quotes of the raw string literal",
+                true,
+            )
+            if (autoCorrect) {
+                (lastNodeBeforeClosingQuotes as LeafPsiElement).rawReplaceWithText(
+                    lastNodeBeforeClosingQuotes.text + "\n" + indent,
+                )
+            }
+        }
+    }
+
+    private fun KtStringTemplateExpression.isMultiLine(): Boolean =
+        node
+            .children()
+            .any { it.elementType == LITERAL_STRING_TEMPLATE_ENTRY && it.text == "\n" }
+
+    private fun KtStringTemplateExpression.isFollowedByTrimIndent() =
+        node
+            .nextSibling { it.elementType != DOT }
+            .let { it?.elementType == CALL_EXPRESSION && it.text == "trimIndent()" }
+
+    private fun String.indentLength() =
+        indexOfFirst { !it.isWhitespace() }
+            .let { if (it == -1) length else it }
+
+    /**
+     * Splits the string at the given index or at the first non-white space character before that index. The returned pair
+     * consists of the indentation and the second part contains the remainder. Note that the second part still can start
+     * with whitespace characters in case the original strings starts with more white space characters than the requested
+     * split index.
+     */
+    private fun String.splitIndentAt(index: Int): Pair<String, String> {
+        require(index >= 0)
+        val firstNonWhitespaceIndex =
+            indexOfFirst { !it.isWhitespace() }
+                .let {
+                    if (it == -1) {
+                        this.length
+                    } else {
+                        it
+                    }
+                }
+        val safeIndex = kotlin.math.min(firstNonWhitespaceIndex, index)
+        return Pair(
+            first = this.take(safeIndex),
+            second = this.substring(safeIndex),
+        )
+    }
+
+    private fun ASTNode.isIndentBeforeClosingQuote() = text.isBlank() && nextCodeSibling()?.elementType == CLOSING_QUOTE
+
+    private companion object {
+        const val RAW_STRING_LITERAL_QUOTES = "\"\"\""
+    }
+}
+
+public val STRING_TEMPLATE_INDENT_RULE_ID: RuleId = StringTemplateIndentRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
@@ -24,11 +24,11 @@ class IfElseBracingRuleTest {
     fun `Given another code style then ktlint_official and IF with inconsistent bracing of the branches`(codeStyle: CodeStyleValue) {
         val code =
             """
-                fun foo() {
-                    if (true) {
-                        doSomething()
-                    } else doSomethingElse()
-                }
+            fun foo() {
+                if (true) {
+                    doSomething()
+                } else doSomethingElse()
+            }
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
@@ -46,21 +46,21 @@ class IfElseBracingRuleTest {
     ) {
         val code =
             """
-                fun foo() {
-                    if (true) {
-                        doSomething()
-                    } else doSomethingElse()
-                }
+            fun foo() {
+                if (true) {
+                    doSomething()
+                } else doSomethingElse()
+            }
             """.trimIndent()
         val formattedCode =
             """
-                fun foo() {
-                    if (true) {
-                        doSomething()
-                    } else {
-                        doSomethingElse()
-                    }
+            fun foo() {
+                if (true) {
+                    doSomething()
+                } else {
+                    doSomethingElse()
                 }
+            }
             """.trimIndent()
         @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
         multiLineIfElseRuleAssertThat(code)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
@@ -13,27 +13,27 @@ internal class ParameterWrappingRuleTest {
     fun `Given that the variable name and the following colon do not fit on the same line as val or var keyword then wrap after the colon`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo,
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo,
-                )
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo,
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo,
+            )
             """.trimIndent()
         val formattedCode =
             // TODO: fix test when changing the default code style to 'ktlint_official'. The variable type is not indented for the
             //  current default code style.
             """
-                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong:
-                    Foo,
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong:
-                    Foo,
-                )
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong:
+                Foo,
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong:
+                Foo,
+            )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -48,31 +48,31 @@ internal class ParameterWrappingRuleTest {
     fun `Given that the type does not fit on the same line as the variable name`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo,
-                    val foooooooooooooNotTooLong: Foo,
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo,
-                    foooooooooooooooooNotTooLong: Foo,
-                )
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo,
+                val foooooooooooooNotTooLong: Foo,
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo,
+                foooooooooooooooooNotTooLong: Foo,
+            )
             """.trimIndent()
         val formattedCode =
             // TODO: fix test when changing the default code style to 'ktlint_official'. The variable type is not indented for the
             //  current default code style.
             """
-                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong:
-                    Foo,
-                    val foooooooooooooNotTooLong: Foo,
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong:
-                    Foo,
-                    foooooooooooooooooNotTooLong: Foo,
-                )
+            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong:
+                Foo,
+                val foooooooooooooNotTooLong: Foo,
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong:
+                Foo,
+                foooooooooooooooooNotTooLong: Foo,
+            )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -87,31 +87,31 @@ internal class ParameterWrappingRuleTest {
     fun `Given that equals sign before the value does not fit on the same line as the type and variable name then wrap after the equals sign`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo = Foo(),
-                    val foooooooooooooNotTooLong: Foo = Foo(),
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo = Foo(),
-                    foooooooooooooooooNotTooLong: Foo = Foo(),
-                )
+            // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo = Foo(),
+                val foooooooooooooNotTooLong: Foo = Foo(),
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo = Foo(),
+                foooooooooooooooooNotTooLong: Foo = Foo(),
+            )
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo =
-                        Foo(),
-                    val foooooooooooooNotTooLong: Foo =
-                        Foo(),
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo =
-                        Foo(),
-                    foooooooooooooooooNotTooLong: Foo =
-                        Foo(),
-                )
+            // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo =
+                    Foo(),
+                val foooooooooooooNotTooLong: Foo =
+                    Foo(),
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo =
+                    Foo(),
+                foooooooooooooooooNotTooLong: Foo =
+                    Foo(),
+            )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -128,29 +128,29 @@ internal class ParameterWrappingRuleTest {
     fun `Given that the value does not fit on the same line as the type and variable name then wrap after the equals sign`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo = Foo(),
-                    val foooooooooooooNotTooLong: Foo = Foo(),
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo = Foo(),
-                    foooooooooooooooooNotTooLong: Foo = Foo(),
-                )
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo = Foo(),
+                val foooooooooooooNotTooLong: Foo = Foo(),
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo = Foo(),
+                foooooooooooooooooNotTooLong: Foo = Foo(),
+            )
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
-                class Bar(
-                    val foooooooooooooooooTooLong: Foo =
-                        Foo(),
-                    val foooooooooooooNotTooLong: Foo = Foo(),
-                )
-                fun bar(
-                    foooooooooooooooooooooTooLong: Foo =
-                        Foo(),
-                    foooooooooooooooooNotTooLong: Foo = Foo(),
-                )
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            class Bar(
+                val foooooooooooooooooTooLong: Foo =
+                    Foo(),
+                val foooooooooooooNotTooLong: Foo = Foo(),
+            )
+            fun bar(
+                foooooooooooooooooooooTooLong: Foo =
+                    Foo(),
+                foooooooooooooooooNotTooLong: Foo = Foo(),
+            )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
             .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
@@ -13,14 +13,14 @@ internal class PropertyWrappingRuleTest {
     fun `Given that the variable name and the following colon do not fit on the same line as val or var keyword then wrap after the colon`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-                val aVariableWithALooooooongName: String
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            val aVariableWithALooooooongName: String
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-                val aVariableWithALooooooongName:
-                    String
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            val aVariableWithALooooooongName:
+                String
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -33,16 +33,16 @@ internal class PropertyWrappingRuleTest {
     fun `Given that the type does not fit on the same line as the variable name`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
-                val aVariableWithALongerName: TypeWithALongName
-                val aVariableWithALongName2: TypeWithALongName
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            val aVariableWithALongerName: TypeWithALongName
+            val aVariableWithALongName2: TypeWithALongName
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
-                val aVariableWithALongerName:
-                    TypeWithALongName
-                val aVariableWithALongName2: TypeWithALongName
+            // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
+            val aVariableWithALongerName:
+                TypeWithALongName
+            val aVariableWithALongName2: TypeWithALongName
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -55,17 +55,17 @@ internal class PropertyWrappingRuleTest {
     fun `Given that equals sign before the value does not fit on the same line as the type and variable name then wrap after the equals sign`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
-                val aVariableWithALongName: TypeWithALongerName = TypeWithALongName(123)
-                val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            val aVariableWithALongName: TypeWithALongerName = TypeWithALongName(123)
+            val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
-                val aVariableWithALongName: TypeWithALongerName =
-                    TypeWithALongName(123)
-                val aVariableWithALongName: TypeWithALongName2 =
-                    TypeWithALongName(123)
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            val aVariableWithALongName: TypeWithALongerName =
+                TypeWithALongName(123)
+            val aVariableWithALongName: TypeWithALongName2 =
+                TypeWithALongName(123)
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -80,16 +80,16 @@ internal class PropertyWrappingRuleTest {
     fun `Given that the value does not fit on the same line as the type and variable name then wrap after the equals sign`() {
         val code =
             """
-                // $MAX_LINE_LENGTH_MARKER                                            $EOL_CHAR
-                val aVariableWithALongName: TypeWithALongerName = TypeWithALongName(123)
-                val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
+            // $MAX_LINE_LENGTH_MARKER                                            $EOL_CHAR
+            val aVariableWithALongName: TypeWithALongerName = TypeWithALongName(123)
+            val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
             """.trimIndent()
         val formattedCode =
             """
-                // $MAX_LINE_LENGTH_MARKER                                            $EOL_CHAR
-                val aVariableWithALongName: TypeWithALongerName =
-                    TypeWithALongName(123)
-                val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
+            // $MAX_LINE_LENGTH_MARKER                                            $EOL_CHAR
+            val aVariableWithALongName: TypeWithALongerName =
+                TypeWithALongName(123)
+            val aVariableWithALongName: TypeWithALongName2 = TypeWithALongName(123)
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
@@ -1,0 +1,423 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
+import com.pinterest.ktlint.test.TAB
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class StringTemplateIndentRuleTest {
+    private val stringTemplateIndentRuleAssertThat =
+        assertThatRule(
+            provider = { StringTemplateIndentRule() },
+            additionalRuleProviders =
+                setOf(
+                    RuleProvider { MultilineExpressionWrapping() },
+                    RuleProvider { IndentationRule() },
+                ),
+            editorConfigProperties = setOf(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official),
+        )
+
+    @Test
+    fun `Do not move a multiline string literal after return statement to a new line as that results in a compilation error`() {
+        val code =
+            """
+            fun someFunction() {
+                return $MULTILINE_STRING_QUOTE
+                       someText
+                       $MULTILINE_STRING_QUOTE.trimIndent()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun someFunction() {
+                return $MULTILINE_STRING_QUOTE
+                    someText
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+            }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 12, "Unexpected indent of raw string literal"),
+                LintViolation(4, 12, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Move a multiline string literal (indented with tabs) as body expression`() {
+        val code =
+            """
+            fun someFunction() = $MULTILINE_STRING_QUOTE
+            ${TAB}${TAB}${TAB}${TAB}someText
+            ${TAB}${TAB}${TAB}${TAB}$MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun someFunction() =
+            ${TAB}$MULTILINE_STRING_QUOTE
+            ${TAB}someText
+            ${TAB}$MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .withEditorConfigOverride(INDENT_STYLE_PROPERTY to IndentConfig.IndentStyle.TAB)
+            .hasLintViolations(
+                LintViolation(2, 5, "Unexpected indent of raw string literal"),
+                LintViolation(3, 5, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `A multiline raw string literal containing both tabs and spaces in the indentation margin can not be autocorrected` {
+        @Suppress("RemoveCurlyBracesFromTemplate")
+        @Test
+        fun `Mixed indentation characters on inner lines`() {
+            val code =
+                """
+                val foo = $MULTILINE_STRING_QUOTE
+                      line1
+                ${TAB} line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
+                1,
+                11,
+                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
+            )
+        }
+
+        @Suppress("RemoveCurlyBracesFromTemplate", "RemoveCurlyBracesFromTemplate")
+        @Test
+        fun `Mixed indentation characters including line with opening quotes`() {
+            val code =
+                """
+                val foo = $MULTILINE_STRING_QUOTE${TAB}line1
+                    ${TAB} line2
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
+                1,
+                11,
+                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
+            )
+        }
+
+        @Suppress("RemoveCurlyBracesFromTemplate")
+        @Test
+        fun `Mixed indentation characters including line with closing quotes`() {
+            val code =
+                """
+                val foo = $MULTILINE_STRING_QUOTE
+                    ${TAB}line1
+                    ${TAB} line2$MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
+                1,
+                11,
+                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
+            )
+        }
+    }
+
+    @Test
+    fun `A multiline raw string literal should not contain text on the same line as the opening quotes`() {
+        val code =
+            """
+            val someVar =
+                ${MULTILINE_STRING_QUOTE}line1
+                line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val someVar =
+                $MULTILINE_STRING_QUOTE
+                line1
+                line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolation(2, 13, "Missing newline after the opening quotes of the raw string literal")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `A multiline raw string literal can contain text on the same line as the closing quotes`() {
+        val code =
+            """
+            val someVar = $MULTILINE_STRING_QUOTE
+                          line1
+                          line2$MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val someVar =
+                $MULTILINE_STRING_QUOTE
+                line1
+                line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 15, "Unexpected indent of raw string literal"),
+                LintViolation(3, 15, "Unexpected indent of raw string literal"),
+                LintViolation(3, 20, "Missing newline before the closing quotes of the raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Move a multiline raw string literal assignment to a variable to a new line`() {
+        val code =
+            """
+            val someVar = $MULTILINE_STRING_QUOTE
+                          someText
+                          $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val someVar =
+                $MULTILINE_STRING_QUOTE
+                someText
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 15, "Unexpected indent of raw string literal"),
+                LintViolation(3, 15, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Move a multiline string literal in a function parameter to a new line`() {
+        val code =
+            """
+            fun someFunction() {
+                println($MULTILINE_STRING_QUOTE
+                        someText
+                        $MULTILINE_STRING_QUOTE.trimIndent())
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun someFunction() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                    someText
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 13, "Unexpected indent of raw string literal"),
+                LintViolation(4, 13, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Format a multiline string literal with text starting at position 1 of the line`() {
+        val code =
+            """
+            fun foo() {
+                println($MULTILINE_STRING_QUOTE
+            Some text starting at the beginning of the line
+
+                Some text not starting at the beginning of the line
+            $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                println(
+                    $MULTILINE_STRING_QUOTE
+                    Some text starting at the beginning of the line
+
+                        Some text not starting at the beginning of the line
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                )
+            }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 1, "Unexpected indent of raw string literal"),
+                LintViolation(5, 1, "Unexpected indent of raw string literal"),
+                LintViolation(6, 1, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Format multiline string with unexpected tabs in indentation margin`() {
+        val code =
+            """
+            val str = $MULTILINE_STRING_QUOTE
+            ${TAB}line1
+            ${TAB}${TAB}line2
+            $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val str =
+                $MULTILINE_STRING_QUOTE
+                line1
+                ${TAB}line2
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 1, "Unexpected 'tab' character(s) in margin of multiline string"),
+                LintViolation(3, 1, "Unexpected 'tab' character(s) in margin of multiline string"),
+                LintViolation(4, 1, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Suppress("RemoveCurlyBracesFromTemplate")
+    @Test
+    fun `Format multiline string without tabs in the indentation margin`() {
+        val code =
+            """
+            val str = $MULTILINE_STRING_QUOTE
+                  ${TAB}Tab at the beginning of this line but after the indentation margin
+                  Tab${TAB}in the middle of this string
+                  Tab at the end of this line.${TAB}
+            $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val str =
+                $MULTILINE_STRING_QUOTE
+                ${TAB}Tab at the beginning of this line but after the indentation margin
+                Tab${TAB}in the middle of this string
+                Tab at the end of this line.${TAB}
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 7, "Unexpected indent of raw string literal"),
+                LintViolation(3, 7, "Unexpected indent of raw string literal"),
+                LintViolation(4, 7, "Unexpected indent of raw string literal"),
+                LintViolation(5, 1, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `lint property delegate is indented properly 1`() {
+        val code =
+            """
+            val string: String
+                by lazy { $MULTILINE_STRING_QUOTE
+                          someText
+                          $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val string: String
+                by lazy {
+                    $MULTILINE_STRING_QUOTE
+                    someText
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 15, "Unexpected indent of raw string literal"),
+                LintViolation(4, 15, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `lint property delegate is indented properly 4`() {
+        val code =
+            """
+            fun lazyString() = lazy { $MULTILINE_STRING_QUOTE
+                                      someText
+                                      $MULTILINE_STRING_QUOTE.trimIndent()
+                                    }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun lazyString() =
+                lazy {
+                    $MULTILINE_STRING_QUOTE
+                    someText
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 27, "Unexpected indent of raw string literal"),
+                LintViolation(3, 27, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `lint parameter with default multiline string raw string literal`() {
+        val code =
+            """
+            data class SomeDataClass(
+                val string: String = $MULTILINE_STRING_QUOTE
+                                     someText
+                                     $MULTILINE_STRING_QUOTE.trimIndent(),
+                val int: Int
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            data class SomeDataClass(
+                val string: String =
+                    $MULTILINE_STRING_QUOTE
+                    someText
+                    $MULTILINE_STRING_QUOTE.trimIndent(),
+                val int: Int
+            )
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 26, "Unexpected indent of raw string literal"),
+                LintViolation(4, 26, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `lint parameter with multiline string raw string literal after arrow`() {
+        val code =
+            """
+            val result = when {
+                someBooleanFunction() -> $MULTILINE_STRING_QUOTE
+                                         someText
+                                         $MULTILINE_STRING_QUOTE.trimIndent()
+                else -> $MULTILINE_STRING_QUOTE
+                        someOtherText
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val result =
+                when {
+                    someBooleanFunction() ->
+                        $MULTILINE_STRING_QUOTE
+                        someText
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                    else ->
+                        $MULTILINE_STRING_QUOTE
+                        someOtherText
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 30, "Unexpected indent of raw string literal"),
+                LintViolation(4, 30, "Unexpected indent of raw string literal"),
+                LintViolation(6, 13, "Unexpected indent of raw string literal"),
+                LintViolation(7, 13, "Unexpected indent of raw string literal"),
+            ).isFormattedAs(formattedCode)
+    }
+}


### PR DESCRIPTION
## Description

Add new experimental rule `string-template-indent` for `ktlint_official` code style

This rule forces multiline string templates which are post-fixed with `.trimIndent()` to be formatted consistently. The opening and closing `"""` are placed on separate lines and the indentation of the content of the template is aligned with the `"""`.

Closes #925

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
