### PR TITLE
Extract rule `no-single-line-block-comment` from `comment-wrapping` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Prevent nullpointer exception (NPE) if or operator at start of line is followed by dot qualified expression `indent` ([#1993](https://github.com/pinterest/ktlint/issues/1993))
 * Fix indentation of multiline parameter list in function literal `indent` ([#1976](https://github.com/pinterest/ktlint/issues/1976))
 * Restrict indentation of closing quotes to `ktlint_official` code style to keep formatting of other code styles consistent with `0.48.x` and before `indent` ([#1971](https://github.com/pinterest/ktlint/issues/1971))
+* Extract rule `no-single-line-block-comment` from `comment-wrapping` rule. The `no-single-line-block-comment` rule is added as experimental rule to the `ktlint_official` code style, but it can be enabled explicitly for the other code styles as well. ([#1980](https://github.com/pinterest/ktlint/issues/1980))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/docs/rules/experimental.md
+++ b/docs/rules/experimental.md
@@ -345,6 +345,32 @@ This rule can also be suppressed with the IntelliJ IDEA inspection suppression `
 
 Rule id: `property-naming`
 
+## No single line block comments
+
+A single line block comment should be replaced with an EOL comment when possible.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    /*
+     * Some comment
+     */
+    val foo = "foo" // Some comment
+    val foo = { /* no-op */ }
+
+    /* ktlint-disable foo-rule-id bar-rule-id */
+    val foo = "foo"
+    /* ktlint-enable foo-rule-id bar-rule-id */
+    ```
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    /* Some comment */
+    val foo = "foo" /* Some comment */
+    ```
+
+Rule id: `no-single-line-block-comment`
+
 ## Spacing
 
 ### No blank lines in list

--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -867,7 +867,7 @@ Rule id: `wrapping`
 
 ### Comment wrapping
 
-A block comment should start and end on a line that does not contain any other element. A block comment should not be used as end of line comment.
+A block comment should start and end on a line that does not contain any other element.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -45,6 +45,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.NoLineBreakAfterElseRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoLineBreakBeforeAssignmentRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoMultipleSpacesRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoSemicolonsRule
+import com.pinterest.ktlint.ruleset.standard.rules.NoSingleLineBlockCommentRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoTrailingSpacesRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoUnitReturnRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoUnusedImportsRule
@@ -126,6 +127,7 @@ public class StandardRuleSetProvider :
             RuleProvider { NoLineBreakBeforeAssignmentRule() },
             RuleProvider { NoMultipleSpacesRule() },
             RuleProvider { NoSemicolonsRule() },
+            RuleProvider { NoSingleLineBlockCommentRule() },
             RuleProvider { NoTrailingSpacesRule() },
             RuleProvider { NoUnitReturnRule() },
             RuleProvider { NoUnusedImportsRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRule.kt
@@ -1,0 +1,81 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
+import org.jetbrains.kotlin.psi.psiUtil.leaves
+
+/**
+ * A block comment following another element on the same line is replaced with an EOL comment, if possible.
+ */
+public class NoSingleLineBlockCommentRule :
+    StandardRule(
+        id = "no-single-line-block-comment",
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
+        visitorModifiers = setOf(RunAfterRule(COMMENT_WRAPPING_RULE_ID, REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED)),
+    ),
+    Rule.Experimental,
+    Rule.OfficialCodeStyle {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType == BLOCK_COMMENT) {
+            val afterBlockComment =
+                node
+                    .leaves()
+                    .takeWhile { it.isWhiteSpace() && !it.textContains('\n') }
+                    .firstOrNull()
+                    ?: node.lastChildLeafOrSelf()
+
+            if (!node.textContains('\n') &&
+                !node.isKtlintSuppressionDirective() &&
+                afterBlockComment.nextLeaf().isWhitespaceWithNewlineOrNull()
+            ) {
+                emit(node.startOffset, "Replace the block comment with an EOL comment", true)
+                if (autoCorrect) {
+                    node.replaceWithEndOfLineComment()
+                }
+            }
+        }
+    }
+
+    private fun ASTNode.replaceWithEndOfLineComment() {
+        val content = text.removeSurrounding("/*", "*/").trim()
+        val eolComment = PsiCommentImpl(EOL_COMMENT, "// $content")
+        (this as LeafPsiElement).rawInsertBeforeMe(eolComment)
+        rawRemove()
+    }
+
+    private fun ASTNode?.isWhitespaceWithNewlineOrNull() = this == null || this.isWhiteSpaceWithNewline()
+
+    // TODO: Remove when ktlint suppression directive in comments are no longer supported
+    private fun ASTNode?.isKtlintSuppressionDirective() =
+        this
+            ?.text
+            ?.removePrefix("/*")
+            ?.removeSuffix("*/")
+            ?.trim()
+            ?.let { it.startsWith("ktlint-enable") || it.startsWith("ktlint-disable") }
+            ?: false
+}
+
+public val NO_SINGLE_LINE_BLOCK_COMMENT_RULE_ID: RuleId = NoSingleLineBlockCommentRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
@@ -1,33 +1,11 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CommentWrappingRuleTest {
     private val commentWrappingRuleAssertThat = assertThatRule { CommentWrappingRule() }
-
-    @Test
-    fun `Given a single line block comment then replace it with an EOL comment`() {
-        val code =
-            """
-            fun bar() {
-                /* Some comment */
-            }
-            """.trimIndent()
-        val formattedCode =
-            """
-            fun bar() {
-                // Some comment
-            }
-            """.trimIndent()
-        commentWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-            .hasLintViolation(2, 5, "A single line block comment must be replaced with an EOL comment")
-            .isFormattedAs(formattedCode)
-    }
 
     @Test
     fun `Given a multi line block comment that start starts and end on a separate line then do not reformat`() {
@@ -107,73 +85,6 @@ class CommentWrappingRuleTest {
         }
     }
 
-    @Nested
-    inner class `Given some code code followed by a block comment on the same line` {
-        @Test
-        fun `Given a comment followed by a property and separated with space`() {
-            val code =
-                """
-                val foo = "foo" /* Some comment */
-                """.trimIndent()
-            val formattedCode =
-                """
-                val foo = "foo" // Some comment
-                """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
-            commentWrappingRuleAssertThat(code)
-                .hasLintViolation(1, 17, "A single line block comment after a code element on the same line must be replaced with an EOL comment")
-                .isFormattedAs(formattedCode)
-        }
-
-        @Test
-        fun `Given a comment followed by a property but not separated with space`() {
-            val code =
-                """
-                val foo = "foo"/* Some comment */
-                """.trimIndent()
-            val formattedCode =
-                """
-                val foo = "foo" // Some comment
-                """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
-            commentWrappingRuleAssertThat(code)
-                .hasLintViolation(1, 16, "A single line block comment after a code element on the same line must be replaced with an EOL comment")
-                .isFormattedAs(formattedCode)
-        }
-
-        @Test
-        fun `Given a comment followed by a function and separated with space`() {
-            val code =
-                """
-                fun foo() = "foo" /* Some comment */
-                """.trimIndent()
-            val formattedCode =
-                """
-                fun foo() = "foo" // Some comment
-                """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
-            commentWrappingRuleAssertThat(code)
-                .hasLintViolation(1, 19, "A single line block comment after a code element on the same line must be replaced with an EOL comment")
-                .isFormattedAs(formattedCode)
-        }
-
-        @Test
-        fun `Given a comment followed by a function but not separated with space`() {
-            val code =
-                """
-                fun foo() = "foo"/* Some comment */
-                """.trimIndent()
-            val formattedCode =
-                """
-                fun foo() = "foo" // Some comment
-                """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
-            commentWrappingRuleAssertThat(code)
-                .hasLintViolation(1, 18, "A single line block comment after a code element on the same line must be replaced with an EOL comment")
-                .isFormattedAs(formattedCode)
-        }
-    }
-
     @Test
     fun `Given a block comment containing a newline which is preceded by another element on the same line then raise lint error but do not autocorrect`() {
         val code =
@@ -185,22 +96,6 @@ class CommentWrappingRuleTest {
         @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 17, "A block comment after any other element on the same line must be separated by a new line")
-    }
-
-    @Test
-    fun `Given a block comment that does not contain a newline and which is after some code om the same line is changed to an EOL comment`() {
-        val code =
-            """
-            val foo = "foo" /* Some comment */
-            """.trimIndent()
-        val formattedCode =
-            """
-            val foo = "foo" // Some comment
-            """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
-        commentWrappingRuleAssertThat(code)
-            .hasLintViolation(1, 17, "A single line block comment after a code element on the same line must be replaced with an EOL comment")
-            .isFormattedAs(formattedCode)
     }
 
     @Test
@@ -245,29 +140,5 @@ class CommentWrappingRuleTest {
         commentWrappingRuleAssertThat(code)
             .hasLintViolation(2, 24, "A block comment may not be followed by any other element on that same line")
             .isFormattedAs(formattedCode)
-    }
-
-    @Test
-    fun `Given a single line block containing a block comment then do not reformat`() {
-        val code =
-            """
-            val foo = { /* no-op */ }
-            """.trimIndent()
-        commentWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-            .hasNoLintViolations()
-    }
-
-    @Test
-    fun `Given single line block comments to disable or enable ktlint then do not reformat`() {
-        val code =
-            """
-            /* ktlint-disable foo-rule-id bar-rule-id */
-            val foo = "foo"
-            /* ktlint-enable foo-rule-id bar-rule-id */
-            """.trimIndent()
-        commentWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-            .hasNoLintViolations()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
@@ -1,0 +1,179 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NoSingleLineBlockCommentRuleTest {
+    private val noSingleLineBlockCommentRuleAssertThat =
+        assertThatRule(
+            provider = { NoSingleLineBlockCommentRule() },
+            additionalRuleProviders = setOf(RuleProvider { CommentWrappingRule() }),
+            editorConfigProperties = setOf(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official),
+        )
+
+    @Test
+    fun `Given a single line block comment then replace it with an EOL comment`() {
+        val code =
+            """
+            fun bar() {
+                /* Some comment */
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun bar() {
+                // Some comment
+            }
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasLintViolation(2, 5, "Replace the block comment with an EOL comment")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a multi line block comment that start starts and end on a separate line then do not reformat`() {
+        val code =
+            """
+            /*
+             * Some comment
+             */
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line block comment that is to be wrapped before replacing it with an EOL comment`() {
+        val code =
+            """
+            /* Some comment */ val foo = "foo"
+            """.trimIndent()
+        val formattedCode =
+            """
+            // Some comment
+            val foo = "foo"
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code)
+            .hasLintViolationForAdditionalRule(1, 20, "A block comment may not be followed by any other element on that same line")
+            // Can not check for the lint violation below as it will only be thrown while formatting with comment wrapping
+            //   A single line block comment must be replaced with an EOL comment
+            .isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given some code code followed by a block comment on the same line` {
+        @Test
+        fun `Given a comment followed by a property and separated with space`() {
+            val code =
+                """
+                val foo = "foo" /* Some comment */
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = "foo" // Some comment
+                """.trimIndent()
+            noSingleLineBlockCommentRuleAssertThat(code)
+                .hasLintViolation(1, 17, "Replace the block comment with an EOL comment")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a comment followed by a property but not separated with space`() {
+            val code =
+                """
+                val foo = "foo"/* Some comment */
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = "foo" // Some comment
+                """.trimIndent()
+            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            noSingleLineBlockCommentRuleAssertThat(code)
+                .hasLintViolation(1, 16, "Replace the block comment with an EOL comment")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a comment followed by a function and separated with space`() {
+            val code =
+                """
+                fun foo() = "foo" /* Some comment */
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo() = "foo" // Some comment
+                """.trimIndent()
+            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            noSingleLineBlockCommentRuleAssertThat(code)
+                .hasLintViolation(1, 19, "Replace the block comment with an EOL comment")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a comment followed by a function but not separated with space`() {
+            val code =
+                """
+                fun foo() = "foo"/* Some comment */
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo() = "foo" // Some comment
+                """.trimIndent()
+            noSingleLineBlockCommentRuleAssertThat(code)
+                .hasLintViolation(1, 18, "Replace the block comment with an EOL comment")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a block comment that does not contain a newline and which is after some code om the same line is changed to an EOL comment`() {
+        val code =
+            """
+            val foo = "foo" /* Some comment */
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = "foo" // Some comment
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code)
+            .hasLintViolation(1, 17, "Replace the block comment with an EOL comment")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line block comment in between code elements on the same line does not raise a lint error`() {
+        val code =
+            """
+            val foo /* some comment */ = "foo"
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code).hasNoLintViolationsExceptInAdditionalRules()
+    }
+
+    @Test
+    fun `Given a single line block containing a block comment then do not reformat`() {
+        val code =
+            """
+            val foo = { /* no-op */ }
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given single line block comments to disable or enable ktlint then do not reformat`() {
+        val code =
+            """
+            /* ktlint-disable foo-rule-id bar-rule-id */
+            val foo = "foo"
+            /* ktlint-enable foo-rule-id bar-rule-id */
+            """.trimIndent()
+        noSingleLineBlockCommentRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
## Description

Extract rule `no-single-line-block-comment` from `comment-wrapping` rule

Closes #1980

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
