### PR TITLE
Fix reference to compare 0.49.0 with 0.49.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1873,7 +1873,7 @@ set in `[*{kt,kts}]` section).
 
 ## 0.1.0 - 2016-07-27
 
-[0.49.0]: https://github.com/pinterest/ktlint/compare/0.49.0...0.49.1
+[0.49.1]: https://github.com/pinterest/ktlint/compare/0.49.0...0.49.1
 [0.49.0]: https://github.com/pinterest/ktlint/compare/0.48.2...0.49.0
 [0.48.2]: https://github.com/pinterest/ktlint/compare/0.48.1...0.48.2
 [0.48.1]: https://github.com/pinterest/ktlint/compare/0.48.0...0.48.1


### PR DESCRIPTION
## Description

Fix reference to compare 0.49.0 with 0.49.1 release

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
