### PR TITLE
Fix Java interoperability issues with `RuleId` and `RuleSetId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+* Fix Java interoperability issues with `RuleId` and `RuleSetId` classes. Those classes were defined as value classes in `0.49.0` and `0.49.1`. Although the classes were marked with `@JvmInline` it seems that it is not possible to uses those classes from Java base API Consumers like Spotless. The classes have now been replaced with data classes ([#2041](https://github.com/pinterest/ktlint/issues/2041))
+
 ## [0.49.1] - 2023-05-12
 
 ### Added

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -5,8 +5,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProper
 import com.pinterest.ktlint.rule.engine.core.internal.IdNamingPolicy
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-@JvmInline
-public value class RuleId(public val value: String) {
+public data class RuleId(public val value: String) {
     init {
         IdNamingPolicy.enforceRuleIdNaming(value)
     }
@@ -27,8 +26,7 @@ public value class RuleId(public val value: String) {
     }
 }
 
-@JvmInline
-public value class RuleSetId(public val value: String) {
+public data class RuleSetId(public val value: String) {
     init {
         IdNamingPolicy.enforceRuleSetIdNaming(value)
     }


### PR DESCRIPTION
## Description

Fix Java interoperability issues with `RuleId` and `RuleSetId` classes. Those classes were defined as value classes in `0.49.0` and `0.49.1`. Although the classes were marked with `@JvmInline` it seems that it is not possible to uses those classes from Java base API Consumers like Spotless. The classes have now been replaced with data classes.

Closes #2041

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
