### PR TITLE
Try to enable Gradle Daemon again

### DIFF
--- a/.github/workflows/gradle-pr-build.yml
+++ b/.github/workflows/gradle-pr-build.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
 
 env:
-  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+  ORG_GRADLE_PROJECT_signingKey : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
   ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-  ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+  ORG_GRADLE_PROJECT_signingKeyPassword : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
   CLI_TEST_MAX_DURATION_IN_SECONDS: 10
 
 jobs:
@@ -21,9 +21,6 @@ jobs:
         # When changing the list of JDK versions, the build configuration has to be changed by a repository admin. See
         # https://github.com/pinterest/ktlint/pull/1787#issuecomment-1409074092
         jdk: [ 8, 11, 17, 19 ]
-        exclude: # windows with JDK8 are *really* flaky
-          - os: windows-latest
-            jdk: 8
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -35,9 +32,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build with release Kotlin version
-        run: ./gradlew build ktlint
+        run: ./gradlew build ktlint --no-daemon
       - name: Build with dev Kotlin version
-        run: ./gradlew -PkotlinDev build ktlint
+        run: ./gradlew -PkotlinDev build ktlint --no-daemon
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/gradle-pr-build.yml
+++ b/.github/workflows/gradle-pr-build.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
 
 env:
-  ORG_GRADLE_PROJECT_signingKey : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
   ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-  ORG_GRADLE_PROJECT_signingKeyPassword : ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+  ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
   CLI_TEST_MAX_DURATION_IN_SECONDS: 10
 
 jobs:
@@ -21,6 +21,9 @@ jobs:
         # When changing the list of JDK versions, the build configuration has to be changed by a repository admin. See
         # https://github.com/pinterest/ktlint/pull/1787#issuecomment-1409074092
         jdk: [ 8, 11, 17, 19 ]
+        exclude: # windows with JDK8 are *really* flaky
+          - os: windows-latest
+            jdk: 8
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -32,9 +35,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build with release Kotlin version
-        run: ./gradlew build ktlint --no-daemon
+        run: ./gradlew build ktlint
       - name: Build with dev Kotlin version
-        run: ./gradlew -PkotlinDev build ktlint --no-daemon
+        run: ./gradlew -PkotlinDev build ktlint
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/gradle-pr-build.yml
+++ b/.github/workflows/gradle-pr-build.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build with release Kotlin version
-        run: ./gradlew build ktlint --no-daemon
+        run: ./gradlew build ktlint
       - name: Build with dev Kotlin version
-        run: ./gradlew -PkotlinDev build ktlint --no-daemon
+        run: ./gradlew -PkotlinDev build ktlint
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.gradle.enterprise.gradleplugin.testretry.retry
 import java.net.URL
 
 plugins {
@@ -18,6 +19,13 @@ allprojects {
             useJUnitPlatform()
         } else {
             logger.warn("Skipping tests for task '$name' as system property 'skipTests=$skipTests'")
+        }
+
+        retry {
+            if (System.getenv().containsKey("CI")) {
+                maxRetries.set(3)
+                maxFailures.set(20)
+            }
         }
 
         val args = mutableSetOf<String>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.gradle.enterprise.gradleplugin.testretry.retry
 import java.net.URL
 
 plugins {
@@ -19,13 +18,6 @@ allprojects {
             useJUnitPlatform()
         } else {
             logger.warn("Skipping tests for task '$name' as system property 'skipTests=$skipTests'")
-        }
-
-        retry {
-            if (System.getenv().containsKey("CI")) {
-                maxRetries.set(3)
-                maxFailures.set(20)
-            }
         }
 
         val args = mutableSetOf<String>()


### PR DESCRIPTION
## Description

Gradle Daemon was disabled for PR Build jobs in #1584 as some there were flaky tests on Windows, re-enable it for now.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
