### PR TITLE
Restrict indentation of closing quotes to `ktlint_official` code style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file `no-consecutive-blank-lines` ([#1987](https://github.com/pinterest/ktlint/issues/1987))
 * Allow to 'unset' the `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` when using `ktlint_official` code style `function-signature` ([#1977](https://github.com/pinterest/ktlint/issues/1977))
 * Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression `indent` ([#1993](https://github.com/pinterest/ktlint/issues/1993))
+* Restrict indentation of closing quotes to `ktlint_official` code style to keep formatting of other code styles consistent with `0.48.x` and before `indent` ([#1971](https://github.com/pinterest/ktlint/issues/1971))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1218,7 +1218,7 @@ private fun String.textWithEscapedTabAndNewline(): String {
 
 private class StringTemplateIndenter(
     private val codeStyle: CodeStyleValue,
-    private val indentConfig: IndentConfig
+    private val indentConfig: IndentConfig,
 ) {
     fun visitClosingQuotes(
         expectedIndent: String,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -89,6 +89,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRu
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
@@ -1083,7 +1084,7 @@ public class IndentationRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         if (!this::stringTemplateIndenter.isInitialized) {
-            stringTemplateIndenter = StringTemplateIndenter(indentConfig)
+            stringTemplateIndenter = StringTemplateIndenter(codeStyle, indentConfig)
         }
         stringTemplateIndenter.visitClosingQuotes(currentIndent(), node.treeParent, autoCorrect, emit)
     }
@@ -1215,7 +1216,10 @@ private fun String.textWithEscapedTabAndNewline(): String {
         ).plus(suffix)
 }
 
-private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
+private class StringTemplateIndenter(
+    private val codeStyle: CodeStyleValue,
+    private val indentConfig: IndentConfig
+) {
     fun visitClosingQuotes(
         expectedIndent: String,
         node: ASTNode,
@@ -1243,7 +1247,7 @@ private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
                 val prefixLength = node.getCommonPrefixLength()
                 val prevLeaf = node.prevLeaf()
                 val correctedExpectedIndent =
-                    if (node.isRawStringLiteralReturnInFunctionBodyBlock()) {
+                    if (codeStyle == ktlint_official && node.isRawStringLiteralReturnInFunctionBodyBlock()) {
                         // Allow:
                         //   fun foo(): String {
                         //       return """
@@ -1253,7 +1257,7 @@ private class StringTemplateIndenter(private val indentConfig: IndentConfig) {
                         node
                             .indent(false)
                             .plus(indentConfig.indent)
-                    } else if (node.isRawStringLiteralFunctionBodyExpression()) {
+                    } else if (codeStyle == ktlint_official && node.isRawStringLiteralFunctionBodyExpression()) {
                         // Allow:
                         //   fun foo(
                         //       bar: String

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
@@ -5056,32 +5057,6 @@ internal class IndentationRuleTest {
     @Nested
     inner class `Given a function with raw string literal as result` {
         @Test
-        fun `As body expression on same line as equals and preceded by space`() {
-            val code =
-                """
-                private fun foo(
-                    bar: String,
-                ) = $MULTILINE_STRING_QUOTE
-                    bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
-            indentationRuleAssertThat(code).hasNoLintViolations()
-        }
-
-        @Test
-        fun `As body expression on same line as equals but not preceded by space`() {
-            val code =
-                """
-                private fun foo(
-                    bar: String,
-                ) =$MULTILINE_STRING_QUOTE
-                    bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
-            indentationRuleAssertThat(code).hasNoLintViolations()
-        }
-
-        @Test
         fun `As body expression on next line`() {
             val code =
                 """
@@ -5093,23 +5068,124 @@ internal class IndentationRuleTest {
             indentationRuleAssertThat(code).hasNoLintViolations()
         }
 
-        @Test
-        fun `As block body`() {
-            val code =
-                """
+        @Nested
+        inner class `Given non-ktlint_official code style` {
+            private val NON_KTLINT_OFFICIAL = CodeStyleValue.android_studio
+
+            @Test
+            fun `As body expression on same line as equals and preceded by space`() {
+                val code =
+                    """
+                private fun foo(
+                    bar: String,
+                ) = $MULTILINE_STRING_QUOTE
+                    bar
+                $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `As body expression on same line as equals but not preceded by space`() {
+                val code =
+                    """
+                private fun foo(
+                    bar: String,
+                ) =$MULTILINE_STRING_QUOTE
+                    bar
+                $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `As block body`() {
+                val code =
+                    """
+                private fun foo( bar: String): String {
+                    return $MULTILINE_STRING_QUOTE
+                        bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `As body expression of function wrapped in class`() {
+                val code =
+                    """
+                class Bar {
+                    private fun foo(
+                        bar: String,
+                    ) = $MULTILINE_STRING_QUOTE
+                        bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                }
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .hasNoLintViolations()
+            }
+        }
+
+        @Nested
+        inner class `Given ktlint_official code style` {
+            @Test
+            fun `As body expression on same line as equals and preceded by space`() {
+                val code =
+                    """
+                private fun foo(
+                    bar: String,
+                ) = $MULTILINE_STRING_QUOTE
+                    bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `As body expression on same line as equals but not preceded by space`() {
+                val code =
+                    """
+                private fun foo(
+                    bar: String,
+                ) =$MULTILINE_STRING_QUOTE
+                    bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                """.trimIndent()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `As block body`() {
+                val code =
+                    """
                 private fun foo( bar: String): String {
                     return $MULTILINE_STRING_QUOTE
                         bar
                         $MULTILINE_STRING_QUOTE.trimIndent()
                 }
                 """.trimIndent()
-            indentationRuleAssertThat(code).hasNoLintViolations()
-        }
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasNoLintViolations()
+            }
 
-        @Test
-        fun `As body expression of function wrapped in class`() {
-            val code =
-                """
+            @Test
+            fun `As body expression of function wrapped in class`() {
+                val code =
+                    """
                 class Bar {
                     private fun foo(
                         bar: String,
@@ -5118,7 +5194,10 @@ internal class IndentationRuleTest {
                         $MULTILINE_STRING_QUOTE.trimIndent()
                 }
                 """.trimIndent()
-            indentationRuleAssertThat(code).hasNoLintViolations()
+                indentationRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasNoLintViolations()
+            }
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5070,20 +5070,20 @@ internal class IndentationRuleTest {
 
         @Nested
         inner class `Given non-ktlint_official code style` {
-            private val NON_KTLINT_OFFICIAL = CodeStyleValue.android_studio
+            private val nonKtlintOfficialCodeStyle = CodeStyleValue.android_studio
 
             @Test
             fun `As body expression on same line as equals and preceded by space`() {
                 val code =
                     """
-                private fun foo(
-                    bar: String,
-                ) = $MULTILINE_STRING_QUOTE
-                    bar
-                $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
+                    private fun foo(
+                        bar: String,
+                    ) = $MULTILINE_STRING_QUOTE
+                        bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
-                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to nonKtlintOfficialCodeStyle)
                     .hasNoLintViolations()
             }
 
@@ -5091,14 +5091,14 @@ internal class IndentationRuleTest {
             fun `As body expression on same line as equals but not preceded by space`() {
                 val code =
                     """
-                private fun foo(
-                    bar: String,
-                ) =$MULTILINE_STRING_QUOTE
-                    bar
-                $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
+                    private fun foo(
+                        bar: String,
+                    ) =$MULTILINE_STRING_QUOTE
+                        bar
+                    $MULTILINE_STRING_QUOTE.trimIndent()
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
-                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to nonKtlintOfficialCodeStyle)
                     .hasNoLintViolations()
             }
 
@@ -5106,14 +5106,14 @@ internal class IndentationRuleTest {
             fun `As block body`() {
                 val code =
                     """
-                private fun foo( bar: String): String {
-                    return $MULTILINE_STRING_QUOTE
-                        bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                }
-                """.trimIndent()
+                    private fun foo( bar: String): String {
+                        return $MULTILINE_STRING_QUOTE
+                            bar
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                    }
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
-                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to nonKtlintOfficialCodeStyle)
                     .hasNoLintViolations()
             }
 
@@ -5121,16 +5121,16 @@ internal class IndentationRuleTest {
             fun `As body expression of function wrapped in class`() {
                 val code =
                     """
-                class Bar {
-                    private fun foo(
-                        bar: String,
-                    ) = $MULTILINE_STRING_QUOTE
-                        bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                }
-                """.trimIndent()
+                    class Bar {
+                        private fun foo(
+                            bar: String,
+                        ) = $MULTILINE_STRING_QUOTE
+                            bar
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                    }
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
-                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to NON_KTLINT_OFFICIAL)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to nonKtlintOfficialCodeStyle)
                     .hasNoLintViolations()
             }
         }
@@ -5141,12 +5141,12 @@ internal class IndentationRuleTest {
             fun `As body expression on same line as equals and preceded by space`() {
                 val code =
                     """
-                private fun foo(
-                    bar: String,
-                ) = $MULTILINE_STRING_QUOTE
-                    bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
+                    private fun foo(
+                        bar: String,
+                    ) = $MULTILINE_STRING_QUOTE
+                        bar
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasNoLintViolations()
@@ -5156,12 +5156,12 @@ internal class IndentationRuleTest {
             fun `As body expression on same line as equals but not preceded by space`() {
                 val code =
                     """
-                private fun foo(
-                    bar: String,
-                ) =$MULTILINE_STRING_QUOTE
-                    bar
-                    $MULTILINE_STRING_QUOTE.trimIndent()
-                """.trimIndent()
+                    private fun foo(
+                        bar: String,
+                    ) =$MULTILINE_STRING_QUOTE
+                        bar
+                        $MULTILINE_STRING_QUOTE.trimIndent()
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasNoLintViolations()
@@ -5171,12 +5171,12 @@ internal class IndentationRuleTest {
             fun `As block body`() {
                 val code =
                     """
-                private fun foo( bar: String): String {
-                    return $MULTILINE_STRING_QUOTE
-                        bar
-                        $MULTILINE_STRING_QUOTE.trimIndent()
-                }
-                """.trimIndent()
+                    private fun foo( bar: String): String {
+                        return $MULTILINE_STRING_QUOTE
+                            bar
+                            $MULTILINE_STRING_QUOTE.trimIndent()
+                    }
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasNoLintViolations()
@@ -5186,14 +5186,14 @@ internal class IndentationRuleTest {
             fun `As body expression of function wrapped in class`() {
                 val code =
                     """
-                class Bar {
-                    private fun foo(
-                        bar: String,
-                    ) = $MULTILINE_STRING_QUOTE
-                        bar
-                        $MULTILINE_STRING_QUOTE.trimIndent()
-                }
-                """.trimIndent()
+                    class Bar {
+                        private fun foo(
+                            bar: String,
+                        ) = $MULTILINE_STRING_QUOTE
+                            bar
+                            $MULTILINE_STRING_QUOTE.trimIndent()
+                    }
+                    """.trimIndent()
                 indentationRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasNoLintViolations()


### PR DESCRIPTION
## Description

Ktlint `0.48.2` and older allowed for an asymmetrical form of aligning the opening and closing quotes. E.g., if the opening quotes are after but on the same line as the assignment operator, and the closing quotes are on a next line, then the closing quotes may be aligned with the start position of the statement.

In `0.49.x` the check of the closing quotes has accidentally been changed for all code styles while it should only have veen changed for the new `ktlint_official` code style only. As the `ktlint_official` code style will allways wrap multiline expression to start on a new line (via rule `standard:multiline-expression-wrapping`) the formatting will be consistent for both functions and properties.

Closes #1971

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
