### PR TITLE
Fix order of build tasks for publication to maven central

### DIFF
--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -110,3 +110,5 @@ tasks.withType<Test>().configureEach {
         systemProperty("ktlint-version", ktlintVersion)
     }
 }
+
+tasks.getByName("publishMavenPublicationToMavenCentralRepository").dependsOn(tasks.named("shadowJarExecutableChecksum"))


### PR DESCRIPTION
## Description

Fix order of build tasks for publication to maven central

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
