### PR TITLE
Delete redundant "org.gradle.configuration-cache=false"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,3 @@ POM_DEVELOPER_NAME=Pinterest, Inc.
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configuration-cache=false


### PR DESCRIPTION
## Description
This pull request deletes the redundant `org.gradle.configuration-cache=false`, which is default.

> By default, Gradle does not use the configuration cache.

https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:enable

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
