### PR TITLE
Naming (potential) mutable extension property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Do not flag a (potential) mutable extension property in case the getter is annotated or prefixed with a modifier `property-naming` ([#2024](https://github.com/pinterest/ktlint/issues/2024))
+
 ### Changed
 
 ## [0.49.1] - 2023-05-12

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONST_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.GET_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_DECLARATION
@@ -102,10 +103,7 @@ public class PropertyNamingRule :
             }
     }
 
-    private fun ASTNode.hasCustomGetter() =
-        findChildByType(PROPERTY_ACCESSOR)
-            ?.firstChildNode
-            ?.text == "get"
+    private fun ASTNode.hasCustomGetter() = findChildByType(PROPERTY_ACCESSOR)?.findChildByType(GET_KEYWORD) != null
 
     private fun ASTNode.hasConstModifier() = hasModifier(CONST_KEYWORD)
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -105,6 +105,20 @@ class PropertyNamingRuleTest {
     }
 
     @Test
+    fun `Given a top level property extension function having a custom get function and not in screaming case notation then do not emit`() {
+        val code =
+            """
+            val fooBar1: Any
+                get() = foobar() // Lint can not check whether data is immutable
+            val fooBar2
+                inline get() = foobar() // Lint can not check whether data is immutable
+            val fooBar3
+                @Bar get() = foobar() // Lint can not check whether data is immutable
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `Given a backing val property name having a custom get function and not in screaming case notation then do not emit`() {
         val code =
             """


### PR DESCRIPTION
## Description

Do not flag a (potential) mutable extension property in case the getter is annotated or prefixed with a modifier

Closes #2024

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
