### PR TITLE
Wrap annotated function parameters and type projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,8 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Allow value arguments with a multiline expression to be indented on a separate line `indent` ([#1217](https://github.com/pinterest/ktlint/issues/1217))
 * When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags (see [faq](https://pinterest.github.io/ktlint/faq/#are-formatter-tags-respected)) ([#670](https://github.com/pinterest/ktlint/issues/670)) 
 * Remove trailing comma if last two enum entries are on the same line and trailing commas are not allowed. `trailing-comma-on-declaration-site` ([#1905](https://github.com/pinterest/ktlint/issues/1905))
+* Wrap annotated function parameters to a separate line in code style `ktlint_official` only. `function-signature`, `parameter-list-wrapping` ([#1908](https://github.com/pinterest/ktlint/issues/1908))
+* Wrap annotated projection types in type argument lists to a separate line `annotation` ([#1909](https://github.com/pinterest/ktlint/issues/1909))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -141,13 +141,6 @@ class AnnotationRuleTest {
                 @[Foo Bar] fun bar() {}
             }
             """.trimIndent()
-        val formattedCode =
-            """
-            @[Foo Bar] class FooBar2 {
-                @[Foo Bar] var foo: String
-                @[Foo Bar] fun bar() {}
-            }
-            """.trimIndent()
         annotationRuleAssertThat(code)
             .hasNoLintViolations()
     }
@@ -347,19 +340,15 @@ class AnnotationRuleTest {
     }
 
     @Test
-    fun `Issue 642 - Given annotations on type arguments on same line as argument`() {
+    fun `Given a function signature having annotated parameters, then allow the annotation to be on the same line as the annotated construct`() {
         val code =
             """
-            val aProperty: Map<@Ann("test") Int, @JvmSuppressWildcards(true) (String) -> Int?>
-            val bProperty: Map<
-                @Ann String,
-                @Ann("test") Int,
-                @JvmSuppressWildcards(true) (String) -> Int?
-                >
-
-            fun doSomething() {
-                funWithGenericsCall<@JvmSuppressWildcards(true) Int>()
-            }
+            fun foo(
+                a: int,
+                @Bar1 b: int,
+                @Bar1 @Bar2 c: int,
+                @Bar3("bar3") @Bar1 d: int
+            ) {}
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
     }
@@ -662,9 +651,9 @@ class AnnotationRuleTest {
                 .addAdditionalRuleProvider { TrailingCommaOnDeclarationSiteRule() }
                 .addAdditionalRuleProvider { WrappingRule() }
                 .hasLintViolations(
-                    LintViolation(1, 18, "Annotations on a type reference should be placed on a separate line"),
+                    LintViolation(1, 17, "Expected newline after '<'"),
                     LintViolation(1, 28, "Multiple annotations should not be placed on the same line as the annotated construct"),
-                    LintViolation(1, 28, "Annotations on a type reference should be placed on a separate line"),
+                    LintViolation(1, 34, "Expected newline before '>'"),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -672,24 +661,32 @@ class AnnotationRuleTest {
         fun `Given a custom type with multiple annotations on it type parameter(s)`() {
             val code =
                 """
-                val fooBar: FooBar<String, @Foo @Bar String, String> = emptyList()
+                val fooBar: FooBar<String, @Foo String, @Foo @Bar String, @Bar("bar") @Foo String> = FooBar()
                 """.trimIndent()
             val formattedCode =
                 """
                 val fooBar: FooBar<
                     String,
+                    @Foo String,
                     @Foo @Bar
                     String,
+                    @Bar("bar")
+                    @Foo
                     String
-                    > = emptyList()
+                    > = FooBar()
                 """.trimIndent()
+            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
             annotationRuleAssertThat(code)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .addAdditionalRuleProvider { WrappingRule() }
                 .hasLintViolations(
-                    LintViolation(1, 28, "Annotations on a type reference should be placed on a separate line"),
-                    LintViolation(1, 38, "Multiple annotations should not be placed on the same line as the annotated construct"),
-                    LintViolation(1, 38, "Annotations on a type reference should be placed on a separate line"),
+                    LintViolation(1, 39, "Expected newline after ','"),
+                    LintViolation(1, 51, "Multiple annotations should not be placed on the same line as the annotated construct"),
+                    LintViolation(1, 57, "Expected newline after ','"),
+                    LintViolation(1, 59, "Expected newline before '@'"),
+                    LintViolation(1, 59, "Annotation with parameter(s) should be placed on a separate line prior to the annotated construct"),
+                    LintViolation(1, 76, "Multiple annotations should not be placed on the same line as the annotated construct"),
+                    LintViolation(1, 82, "Expected newline before '>'"),
                 ).isFormattedAs(formattedCode)
         }
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -4820,11 +4820,7 @@ internal class IndentationRuleTest {
             indentationRuleAssertThat(code)
                 .addAdditionalRuleProvider { ParameterListWrappingRule() }
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationForAdditionalRule(
-                    2,
-                    20,
-                    "Parameter should be on a separate line (unless all parameters can fit a single line)",
-                )
+                .hasLintViolationForAdditionalRule(2, 20, "Parameter should start on a newline")
                 .hasLintViolations(
                     LintViolation(3, 1, "Unexpected indentation (19) (should be 12)"),
                     LintViolation(4, 1, "Unexpected indentation (19) (should be 12)"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -41,8 +41,8 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 14, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 30, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(1, 14, "Parameter should start on a newline"),
+                LintViolation(1, 30, "Parameter should start on a newline"),
                 LintViolation(2, 28, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
@@ -64,9 +64,9 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code)
             .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
             .hasLintViolations(
-                LintViolation(1, 14, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 30, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 46, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(1, 14, "Parameter should start on a newline"),
+                LintViolation(1, 30, "Parameter should start on a newline"),
+                LintViolation(1, 46, "Parameter should start on a newline"),
                 LintViolation(1, 60, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
@@ -124,7 +124,7 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 7, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(1, 7, "Parameter should start on a newline"),
                 LintViolation(3, 13, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
@@ -148,7 +148,7 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
         parameterListWrappingRuleAssertThat(code)
-            .hasLintViolation(3, 13, "Parameter should be on a separate line (unless all parameters can fit a single line)")
+            .hasLintViolation(3, 13, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)
     }
 
@@ -171,9 +171,9 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code)
             .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
             .hasLintViolations(
-                LintViolation(1, 7, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 15, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 23, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(1, 7, "Parameter should start on a newline"),
+                LintViolation(1, 15, "Parameter should start on a newline"),
+                LintViolation(1, 23, "Parameter should start on a newline"),
                 LintViolation(1, 29, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
@@ -257,8 +257,8 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code)
             .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
             .hasLintViolations(
-                LintViolation(2, 11, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(6, 19, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(2, 11, "Parameter should start on a newline"),
+                LintViolation(6, 19, "Parameter should start on a newline"),
                 LintViolation(6, 37, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
@@ -288,7 +288,7 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
         parameterListWrappingRuleAssertThat(code)
-            .hasLintViolation(2, 11, "Parameter should be on a separate line (unless all parameters can fit a single line)")
+            .hasLintViolation(2, 11, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)
     }
 
@@ -316,8 +316,8 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(4, 12, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(4, 25, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(4, 12, "Parameter should start on a newline"),
+                LintViolation(4, 25, "Parameter should start on a newline"),
                 LintViolation(5, 32, """Missing newline before ")""""),
                 LintViolation(5, 41, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
@@ -344,12 +344,12 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code)
             .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
             .hasLintViolations(
-                LintViolation(1, 11, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 26, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 48, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 55, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 68, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
-                LintViolation(1, 90, "Parameter should be on a separate line (unless all parameters can fit a single line)"),
+                LintViolation(1, 11, "Parameter should start on a newline"),
+                LintViolation(1, 26, "Parameter should start on a newline"),
+                LintViolation(1, 48, "Parameter should start on a newline"),
+                LintViolation(1, 55, "Parameter should start on a newline"),
+                LintViolation(1, 68, "Parameter should start on a newline"),
+                LintViolation(1, 90, "Parameter should start on a newline"),
                 LintViolation(1, 117, "Missing newline before \")\""),
                 LintViolation(1, 126, "Missing newline before \")\""),
             ).isFormattedAs(formattedCode)
@@ -513,5 +513,48 @@ class ParameterListWrappingRuleTest {
                 LintViolation(1, 22, "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
                 LintViolation(1, 95, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given a single line function signature with an annotated parameter` {
+        @Test
+        fun `Given ktlint_official code style`() {
+            val code =
+                """
+                fun foo(a: Int, @Bar bar: String, b: Int) = "some-result"
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo(
+                    a: Int,
+                    @Bar bar: String,
+                    b: Int
+                ) = "some-result"
+                """.trimIndent()
+            parameterListWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolations(
+                    LintViolation(1, 9, "Parameter should start on a newline"),
+                    LintViolation(1, 17, "Parameter should start on a newline"),
+                    LintViolation(1, 35, "Parameter should start on a newline"),
+                    LintViolation(1, 41, "Missing newline before \")\""),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(
+            value = CodeStyleValue::class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = ["ktlint_official"],
+        )
+        fun `Given non-ktlint_official code style`(codeStyle: CodeStyleValue) {
+            val code =
+                """
+                fun foo(a: Int, @Bar bar: String, b: Int) = "some-result"
+                """.trimIndent()
+            parameterListWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
+                .hasNoLintViolations()
+        }
     }
 }


### PR DESCRIPTION
## Description

Wrap annotated function parameters to a separate line in code style `ktlint_official` only

Closes #1908

Wrap annotated projection types in type argument lists to a separate line `annotation`

Closes #1909

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
