### PR TITLE
Store relative path in baseline file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
+
 ### Changed
 
 ## [0.49.0] - 2023-04-21

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
@@ -121,10 +121,12 @@ private class BaselineLoader(private val path: String) {
         with(parseDocument().getElementsByTagName("file")) {
             for (i in 0 until length) {
                 with(item(i) as Element) {
+                    // Use relative path to file starting from baseline path
                     val fileName =
                         Paths
                             .get(getAttribute("name"))
                             .absolutePathString()
+                            .removePrefix(path)
                     lintErrorsPerFile[fileName] = parseBaselineFileElement()
                 }
             }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -10,26 +10,31 @@ import java.nio.file.Path
 
 class BaselineCLITest {
     @Test
-    fun `Given a file containing lint errors then find those errors when the baseline is ignored`(
+    fun `Given files containing lint errors then find those errors when the baseline is ignored`(
         @TempDir
         tempDir: Path,
     ) {
         CommandLineTestRunner(tempDir)
             .run(
                 "baseline",
-                listOf("TestBaselineFile.kt.test"),
+                listOf(
+                    "TestBaselineFile.kt.test",
+                    "some/path/to/TestBaselineFile2.kt.test"
+                ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()
                     assertThat(normalOutput)
-                        .containsLineMatching(Regex(".*:1:24: Unnecessary block.*"))
-                        .containsLineMatching(Regex(".*:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                        .containsLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex("^some/path/to/TestBaselineFile2.kt.test:1:25: Unnecessary block.*"))
+                        .containsLineMatching(Regex("^some/path/to/TestBaselineFile2.kt.test:2:1: Unexpected blank line.*"))
                 }.assertAll()
             }
     }
 
     @Test
-    fun `Given a file containing lint errors which are all registered in the baseline file and as of that are all ignored`(
+    fun `Given files containing lint errors which are all registered in the baseline file and as of that are all ignored`(
         @TempDir
         tempDir: Path,
     ) {
@@ -41,16 +46,19 @@ class BaselineCLITest {
                 listOf(
                     "--baseline=$baselinePath",
                     "TestBaselineFile.kt.test",
+                    "some/path/to/TestBaselineFile2.kt.test",
                 ),
             ) {
                 SoftAssertions().apply {
                     assertNormalExitCode()
                     assertThat(normalOutput)
-                        .doesNotContainLineMatching(Regex(".*:1:24: Unnecessary block.*"))
-                        .doesNotContainLineMatching(Regex(".*:2:1: Unexpected blank line.*"))
+                        .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                        .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                        .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                        .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
                         .containsLineMatching(
                             Regex(
-                                ".*Baseline file '$baselinePath' contains 3 reference\\(s\\) to rule ids without a rule set id. For " +
+                                ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
                                     "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
                                     "file.*",
                             ),
@@ -60,7 +68,7 @@ class BaselineCLITest {
     }
 
     @Test
-    fun `Given a file containing lint errors which are not registered in the baseline file and as of that are all reported`(
+    fun `Given files containing lint errors which are not registered in the baseline file and as of that are all reported`(
         @TempDir
         tempDir: Path,
     ) {
@@ -72,15 +80,17 @@ class BaselineCLITest {
                 listOf(
                     "--baseline=$baselinePath",
                     "TestBaselineExtraErrorFile.kt.test",
+                    "some/path/to/TestBaselineExtraErrorFile2.kt.test",
                 ),
             ) {
                 SoftAssertions().apply {
                     assertErrorExitCode()
                     assertThat(normalOutput)
-                        .containsLineMatching(Regex(".*:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex("^TestBaselineExtraErrorFile.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex("^some/path/to/TestBaselineExtraErrorFile2.kt.test:2:1: Unexpected blank line.*"))
                         .containsLineMatching(
                             Regex(
-                                ".*Baseline file '$baselinePath' contains 3 reference\\(s\\) to rule ids without a rule set id. For " +
+                                ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
                                     "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
                                     "file.*",
                             ),

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -19,7 +19,7 @@ class BaselineCLITest {
                 "baseline",
                 listOf(
                     "TestBaselineFile.kt.test",
-                    "some/path/to/TestBaselineFile2.kt.test"
+                    "some/path/to/TestBaselineFile2.kt.test",
                 ),
             ) {
                 SoftAssertions().apply {

--- a/ktlint-cli/src/test/resources/cli/baseline/some/path/to/TestBaselineExtraErrorFile2.kt.test
+++ b/ktlint-cli/src/test/resources/cli/baseline/some/path/to/TestBaselineExtraErrorFile2.kt.test
@@ -1,0 +1,3 @@
+class TestBaselineExtraErrorFile2 {
+
+}

--- a/ktlint-cli/src/test/resources/cli/baseline/some/path/to/TestBaselineFile2.kt.test
+++ b/ktlint-cli/src/test/resources/cli/baseline/some/path/to/TestBaselineFile2.kt.test
@@ -1,0 +1,3 @@
+class TestBaselineFile2 {
+
+}

--- a/ktlint-cli/src/test/resources/cli/baseline/test-baseline.xml
+++ b/ktlint-cli/src/test/resources/cli/baseline/test-baseline.xml
@@ -7,4 +7,11 @@
     <file name="TestBaselineExtraErrorFile.kt.test">
         <error line="1" column="34" source="no-empty-class-body" />
     </file>
+    <file name="some/path/to/TestBaselineFile2.kt.test">
+        <error line="1" column="25" source="no-empty-class-body" />
+        <error line="2" column="1" source="no-blank-line-before-rbrace" />
+    </file>
+    <file name="some/path/to/TestBaselineExtraErrorFile2.kt.test">
+        <error line="1" column="35" source="no-empty-class-body" />
+    </file>
 </baseline>


### PR DESCRIPTION
## Description

Store path of file containing a lint violation relative to the path of the baseline file itself

Closes #1962 

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
