### PR TITLE
Remove trailing comma if last two enum entries are on the same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Wrap each type parameter in a multiline type parameter list `wrapping` ([#1867](https://github.com/pinterest/ktlint/issues/1867))
 * Allow value arguments with a multiline expression to be indented on a separate line `indent` ([#1217](https://github.com/pinterest/ktlint/issues/1217))
 * When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags (see [faq](https://pinterest.github.io/ktlint/faq/#are-formatter-tags-respected)) ([#670](https://github.com/pinterest/ktlint/issues/670)) 
+* Remove trailing comma if last two enum entries are on the same line and trailing commas are not allowed. `trailing-comma-on-declaration-site` ([#1905](https://github.com/pinterest/ktlint/issues/1905))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -708,16 +708,23 @@ class TrailingCommaOnDeclarationSiteRuleTest {
     }
 
     @Test
-    fun `Given that a trailing comma is not allowed then it is not removed for enums where last two entries are on same line`() {
+    fun `Given that a trailing comma is not allowed then remove it for enums where last two entries are on same line and followed by trailing comma`() {
         val code =
             """
             enum class Shape {
                 SQUARE, TRIANGLE,
             }
             """.trimIndent()
+        val formattedCode =
+            """
+            enum class Shape {
+                SQUARE, TRIANGLE
+            }
+            """.trimIndent()
         trailingCommaOnDeclarationSiteRuleAssertThat(code)
             .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to false)
-            .hasNoLintViolations()
+            .hasLintViolation(2, 21, "Unnecessary trailing comma before \"}\"")
+            .isFormattedAs(formattedCode)
     }
 
     @Nested


### PR DESCRIPTION
## Description

Remove trailing comma if last two enum entries are on the same line and trailing commas are not allowed

Closes #1905

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
