### PR TITLE
Fix for SDKMan config, and temporarily disabling

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -72,7 +72,7 @@ jobs:
           download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
 
       - name: Release to sdkman
-        if: ${{ success() }}
+        if: false
         env:
           SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
           SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* `ktlint` is now available on SDKMAN!
-
 ### Removed
 
 ### Fixed

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -142,7 +142,7 @@ tasks.withType<Test>().configureEach {
 }
 
 sdkman {
-    val sdkmanVersion = providers.environmentVariable("SDKMAN_KEY").orElse(project.version.toString())
+    val sdkmanVersion = providers.environmentVariable("SDKMAN_VERSION").orElse(project.version.toString())
     candidate.set("ktlint")
     version.set(sdkmanVersion)
     url.set("https://github.com/pinterest/ktlint/releases/download/$sdkmanVersion/ktlint-$sdkmanVersion.zip")


### PR DESCRIPTION
## Description

The SDKMan job was misconfigured. Fixing this, but also disabling releases to SDKMan for now.

## Checklist
- [x] `CHANGELOG.md` is updated
