### PR TITLE
Print absolute path of file in lint violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
-* Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963))
-* Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
+* Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963)) 
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
+* Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963)) 
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
-* Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963)) 
+* Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963))
+* Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -334,9 +334,18 @@ private val onWindowsOS
             .getProperty("os.name")
             .startsWith("windows", true)
 
+/**
+ * Gets the relative route of the path. Also adjusts the slashes for uniformity between file systems.
+ */
 internal fun File.location(relative: Boolean) =
     if (relative) {
-        this.toPath().relativeToOrSelf(Path(WORK_DIR)).pathString
+        this
+            .toPath()
+            .relativeToOrSelf(Path(WORK_DIR))
+            .pathString
+            .replace(File.separatorChar, '/')
     } else {
-        this.path
+        this
+            .path
+            .replace(File.separatorChar, '/')
     }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -23,7 +23,7 @@ import kotlin.system.measureTimeMillis
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
-private val WORK_DIR: String = File(".").canonicalPath
+private val ROOT_DIR_PATH: Path = Paths.get("").toAbsolutePath()
 
 private val TILDE_REGEX = Regex("^(!)?~")
 private const val NEGATION_PREFIX = "!"
@@ -341,7 +341,7 @@ internal fun File.location(relative: Boolean) =
     if (relative) {
         this
             .toPath()
-            .relativeToOrSelf(Path(WORK_DIR))
+            .relativeToOrSelf(ROOT_DIR_PATH)
             .pathString
             .replace(File.separatorChar, '/')
     } else {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -260,9 +260,9 @@ internal class KtlintCommandLine {
                 }.applyIf(disabledRules.isNotBlank()) {
                     logger.debug { "Add editor config override to disable rules: '$disabledRules'" }
                     plus(*disabledRulesEditorConfigOverrides())
-                }.applyIf(android || codeStyle == CodeStyleValue.android || codeStyle == CodeStyleValue.android_studio) {
-                    logger.debug { "Add editor config override to set code style to 'android_studio'" }
-                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android_studio)
+                }.applyIf(android) {
+                    logger.debug { "Add editor config override to set code style to 'android'" }
+                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android)
                 }.applyIf(stdin) {
                     logger.debug {
                         "Add editor config override to disable 'filename' rule which can not be used in combination with reading from " +

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -260,9 +260,9 @@ internal class KtlintCommandLine {
                 }.applyIf(disabledRules.isNotBlank()) {
                     logger.debug { "Add editor config override to disable rules: '$disabledRules'" }
                     plus(*disabledRulesEditorConfigOverrides())
-                }.applyIf(android) {
-                    logger.debug { "Add editor config override to set code style to 'android'" }
-                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android)
+                }.applyIf(android || codeStyle == CodeStyleValue.android || codeStyle == CodeStyleValue.android_studio) {
+                    logger.debug { "Add editor config override to set code style to 'android_studio'" }
+                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android_studio)
                 }.applyIf(stdin) {
                     logger.debug {
                         "Add editor config override to disable 'filename' rule which can not be used in combination with reading from " +

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -407,7 +407,7 @@ internal class KtlintCommandLine {
             .takeWhile { errorNumber.get() < limit }
             .map { file ->
                 Callable {
-                    file.location(relative) to
+                    file to
                         process(
                             ktLintRuleEngine = ktLintRuleEngine,
                             code = Code.fromFile(file),
@@ -420,7 +420,7 @@ internal class KtlintCommandLine {
                                     ),
                         )
                 }
-            }.parallel({ (fileName, errList) -> report(File(fileName).location(relative), errList, reporter) })
+            }.parallel({ (file, errList) -> report(file.location(relative), errList, reporter) })
     }
 
     private fun lintStdin(

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -51,10 +51,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.collections.ArrayList
-import kotlin.collections.LinkedHashSet
 import kotlin.concurrent.thread
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString
 import kotlin.io.path.relativeToOrSelf
 import kotlin.system.exitProcess
@@ -404,35 +401,12 @@ internal class KtlintCommandLine {
         lintErrorsPerFile: Map<String, List<KtlintCliError>>,
         reporter: ReporterV2,
     ) {
-        logger.debug {
-            """
-            lintErrorsPerFile: $lintErrorsPerFile
-            """.trimIndent()
-        }
         FileSystems
             .getDefault()
             .fileSequence(patterns)
             .map { it.toFile() }
             .takeWhile { errorNumber.get() < limit }
             .map { file ->
-                logger.debug {
-                    """
-                    File (absolutePathString): ${file.toPath().absolutePathString()}
-
-                      - file.location(true): ${file.location(true)}
-                        lintErrorsPerFile: ${lintErrorsPerFile
-                        .getOrDefault(
-                            // Baseline stores the lint violations as relative path to work dir
-                            file.location(true),
-                            emptyList(),
-                        )}
-
-                      - file.toPath().relativeRoute: ${file.toPath().relativeRoute}
-                        lintErrorsPerFile: ${lintErrorsPerFile.getOrDefault(file.toPath().relativeRoute, kotlin.collections.emptyList())}
-                    }
-
-                    """.trimIndent()
-                }
                 Callable {
                     file to
                         process(

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -41,7 +41,6 @@ import picocli.CommandLine.ParameterException
 import picocli.CommandLine.Parameters
 import java.io.File
 import java.nio.file.FileSystems
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
 import java.util.concurrent.ArrayBlockingQueue
@@ -54,8 +53,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.ArrayList
 import kotlin.collections.LinkedHashSet
 import kotlin.concurrent.thread
-import kotlin.io.path.pathString
-import kotlin.io.path.relativeToOrSelf
 import kotlin.system.exitProcess
 
 private lateinit var logger: KLogger
@@ -419,7 +416,7 @@ internal class KtlintCommandLine {
                                     .getOrDefault(
                                         // Baseline stores the lint violations as relative path to work dir
                                         file.location(true),
-                                        emptyList()
+                                        emptyList(),
                                     ),
                         )
                 }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -476,4 +476,39 @@ class SimpleCLITest {
                     .doesNotContainLineMatching(Regex(".*Needless blank line.*"))
             }
     }
+
+    @Nested
+    inner class `Issue 1983 - Enable android code style` {
+        @Test
+        fun `Enable android code style via parameter --android`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    testProjectName = "too-many-empty-lines",
+                    arguments = listOf("--android"),
+                ) {
+                    assertThat(normalOutput).containsLineMatching(
+                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
+                    )
+                }
+        }
+
+        @Test
+        fun `Enable android code style via parameter --code-style=android_studio`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    testProjectName = "too-many-empty-lines",
+                    arguments = listOf("--code-style=android_studio"),
+                ) {
+                    assertThat(normalOutput).containsLineMatching(
+                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
+                    )
+                }
+        }
+    }
 }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -476,39 +476,4 @@ class SimpleCLITest {
                     .doesNotContainLineMatching(Regex(".*Needless blank line.*"))
             }
     }
