### PR TITLE
Rename Github workflows and restrict publish-snapshot-build to code files

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,4 +1,4 @@
-name: PR Build
+name: Build pull request
 
 on:
   push:
@@ -38,4 +38,3 @@ jobs:
         run: ./gradlew build ktlintCheck --no-configuration-cache
       - name: Build with dev Kotlin version
         run: ./gradlew -PkotlinDev build ktlintCheck --no-configuration-cache
-

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,4 +1,5 @@
 name: "Validate Gradle Wrapper"
+
 on: [ push, pull_request ]
 
 jobs:

--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -1,4 +1,4 @@
-name: Publish Release
+name: Publish release build
 
 on :
   push :

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -1,8 +1,10 @@
 name: Publish release documentation
+
 on:
   push:
     branches: ['master']
     paths: ['documentation/release-latest/**']
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snapshot-build.yml
+++ b/.github/workflows/publish-snapshot-build.yml
@@ -1,8 +1,9 @@
-name: Snapshot Publish
+name: Publish snapshot build
 
 on:
   push:
     branches: [ master ]
+    paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
 
 env:
   SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/publish-snapshot-docs.yml
+++ b/.github/workflows/publish-snapshot-docs.yml
@@ -1,8 +1,10 @@
 name: Publish snapshot documentation
+
 on:
   push:
     branches: ['master']
     paths: ['documentation/snapshot/**']
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

* Align naming and formatting of Github workflows
* Restrict publish-snapshot-build workflow to builds containing code related files

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
