### PR TITLE
Unit test for loading properties from editorConfigProperties for snippet

### DIFF
--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -262,6 +262,31 @@ internal class EditorConfigLoaderTest {
                         .contains("some_property = some_value")
                 }
         }
+
+        @Test
+        fun `Given some properties in an editorconfig file which is passed in as default editorconfig then return the properties from this file`() {
+            ktlintTestFileSystem.apply {
+                writeEditorConfigFile(
+                    "some/dir",
+                    //language=EditorConfig
+                    """
+                    [*.{kt,kts}]
+                    some_property = some_value
+                    """.trimIndent(),
+                )
+            }
+
+            val editorConfigDefaults = EditorConfigDefaults.load(
+                path = ktlintTestFileSystem.resolve("some/dir/.editorconfig"),
+                propertyTypes = setOf(SOME_EDITOR_CONFIG_PROPERTY.type)
+            )
+            createEditorConfigLoader(editorConfigDefaults)
+                .load(ktlintTestFileSystem.resolve(".kt"))
+                .run {
+                    assertThat(convertToPropertyValues())
+                        .contains("some_property = some_value")
+                }
+        }
     }
 
     @Nested

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -276,10 +276,11 @@ internal class EditorConfigLoaderTest {
                 )
             }
 
-            val editorConfigDefaults = EditorConfigDefaults.load(
-                path = ktlintTestFileSystem.resolve("some/dir/.editorconfig"),
-                propertyTypes = setOf(SOME_EDITOR_CONFIG_PROPERTY.type)
-            )
+            val editorConfigDefaults =
+                EditorConfigDefaults.load(
+                    path = ktlintTestFileSystem.resolve("some/dir/.editorconfig"),
+                    propertyTypes = setOf(SOME_EDITOR_CONFIG_PROPERTY.type),
+                )
             createEditorConfigLoader(editorConfigDefaults)
                 .load(ktlintTestFileSystem.resolve(".kt"))
                 .run {


### PR DESCRIPTION
## Description

Verifies that `.editorconfig` properties are loaded via the EditorConfigDefaults.load(...) when a `Code.fromSnippet(...)` is being passed to the `ktlintRuleEngine`.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
