### PR TITLE
Fix interchanged sample code

### DIFF
--- a/docs/rules/standard.md
+++ b/docs/rules/standard.md
@@ -450,7 +450,6 @@ Rule id: `no-empty-class-body`
 
     ```kotlin
     fun bar() {
-
        val a = 2
     }
     ```
@@ -458,6 +457,7 @@ Rule id: `no-empty-class-body`
 
     ```kotlin
     fun bar() {
+
        val a = 2
     }
     ```


### PR DESCRIPTION
## Description

It appears that the sample codes provided for the rule ID "no-empty-first-line-in-method-block" in [standard.md](https://github.com/pinterest/ktlint/blob/master/docs/rules/standard.md#no-leading-empty-lines-in-method-blocks) have been mistakenly interchanged, which could lead to confusion for viewers.