### PR TITLE
Add new experimental rule no-empty-file #1963

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Add new experimental rule `no-empty-file` for all code styles. Kotlin file may not be empty.
+* Add new experimental rule `no-empty-file` for all code styles. A kotlin (script) file may not be empty ([#1074](https://github.com/pinterest/ktlint/issues/1074))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* Add new experimental rule `no-empty-file` for all code styles. Kotlin file may not be empty.
+
 ### Removed
 
 ### Fixed

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -345,6 +345,12 @@ This rule can also be suppressed with the IntelliJ IDEA inspection suppression `
 
 Rule id: `property-naming`
 
+## No empty file
+
+A kotlin (script) file should not be empty. It needs to contain at least one declaration. Files only contain a package and/or import statements are as of that disallowed.
+
+Rule id: `no-empty-file`
+
 ## No single line block comments
 
 A single line block comment should be replaced with an EOL comment when possible.

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -39,6 +39,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.NoBlankLinesInChainedMethodCa
 import com.pinterest.ktlint.ruleset.standard.rules.NoConsecutiveBlankLinesRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoConsecutiveCommentsRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoEmptyClassBodyRule
+import com.pinterest.ktlint.ruleset.standard.rules.NoEmptyFileRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoEmptyFirstLineInClassBodyRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoEmptyFirstLineInMethodBlockRule
 import com.pinterest.ktlint.ruleset.standard.rules.NoLineBreakAfterElseRule
@@ -121,6 +122,7 @@ public class StandardRuleSetProvider :
             RuleProvider { NoConsecutiveBlankLinesRule() },
             RuleProvider { NoConsecutiveCommentsRule() },
             RuleProvider { NoEmptyClassBodyRule() },
+            RuleProvider { NoEmptyFileRule() },
             RuleProvider { NoEmptyFirstLineInClassBodyRule() },
             RuleProvider { NoEmptyFirstLineInMethodBlockRule() },
             RuleProvider { NoLineBreakAfterElseRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRule.kt
@@ -1,0 +1,40 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.isRoot
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+public class NoEmptyFileRule : StandardRule(id = "no-empty-file"), Rule.Experimental {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        node
+            .takeIf { it.isRoot() }
+            ?.takeIf { it.isEmptyFile() }
+            ?.let {
+                val fileName =
+                    node.psi.containingFile.virtualFile.name
+                        .replace("\\", "/") // Ensure compatibility with Windows OS
+                        .substringAfterLast("/")
+                emit(0, "File `$fileName` should not be empty", false)
+            }
+    }
+
+    private fun ASTNode.isEmptyFile(): Boolean {
+        if (text.isBlank()) return true
+
+        return this.children()
+            .toList()
+            .filter {
+                !it.isWhiteSpace() &&
+                    it.elementType != ElementType.PACKAGE_DIRECTIVE &&
+                    it.elementType != ElementType.IMPORT_LIST
+            }.isEmpty()
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
@@ -10,9 +10,95 @@ class NoEmptyFileRuleTest {
     fun `Given non-empty kotlin file then ignore the rule for this file`() {
         val code =
             """
-            package tmp
-            fun main(){
-                println("Hello world")
+            package foo
+            fun main() {
+                println("foo")
+            }
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an empty kotlin file then do a return lint error`() {
+        val code = EMPTY_FILE
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kt' should not be empty")
+    }
+
+    @Test
+    fun `Given an empty kotlin script file then do a return lint error`() {
+        val code = EMPTY_FILE
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kts")
+            .asKotlinScript()
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kts' should not be empty")
+    }
+
+    @Test
+    fun `Given only package statement in kotlin file then do a return lint error`() {
+        val code =
+            """
+            package foo
+            """.trimIndent()
+
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kt' should not be empty")
+    }
+
+    @Test
+    fun `Given only import statement in kotlin file then do a return lint error`() {
+        val code =
+            """
+            import foo.Bar
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kt' should not be empty")
+    }
+
+    @Test
+    fun `Given only package and import statements in kotlin file then do a return lint error`() {
+        val code =
+            """
+            package foo
+            import foo.Bar
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kt' should not be empty")
+    }
+
+    @Test
+    fun `Given only package, import statements and comments in kotlin file then do a return lint error`() {
+        val code =
+            """
+            package foo
+            import foo.Bar
+
+            // some comment
+
+            /*
+             * some comment
+             */
+
+            /**
+             * some comment
+             */
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File 'Tmp.kt' should not be empty")
+    }
+
+    @Test
+    fun `Given non-empty kotlin file then ignore this file`() {
+        val code =
+            """
+            package foo
+            fun main() {
+                println("foo")
             }
             """.trimIndent()
         noEmptyFileRuleAssertThat(code)
@@ -21,67 +107,26 @@ class NoEmptyFileRuleTest {
     }
 
     @Test
-    fun `Given an empty kotlin file then do a return lint error`() {
-        val code = EMPTY_FILE
-        noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
-    }
-
-    @Test
-    fun `Given an empty kotlin script file then do a return lint error`() {
-        val code = EMPTY_FILE
-        noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kts")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kts` should not be empty")
-    }
-
-    @Test
-    fun `Given only package statement in kotlin file then do a return lint error`() {
+    fun `x x`() {
         val code =
             """
-            package path
-            """.trimIndent()
+            plugins {
+                id("ktlint-publication-library")
+            }
 
-        noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
-    }
-
-    @Test
-    fun `Given only import statement in kotlin file then do a return lint error`() {
-        val code =
-            """
-            import sample.Hello
-            """.trimIndent()
-        noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
-    }
-
-    @Test
-    fun `Given only package and import statements in kotlin file then do a return lint error`() {
-        val code =
-            """
-            package path
-            import sample.Hello
-            """.trimIndent()
-        noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kt")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
-    }
-
-    @Test
-    fun `Given non-empty kotlin file then ignore this file`() {
-        val code =
-            """
-            package tmp
-            fun main(){
-                println("Hello world")
+            dependencies {
+                implementation(projects.ktlintLogger)
+                implementation(projects.ktlintRuleEngine)
+                implementation(projects.ktlintCliRulesetCore)
+                api(libs.assertj)
+                api(libs.junit5)
+                api(libs.janino)
+                api(libs.jimfs)
             }
             """.trimIndent()
         noEmptyFileRuleAssertThat(code)
-            .asFileWithPath("/some/path/Tmp.kt")
+            .asFileWithPath("/some/path/Tmp.kts")
+            .asKotlinScript()
             .hasNoLintViolations()
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
@@ -1,0 +1,91 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class NoEmptyFileRuleTest {
+    private val noEmptyFileRuleAssertThat = assertThatRule { NoEmptyFileRule() }
+
+    @Test
+    fun `Given non-empty kotlin file then ignore the rule for this file`() {
+        val code =
+            """
+            package tmp
+            fun main(){
+                println("Hello world")
+            }
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an empty kotlin file then do a return lint error`() {
+        val code = EMPTY_FILE
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
+    }
+
+    @Test
+    fun `Given an empty kotlin script file then do a return lint error`() {
+        val code = EMPTY_FILE
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kts")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kts` should not be empty")
+    }
+
+    @Test
+    fun `Given only package statement in kotlin file then do a return lint error`() {
+        val code =
+            """
+            package path
+            """.trimIndent()
+
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
+    }
+
+    @Test
+    fun `Given only import statement in kotlin file then do a return lint error`() {
+        val code =
+            """
+            import sample.Hello
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
+    }
+
+    @Test
+    fun `Given only package and import statements in kotlin file then do a return lint error`() {
+        val code =
+            """
+            package path
+            import sample.Hello
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File `Tmp.kt` should not be empty")
+    }
+
+    @Test
+    fun `Given non-empty kotlin file then ignore this file`() {
+        val code =
+            """
+            package tmp
+            fun main(){
+                println("Hello world")
+            }
+            """.trimIndent()
+        noEmptyFileRuleAssertThat(code)
+            .asFileWithPath("/some/path/Tmp.kt")
+            .hasNoLintViolations()
+    }
+
+    private companion object {
+        private const val EMPTY_FILE = ""
+    }
+}


### PR DESCRIPTION
## Description

Add new experimental rule no-empty-file for all code style.
This rule disallow empty files.

Close 1074

NOTE: replacement for PR #1963 in which rebase potentially got wrong

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
