### PR TITLE
Fix NPE if or operator at start of line followed by dot qualified expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963)) 
 * Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
 * Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file `no-consecutive-blank-lines` ([#1987](https://github.com/pinterest/ktlint/issues/1987))
+* Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression `indent` ([#1993](https://github.com/pinterest/ktlint/issues/1993))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1091,7 +1091,7 @@ public class IndentationRule :
     private fun ASTNode?.isElvisOperator() =
         this != null &&
             elementType == OPERATION_REFERENCE &&
-            firstChildNode.elementType == ELVIS
+            firstChildNode?.elementType == ELVIS
 
     private fun ASTNode.acceptableTrailingSpaces(): String {
         require(elementType == WHITE_SPACE)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5122,6 +5122,32 @@ internal class IndentationRuleTest {
         }
     }
 
+    @Test
+    fun `Issue 1993 - An or operator at start of line followed by a dot qualified expressions should not throw an exception`() {
+        val code =
+            """
+            val foo =
+                if (false
+                    || foobar.bar()
+                ) {
+                    // Do something
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                if (false ||
+                    foobar.bar()
+                ) {
+                    // Do something
+                }
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .addAdditionalRuleProvider { ChainWrappingRule() }
+            .hasLintViolationForAdditionalRule(3, 9, "Line must not begin with \"||\"")
+            .isFormattedAs(formattedCode)
+    }
+
     private companion object {
         val INDENT_STYLE_TAB =
             INDENT_STYLE_PROPERTY to PropertyType.IndentStyleValue.tab


### PR DESCRIPTION
## Description

Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression

Closes #1993

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
