### PR TITLE
Add newline after adding trailing comma in parameter list of a function literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,7 @@ Previously the default value for `.editorconfig` property `max_line_length` was 
 * Remove trailing comma if last two enum entries are on the same line and trailing commas are not allowed. `trailing-comma-on-declaration-site` ([#1905](https://github.com/pinterest/ktlint/issues/1905))
 * Wrap annotated function parameters to a separate line in code style `ktlint_official` only. `function-signature`, `parameter-list-wrapping` ([#1908](https://github.com/pinterest/ktlint/issues/1908))
 * Wrap annotated projection types in type argument lists to a separate line `annotation` ([#1909](https://github.com/pinterest/ktlint/issues/1909))
+* Add newline after adding trailing comma in parameter list of a function literal `trailing-comma-on-declaration-site` ([#1911](https://github.com/pinterest/ktlint/issues/1911))
 
 ### Changed
 * Wrap the parameters of a function literal containing a multiline parameter list (only in `ktlint_official` code style) `parameter-list-wrapping` ([#1681](https://github.com/pinterest/ktlint/issues/1681)).

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -89,13 +89,10 @@ public class ParameterListSpacingRule :
                 }
                 COMMA -> {
                     // Comma must be followed by whitespace
-                    val nextSibling =
-                        el
-                            .nextSibling()
-                            ?.elementType
-                    if (nextSibling != WHITE_SPACE) {
-                        addMissingWhiteSpaceAfterMe(el, emit, autoCorrect)
-                    }
+                    el
+                        .nextLeaf()
+                        ?.takeIf { it.elementType != WHITE_SPACE }
+                        ?.let { addMissingWhiteSpaceAfterMe(el, emit, autoCorrect) }
                 }
                 VALUE_PARAMETER -> {
                     valueParameterCount += 1

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
@@ -447,6 +447,21 @@ class ParameterListSpacingRuleTest {
             .hasNoLintViolations()
     }
 
+    @Test
+    fun `Given a function literal with a trailing comma in the parameter list and arrow on the next line then do not report a violation`() {
+        val code =
+            """
+            val foo = {
+                    string: String,
+                    int: Int,
+                ->
+                // do something
+            }
+            """.trimIndent()
+        parameterListSpacingRuleAssertThat(code)
+            .hasNoLintViolations()
+    }
+
     private companion object {
         const val TOO_MANY_SPACES = "  "
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -1056,4 +1056,29 @@ class TrailingCommaOnDeclarationSiteRuleTest {
             .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Given a function literal with a trailing comma in the parameter list and arrow on the next line then do not report a violation`() {
+        val code =
+            """
+            val foo = {
+                    string: String,
+                    int: Int ->
+                // do something
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = {
+                    string: String,
+                    int: Int,
+                ->
+                // do something
+            }
+            """.trimIndent()
+        trailingCommaOnDeclarationSiteRuleAssertThat(code)
+            .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
+            .hasLintViolation(3, 17, "Missing trailing comma and newline before \"->\"")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Add newline after adding trailing comma in parameter list of a function literal

Closes #1911

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
