### PR TITLE
Disable the gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ POM_DEVELOPER_NAME=Pinterest, Inc.
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false


### PR DESCRIPTION
## Description

The configuration cache is not yet supported by all tasks used in the build pipelines. For all github workflows the configuration-cache was already disabled. But also on the local machine, this now causes a simple task like `gradlew test` to fail as the `shadowJar` task is invoked which fails with error:
```
- Task `:ktlint-cli:shadowJarExecutable` of type `org.gradle.api.DefaultTask`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
```

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
