### PR TITLE
Correct the group of ktlint-cli

### DIFF
--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -14,7 +14,8 @@ if (providers.gradleProperty("isKotlinDev").orNull.toBoolean()) {
 
 project.version = providers.gradleProperty("VERSION_NAME").orNull
     ?: throw GradleException("Project version property is missing")
-project.group = providers.gradleProperty("GROUP").orNull
+// TODO: Rename ktlint-cli's group to com.pinterest.ktlint whenever releasing version 1.0, or remove `localGradleProperty` once https://github.com/gradle/gradle/issues/23572 is fixed.
+project.group = localGradleProperty("GROUP").orNull ?: providers.gradleProperty("GROUP").orNull
     ?: throw GradleException("Project group property is missing")
 
 publishing {

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -14,7 +14,7 @@ if (providers.gradleProperty("isKotlinDev").orNull.toBoolean()) {
 
 project.version = providers.gradleProperty("VERSION_NAME").orNull
     ?: throw GradleException("Project version property is missing")
-// TODO: Rename ktlint-cli's group to com.pinterest.ktlint whenever releasing version 1.0, or remove `localGradleProperty` once https://github.com/gradle/gradle/issues/23572 is fixed.
+// TODO: Remove `localGradleProperty` once https://github.com/gradle/gradle/issues/23572 or https://github.com/pinterest/ktlint/issues/1931 is fixed.
 project.group = localGradleProperty("GROUP").orNull ?: providers.gradleProperty("GROUP").orNull
     ?: throw GradleException("Project group property is missing")
 

--- a/ktlint-cli/gradle.properties
+++ b/ktlint-cli/gradle.properties
@@ -1,4 +1,4 @@
-# TODO: Rename POM to ktlint-cli and move the group to com.pinterest.ktlint whenever releasing version 1.0
+# TODO: https://github.com/pinterest/ktlint/issues/1931
 GROUP=com.pinterest
 POM_NAME=ktlint
 POM_ARTIFACT_ID=ktlint

--- a/ktlint-cli/gradle.properties
+++ b/ktlint-cli/gradle.properties
@@ -1,4 +1,4 @@
-# TODO: Rename POM to ktlint-cli whenever releasing version 1.0
+# TODO: Rename POM to ktlint-cli and move the group to com.pinterest.ktlint whenever releasing version 1.0
 GROUP=com.pinterest
 POM_NAME=ktlint
 POM_ARTIFACT_ID=ktlint


### PR DESCRIPTION
## Description

Follow up #1898, we preferred root Gradle properties over current project's in that PR, the current group of `ktlint-cli` should be `com.pinterest` instead of `com.pinterest.ktlint`, we can remove this workaround whenever releasing version 1.0, to unify all group to `com.pinterest`.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
