### PR TITLE
Clean up logging dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression `indent` ([#1993](https://github.com/pinterest/ktlint/issues/1993))
 * Fix indentation of multiline parameter list in function literal `indent` ([#1976](https://github.com/pinterest/ktlint/issues/1976))
 * Restrict indentation of closing quotes to `ktlint_official` code style to keep formatting of other code styles consistent with `0.48.x` and before `indent` ([#1971](https://github.com/pinterest/ktlint/issues/1971))
+* Clean-up unwanted logging dependencies ([#1998](https://github.com/pinterest/ktlint/issues/1998))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
@@ -1,10 +1,5 @@
 package com.pinterest.ktlint.rule.engine.internal
 
-import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger
-import com.pinterest.ktlint.logger.api.initKtLintKLogger
-import com.pinterest.ktlint.logger.api.setDefaultLoggerModifier
-import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.EditorConfigLoader
 import org.ec4j.core.Resource
@@ -17,16 +12,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 class ThreadSafeEditorConfigCacheTest {
-    init {
-        // Overwrite default logging with TRACE logging by initializing *and* printing first log statement before
-        // loading any other classes.
-        KotlinLogging
-            .logger {}
-            .setDefaultLoggerModifier { logger -> (logger.underlyingLogger as Logger).level = Level.TRACE }
-            .initKtLintKLogger()
-            .trace { "Enable trace logging for unit test" }
-    }
-
     @Test
     fun `Given a file which is requested multiple times then it is read only once and then stored into and retrieved from the cache`() {
         val threadSafeEditorConfigCache = ThreadSafeEditorConfigCache()

--- a/ktlint-ruleset-standard/build.gradle.kts
+++ b/ktlint-ruleset-standard/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation(projects.ktlintLogger)
-    implementation(libs.logging)
 
     api(projects.ktlintCliRulesetCore)
     api(projects.ktlintRuleEngineCore)

--- a/ktlint-test/build.gradle.kts
+++ b/ktlint-test/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation(projects.ktlintCliRulesetCore)
     api(libs.assertj)
     api(libs.junit5)
-    api(libs.logback)
     api(libs.janino)
     api(libs.jimfs)
 }


### PR DESCRIPTION
## Description

Clean up unwanted dependencies below:
* ktlint-ruleset-standard has an unneeded implementation dependency on io.github.microutils:kotlin-logging-jvm:3.0.5 and ktlint-rule-engine has a testImplementation dependency on ktlint-ruleset-standard.
* ktlint-test has an api dependency on logback which is only needed for a unit test. The ktlint-rule-engine has a test implementation dependency on ktlint-test.

Closes #1998

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
