### PR TITLE
Respect formatter tags when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Do not remove newlines from multiline type parameter lists `type-parameter-list-spacing` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
 * Wrap each type parameter in a multiline type parameter list `wrapping` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
 * Allow value arguments with a multiline expression to be indented on a separate line `indent` ([#1217](https://github.com/pinterest/ktlint/issues/1217))
+* When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags (see [faq](https://pinterest.github.io/ktlint/faq/#are-formatter-tags-respected)) ([#670](https://github.com/pinterest/ktlint/issues/670)) 
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -112,9 +112,9 @@ or
 ```
 
 ## How do I globally disable a rule?
-With [`.editorConfig` property `disabled_rules`](../rules/configuration-ktlint#disabled-rules) a rule can be disabled globally.
+Rules can be disabled globally by setting a [`.editorConfig` property](../rules/configuration-ktlint#disabled-rules).
 
-You may also pass a list of disabled rules via the `--disabled_rules` command line flag. It has the same syntax as the EditorConfig property.
+You may also pass a list of disabled rules via the `--disabled_rules` command line flag of Ktlint CLI. The value is a comma separated list of rule id's that have to be disabled. The rule id must be fully qualified (e.g. must be prefixed with the rule set id). 
 
 
 ## Why is `.editorconfig` property `disabled_rules` deprecated and how do I resolve this?
@@ -199,3 +199,14 @@ kotlinFile.writeText(
   )
 )
 ```
+
+# Are formatter tags respected?
+
+As of version `0.49.x` the formatter tags of IntelliJ IDEA are respected. By default, those formatter tags are disabled. The formatter tags can be enabled with `.editorconfig` properties below:
+```editorconfig
+ij_formatter_tags_enabled = true # Defaults to 'false'
+ij_formatter_off_tag = some-custom-off-tag # Defaults to '@formatter:off'
+ij_formatter_on_tag = some-custom-on-tag # Defaults to '@formatter:on'
+```
+
+When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags.

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -13,6 +13,9 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EXPERIMENTAL_RULES
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAGS_ENABLED_PROPERTY
+import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAG_OFF_ENABLED_PROPERTY
+import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAG_ON_ENABLED_PROPERTY
 import com.pinterest.ktlint.rule.engine.internal.ThreadSafeEditorConfigCache.Companion.THREAD_SAFE_EDITOR_CONFIG_CACHE
 import mu.KotlinLogging
 import org.ec4j.core.EditorConfigLoader
@@ -98,6 +101,18 @@ internal class EditorConfigLoader(
                          * Used by [VisitorProvider] to determine whether experimental rules have to be executed.
                          */
                         EXPERIMENTAL_RULES_EXECUTION_PROPERTY,
+                        /**
+                         * Used by [FormatterTags] to determine whether formatter tags should be respected.
+                         */
+                        FORMATTER_TAGS_ENABLED_PROPERTY,
+                        /**
+                         * Used by [FormatterTags] to get the tag to disable the formatter.
+                         */
+                        FORMATTER_TAG_OFF_ENABLED_PROPERTY,
+                        /**
+                         * Used by [FormatterTags] to get the tag to enable the formatter.
+                         */
+                        FORMATTER_TAG_ON_ENABLED_PROPERTY,
                     )
             }
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/FormatterTags.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/FormatterTags.kt
@@ -1,0 +1,59 @@
+package com.pinterest.ktlint.rule.engine.internal
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import org.ec4j.core.model.PropertyType
+
+internal data class FormatterTags(
+    val formatterTagOff: String?,
+    val formatterTagOn: String?,
+) {
+    companion object {
+        private val DISABLED_FORMATTER_TAGS = FormatterTags(null, null)
+
+        fun from(editorConfig: EditorConfig): FormatterTags =
+            if (editorConfig[FORMATTER_TAGS_ENABLED_PROPERTY]) {
+                FormatterTags(
+                    formatterTagOff = editorConfig[FORMATTER_TAG_OFF_ENABLED_PROPERTY],
+                    formatterTagOn = editorConfig[FORMATTER_TAG_ON_ENABLED_PROPERTY],
+                )
+            } else {
+                DISABLED_FORMATTER_TAGS
+            }
+
+        val FORMATTER_TAGS_ENABLED_PROPERTY: EditorConfigProperty<Boolean> =
+            EditorConfigProperty(
+                type =
+                PropertyType.LowerCasingPropertyType(
+                    "ij_formatter_tags_enabled",
+                    "When enabled, IntelliJ IDEA Formatter tags will be respected (e.g. disable and enable all ktlint rules for the " +
+                            "code enclosed between the formatter tags.",
+                    PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                    setOf(true.toString(), false.toString()),
+                ),
+                defaultValue = false,
+            )
+
+        val FORMATTER_TAG_OFF_ENABLED_PROPERTY: EditorConfigProperty<String> =
+            EditorConfigProperty(
+                type =
+                PropertyType.LowerCasingPropertyType(
+                    "ij_formatter_off_tag",
+                    "The IntelliJ IDEA formatter tag to disable formatting. This also disables the ktlint rules.",
+                    PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                ),
+                defaultValue = "@formatter:off",
+            )
+
+        val FORMATTER_TAG_ON_ENABLED_PROPERTY: EditorConfigProperty<String> =
+            EditorConfigProperty(
+                type =
+                PropertyType.LowerCasingPropertyType(
+                    "ij_formatter_on_tag",
+                    "The IntelliJ IDEA formatter tag to enable formatting. This also enables the ktlint rules.",
+                    PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                ),
+                defaultValue = "@formatter:on",
+            )
+    }
+}

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/FormatterTags.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/FormatterTags.kt
@@ -24,35 +24,35 @@ internal data class FormatterTags(
         val FORMATTER_TAGS_ENABLED_PROPERTY: EditorConfigProperty<Boolean> =
             EditorConfigProperty(
                 type =
-                PropertyType.LowerCasingPropertyType(
-                    "ij_formatter_tags_enabled",
-                    "When enabled, IntelliJ IDEA Formatter tags will be respected (e.g. disable and enable all ktlint rules for the " +
+                    PropertyType.LowerCasingPropertyType(
+                        "ij_formatter_tags_enabled",
+                        "When enabled, IntelliJ IDEA Formatter tags will be respected (e.g. disable and enable all ktlint rules for the " +
                             "code enclosed between the formatter tags.",
-                    PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
-                    setOf(true.toString(), false.toString()),
-                ),
+                        PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER,
+                        setOf(true.toString(), false.toString()),
+                    ),
                 defaultValue = false,
             )
 
         val FORMATTER_TAG_OFF_ENABLED_PROPERTY: EditorConfigProperty<String> =
             EditorConfigProperty(
                 type =
-                PropertyType.LowerCasingPropertyType(
-                    "ij_formatter_off_tag",
-                    "The IntelliJ IDEA formatter tag to disable formatting. This also disables the ktlint rules.",
-                    PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
-                ),
+                    PropertyType.LowerCasingPropertyType(
+                        "ij_formatter_off_tag",
+                        "The IntelliJ IDEA formatter tag to disable formatting. This also disables the ktlint rules.",
+                        PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                    ),
                 defaultValue = "@formatter:off",
             )
 
         val FORMATTER_TAG_ON_ENABLED_PROPERTY: EditorConfigProperty<String> =
             EditorConfigProperty(
                 type =
-                PropertyType.LowerCasingPropertyType(
-                    "ij_formatter_on_tag",
-                    "The IntelliJ IDEA formatter tag to enable formatting. This also enables the ktlint rules.",
-                    PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
-                ),
+                    PropertyType.LowerCasingPropertyType(
+                        "ij_formatter_on_tag",
+                        "The IntelliJ IDEA formatter tag to enable formatting. This also enables the ktlint rules.",
+                        PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+                    ),
                 defaultValue = "@formatter:on",
             )
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -39,7 +39,7 @@ internal class RuleExecutionContext private constructor(
     }
 
     fun rebuildSuppressionLocator() {
-        suppressionLocator = SuppressionLocatorBuilder.buildSuppressedRegionsLocator(rootNode)
+        suppressionLocator = SuppressionLocatorBuilder.buildSuppressedRegionsLocator(rootNode, editorConfig)
     }
 
     fun executeRule(

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
@@ -50,7 +50,10 @@ internal object SuppressionLocatorBuilder {
     /**
      * Builds [SuppressionLocator] for given [rootNode] of AST tree.
      */
-    fun buildSuppressedRegionsLocator(rootNode: ASTNode, editorConfig: EditorConfig): SuppressionLocator {
+    fun buildSuppressedRegionsLocator(
+        rootNode: ASTNode,
+        editorConfig: EditorConfig,
+    ): SuppressionLocator {
         val hintsList = collect(rootNode, FormatterTags.from(editorConfig))
         return if (hintsList.isEmpty()) {
             NO_SUPPRESSION
@@ -66,7 +69,10 @@ internal object SuppressionLocatorBuilder {
                 .any { hint -> hint.disabledRuleIds.isEmpty() || hint.disabledRuleIds.contains(ruleId) }
         }
 
-    private fun collect(rootNode: ASTNode, formatterTags: FormatterTags): List<SuppressionHint> {
+    private fun collect(
+        rootNode: ASTNode,
+        formatterTags: FormatterTags,
+    ): List<SuppressionHint> {
         val suppressionHints = ArrayList<SuppressionHint>()
         val commentSuppressionsHints = mutableListOf<CommentSuppressionHint>()
         rootNode.collect { node ->
@@ -84,7 +90,7 @@ internal object SuppressionLocatorBuilder {
         }
 
         return suppressionHints.plus(
-            commentSuppressionsHints.toSuppressionHints(rootNode)
+            commentSuppressionsHints.toSuppressionHints(rootNode),
         )
     }
 
@@ -113,7 +119,7 @@ internal object SuppressionLocatorBuilder {
                 CommentSuppressionHint(
                     this,
                     HashSet(parts.tailToRuleIds()),
-                    EOL
+                    EOL,
                 )
             }
 
@@ -142,9 +148,7 @@ internal object SuppressionLocatorBuilder {
                 }
             }
 
-    private fun MutableList<CommentSuppressionHint>.toSuppressionHints(
-        rootNode: ASTNode
-    ): MutableList<SuppressionHint> {
+    private fun MutableList<CommentSuppressionHint>.toSuppressionHints(rootNode: ASTNode): MutableList<SuppressionHint> {
         val suppressionHints = mutableListOf<SuppressionHint>()
         val blockCommentSuppressionHints = mutableListOf<CommentSuppressionHint>()
         forEach { commentSuppressionHint ->
@@ -154,8 +158,8 @@ internal object SuppressionLocatorBuilder {
                     suppressionHints.add(
                         SuppressionHint(
                             IntRange(commentNode.prevNewLineOffset(), commentNode.startOffset),
-                            commentSuppressionHint.disabledRuleIds
-                        )
+                            commentSuppressionHint.disabledRuleIds,
+                        ),
                     )
                 }
 
@@ -173,8 +177,8 @@ internal object SuppressionLocatorBuilder {
                             suppressionHints.add(
                                 SuppressionHint(
                                     IntRange(openHint.node.startOffset, commentSuppressionHint.node.startOffset - 1),
-                                    commentSuppressionHint.disabledRuleIds
-                                )
+                                    commentSuppressionHint.disabledRuleIds,
+                                ),
                             )
                         }
                 }
@@ -184,7 +188,7 @@ internal object SuppressionLocatorBuilder {
             blockCommentSuppressionHints.map {
                 SuppressionHint(
                     IntRange(it.node.startOffset, rootNode.textLength),
-                    it.disabledRuleIds
+                    it.disabledRuleIds,
                 )
             },
         )
@@ -274,7 +278,7 @@ internal object SuppressionLocatorBuilder {
     private data class CommentSuppressionHint(
         val node: ASTNode,
         val disabledRuleIds: Set<RuleId> = emptySet(),
-        val type: Type
+        val type: Type,
     ) {
         enum class Type {
             EOL,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -226,6 +226,9 @@ internal class EditorConfigLoaderTest {
                     assertThat(convertToPropertyValues())
                         .containsExactlyInAnyOrder(
                             "end_of_line = lf",
+                            "ij_formatter_tags_enabled = false",
+                            "ij_formatter_off_tag = @formatter:off",
+                            "ij_formatter_on_tag = @formatter:on",
                             "ktlint_code_style = intellij_idea",
                             "ktlint_experimental = disabled",
                         )
@@ -300,6 +303,9 @@ internal class EditorConfigLoaderTest {
                     assertThat(convertToPropertyValues())
                         .containsExactlyInAnyOrder(
                             "end_of_line = lf",
+                            "ij_formatter_tags_enabled = false",
+                            "ij_formatter_off_tag = @formatter:off",
+                            "ij_formatter_on_tag = @formatter:on",
                             "ktlint_code_style = intellij_idea",
                             "ktlint_experimental = disabled",
                         )
@@ -348,6 +354,9 @@ internal class EditorConfigLoaderTest {
                     assertThat(convertToPropertyValues())
                         .containsExactlyInAnyOrder(
                             "end_of_line = lf",
+                            "ij_formatter_tags_enabled = false",
+                            "ij_formatter_off_tag = @formatter:off",
+                            "ij_formatter_on_tag = @formatter:on",
                             "ktlint_code_style = intellij_idea",
                             "ktlint_experimental = disabled",
                         )

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
@@ -220,17 +220,17 @@ class SuppressionLocatorBuilderTest {
         fun `Given that a NoFooIdentifierRule violation is suppressed with the default formatter tags in a block comment then do not find a violation in that block`() {
             val code =
                 """
-            /* @formatter:off */
-            val fooNotReported = "foo"
-            /* @formatter:on */
-            val fooReported = "foo"
-            """.trimIndent()
+                /* @formatter:off */
+                val fooNotReported = "foo"
+                /* @formatter:on */
+                val fooReported = "foo"
+                """.trimIndent()
 
-            val actual = lint(
-                code,
-                editorConfigOverride = EditorConfigOverride.from(FORMATTER_TAGS_ENABLED_PROPERTY to true)
-            )
-
+            val actual =
+                lint(
+                    code,
+                    editorConfigOverride = EditorConfigOverride.from(FORMATTER_TAGS_ENABLED_PROPERTY to true),
+                )
             assertThat(actual).containsExactly(
                 lintError(4, 5, "standard:no-foo-identifier-standard"),
                 lintError(4, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),
@@ -241,17 +241,17 @@ class SuppressionLocatorBuilderTest {
         fun `Given that a NoFooIdentifierRule violation is suppressed with the default formatter tags in EOL comments then do not find a violation in that block`() {
             val code =
                 """
-            // @formatter:off
-            val fooNotReported = "foo"
-            // @formatter:on
-            val fooReported = "foo"
-            """.trimIndent()
+                // @formatter:off
+                val fooNotReported = "foo"
+                // @formatter:on
+                val fooReported = "foo"
+                """.trimIndent()
 
-            val actual = lint(
-                code,
-                editorConfigOverride = EditorConfigOverride.from(FORMATTER_TAGS_ENABLED_PROPERTY to true)
-            )
-
+            val actual =
+                lint(
+                    code,
+                    editorConfigOverride = EditorConfigOverride.from(FORMATTER_TAGS_ENABLED_PROPERTY to true),
+                )
             assertThat(actual).containsExactly(
                 lintError(4, 5, "standard:no-foo-identifier-standard"),
                 lintError(4, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),
@@ -262,21 +262,22 @@ class SuppressionLocatorBuilderTest {
         fun `Given that a NoFooIdentifierRule violation is suppressed with custom formatter tags in block comments then do not find a violation in that block`() {
             val code =
                 """
-            /* custom-formatter-tag-off */
-            val fooNotReported = "foo"
-            /* custom-formatter-tag-on */
-            val fooReported = "foo"
-            """.trimIndent()
+                /* custom-formatter-tag-off */
+                val fooNotReported = "foo"
+                /* custom-formatter-tag-on */
+                val fooReported = "foo"
+                """.trimIndent()
 
-            val actual = lint(
-                code,
-                editorConfigOverride = EditorConfigOverride.from(
-                    FORMATTER_TAGS_ENABLED_PROPERTY to true,
-                    FORMATTER_TAG_OFF_ENABLED_PROPERTY to "custom-formatter-tag-off",
-                    FORMATTER_TAG_ON_ENABLED_PROPERTY to "custom-formatter-tag-on",
+            val actual =
+                lint(
+                    code,
+                    editorConfigOverride =
+                        EditorConfigOverride.from(
+                            FORMATTER_TAGS_ENABLED_PROPERTY to true,
+                            FORMATTER_TAG_OFF_ENABLED_PROPERTY to "custom-formatter-tag-off",
+                            FORMATTER_TAG_ON_ENABLED_PROPERTY to "custom-formatter-tag-on",
+                        ),
                 )
-            )
-
             assertThat(actual).containsExactly(
                 lintError(4, 5, "standard:no-foo-identifier-standard"),
                 lintError(4, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),
@@ -287,21 +288,22 @@ class SuppressionLocatorBuilderTest {
         fun `Given that a NoFooIdentifierRule violation is suppressed with custom formatter tags in EOL comments then do not find a violation in that block`() {
             val code =
                 """
-            // custom-formatter-tag-off
-            val fooNotReported = "foo"
-            // custom-formatter-tag-on
-            val fooReported = "foo"
-            """.trimIndent()
+                // custom-formatter-tag-off
+                val fooNotReported = "foo"
+                // custom-formatter-tag-on
+                val fooReported = "foo"
+                """.trimIndent()
 
-            val actual = lint(
-                code,
-                editorConfigOverride = EditorConfigOverride.from(
-                    FORMATTER_TAGS_ENABLED_PROPERTY to true,
-                    FORMATTER_TAG_OFF_ENABLED_PROPERTY to "custom-formatter-tag-off",
-                    FORMATTER_TAG_ON_ENABLED_PROPERTY to "custom-formatter-tag-on",
+            val actual =
+                lint(
+                    code,
+                    editorConfigOverride =
+                        EditorConfigOverride.from(
+                            FORMATTER_TAGS_ENABLED_PROPERTY to true,
+                            FORMATTER_TAG_OFF_ENABLED_PROPERTY to "custom-formatter-tag-off",
+                            FORMATTER_TAG_ON_ENABLED_PROPERTY to "custom-formatter-tag-on",
+                        ),
                 )
-            )
-
             assertThat(actual).containsExactly(
                 lintError(4, 5, "standard:no-foo-identifier-standard"),
                 lintError(4, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),
@@ -327,24 +329,23 @@ class SuppressionLocatorBuilderTest {
     private fun lint(
         code: String,
         editorConfigOverride: EditorConfigOverride = EditorConfigOverride.EMPTY_EDITOR_CONFIG_OVERRIDE,
-    ) =
-        ArrayList<LintError>().apply {
-            KtLintRuleEngine(
-                ruleProviders =
-                    setOf(
-                        // The same rule is supplied once a standard rule and once as non-standard rule. Note that the
-                        // ruleIds are different.
-                        RuleProvider { NoFooIdentifierRule(STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
-                        RuleProvider { NoFooIdentifierRule(NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
+    ) = ArrayList<LintError>().apply {
+        KtLintRuleEngine(
+            ruleProviders =
+                setOf(
+                    // The same rule is supplied once a standard rule and once as non-standard rule. Note that the
+                    // ruleIds are different.
+                    RuleProvider { NoFooIdentifierRule(STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
+                    RuleProvider { NoFooIdentifierRule(NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID) },
+                ),
+            editorConfigOverride =
+                editorConfigOverride
+                    .plus(
+                        STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
+                        NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
                     ),
-                editorConfigOverride =
-                    editorConfigOverride
-                        .plus(
-                            STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
-                            NON_STANDARD_NO_FOO_IDENTIFIER_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled,
-                        ),
-            ).lint(Code.fromSnippet(code)) { e -> add(e) }
-        }
+        ).lint(Code.fromSnippet(code)) { e -> add(e) }
+    }
 
     private fun lintError(
         line: Int,


### PR DESCRIPTION
## Description

Respect formatter tags when enabled

Closes #670
Closes #1163

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
