### PR TITLE
Fix typo in BlockCommentInitialStarAlignmentRule message output

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
@@ -42,7 +42,7 @@ public class BlockCommentInitialStarAlignmentRule :
                         ?.let { matchResult ->
                             val (prefix, content) = matchResult.destructured
                             if (prefix != expectedIndentForLineWithInitialStar) {
-                                emit(offset + prefix.length, "Initial star should be align with start of block comment", true)
+                                emit(offset + prefix.length, "Initial star should align with start of block comment", true)
                                 expectedIndentForLineWithInitialStar + content
                             } else {
                                 line

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRuleTest.kt
@@ -56,8 +56,8 @@ class BlockCommentInitialStarAlignmentRuleTest {
             """.trimIndent()
         blockCommentInitialStarAlignmentRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(2, 8, "Initial star should be align with start of block comment"),
-                LintViolation(3, 6, "Initial star should be align with start of block comment"),
+                LintViolation(2, 8, "Initial star should align with start of block comment"),
+                LintViolation(3, 6, "Initial star should align with start of block comment"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -83,9 +83,9 @@ class BlockCommentInitialStarAlignmentRuleTest {
             """.trimIndent()
         blockCommentInitialStarAlignmentRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(3, 12, "Initial star should be align with start of block comment"),
-                LintViolation(4, 4, "Initial star should be align with start of block comment"),
-                LintViolation(5, 10, "Initial star should be align with start of block comment"),
+                LintViolation(3, 12, "Initial star should align with start of block comment"),
+                LintViolation(4, 4, "Initial star should align with start of block comment"),
+                LintViolation(5, 10, "Initial star should align with start of block comment"),
             ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Fix a typo in BlockCommentInitialStarAlignmentRule message output.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
