### PR TITLE
Fix indentation of multiline parameter list in function literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Prevent nullpointer exception (NPE) if class without body is followed by multiple blank lines until end of file `no-consecutive-blank-lines` ([#1987](https://github.com/pinterest/ktlint/issues/1987))
 * Allow to 'unset' the `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` when using `ktlint_official` code style `function-signature` ([#1977](https://github.com/pinterest/ktlint/issues/1977))
 * Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression `indent` ([#1993](https://github.com/pinterest/ktlint/issues/1993))
+* Fix indentation of multiline parameter list in function literal `indent` ([#1976](https://github.com/pinterest/ktlint/issues/1976))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -53,7 +53,6 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_ACCESSOR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACKET
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REGULAR_STRING_PART
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RETURN_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
@@ -95,6 +94,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isRoot
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
@@ -451,7 +451,7 @@ public class IndentationRule :
     }
 
     private fun ASTNode.calculateIndentOfFunctionLiteralParameters() =
-        if (codeStyle == ktlint_official || isFirstParameterOfFunctionLiteralPrecededByNewLine()) {
+        if (isFirstParameterOfFunctionLiteralPrecededByNewLine()) {
             // val fieldExample =
             //      LongNameClass {
             //              paramA,
@@ -468,13 +468,23 @@ public class IndentationRule :
             //                     paramC ->
             //         ClassB(paramA, paramB, paramC)
             //     }
-            parent(CALL_EXPRESSION)
-                ?.let { callExpression ->
-                    val textBeforeFirstParameter =
-                        callExpression.findChildByType(REFERENCE_EXPRESSION)?.text +
-                            " { "
-                    " ".repeat(textBeforeFirstParameter.length)
-                }
+            // val fieldExample =
+            //     someFunction(
+            //         1,
+            //         2,
+            //     ) { paramA,
+            //         paramB,
+            //         paramC ->
+            //         ClassB(paramA, paramB, paramC)
+            //     }
+            this
+                .takeIf { it.isPartOf(CALL_EXPRESSION) }
+                ?.treeParent
+                ?.leaves(false)
+                ?.takeWhile { !it.isWhiteSpaceWithNewline() }
+                ?.sumOf { it.textLength }
+                ?.plus(2) // need to add spaces to compensate for "{ "
+                ?.let { length -> " ".repeat(length) }
                 ?: indentConfig.indent.repeat(2)
         }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -4818,10 +4818,11 @@ internal class IndentationRuleTest {
                 .addAdditionalRuleProvider { ParameterListWrappingRule() }
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationForAdditionalRule(2, 20, "Parameter should start on a newline")
-                .hasLintViolations(
-                    LintViolation(3, 1, "Unexpected indentation (19) (should be 12)"),
-                    LintViolation(4, 1, "Unexpected indentation (19) (should be 12)"),
-                ).isFormattedAs(formattedCode)
+//                .hasLintViolations(
+//                    LintViolation(3, 1, "Unexpected indentation (19) (should be 12)"),
+//                    LintViolation(4, 1, "Unexpected indentation (19) (should be 12)"),
+//                )
+                .isFormattedAs(formattedCode)
         }
 
         @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -179,7 +179,7 @@ class ParameterListWrappingRuleTest {
     }
 
     @Nested
-    inner class `Given a function literal having a multiline parameter list` {
+    inner class `Given a function literal having a multiline parameter list and the first parameter starts on same line as LBRACE` {
         private val code =
             """
             val fieldExample =
@@ -204,10 +204,9 @@ class ParameterListWrappingRuleTest {
                 """.trimIndent()
             parameterListWrappingRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationsForAdditionalRule(
-                    LintViolation(3, 1, "Unexpected indentation (20) (should be 12)"),
-                    LintViolation(4, 1, "Unexpected indentation (20) (should be 12)"),
-                ).isFormattedAs(formattedCode)
+                // Indent violations will not be reported until after the wrapping of the first parameter is completed and as of that will
+                // not be found during linting
+                .isFormattedAs(formattedCode)
         }
 
         @ParameterizedTest(name = "Code style = {0}")
@@ -216,15 +215,33 @@ class ParameterListWrappingRuleTest {
             mode = EnumSource.Mode.EXCLUDE,
             names = ["ktlint_official"],
         )
-        fun `Given another than ktlint_official code style then do not reformat`(codeStyleValue: CodeStyleValue) {
+        fun `Given another code style than ktlint_official then do not reformat`(codeStyleValue: CodeStyleValue) {
             parameterListWrappingRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue)
                 .hasNoLintViolations()
-//                .hasLintViolationsForAdditionalRule(
-//                    LintViolation(3, 1, "Unexpected indentation (20) (should be 12)"),
-//                    LintViolation(4, 1, "Unexpected indentation (20) (should be 12)"),
-//                )
         }
+    }
+
+    @ParameterizedTest(name = "Code style = {0}")
+    @EnumSource(value = CodeStyleValue::class)
+    fun `Given a multiline reference expression with trailing lambda having a multiline parameter list and the first parameter starts on same line as LBRACE`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            val foo =
+                bar(
+                    Any(),
+                    Any()
+                ) { a,
+                    b
+                    ->
+                    foobar()
+                }
+            """.trimIndent()
+        parameterListWrappingRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue)
+            .hasNoLintViolations()
     }
 
     @Test


### PR DESCRIPTION
## Description

Closes #1976

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
