### PR TITLE
Use modern API to get Gradle property values

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     val kotlinPlugin =
-        if (project.hasProperty("kotlinDev")) {
+        if (providers.gradleProperty("kotlinDev").orNull.toBoolean()) {
             // Pass '-PkotlinDev' to command line to enable kotlin-in-development version
             logger.warn("Enabling kotlin dev version!")
             libs.kotlin.plugin.dev

--- a/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -23,9 +23,9 @@ tasks.withType<JavaCompile>().configureEach {
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }
 
-val skipTests: String = System.getProperty("skipTests", "false")
+val skipTests: Boolean = providers.systemProperty("skipTests").orNull == "false"
 tasks.withType<Test>().configureEach {
-    if (skipTests == "false") {
+    if (skipTests) {
         useJUnitPlatform()
     } else {
         logger.warn("Skipping tests for task '$name' as system property 'skipTests=$skipTests'")

--- a/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -23,9 +23,9 @@ tasks.withType<JavaCompile>().configureEach {
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }
 
-val skipTests: Boolean = providers.systemProperty("skipTests").orNull == "false"
+val skipTests: String = providers.systemProperty("skipTests").getOrElse("false")
 tasks.withType<Test>().configureEach {
-    if (skipTests) {
+    if (skipTests == "false") {
         useJUnitPlatform()
     } else {
         logger.warn("Skipping tests for task '$name' as system property 'skipTests=$skipTests'")

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -95,7 +95,7 @@ tasks.withType<Sign>().configureEach {
     notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
 }
 
-// TODO remove this once https://github.com/gradle/gradle/issues/23572 is fixed
+// TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
 fun Project.localGradleProperty(name: String): Provider<String> =
     provider {
         if (hasProperty(name)) property(name)?.toString() else null

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import java.net.URI
 
 plugins {
@@ -20,10 +22,10 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = group.toString()
             version = version.toString()
-            artifactId = providers.gradleProperty("POM_ARTIFACT_ID").get()
+            artifactId = localGradleProperty("POM_ARTIFACT_ID").get()
 
             pom {
-                name.set(providers.gradleProperty("POM_NAME"))
+                name.set(localGradleProperty("POM_NAME").get())
                 description.set(providers.gradleProperty("POM_DESCRIPTION"))
                 url.set(providers.gradleProperty("POM_URL"))
                 licenses {
@@ -92,3 +94,9 @@ signing {
 tasks.withType<Sign>().configureEach {
     notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
 }
+
+// TODO remove this once https://github.com/gradle/gradle/issues/23572 is fixed
+fun Project.localGradleProperty(name: String): Provider<String> =
+    provider {
+        if (hasProperty(name)) property(name)?.toString() else null
+    }

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -18,9 +18,9 @@ project.group = providers.gradleProperty("GROUP").orNull
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = providers.gradleProperty("GROUP").orNull
-            artifactId = providers.gradleProperty("POM_ARTIFACT_ID").orNull
-            version = providers.gradleProperty("VERSION_NAME").orNull
+            groupId = group.toString()
+            version = version.toString()
+            artifactId = providers.gradleProperty("POM_ARTIFACT_ID").get()
 
             pom {
                 name.set(providers.gradleProperty("POM_NAME"))

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -57,9 +57,9 @@ publishing {
 
             credentials {
                 username = providers.gradleProperty("SONATYPE_NEXUS_USERNAME").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_USERNAME")
+                    ?: providers.systemProperty("SONATYPE_NEXUS_USERNAME").orNull
                 password = providers.gradleProperty("SONATYPE_NEXUS_PASSWORD").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+                    ?: providers.systemProperty("SONATYPE_NEXUS_PASSWORD").orNull
             }
         }
     }
@@ -78,9 +78,9 @@ signing {
     // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent how to configure it
     // useGpgCmd()
 
-    val signingKeyId = System.getenv("ORG_GRADLE_PROJECT_signingKeyId")
-    val signingKey = System.getenv("ORG_GRADLE_PROJECT_signingKey")
-    val signingPassword = System.getenv("ORG_GRADLE_PROJECT_signingKeyPassword")
+    val signingKeyId = providers.systemProperty("ORG_GRADLE_PROJECT_signingKeyId").orNull
+    val signingKey = providers.systemProperty("ORG_GRADLE_PROJECT_signingKey").orNull
+    val signingPassword = providers.systemProperty("ORG_GRADLE_PROJECT_signingKeyPassword").orNull
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
 
     // This property allows OS package maintainers to disable signing

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -5,44 +5,44 @@ plugins {
     signing
 }
 
-if (project.hasProperty("isKotlinDev")) {
+if (providers.gradleProperty("isKotlinDev").orNull.toBoolean()) {
     val definedVersion = ext["VERSION_NAME"].toString().removeSuffix("-SNAPSHOT")
     ext["VERSION_NAME"] = "$definedVersion-kotlin-dev-SNAPSHOT"
 }
 
-project.version = project.property("VERSION_NAME")
+project.version = providers.gradleProperty("VERSION_NAME").orNull
     ?: throw GradleException("Project version property is missing")
-project.group = project.property("GROUP")
+project.group = providers.gradleProperty("GROUP").orNull
     ?: throw GradleException("Project group property is missing")
 
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = project.property("GROUP").toString()
-            artifactId = project.property("POM_ARTIFACT_ID").toString()
-            version = project.property("VERSION_NAME").toString()
+            groupId = providers.gradleProperty("GROUP").orNull
+            artifactId = providers.gradleProperty("POM_ARTIFACT_ID").orNull
+            version = providers.gradleProperty("VERSION_NAME").orNull
 
             pom {
-                name.set(project.property("POM_NAME").toString())
-                description.set(project.property("POM_DESCRIPTION").toString())
-                url.set(project.property("POM_URL").toString())
+                name.set(providers.gradleProperty("POM_NAME"))
+                description.set(providers.gradleProperty("POM_DESCRIPTION"))
+                url.set(providers.gradleProperty("POM_URL"))
                 licenses {
                     license {
-                        name.set(project.property("POM_LICENSE_NAME").toString())
-                        url.set(project.property("POM_LICENSE_URL").toString())
+                        name.set(providers.gradleProperty("POM_LICENSE_NAME"))
+                        url.set(providers.gradleProperty("POM_LICENSE_URL"))
                         distribution.set("repo")
                     }
                 }
                 developers {
                     developer {
-                        id.set(project.property("POM_DEVELOPER_ID").toString())
-                        name.set(project.property("POM_DEVELOPER_NAME").toString())
+                        id.set(providers.gradleProperty("POM_DEVELOPER_ID"))
+                        name.set(providers.gradleProperty("POM_DEVELOPER_NAME"))
                     }
                 }
                 scm {
-                    url.set(project.property("POM_SCM_URL").toString())
-                    connection.set(project.property("POM_SCM_CONNECTION").toString())
-                    developerConnection.set(project.property("POM_SCM_DEV_CONNECTION").toString())
+                    url.set(providers.gradleProperty("POM_SCM_URL"))
+                    connection.set(providers.gradleProperty("POM_SCM_CONNECTION"))
+                    developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION"))
                 }
             }
         }
@@ -56,9 +56,9 @@ publishing {
             url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
 
             credentials {
-                username = project.findProperty("SONATYPE_NEXUS_USERNAME")?.toString()
+                username = providers.gradleProperty("SONATYPE_NEXUS_USERNAME").orNull
                     ?: System.getenv("SONATYPE_NEXUS_USERNAME")
-                password = project.findProperty("SONATYPE_NEXUS_PASSWORD")?.toString()
+                password = providers.gradleProperty("SONATYPE_NEXUS_PASSWORD").orNull
                     ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
             }
         }
@@ -84,7 +84,7 @@ signing {
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
 
     // This property allows OS package maintainers to disable signing
-    val enableSigning = project.findProperty("ktlint.publication.signing.enable") != "false"
+    val enableSigning = providers.gradleProperty("ktlint.publication.signing.enable").orNull != "false"
     sign(publishing.publications["maven"])
     isRequired = enableSigning && !version.toString().endsWith("SNAPSHOT")
 }

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 tasks.jar {
     manifest {
         attributes("Main-Class" to "com.pinterest.ktlint.Main")
-        attributes("Implementation-Version" to project.property("VERSION_NAME"))
+        attributes("Implementation-Version" to version)
     }
 }
 

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -98,12 +98,14 @@ tasks.register<Checksum>("shadowJarExecutableChecksum") {
 tasks.withType<Test>().configureEach {
     dependsOn(shadowJarExecutable)
 
-    notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/12247")
+    val executableFilePath =
+        providers.provider { shadowJarExecutable.get().outputs.files.first { it.name == "ktlint" }.absolutePath }.get()
+    val ktlintVersion = providers.provider { version }.get()
     doFirst {
         systemProperty(
             "ktlint-cli",
-            shadowJarExecutable.get().outputs.files.first { it.name == "ktlint" }.absolutePath,
+            executableFilePath,
         )
-        systemProperty("ktlint-version", version)
+        systemProperty("ktlint-version", ktlintVersion)
     }
 }

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -98,6 +98,7 @@ tasks.register<Checksum>("shadowJarExecutableChecksum") {
 tasks.withType<Test>().configureEach {
     dependsOn(shadowJarExecutable)
 
+    // TODO: Use providers directly after https://github.com/gradle/gradle/issues/12247 is fixed.
     val executableFilePath =
         providers.provider { shadowJarExecutable.get().outputs.files.first { it.name == "ktlint" }.absolutePath }.get()
     val ktlintVersion = providers.provider { version }.get()


### PR DESCRIPTION
## Description

The `gradleProperty` method was introduced in Gradle 6.2 and improves compatibility with Gradle's configuration cache.

https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ProviderFactory.html

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
