### PR TITLE
Handle parameter `--code-style=android_studio` in Ktlint CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
+* Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -263,9 +263,9 @@ internal class KtlintCommandLine {
                 }.applyIf(disabledRules.isNotBlank()) {
                     logger.debug { "Add editor config override to disable rules: '$disabledRules'" }
                     plus(*disabledRulesEditorConfigOverrides())
-                }.applyIf(android) {
-                    logger.debug { "Add editor config override to set code style to 'android'" }
-                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android)
+                }.applyIf(android || codeStyle == CodeStyleValue.android || codeStyle == CodeStyleValue.android_studio) {
+                    logger.debug { "Add editor config override to set code style to 'android_studio'" }
+                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android_studio)
                 }.applyIf(stdin) {
                     logger.debug {
                         "Add editor config override to disable 'filename' rule which can not be used in combination with reading from " +

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -476,4 +476,39 @@ class SimpleCLITest {
                     .doesNotContainLineMatching(Regex(".*Needless blank line.*"))
             }
     }
+
+    @Nested
+    inner class `Issue 1983 - Enable android code style` {
+        @Test
+        fun `Enable android code style via parameter --android`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    testProjectName = "too-many-empty-lines",
+                    arguments = listOf("--android"),
+                ) {
+                    assertThat(normalOutput).containsLineMatching(
+                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
+                    )
+                }
+        }
+
+        @Test
+        fun `Enable android code style via parameter --code-style=android_studio`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    testProjectName = "too-many-empty-lines",
+                    arguments = listOf("--code-style=android_studio"),
+                ) {
+                    assertThat(normalOutput).containsLineMatching(
+                        Regex(".*Add editor config override to set code style to 'android_studio'.*"),
+                    )
+                }
+        }
+    }
 }


### PR DESCRIPTION
## Description

Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android`

Closes #1982

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
