### PR TITLE
Disable wrapping of parameters (ktlint_official)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Print absolute path of file in lint violations when flag "--relative" is not specified in Ktlint CLI ([#1963](https://github.com/pinterest/ktlint/issues/1963)) 
 * Handle parameter `--code-style=android_studio` in Ktlint CLI identical to deprecated parameter `--android` ([#1982](https://github.com/pinterest/ktlint/issues/1982))
 * Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file `no-consecutive-blank-lines` ([#1987](https://github.com/pinterest/ktlint/issues/1987))
+* Allow to 'unset' the `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` when using `ktlint_official` code style `function-signature` ([#1977](https://github.com/pinterest/ktlint/issues/1977))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/docs/rules/configuration-ktlint.md
+++ b/docs/rules/configuration-ktlint.md
@@ -59,11 +59,14 @@ This setting only takes effect when rule `final-newline` is enabled.
 
 ## Force multiline function signature based on number of parameters
 
-By default, the number of parameters in a function signature is not relevant when rewriting the function signature. Only the maximum line length determines when a function signature should be written on a single line or with multiple lines. Setting `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` can be used, to force a multiline function signature in case the function contain at least a number of parameters even in case the function signature would fit on a single line. Use value `-1` (default) to disable this setting.
+Setting `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` forces a multiline function signature in case the function contains the specified minimum number of parameters even in case the function signature would fit on a single line. Use value `unset` (default) to disable this setting.
+
+!!! note
+    By default, the `ktlint_official` code style wraps parameters of functions having at least 2 parameters. For other code styles, this setting is disabled by default. 
 
 ```ini
 [*.{kt,kts}]
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than= -1
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
 ```
 
 This setting only takes effect when rule `function-signature` is enabled.

--- a/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/KtLintRuleEngineTest.kt
+++ b/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/KtLintRuleEngineTest.kt
@@ -12,7 +12,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EXPERIMENTAL_RULES_EXECUTION_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RuleExecution
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleExecutionEditorConfigProperty
-import com.pinterest.ktlint.rule.engine.internal.toPropertyBuilderWithValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyBuilderWithValue
 import com.pinterest.ktlint.ruleset.standard.rules.FilenameRule
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import com.pinterest.ktlint.test.KtlintTestFileSystem

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/ec4j/EditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/ec4j/EditorConfigProperty.kt
@@ -1,0 +1,36 @@
+package com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
+
+/**
+ * Creates an [org.ec4j.core.model.Property.Builder] for given [value].
+ */
+public fun <T> EditorConfigProperty<T>.toPropertyBuilderWithValue(value: String): Property.Builder =
+    Property
+        .builder()
+        .type(type)
+        .name(name)
+        .value(value)
+
+/**
+ * Creates an [org.ec4j.core.model.Property] for given [value].
+ */
+public fun <T> EditorConfigProperty<T>.toPropertyWithValue(value: String): Property = toPropertyBuilderWithValue(value).build()
+
+/**
+ * Creates an [org.ec4j.core.model.Property.Builder] for given [value].
+ */
+public fun <T> EditorConfigProperty<T>.toPropertyBuilderWithValue(value: PropertyType.PropertyValue<*>): Property.Builder =
+    Property
+        .builder()
+        .type(type)
+        .name(name)
+        .value(value)
+
+/**
+ * Creates an [org.ec4j.core.model.Property] for given [value].
+ */
+public fun <T> EditorConfigProperty<T>.toPropertyWithValue(value: PropertyType.PropertyValue<*>): Property =
+    toPropertyBuilderWithValue(value).build()

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
@@ -1,7 +1,7 @@
 package com.pinterest.ktlint.rule.engine.core.api.editorconfig
 
 import com.pinterest.ktlint.rule.engine.api.EditorConfigDefaults
-import com.pinterest.ktlint.rule.engine.internal.toPropertyWithValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
 import com.pinterest.ktlint.test.KtlintTestFileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/IndentSizeEditorConfigPropertyTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/IndentSizeEditorConfigPropertyTest.kt
@@ -1,6 +1,6 @@
 package com.pinterest.ktlint.rule.engine.core.api.editorconfig
 
-import com.pinterest.ktlint.rule.engine.internal.toPropertyWithValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/MaxLineLengthEditorConfigPropertyTest.kt
@@ -1,6 +1,6 @@
 package com.pinterest.ktlint.rule.engine.core.api.editorconfig
 
-import com.pinterest.ktlint.rule.engine.internal.toPropertyWithValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -13,6 +13,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EXPERIMENTAL_RULES
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
 import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAGS_ENABLED_PROPERTY
 import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAG_OFF_ENABLED_PROPERTY
 import com.pinterest.ktlint.rule.engine.internal.FormatterTags.Companion.FORMATTER_TAG_ON_ENABLED_PROPERTY

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigProperty.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigProperty.kt
@@ -3,34 +3,34 @@ package com.pinterest.ktlint.rule.engine.internal
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import org.ec4j.core.model.Property
 import org.ec4j.core.model.PropertyType
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyBuilderWithValue as ec4jToPropertyBuilderWithPropertyValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyBuilderWithValue as ec4jToPropertyBuilderWithStringValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue as ec4jToPropertyWithPropertyValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue as ec4jToPropertyWithStringValue
 
 /**
  * Creates an [org.ec4j.core.model.Property.Builder] for given [value].
  */
+@Deprecated("Marked for removal in ktlint 0.50. Use function exposed by ktlint-rule-engine-core instead")
 public fun <T> EditorConfigProperty<T>.toPropertyBuilderWithValue(value: String): Property.Builder =
-    Property
-        .builder()
-        .type(type)
-        .name(name)
-        .value(value)
+    ec4jToPropertyBuilderWithStringValue(value)
 
 /**
  * Creates an [org.ec4j.core.model.Property] for given [value].
  */
-public fun <T> EditorConfigProperty<T>.toPropertyWithValue(value: String): Property = toPropertyBuilderWithValue(value).build()
+@Deprecated("Marked for removal in ktlint 0.50. Use function exposed by ktlint-rule-engine-core instead")
+public fun <T> EditorConfigProperty<T>.toPropertyWithValue(value: String): Property = ec4jToPropertyWithStringValue(value)
 
 /**
  * Creates an [org.ec4j.core.model.Property.Builder] for given [value].
  */
+@Deprecated("Marked for removal in ktlint 0.50. Use function exposed by ktlint-rule-engine-core instead")
 public fun <T> EditorConfigProperty<T>.toPropertyBuilderWithValue(value: PropertyType.PropertyValue<*>): Property.Builder =
-    Property
-        .builder()
-        .type(type)
-        .name(name)
-        .value(value)
+    ec4jToPropertyBuilderWithPropertyValue(value)
 
 /**
  * Creates an [org.ec4j.core.model.Property] for given [value].
  */
+@Deprecated("Marked for removal in ktlint 0.50. Use function exposed by ktlint-rule-engine-core instead")
 public fun <T> EditorConfigProperty<T>.toPropertyWithValue(value: PropertyType.PropertyValue<*>): Property =
-    toPropertyBuilderWithValue(value).build()
+    ec4jToPropertyWithPropertyValue(value)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -717,6 +717,7 @@ public class FunctionSignatureRule :
             ?.prevCodeLeaf()
 
     public companion object {
+        private const val FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET = Int.MAX_VALUE
         public val FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY: EditorConfigProperty<Int> =
             EditorConfigProperty(
                 type =
@@ -728,8 +729,22 @@ public class FunctionSignatureRule :
                         PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
                         setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
                     ),
-                defaultValue = Int.MAX_VALUE,
+                defaultValue = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET,
                 ktlintOfficialCodeStyleDefaultValue = 2,
+                propertyMapper = { property, _ ->
+                    if (property?.isUnset == true) {
+                        FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET
+                    } else {
+                        property?.getValueAs<Int>()
+                    }
+                },
+                propertyWriter = { property ->
+                    if (property == FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET) {
+                        "unset"
+                    } else {
+                        property.toString()
+                    }
+                },
             )
 
         public val FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY: EditorConfigProperty<FunctionBodyExpressionWrapping> =


### PR DESCRIPTION
## Description

Allow to 'unset' the `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` when using `ktlint_official` code style `function-signature`

Closes #1977

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
