### PR TITLE
Move Baseline to ktlint-cli-reporter-baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fix directory traversal for patterns referring to paths outside of current working directory or any of it child directories ([#2002](https://github.com/pinterest/ktlint/issues/2002))
 
 ### Changed
-* Separated Baseline functionality out of `ktlint-cli` into separate `ktlint-baseline` module for API consumers
+
+* Moved class `Baseline` from `ktlint-cli` to `ktlint-cli-reporter-baseline` so that Baseline functionality is reusable for API Consumers.
 
 ## [0.49.0] - 2023-04-21
 

--- a/ktlint-baseline/build.gradle.kts
+++ b/ktlint-baseline/build.gradle.kts
@@ -1,9 +1,0 @@
-plugins {
-    id("ktlint-publication-library")
-}
-
-dependencies {
-    implementation(projects.ktlintLogger)
-    implementation(projects.ktlintRuleEngineCore)
-    implementation(projects.ktlintCliReporterCore)
-}

--- a/ktlint-baseline/gradle.properties
+++ b/ktlint-baseline/gradle.properties
@@ -1,2 +1,0 @@
-POM_NAME=ktlint-baseline
-POM_ARTIFACT_ID=ktlint-baseline

--- a/ktlint-cli-reporter-baseline/build.gradle.kts
+++ b/ktlint-cli-reporter-baseline/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    implementation(projects.ktlintLogger)
+    implementation(projects.ktlintRuleEngineCore)
     implementation(projects.ktlintCliReporterCore)
 
     testImplementation(projects.ktlintTest)

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
@@ -1,8 +1,8 @@
-package com.pinterest.ktlint.cli.api
+package com.pinterest.ktlint.cli.reporter.baseline
 
-import com.pinterest.ktlint.cli.api.Baseline.Status.INVALID
-import com.pinterest.ktlint.cli.api.Baseline.Status.NOT_FOUND
-import com.pinterest.ktlint.cli.api.Baseline.Status.VALID
+import com.pinterest.ktlint.cli.reporter.baseline.Baseline.Status.INVALID
+import com.pinterest.ktlint.cli.reporter.baseline.Baseline.Status.NOT_FOUND
+import com.pinterest.ktlint.cli.reporter.baseline.Baseline.Status.VALID
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError.Status.BASELINE_IGNORED
 import com.pinterest.ktlint.logger.api.initKtLintKLogger

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -20,7 +20,6 @@ tasks.shadowJar {
 }
 
 dependencies {
-    implementation(projects.ktlintBaseline)
     implementation(projects.ktlintCore)
     implementation(projects.ktlintLogger)
     implementation(projects.ktlintCliReporterBaseline)

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -2,9 +2,9 @@ package com.pinterest.ktlint.cli.internal
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
-import com.pinterest.ktlint.cli.api.Baseline
-import com.pinterest.ktlint.cli.api.doesNotContain
-import com.pinterest.ktlint.cli.api.loadBaseline
+import com.pinterest.ktlint.cli.reporter.baseline.Baseline
+import com.pinterest.ktlint.cli.reporter.baseline.doesNotContain
+import com.pinterest.ktlint.cli.reporter.baseline.loadBaseline
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError.Status.FORMAT_IS_AUTOCORRECTED
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError.Status.KOTLIN_PARSE_EXCEPTION

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
@@ -1,8 +1,8 @@
 package com.pinterest.ktlint.cli.internal
 
-import com.pinterest.ktlint.cli.api.Baseline
 import com.pinterest.ktlint.cli.internal.ReporterAggregator.ReporterConfigurationElement.ARTIFACT
 import com.pinterest.ktlint.cli.internal.ReporterAggregator.ReporterConfigurationElement.OUTPUT
+import com.pinterest.ktlint.cli.reporter.baseline.Baseline
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
 import com.pinterest.ktlint.cli.reporter.core.api.ReporterProviderV2
 import com.pinterest.ktlint.cli.reporter.core.api.ReporterV2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,7 +34,6 @@ include(
     // ktlint-core module is no longer used internally in the ktlint project except for backwards compatibility
     ":ktlint-core",
     ":ktlint-api-consumer",
-    ":ktlint-baseline",
     ":ktlint-bom",
     ":ktlint-cli",
     ":ktlint-cli-reporter-baseline",


### PR DESCRIPTION
## Description

The baseline reporter creates the "baseline.xml" file which is read by the Baseline class. By moving the Baseline class into the reporter module, both the producer and consumer of the "baseline.xml" are located in same module which encapsulates this functionality. Also, it makes it possible for API consumers to reuse the functionality *and* to keep in sync with the Ktlint CLI.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
