### PR TITLE
Return the unmodified filename from the baseline

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
@@ -121,12 +121,7 @@ private class BaselineLoader(private val path: String) {
         with(parseDocument().getElementsByTagName("file")) {
             for (i in 0 until length) {
                 with(item(i) as Element) {
-                    // Use relative path to file starting from baseline path
-                    val fileName =
-                        Paths
-                            .get(getAttribute("name"))
-                            .absolutePathString()
-                            .removePrefix(path)
+                    val fileName = getAttribute("name")
                     lintErrorsPerFile[fileName] = parseBaselineFileElement()
                 }
             }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/api/Baseline.kt
@@ -17,7 +17,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString
 import kotlin.io.path.relativeToOrSelf
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -410,7 +410,7 @@ internal class KtlintCommandLine {
             .map { it.toFile() }
             .takeWhile { errorNumber.get() < limit }
             .map { file ->
-                val fileName = file.toPath().absolutePathString()
+                val fileName = file.toPath().relativeRoute
                 Callable {
                     fileName to
                         process(

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.ArrayList
 import kotlin.collections.LinkedHashSet
 import kotlin.concurrent.thread
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString
 import kotlin.io.path.relativeToOrSelf
 import kotlin.system.exitProcess

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -62,8 +62,8 @@ class BaselineCLITest {
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
-                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
-                                        "file.*",
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this " +
+                                        "baseline file.*",
                                 ),
                             )
                     }.assertAll()
@@ -96,8 +96,8 @@ class BaselineCLITest {
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
-                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
-                                        "file.*",
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this " +
+                                        "baseline file.*",
                                 ),
                             )
                     }.assertAll()
@@ -130,8 +130,8 @@ class BaselineCLITest {
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
-                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
-                                        "file.*",
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this " +
+                                        "baseline file.*",
                                 ),
                             )
                     }.assertAll()

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -130,9 +130,9 @@ class BaselineCLITest {
                             .containsLineMatching(
                                 Regex(
                                     // Escape "\" in baseline path for Windows
-                                    ".*Baseline file '${baselinePath.replace("\\", "\\\\")}' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
-                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this " +
-                                        "baseline file.*",
+                                    ".*Baseline file '${baselinePath.replace("\\", "\\\\")}' contains 6 " +
+                                        "reference\\(s\\) to rule ids without a rule set id. For those references the rule set id " +
+                                        "'standard' is assumed. It is advised to regenerate this baseline file.*",
                                 ),
                             )
                     }.assertAll()

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.cli.CommandLineTestRunner
 import com.pinterest.ktlint.cli.containsLineMatching
 import com.pinterest.ktlint.cli.doesNotContainLineMatching
 import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -33,38 +34,109 @@ class BaselineCLITest {
             }
     }
 
-    @Test
-    fun `Given files containing lint errors which are all registered in the baseline file and as of that are all ignored`(
-        @TempDir
-        tempDir: Path,
-    ) {
-        val baselinePath = "test-baseline.xml"
+    @Nested
+    inner class `Given files containing lint errors which are all registered in the baseline file and as of that are all ignored` {
+        @Test
+        fun `Given a baseline file in the root of the working directory`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val baselinePath = "test-baseline.xml"
 
-        CommandLineTestRunner(tempDir)
-            .run(
-                "baseline",
-                listOf(
-                    "--baseline=$baselinePath",
-                    "TestBaselineFile.kt.test",
-                    "some/path/to/TestBaselineFile2.kt.test",
-                ),
-            ) {
-                SoftAssertions().apply {
-                    assertNormalExitCode()
-                    assertThat(normalOutput)
-                        .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                        .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                        .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                        .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                        .containsLineMatching(
-                            Regex(
-                                ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
-                                    "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
-                                    "file.*",
-                            ),
-                        )
-                }.assertAll()
-            }
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "baseline",
+                    listOf(
+                        "--baseline=$baselinePath",
+                        "TestBaselineFile.kt.test",
+                        "some/path/to/TestBaselineFile2.kt.test",
+                    ),
+                ) {
+                    SoftAssertions().apply {
+                        assertNormalExitCode()
+                        assertThat(normalOutput)
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .containsLineMatching(
+                                Regex(
+                                    ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
+                                        "file.*",
+                                ),
+                            )
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given a baseline file in a subdirectory of the working directory`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val baselinePath = "config/test-baseline.xml"
+
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "baseline",
+                    listOf(
+                        "--baseline=$baselinePath",
+                        "TestBaselineFile.kt.test",
+                        "some/path/to/TestBaselineFile2.kt.test",
+                    ),
+                ) {
+                    SoftAssertions().apply {
+                        assertNormalExitCode()
+                        assertThat(normalOutput)
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .containsLineMatching(
+                                Regex(
+                                    ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
+                                        "file.*",
+                                ),
+                            )
+                    }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Given a baseline file with an absolute path, not necessarily in the working directory or one of its subdirectories`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val baselinePath = "$tempDir/baseline/config/test-baseline.xml"
+
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "baseline",
+                    listOf(
+                        "--baseline=$baselinePath",
+                        "TestBaselineFile.kt.test",
+                        "some/path/to/TestBaselineFile2.kt.test",
+                    ),
+                ) {
+                    SoftAssertions().apply {
+                        assertNormalExitCode()
+                        assertThat(normalOutput)
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .containsLineMatching(
+                                Regex(
+                                    ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
+                                        "those references the rule set id 'standard' is assumed. It is advised to regenerate this baseline " +
+                                        "file.*",
+                                ),
+                            )
+                    }.assertAll()
+                }
+        }
     }
 
     @Test

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -129,7 +129,8 @@ class BaselineCLITest {
                             .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
                             .containsLineMatching(
                                 Regex(
-                                    ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
+                                    // Escape "\" in baseline path for Windows
+                                    ".*Baseline file '${baselinePath.replace("\\", "\\\\")}' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
                                         "those references the rule set id 'standard' is assumed. It is advised to regenerate this " +
                                         "baseline file.*",
                                 ),

--- a/ktlint-cli/src/test/resources/cli/baseline/config/test-baseline.xml
+++ b/ktlint-cli/src/test/resources/cli/baseline/config/test-baseline.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="TestBaselineFile.kt.test">
+        <error line="1" column="24" source="no-empty-class-body" />
+        <error line="2" column="1" source="no-blank-line-before-rbrace" />
+    </file>
+    <file name="TestBaselineExtraErrorFile.kt.test">
+        <error line="1" column="34" source="no-empty-class-body" />
+    </file>
+    <file name="some/path/to/TestBaselineFile2.kt.test">
+        <error line="1" column="25" source="no-empty-class-body" />
+        <error line="2" column="1" source="no-blank-line-before-rbrace" />
+    </file>
+    <file name="some/path/to/TestBaselineExtraErrorFile2.kt.test">
+        <error line="1" column="35" source="no-empty-class-body" />
+    </file>
+</baseline>


### PR DESCRIPTION
## Description

It is the responsibility of the Ktlint CLI to consistently store, retrieve and handle the path of the file in which the error is found.

Closes #1962 

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
