### PR TITLE
Disbaled -> Disabled

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,7 +118,7 @@ You may also pass a list of disabled rules via the `--disabled_rules` command li
 
 
 ## Why is `.editorconfig` property `disabled_rules` deprecated and how do I resolve this?
-The `.editorconfig` properties `disabled_rules` and `ktlint_disbaled_rules` are deprecated as of KtLint version `0.48` and are marked for removal in version `0.49`. Those properties contain a comma separated list of rules which are disabled. Using a comma separated list of values has some disadvantages.
+The `.editorconfig` properties `disabled_rules` and `ktlint_disabled_rules` are deprecated as of KtLint version `0.48` and are marked for removal in version `0.49`. Those properties contain a comma separated list of rules which are disabled. Using a comma separated list of values has some disadvantages.
 
 A big disadvantage is that it is not possible to override the property partially in an `.editorconfig` file in a subpackage. Another disadvantage is that it is not possible to express explicitly that a rule is enabled. Lastly, (qualified) rule ids can be 20 characters or longer, which makes a list with multiple entries hard to read.
 


### PR DESCRIPTION
I was looking up how to migrate from `disabled_rules` and came across this.

## Description

Updates spelling in docs

If the PR solves an issue then provide a link to that issue. -->

## Checklist
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated