### PR TITLE
Prevent nullpointer exception (NPE) in no-consecutive-blank-lines rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 * Store path of file containing a lint violation relative to the location of the baseline file itself ([#1962](https://github.com/pinterest/ktlint/issues/1962))
 * Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
+* Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file `no-consecutive-blank-lines` ([#1987](https://github.com/pinterest/ktlint/issues/1987))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRule.kt
@@ -62,7 +62,7 @@ public class NoConsecutiveBlankLinesRule : StandardRule("no-consecutive-blank-li
             ?.let { prevNode ->
                 prevNode.elementType == IDENTIFIER &&
                     prevNode.treeParent.elementType == CLASS &&
-                    this.treeNext.elementType == PRIMARY_CONSTRUCTOR
+                    this.treeNext?.elementType == PRIMARY_CONSTRUCTOR
             }
             ?: false
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveBlankLinesRuleTest.kt
@@ -212,4 +212,13 @@ class NoConsecutiveBlankLinesRuleTest {
                 """.trimIndent(),
             )
     }
+
+    @Test
+    fun `Issue 1987 - Class without body but followed by multiple blank lines until end of file should not throw exception`() {
+        val code = "class Foo\n\n\n"
+        val formattedCode = "class Foo\n"
+        noConsecutiveBlankLinesRuleAssertThat(code)
+            .hasLintViolations(LintViolation(3, 1, "Needless blank line(s)"))
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file

Closes #1987

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
