### PR TITLE
Release to SDKMan when publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,11 @@ jobs:
         if: ${{ success() }}
         run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: Create zip for sdkman
+      - name: Create zip for dependency managers
         if: ${{ success() }}
         run: |
           cd ktlint-cli/build/run
+          # Doing this for Homebrew and https://github.com/sdkman/sdkman-cli/wiki/Well-formed-SDK-archives
           mkdir -p ktlint-${{ env.version }}/bin
           cp ktlint ktlint-${{ env.version }}/bin
           zip -rm ktlint-${{ env.version }}.zip ktlint-${{ env.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           cd ktlint-cli/build/run
           # Doing this for Homebrew and https://github.com/sdkman/sdkman-cli/wiki/Well-formed-SDK-archives
           mkdir -p ktlint-${{ env.version }}/bin
-          cp ktlint ktlint-${{ env.version }}/bin/ktlint-${{ env.version }}
+          cp ktlint ktlint-${{ env.version }}/bin
           zip -rm ktlint-${{ env.version }}.zip ktlint-${{ env.version }}
 
       - name : Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,19 @@ jobs:
         if: ${{ success() }}
         uses : ffurrer2/extract-release-notes@v1
 
+      - name: Get version
+        id: get_version
+        if: ${{ success() }}
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Create zip for sdkman
+        if: ${{ success() }}
+        run: |
+          cd ktlint-cli/build/run
+          mkdir -p ktlint-${{ env.version }}/bin
+          cp ktlint ktlint-${{ env.version }}/bin
+          zip -rm ktlint-${{ env.version }}.zip ktlint-${{ env.version }}
+
       - name : Create release
         id: github_release
         if: ${{ success() }}
@@ -48,11 +61,6 @@ jobs:
         env :
           GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get version
-        id: get_version
-        if: ${{ success() }}
-        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
       - name: Bump Homebrew Formula
         if: ${{ success() }}
         uses: mislav/bump-homebrew-formula-action@v2
@@ -60,7 +68,15 @@ jobs:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
         with:
           formula-name: ktlint
-          download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint
+          download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
+
+      - name: Release to sdkman
+        if: ${{ success() }}
+        env:
+          SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
+          SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
+          SDKMAN_VERSION: ${{ env.version }}
+        run: ./gradlew :ktlint-cli:sdkMajorRelease
 
       - name: Announce Release
         if: ${{ success() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           cd ktlint-cli/build/run
           # Doing this for Homebrew and https://github.com/sdkman/sdkman-cli/wiki/Well-formed-SDK-archives
           mkdir -p ktlint-${{ env.version }}/bin
-          cp ktlint ktlint-${{ env.version }}/bin
+          cp ktlint ktlint-${{ env.version }}/bin/ktlint-${{ env.version }}
           zip -rm ktlint-${{ env.version }}.zip ktlint-${{ env.version }}
 
       - name : Create release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* `ktlint` is now available on SDKMAN!
+
 ### Removed
 
 ### Fixed

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -48,6 +48,11 @@ Install with [MacPorts](https://www.macports.org/)
 port install ktlint
 ```
 
+Install with [SDKMAN! on macOS and Linux](https://sdkman.io/)
+```sh
+sdk install ktlint
+```
+
 On Arch Linux install package [ktlint <sup>AUR</sup>](https://aur.archlinux.org/packages/ktlint/).
 
 ## Command line usage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlinDev = "1.8.20"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 checksum = "org.gradle.crypto.checksum:1.4.0"
 shadow = "com.github.johnrengelman.shadow:8.1.1"
+sdkman = "io.sdkman.vendors:3.0.0"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("ktlint-publication-library")
     alias(libs.plugins.shadow)
     alias(libs.plugins.checksum)
+    alias(libs.plugins.sdkman)
     signing
 }
 
@@ -138,4 +139,12 @@ tasks.withType<Test>().configureEach {
         )
         systemProperty("ktlint-version", ktlintVersion)
     }
+}
+
+sdkman {
+    val sdkmanVersion = providers.environmentVariable("SDKMAN_KEY").orElse(project.version.toString())
+    candidate.set("ktlint")
+    version.set(sdkmanVersion)
+    url.set("https://github.com/pinterest/ktlint/releases/download/$sdkmanVersion/ktlint-$sdkmanVersion.zip")
+    hashtag.set("ktlint")
 }


### PR DESCRIPTION
## Description

Follows the process laid out in the SDKMan [vendor onboarding process](https://github.com/sdkman/sdkman-cli/wiki/Vendor-onboarding-process) and [gradle plugin](https://github.com/sdkman/sdkman-vendor-gradle-plugin) to push releases of ktlint to SDKMan.

Fixes https://github.com/pinterest/ktlint/issues/1363

## Checklist

- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
