### PR TITLE
Fix directory traversal for patterns outside workdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fix indentation of multiline parameter list in function literal `indent` ([#1976](https://github.com/pinterest/ktlint/issues/1976))
 * Restrict indentation of closing quotes to `ktlint_official` code style to keep formatting of other code styles consistent with `0.48.x` and before `indent` ([#1971](https://github.com/pinterest/ktlint/issues/1971))
 * Clean-up unwanted logging dependencies ([#1998](https://github.com/pinterest/ktlint/issues/1998))
+* Fix directory traversal for patterns referring to paths outside of current working directory or any of it child directories ([#2002](https://github.com/pinterest/ktlint/issues/2002))
 
 ### Changed
 * Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -14,7 +14,6 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.Deque
 import java.util.LinkedList
-import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.isDirectory
 import kotlin.io.path.pathString
@@ -66,7 +65,7 @@ internal fun FileSystem.fileSequence(
             .filter { it.startsWith(NEGATION_PREFIX) }
             .map { getPathMatcher(it.removePrefix(NEGATION_PREFIX)) }
 
-    val pathMatchers =
+    val includeGlobs =
         globs
             .filterNot { it.startsWith(NEGATION_PREFIX) }
             .let { includeMatchers ->
@@ -81,23 +80,23 @@ internal fun FileSystem.fileSequence(
                 } else {
                     includeMatchers
                 }
-            }.map { getPathMatcher(it) }
-
-    LOGGER.debug {
-        """
-        Start walkFileTree for rootDir: '$rootDir'
-           include:
-        ${pathMatchers.map {
-            "      - $it"
-        }}
-           exclude:
-        ${negatedPathMatchers.map { "      - $it" }}
-        """.trimIndent()
+            }
+    var commonRootDir = rootDir
+    patterns.forEach { pattern ->
+        val patternDir =
+            rootDir
+                .resolve(pattern)
+                .normalize()
+        commonRootDir = commonRootDir.findCommonParentDir(patternDir)
     }
+
+    val pathMatchers = includeGlobs.map { getPathMatcher(it) }
+
+    LOGGER.debug { "Start walkFileTree from directory: '$commonRootDir'" }
     val duration =
         measureTimeMillis {
             Files.walkFileTree(
-                rootDir,
+                commonRootDir,
                 object : SimpleFileVisitor<Path>() {
                     override fun visitFile(
                         filePath: Path,
@@ -147,6 +146,16 @@ internal fun FileSystem.fileSequence(
 
     return result.asSequence()
 }
+
+private fun Path.findCommonParentDir(path: Path): Path =
+    when {
+        path.startsWith(this) ->
+            this
+        startsWith(path) ->
+            path
+        else ->
+            this@findCommonParentDir.findCommonParentDir(path.parent)
+    }
 
 private fun FileSystem.expand(
     patterns: List<String>,

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -83,11 +83,15 @@ internal fun FileSystem.fileSequence(
             }
     var commonRootDir = rootDir
     patterns.forEach { pattern ->
-        val patternDir =
-            rootDir
-                .resolve(pattern)
-                .normalize()
-        commonRootDir = commonRootDir.findCommonParentDir(patternDir)
+        try {
+            val patternDir =
+                rootDir
+                    .resolve(pattern)
+                    .normalize()
+            commonRootDir = commonRootDir.findCommonParentDir(patternDir)
+        } catch (e: InvalidPathException) {
+            // Windows throws an exception when you pass a glob to Path#resolve.
+        }
     }
 
     val pathMatchers = includeGlobs.map { getPathMatcher(it) }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -417,8 +417,9 @@ internal class FileUtilsTest {
             )
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
-    fun `Issue 2002 - Find files in a sibling directory based on a relative path to the working directory`() {
+    fun `Issue 2002 - On non-Windows OS, find files in a sibling directory based on a relative path to the working directory`() {
         val foundFiles =
             getFiles(
                 patterns = listOf("../project1"),
@@ -438,8 +439,9 @@ internal class FileUtilsTest {
             )
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
-    fun `Issue 2002 - Find files in a sibling directory based on a relative glob`() {
+    fun `Issue 2002 - On non-Windows OS, find files in a sibling directory based on a relative glob`() {
         val foundFiles =
             getFiles(
                 patterns = listOf("../project1/**/*.kt"),


### PR DESCRIPTION
## Description

Fix directory traversal for patterns referring to paths outside of current working directory or any of it child directories

Closes #2002

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