-
-    @Nested
-    inner class `Issue 1983 - Enable android code style` {
-        @Test
-        fun `Enable android code style via parameter --android`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    testProjectName = "too-many-empty-lines",
-                    arguments = listOf("--android"),
-                ) {
-                    assertThat(normalOutput).containsLineMatching(
-                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
-                    )
-                }
-        }
-
-        @Test
-        fun `Enable android code style via parameter --code-style=android_studio`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    testProjectName = "too-many-empty-lines",
-                    arguments = listOf("--code-style=android_studio"),
-                ) {
-                    assertThat(normalOutput).containsLineMatching(
-                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
-                    )
-                }
-        }
-    }
 }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -15,9 +15,10 @@ class BaselineCLITest {
         @TempDir
         tempDir: Path,
     ) {
+        val projectName = "baseline"
         CommandLineTestRunner(tempDir)
             .run(
-                "baseline",
+                projectName,
                 listOf(
                     "TestBaselineFile.kt.test",
                     "some/path/to/TestBaselineFile2.kt.test",
@@ -26,10 +27,10 @@ class BaselineCLITest {
                 SoftAssertions().apply {
                     assertErrorExitCode()
                     assertThat(normalOutput)
-                        .containsLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                        .containsLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                        .containsLineMatching(Regex("^some/path/to/TestBaselineFile2.kt.test:1:25: Unnecessary block.*"))
-                        .containsLineMatching(Regex("^some/path/to/TestBaselineFile2.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                        .containsLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile2.kt.test:1:25: Unnecessary block.*"))
+                        .containsLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile2.kt.test:2:1: Unexpected blank line.*"))
                 }.assertAll()
             }
     }
@@ -41,11 +42,12 @@ class BaselineCLITest {
             @TempDir
             tempDir: Path,
         ) {
+            val projectName = "baseline"
             val baselinePath = "test-baseline.xml"
 
             CommandLineTestRunner(tempDir)
                 .run(
-                    "baseline",
+                    projectName,
                     listOf(
                         "--baseline=$baselinePath",
                         "TestBaselineFile.kt.test",
@@ -55,10 +57,10 @@ class BaselineCLITest {
                     SoftAssertions().apply {
                         assertNormalExitCode()
                         assertThat(normalOutput)
-                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
@@ -75,11 +77,12 @@ class BaselineCLITest {
             @TempDir
             tempDir: Path,
         ) {
+            val projectName = "baseline"
             val baselinePath = "config/test-baseline.xml"
 
             CommandLineTestRunner(tempDir)
                 .run(
-                    "baseline",
+                    projectName,
                     listOf(
                         "--baseline=$baselinePath",
                         "TestBaselineFile.kt.test",
@@ -89,10 +92,10 @@ class BaselineCLITest {
                     SoftAssertions().apply {
                         assertNormalExitCode()
                         assertThat(normalOutput)
-                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex("^TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex("^some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
+                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
@@ -145,11 +148,12 @@ class BaselineCLITest {
         @TempDir
         tempDir: Path,
     ) {
+        val projectName = "baseline"
         val baselinePath = "test-baseline.xml"
 
         CommandLineTestRunner(tempDir)
             .run(
-                "baseline",
+                projectName,
                 listOf(
                     "--baseline=$baselinePath",
                     "TestBaselineExtraErrorFile.kt.test",
@@ -159,8 +163,8 @@ class BaselineCLITest {
                 SoftAssertions().apply {
                     assertErrorExitCode()
                     assertThat(normalOutput)
-                        .containsLineMatching(Regex("^TestBaselineExtraErrorFile.kt.test:2:1: Unexpected blank line.*"))
-                        .containsLineMatching(Regex("^some/path/to/TestBaselineExtraErrorFile2.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex(".*/$projectName/TestBaselineExtraErrorFile.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineExtraErrorFile2.kt.test:2:1: Unexpected blank line.*"))
                         .containsLineMatching(
                             Regex(
                                 ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -59,8 +59,12 @@ class BaselineCLITest {
                         assertThat(normalOutput)
                             .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
                             .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(
+                                Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"),
+                            )
+                            .doesNotContainLineMatching(
+                                Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"),
+                            )
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
@@ -94,8 +98,12 @@ class BaselineCLITest {
                         assertThat(normalOutput)
                             .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
                             .doesNotContainLineMatching(Regex(".*/$projectName/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
-                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"))
-                            .doesNotContainLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"))
+                            .doesNotContainLineMatching(
+                                Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:1:24: Unnecessary block.*"),
+                            )
+                            .doesNotContainLineMatching(
+                                Regex(".*/$projectName/some/path/to/TestBaselineFile.kt.test:2:1: Unexpected blank line.*"),
+                            )
                             .containsLineMatching(
                                 Regex(
                                     ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +
@@ -164,7 +172,9 @@ class BaselineCLITest {
                     assertErrorExitCode()
                     assertThat(normalOutput)
                         .containsLineMatching(Regex(".*/$projectName/TestBaselineExtraErrorFile.kt.test:2:1: Unexpected blank line.*"))
-                        .containsLineMatching(Regex(".*/$projectName/some/path/to/TestBaselineExtraErrorFile2.kt.test:2:1: Unexpected blank line.*"))
+                        .containsLineMatching(
+                            Regex(".*/$projectName/some/path/to/TestBaselineExtraErrorFile2.kt.test:2:1: Unexpected blank line.*"),
+                        )
                         .containsLineMatching(
                             Regex(
                                 ".*Baseline file '$baselinePath' contains 6 reference\\(s\\) to rule ids without a rule set id. For " +


### PR DESCRIPTION
## Description

Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI

Closes #1983 

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
