### PR TITLE
Add new experimental rule `enum-wrapping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
   }
   ```
 * Add new experimental rule `if-else-wrapping` for `ktlint_official` code style. This enforces that a single line if-statement is kept simple. A single line if-statement may contain no more than one else-branch. The branches a single line if-statement may not be wrapped in a block. ([#812](https://github.com/pinterest/ktlint/issues/812))
+* Add new experimental rule `enum-wrapping` for all code styles. An enum should either be a single line, or each enum entry should be defined on a separate line. ([#1903](https://github.com/pinterest/ktlint/issues/1903))
 
 ### Removed
 

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -570,6 +570,43 @@ Wraps the content receiver list to a separate line regardless of maximum line le
 
 Rule id: `context-receiver-wrapping`
 
+## Enum wrapping
+
+An enum should be a single line, or each enum entry has to be placed on a separate line. In case the enumeration contains enum entries and declarations those are to be separated by a blank line.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    enum class Foo { A, B, C, D }
+
+    enum class Foo {
+        A,
+        B,
+        C,
+        D,
+        ;
+
+        fun foo() = "foo"
+    }
+    ```
+
+=== "[:material-heart:](#) Disallowed"
+
+    ```kotlin
+    enum class Foo {
+        A,
+        B, C,
+        D
+    }
+
+    enum class Foo {
+        A;
+        fun foo() = "foo"
+    }
+    ```
+
+Rule id: `enum-wrapping`
+
 ### Kdoc wrapping
 
 A KDoc comment should start and end on a line that does not contain any other element.

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
@@ -64,9 +64,9 @@ internal class RuleProviderSorter {
         val sortedRuleProviders = mutableListOf<RuleProvider>()
         val ruleIdsSortedRuleProviders = mutableSetOf<RuleId>()
 
-        // Initially the list only contains the rules which have no RunAfterRules (e.g. are not depending on another rule).
+        // Initially the list only contains the rules not depending on another rule.
         unprocessedRuleProviders
-            .filter { it.hasNoRunAfterRules() }
+            .filter { !it.runAsLateAsPossible && it.hasNoRunAfterRules() }
             .forEach { ruleProvider ->
                 sortedRuleProviders.add(ruleProvider)
                 ruleIdsSortedRuleProviders.add(ruleProvider.ruleId)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -14,6 +14,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.CommentWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ContextReceiverWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.DiscouragedCommentLocationRule
 import com.pinterest.ktlint.ruleset.standard.rules.EnumEntryNameCaseRule
+import com.pinterest.ktlint.ruleset.standard.rules.EnumWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.FilenameRule
 import com.pinterest.ktlint.ruleset.standard.rules.FinalNewlineRule
 import com.pinterest.ktlint.ruleset.standard.rules.FunKeywordSpacingRule
@@ -94,6 +95,7 @@ public class StandardRuleSetProvider :
             RuleProvider { ContextReceiverWrappingRule() },
             RuleProvider { DiscouragedCommentLocationRule() },
             RuleProvider { EnumEntryNameCaseRule() },
+            RuleProvider { EnumWrappingRule() },
             RuleProvider { FilenameRule() },
             RuleProvider { FinalNewlineRule() },
             RuleProvider { FunctionNamingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -14,6 +14,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
@@ -80,6 +82,13 @@ public class AnnotationRule :
                 INDENT_SIZE_PROPERTY,
                 INDENT_STYLE_PROPERTY,
             ),
+        visitorModifiers =
+            setOf(
+                RunAfterRule(
+                    ruleId = ENUM_WRAPPING_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+            ),
     ) {
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
 
@@ -88,7 +97,6 @@ public class AnnotationRule :
             indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
             tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
         )
-        Unit
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
@@ -1,0 +1,197 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtClass
+
+/**
+ *
+ */
+public class EnumWrappingRule :
+    StandardRule(
+        id = "enum-wrapping",
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
+    ),
+    Rule.Experimental {
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig = IndentConfig(
+            indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+            tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+        )
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        node
+            .takeIf { node.elementType == CLASS }
+            ?.takeIf { (node.psi as KtClass).isEnum() }
+            ?.findChildByType(CLASS_BODY)
+            ?.let { classBody ->
+                visitEnumClass(classBody, autoCorrect, emit)
+            }
+    }
+
+    private fun visitEnumClass(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(node.elementType == CLASS_BODY)
+
+        val commentBeforeFirstEnumEntry = wrapCommentBeforeFirstEnumEntry(node, emit, autoCorrect)
+        if (commentBeforeFirstEnumEntry || node.isMultiline() || node.hasAnnotatedEnumEntry() || node.hasCommentedEnumEntry()) {
+            wrapEnumEntries(node, autoCorrect, emit)
+            wrapClosingBrace(node, emit, autoCorrect)
+        }
+        addBlankLineBetweenEnumEntriesAndOtherDeclarations(node, emit, autoCorrect)
+    }
+
+    private fun wrapCommentBeforeFirstEnumEntry(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ): Boolean {
+        val firstEnumEntry = node.findChildByType(ENUM_ENTRY)
+        if (firstEnumEntry != null) {
+            node
+                .children()
+                .takeWhile { it != firstEnumEntry }
+                .firstOrNull { it.isPartOfComment() }
+                ?.let { commentBeforeFirstEnumEntry ->
+                    val expectedIndent = node.treeParent.indent()
+                    if (commentBeforeFirstEnumEntry.prevLeaf()?.text != expectedIndent) {
+                        emit(node.startOffset, "Expected a newline before comment", true)
+                        if (autoCorrect) {
+                            commentBeforeFirstEnumEntry.upsertWhitespaceBeforeMe(node.treeParent.indent().plus(indentConfig.indent))
+                        }
+                        return true
+                    }
+                }
+            }
+        return false
+    }
+
+    private fun ASTNode.isMultiline() = text.contains('\n')
+
+    private fun ASTNode.hasAnnotatedEnumEntry() =
+        children()
+            .filter { it.elementType == ENUM_ENTRY }
+            .any { it.isAnnotated() }
+
+    private fun ASTNode.isAnnotated(): Boolean =
+        findChildByType(MODIFIER_LIST)
+            ?.children()
+            .orEmpty()
+            .any { it.elementType == ANNOTATION_ENTRY }
+
+    private fun ASTNode.hasCommentedEnumEntry() = children().any { it.containsCommentInEnumEntry() }
+
+    private fun ASTNode.containsCommentInEnumEntry() = children().any { it.isPartOfComment() }
+
+    private fun wrapEnumEntries(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        node
+            .children()
+            .filter { it.elementType == ENUM_ENTRY }
+            .forEach { enumEntry ->
+                wrapEnumEntry(enumEntry, autoCorrect, emit)
+            }
+    }
+
+    private fun wrapEnumEntry(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        node
+            .prevLeaf { !it.isPartOfComment() && !it.isWhiteSpaceWithoutNewline() }
+            ?.takeUnless { it.isWhiteSpaceWithNewline() }
+            ?.let { prevLeaf ->
+                emit(node.startOffset, "Enum entry should start on a separate line", true)
+                if (autoCorrect) {
+                    prevLeaf.upsertWhitespaceAfterMe(node.treeParent.indent().plus(indentConfig.indent))
+                }
+            }
+    }
+
+    private fun wrapClosingBrace(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        node
+            .findChildByType(RBRACE)
+            ?.let { rbrace ->
+                val prevLeaf = rbrace.prevLeaf()
+                val expectedIndent = node.treeParent.indent()
+                if (prevLeaf?.text != expectedIndent) {
+                    emit(rbrace.startOffset, "Expected newline before '}'", true)
+                    if (autoCorrect) {
+                        rbrace.upsertWhitespaceBeforeMe(expectedIndent)
+                    }
+                }
+            }
+    }
+
+    private fun addBlankLineBetweenEnumEntriesAndOtherDeclarations(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean
+    ) {
+        node
+            .children()
+            .lastOrNull { it.elementType == ENUM_ENTRY }
+            ?.nextSibling { !it.isPartOfComment() }
+            ?.takeUnless { it.nextCodeSibling()?.elementType == RBRACE }
+            ?.let { nextSibling ->
+                val expectedIndent =
+                    "\n"
+                        .plus(node.treeParent.indent())
+                        .plus(indentConfig.indent)
+                if (nextSibling.text != expectedIndent) {
+                    emit(nextSibling.startOffset + 1, "Expected blank line between enum entries and other declaration(s)", true)
+                    if (autoCorrect) {
+                        nextSibling.upsertWhitespaceBeforeMe(expectedIndent)
+                    }
+                }
+            }
+    }
+
+
+}
+
+public val ENUM_WRAPPING_RULE_ID: RuleId = EnumWrappingRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
@@ -80,7 +80,7 @@ public class EnumWrappingRule :
     private fun wrapCommentBeforeFirstEnumEntry(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        autoCorrect: Boolean
+        autoCorrect: Boolean,
     ): Boolean {
         val firstEnumEntry = node.findChildByType(ENUM_ENTRY)
         if (firstEnumEntry != null) {
@@ -98,7 +98,7 @@ public class EnumWrappingRule :
                         return true
                     }
                 }
-            }
+        }
         return false
     }
 
@@ -122,7 +122,7 @@ public class EnumWrappingRule :
     private fun wrapEnumEntries(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         node
             .children()
@@ -151,7 +151,7 @@ public class EnumWrappingRule :
     private fun wrapClosingBrace(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        autoCorrect: Boolean
+        autoCorrect: Boolean,
     ) {
         node
             .findChildByType(RBRACE)
@@ -170,7 +170,7 @@ public class EnumWrappingRule :
     private fun addBlankLineBetweenEnumEntriesAndOtherDeclarations(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-        autoCorrect: Boolean
+        autoCorrect: Boolean,
     ) {
         node
             .children()
@@ -190,8 +190,6 @@ public class EnumWrappingRule :
                 }
             }
     }
-
-
 }
 
 public val ENUM_WRAPPING_RULE_ID: RuleId = EnumWrappingRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -42,6 +42,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
@@ -97,6 +99,13 @@ public class WrappingRule :
                 INDENT_SIZE_PROPERTY,
                 INDENT_STYLE_PROPERTY,
                 MAX_LINE_LENGTH_PROPERTY,
+            ),
+        visitorModifiers =
+            setOf(
+                RunAfterRule(
+                    ruleId = ANNOTATION_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
             ),
     ) {
     private var line = 1

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -706,4 +706,35 @@ class AnnotationRuleTest {
                 .hasNoLintViolations()
         }
     }
+
+    @Test
+    fun `Given property allow trailing comma on declaration site is not set then remove trailing commas`() {
+        val code =
+            """
+            enum class Foo {
+                A,
+                @Bar1 B,
+                @Bar1 @Bar2 C,
+                @Bar3("bar3") @Bar1 D
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            enum class Foo {
+                A,
+                @Bar1 B,
+                @Bar1 @Bar2
+                C,
+                @Bar3("bar3")
+                @Bar1
+                D
+            }
+            """.trimIndent()
+        annotationRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(4, 17, "Multiple annotations should not be placed on the same line as the annotated construct"),
+                LintViolation(5, 5, "Annotation with parameter(s) should be placed on a separate line prior to the annotated construct"),
+                LintViolation(5, 25, "Multiple annotations should not be placed on the same line as the annotated construct"),
+            ).isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
@@ -127,7 +127,7 @@ class EnumWrappingRuleTest {
             .isFormattedAs(formattedCode)
     }
 
-   @Nested
+    @Nested
     inner class `Given an enum with comments` {
         @Test
         fun `Given a single line enum class containing a block comment but not entries`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
@@ -1,0 +1,245 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EnumWrappingRuleTest {
+    private val enumWrappingRuleAssertThat = KtLintAssertThat.assertThatRule { EnumWrappingRule() }
+
+    @Test
+    fun `Given a single line enum class which does not need to be wrapped`() {
+        val code =
+            """
+            enum class Foo { A, B, C, D }
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a multi line enum class which does not need to be wrapped`() {
+        val code =
+            """
+            enum class Foo {
+                A,
+                B,
+                C,
+                D
+            }
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Nested
+    inner class `Given an annotated enum entry` {
+        @Test
+        fun `Given an enum class with an enum entry with a single annotation`() {
+            val code =
+                """
+                enum class Foo { @Bar BAR }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    @Bar BAR
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { AnnotationRule() }
+                .hasLintViolations(
+                    LintViolation(1, 18, "Enum entry should start on a separate line"),
+                    LintViolation(1, 27, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given an enum class with multiple annotated enum entries`() {
+            val code =
+                """
+                enum class Foo { A, @Bar1 B, @Bar1 @Bar2 C, @Bar3("bar3") @Bar1 D }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    A,
+                    @Bar1 B,
+                    @Bar1 @Bar2
+                    C,
+                    @Bar3("bar3")
+                    @Bar1
+                    D
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { AnnotationRule() }
+                .hasLintViolations(
+                    LintViolation(1, 18, "Enum entry should start on a separate line"),
+                    LintViolation(1, 21, "Enum entry should start on a separate line"),
+                    LintViolation(1, 30, "Enum entry should start on a separate line"),
+                    LintViolation(1, 45, "Enum entry should start on a separate line"),
+                    LintViolation(1, 67, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a multiline enum class then each entry should be on a separate line`() {
+        val code =
+            """
+            enum class Foo {
+                A, B
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            enum class Foo {
+                A,
+                B
+            }
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code)
+            .hasLintViolation(2, 8, "Enum entry should start on a separate line")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a enum class without blank line between enum entries and other declarations`() {
+        val code =
+            """
+            enum class Foo {
+                A,
+                B;
+                fun foo() = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            enum class Foo {
+                A,
+                B;
+
+                fun foo() = "foo"
+            }
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code)
+            .hasLintViolation(4, 1, "Expected blank line between enum entries and other declaration(s)")
+            .isFormattedAs(formattedCode)
+    }
+
+   @Nested
+    inner class `Given an enum with comments` {
+        @Test
+        fun `Given a single line enum class containing a block comment but not entries`() {
+            val code =
+                """
+                enum class Foo { /* empty */ }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a single line enum class with a block comment before the enum entries`() {
+            val code =
+                """
+                enum class Foo { /* comment */ A, B }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    /* comment */ A,
+                    B
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 16, "Expected a newline before comment"),
+                    LintViolation(1, 32, "Enum entry should start on a separate line"),
+                    LintViolation(1, 35, "Enum entry should start on a separate line"),
+                    LintViolation(1, 37, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line enum class with a block comment after an enum entry`() {
+            val code =
+                """
+                enum class Foo { A /* comment */, B }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    A /* comment */,
+                    B
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 18, "Enum entry should start on a separate line"),
+                    LintViolation(1, 35, "Enum entry should start on a separate line"),
+                    LintViolation(1, 37, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line enum class with a block comments before an enum entry`() {
+            val code =
+                """
+                enum class Foo { A, /* comment */ B }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    A,
+                    /* comment */ B
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 18, "Enum entry should start on a separate line"),
+                    LintViolation(1, 35, "Enum entry should start on a separate line"),
+                    LintViolation(1, 37, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line enum class with a block comment after the last enum entry`() {
+            val code =
+                """
+                enum class Foo { A, B /* comment */ }
+                """.trimIndent()
+            val formattedCode =
+                """
+                enum class Foo {
+                    A,
+                    B /* comment */
+                }
+                """.trimIndent()
+            enumWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 18, "Enum entry should start on a separate line"),
+                    LintViolation(1, 21, "Enum entry should start on a separate line"),
+                    LintViolation(1, 37, "Expected newline before '}'"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given an enum class without body`() {
+        val code =
+            """
+            enum class Foo
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an enum class without enum entries in the body`() {
+        val code =
+            """
+            enum class Foo {}
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
## Description

Add new experimental rule `enum-wrapping` for all code styles. An enum should either be a single line, or each enum entry should be defined on a separate line

Closes #1903

Fix bug in RuleProviderSorter. A rule marked with RunAsLateAsPossible should never be run before a rule not having any Rule.VisitorModifier.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
