### PR TITLE
Disable extension point org.jetbrains.kotlin.com.intellij.treeCopyHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Custom Rule Providers need to prepare for Kotlin 1.9
+
+In Kotlin 1.9 the extension points of the embedded kotlin compiler will change. Ktlint only uses the `org.jetbrains.kotlin.com.intellij.treeCopyHandler` extension point. This extension is not yet supported in 1.9, neither is it documented ([#KT-58704](https://youtrack.jetbrains.com/issue/KT-58704/Support-and-document-extension-point-org.jetbrains.kotlin.com.intellij.treeCopyHandler)). Without this extension point it might happen that your custom rules will throw exceptions during runtime. See [#1981](https://github.com/pinterest/ktlint/issues/1981).
+
+In Ktlint, 7 out of 77 rules needed small and sometimes bigger changes to become independent of the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler`. The impact on your custom rules may vary dependent on the way the autocorrect has been implemented. When manipulating `ASTNode`s there seems to be no impact. When, manipulating `PsiElement`s, some functions consistently result in a runtime exception.
+
+Based on the refactoring of the rules as provided by `ktlint-ruleset-standard` in Ktlint `0.49.x` the suggested refactoring is as follows:
+
+* Replace `LeafElement.replaceWithText(String)` with `LeafElement.rawReplaceWithText(String)`.
+* Replace `PsiElement.addAfter(PsiElement, PsiElement)` with `AstNode.addChild(AstNode, AstNode)`. Note that this method inserts the new node (first) argument *before* the second argument node and as of that is not a simple replacement of the `PsiElement.addAfter(PsiElement, PsiElement)`.
+* Replace `PsiElement.replace(PsiElement)` with a sequence of `AstNode.addChild(AstNode, AstNode)` and `AstNode.removeChild(AstNode)`.
+
+Be aware that your custom rules might use other functions which also throw exceptions when the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` is no longer supported.
+
+In order to help you to analyse and fix the problems with your custom rules, ktlint temporarily supports to disable the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` using a flag. This flag is available in the Ktlint CLI and in the `KtlintRuleEngine`. By default, the extension point is enabled like it was in previous versions of ktlint.
+
+At least you should analyse the problems by running your test suits by running ktlint and disabling the extension point. Next you can start with fixing and releasing the updated rules. All rules in this version of ktlint have already been refactored and are not dependent on the extension point anymore. In Ktlint CLI the flag is to be activated with parameter `--disable-kotlin-extension-point`. API Consumers that use the `KtlintRuleEngine` directly, have to set property `enableKotlinCompilerExtensionPoint` to `false`.
+
+At this point in time, it is not yet decided what the next steps will be. Ktlint might drop the support of the extension points entirely. Or, if the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` is fully supported at the time that ktlint will be based on kotlin 1.9 it might be kept. In either case, the flag will be dropped in a next version of ktlint.
+
 ### Added
+
+* Add flag to disable extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` to analyse impact on custom rules [#1981](https://github.com/pinterest/ktlint/issues/1981)
 
 ### Removed
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -233,6 +233,12 @@ internal class KtlintCommandLine {
     )
     private var minLogLevel: Level = Level.INFO
 
+    @Option(
+        hidden = true,
+        names = ["--disable-kotlin-extension-point"],
+    )
+    var disableKotlinExtensionPoint: Boolean = false
+
     private val tripped = AtomicBoolean()
     private val fileNumber = AtomicInteger()
     private val errorNumber = AtomicInteger()
@@ -291,6 +297,7 @@ internal class KtlintCommandLine {
                 editorConfigDefaults = editorConfigDefaults(ruleProviders),
                 editorConfigOverride = editorConfigOverride,
                 isInvokedFromCli = true,
+                enableKotlinCompilerExtensionPoint = !disableKotlinExtensionPoint,
             )
 
         val baseline =

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -50,6 +50,14 @@ public class KtLintRuleEngine(
      */
     public val editorConfigOverride: EditorConfigOverride = EMPTY_EDITOR_CONFIG_OVERRIDE,
     /**
+     * Temporary flag to indicate that kotlin embeddable compiler is to be executed with (default) or without the extension point
+     * 'org.jetbrains.kotlin.com.intellij.treeCopyHandler'. This extension point is not (yet) supported in the preview of Kotlin 1.9. Some
+     * rules might no longer work and throw exceptions at runtime.
+     * It is unclear whether the extension point will be supported. Disabling this flag on the Kotlin 1.8 compiler has the same effect. As
+     * of that it can be used to assess the impact, and to fix rules before release of the Ktlint version which will be based on Kotlin 1.9.
+     */
+    public val enableKotlinCompilerExtensionPoint: Boolean = true,
+    /**
      * **For internal use only**: indicates that linting was invoked from KtLint CLI tool. It enables some internals workarounds for Kotlin
      * Compiler initialization. This property is likely to be removed in any of next versions without further notice.
      */

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -139,7 +139,7 @@ internal class RuleExecutionContext private constructor(
             ktLintRuleEngine: KtLintRuleEngine,
             code: Code,
         ): RuleExecutionContext {
-            val psiFileFactory = KOTLIN_PSI_FILE_FACTORY_PROVIDER.getKotlinPsiFileFactory(ktLintRuleEngine.isInvokedFromCli)
+            val psiFileFactory = KOTLIN_PSI_FILE_FACTORY_PROVIDER.getKotlinPsiFileFactory(ktLintRuleEngine)
             val normalizedText = normalizeText(code.content)
             val positionInTextLocator = buildPositionInTextLocator(normalizedText)
 

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -503,7 +503,7 @@ private class AutoCorrectErrorRule : Rule(
                 STRING_VALUE_TO_BE_AUTOCORRECTED -> {
                     emit(node.startOffset, ERROR_MESSAGE_CAN_BE_AUTOCORRECTED, true)
                     if (autoCorrect) {
-                        (node as LeafElement).replaceWithText(STRING_VALUE_AFTER_AUTOCORRECT)
+                        (node as LeafElement).rawReplaceWithText(STRING_VALUE_AFTER_AUTOCORRECT)
                     }
                 }
                 STRING_VALUE_NOT_TO_BE_CORRECTED ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoLineBreakBeforeAssignmentRule.kt
@@ -5,12 +5,12 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
-import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 public class NoLineBreakBeforeAssignmentRule : StandardRule("no-line-break-before-assignment") {
@@ -20,27 +20,46 @@ public class NoLineBreakBeforeAssignmentRule : StandardRule("no-line-break-befor
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         if (node.elementType == EQ) {
-            val prevCodeSibling = node.prevCodeSibling()
-            val unexpectedLinebreak =
-                prevCodeSibling
-                    ?.siblings()
-                    ?.takeWhile { it.isWhiteSpace() || it.isPartOfComment() }
-                    ?.lastOrNull { it.isWhiteSpaceWithNewline() }
-            if (unexpectedLinebreak != null) {
-                emit(unexpectedLinebreak.startOffset, "Line break before assignment is not allowed", true)
+            visitEquals(node, emit, autoCorrect)
+        }
+    }
+
+    private fun visitEquals(
+        assignmentNode: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        assignmentNode
+            .prevSibling()
+            .takeIf { it.isWhiteSpaceWithNewline() }
+            ?.let { unexpectedNewlineBeforeAssignment ->
+                emit(unexpectedNewlineBeforeAssignment.startOffset, "Line break before assignment is not allowed", true)
                 if (autoCorrect) {
-                    val prevPsi = prevCodeSibling.psi
-                    val parentPsi = prevPsi.parent
-                    val psiFactory = KtPsiFactory(prevPsi)
-                    if (prevPsi.nextSibling !is PsiWhiteSpace) {
-                        parentPsi.addAfter(psiFactory.createWhiteSpace(), prevPsi)
-                    }
-                    parentPsi.addAfter(psiFactory.createEQ(), prevPsi)
-                    parentPsi.addAfter(psiFactory.createWhiteSpace(), prevPsi)
-                    (node as? LeafPsiElement)?.delete()
+                    val parent = assignmentNode.treeParent
+                    // Insert assigment surrounded by whitespaces at new position
+                    assignmentNode
+                        .siblings(false)
+                        .takeWhile { it.isWhiteSpace() || it.isPartOfComment() }
+                        .last()
+                        .let { before ->
+                            if (!before.prevSibling().isWhiteSpace()) {
+                                parent.addChild(PsiWhiteSpaceImpl(" "), before)
+                            }
+                            parent.addChild(LeafPsiElement(EQ, "="), before)
+                            if (!before.isWhiteSpace()) {
+                                parent.addChild(PsiWhiteSpaceImpl(" "), before)
+                            }
+                        }
+                    // Cleanup old assignment and whitespace after it. The indent before the old assignment is kept unchanged
+                    assignmentNode
+                        .nextSibling()
+                        .takeIf { it.isWhiteSpace() }
+                        ?.let { whiteSpaceAfterEquals ->
+                            parent.removeChild(whiteSpaceAfterEquals)
+                        }
+                    parent.removeChild(assignmentNode)
                 }
             }
-        }
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
@@ -73,7 +73,7 @@ public class NoTrailingSpacesRule : StandardRule("no-trailing-spaces") {
                 regex = SPACE_OR_TAB_BEFORE_NEWLINE_REGEX,
                 replacement = "\n",
             )
-        (this as LeafPsiElement).replaceWithText(newText)
+        (this as LeafPsiElement).rawReplaceWithText(newText)
     }
 
     private fun String.hasTrailingSpace() = takeLast(1) == " "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -249,7 +249,7 @@ public class ParameterListSpacingRule :
     ) {
         emit(node.startOffset, "Expected a single space", true)
         if (autoCorrect) {
-            (node as LeafPsiElement).replaceWithText(" ")
+            (node as LeafPsiElement).rawReplaceWithText(" ")
         }
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
@@ -2,23 +2,22 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EQ
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
-import com.pinterest.ktlint.rule.engine.core.api.isPartOfString
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -35,32 +34,26 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString() && !node.isPartOfComment()) {
+        if (node.elementType == COLON) {
+            val psiParent = node.psi.parent
             if (node.isPartOf(ANNOTATION) || node.isPartOf(ANNOTATION_ENTRY)) {
                 // todo: enforce "no spacing"
                 return
             }
-            val removeSpacingBefore =
-                node.parent !is KtClassOrObject &&
-                    node.parent !is KtConstructor<*> && // constructor : this/super
-                    node.parent !is KtTypeConstraint && // where T : S
-                    node.parent?.parent !is KtTypeParameterList
             val prevLeaf = node.prevLeaf()
             if (prevLeaf != null && prevLeaf.isWhiteSpaceWithNewline()) {
                 emit(prevLeaf.startOffset, "Unexpected newline before \":\"", true)
                 if (autoCorrect) {
-                    val parent = node.parent
                     val prevNonCodeElements =
                         node
-                            .siblings(forward = false, withItself = false)
-                            .takeWhile { it.node.isWhiteSpace() || it.node.isPartOfComment() }
+                            .siblings(forward = false)
+                            .takeWhile { it.isWhiteSpace() || it.isPartOfComment() }
                             .toList()
                             .reversed()
                     when {
-                        parent is KtProperty || parent is KtNamedFunction -> {
+                        psiParent is KtProperty || psiParent is KtNamedFunction -> {
                             val equalsSignElement =
                                 node
-                                    .node
                                     .siblings(forward = true)
                                     .firstOrNull { it.elementType == EQ }
                             if (equalsSignElement != null) {
@@ -68,7 +61,7 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                                     .treeNext
                                     ?.let { treeNext ->
                                         prevNonCodeElements.forEach {
-                                            parent.node.addChild(it.node, treeNext)
+                                            node.treeParent.addChild(it, treeNext)
                                         }
                                         if (treeNext.isWhiteSpace()) {
                                             equalsSignElement.treeParent.removeChild(treeNext)
@@ -78,9 +71,8 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                             }
                             val blockElement =
                                 node
-                                    .siblings(forward = true, withItself = false)
+                                    .siblings(forward = true)
                                     .firstIsInstanceOrNull<KtBlockExpression>()
-                                    ?.node
                             if (blockElement != null) {
                                 val before =
                                     blockElement
@@ -88,36 +80,27 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                                         .nextSibling()
                                 prevNonCodeElements
                                     .let {
-                                        if (it.first().node.isWhiteSpace()) {
-                                            blockElement.treeParent.removeChild(it.first().node)
+                                        if (it.first().isWhiteSpace()) {
+                                            blockElement.treeParent.removeChild(it.first())
                                             it.drop(1)
                                         } else {
-                                            blockElement.addChild(PsiWhiteSpaceImpl("#"), before)
                                             it
                                         }
-                                        if (it.last().node.isWhiteSpaceWithNewline()) {
-                                            blockElement.treeParent.removeChild(it.last().node)
+                                        if (it.last().isWhiteSpaceWithNewline()) {
+                                            blockElement.treeParent.removeChild(it.last())
                                             it.dropLast(1)
                                         } else {
                                             it
                                         }
                                     }.forEach {
-                                        blockElement.addChild(it.node, before)
+                                        blockElement.addChild(it, before)
                                     }
-                            }
-                            if (prevNonCodeElements.first() != prevNonCodeElements.last()) {
-                                //                                parent.deleteChildRange(prevNonCodeElements.first(), prevNonCodeElements.last())
-//                                parent.node.removeRange(prevNonCodeElements.first().node, prevNonCodeElements.last().node)
-                                Unit
-                            } else {
-                                //                                parent.node.removeChild(prevNonCodeElements.first().node)
-                                Unit
                             }
                         }
                         prevLeaf.prevLeaf()?.isPartOfComment() == true -> {
                             val nextLeaf = node.nextLeaf()
                             prevNonCodeElements.forEach {
-                                node.treeParent.addChild(it.node, nextLeaf)
+                                node.treeParent.addChild(it, nextLeaf)
                             }
                             if (nextLeaf != null && nextLeaf.isWhiteSpace()) {
                                 node.treeParent.removeChild(nextLeaf)
@@ -125,52 +108,67 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                         }
                         else -> {
                             val text = prevLeaf.text
-                            if (removeSpacingBefore) {
+                            if (node.removeSpacingBefore) {
                                 prevLeaf.treeParent.removeChild(prevLeaf)
                             } else {
                                 (prevLeaf as LeafPsiElement).rawReplaceWithText(" ")
                             }
-                            (node as ASTNode).upsertWhitespaceAfterMe(text)
+                            node.upsertWhitespaceAfterMe(text)
                         }
                     }
                 }
             }
-            if (node.prevSibling is PsiWhiteSpace && removeSpacingBefore && !prevLeaf.isWhiteSpaceWithNewline()) {
+            if (node.prevSibling().isWhiteSpace() && node.removeSpacingBefore && !prevLeaf.isWhiteSpaceWithNewline()) {
                 emit(node.startOffset, "Unexpected spacing before \":\"", true)
                 if (autoCorrect) {
-                    node.prevSibling.node.treeParent.removeChild(node.prevSibling.node)
+                    node
+                        .prevSibling()
+                        ?.let { prevSibling ->
+                            prevSibling.treeParent.removeChild(prevSibling)
+                        }
                 }
             }
             val missingSpacingBefore =
-                node.prevSibling !is PsiWhiteSpace &&
+                !node.prevSibling().isWhiteSpace() &&
                     (
-                        node.parent is KtClassOrObject || node.parent is KtConstructor<*> ||
-                            node.parent is KtTypeConstraint || node.parent.parent is KtTypeParameterList
+                        psiParent is KtClassOrObject || psiParent is KtConstructor<*> ||
+                            psiParent is KtTypeConstraint || psiParent.parent is KtTypeParameterList
                         )
-            val missingSpacingAfter = node.nextSibling !is PsiWhiteSpace
+            val missingSpacingAfter = !node.nextSibling().isWhiteSpace()
             when {
                 missingSpacingBefore && missingSpacingAfter -> {
                     emit(node.startOffset, "Missing spacing around \":\"", true)
                     if (autoCorrect) {
-                        (node as ASTNode).upsertWhitespaceBeforeMe(" ")
-                        (node as ASTNode).upsertWhitespaceAfterMe(" ")
+                        node.upsertWhitespaceBeforeMe(" ")
+                        node.upsertWhitespaceAfterMe(" ")
                     }
                 }
                 missingSpacingBefore -> {
                     emit(node.startOffset, "Missing spacing before \":\"", true)
                     if (autoCorrect) {
-                        (node as ASTNode).upsertWhitespaceBeforeMe(" ")
+                        node.upsertWhitespaceBeforeMe(" ")
                     }
                 }
                 missingSpacingAfter -> {
                     emit(node.startOffset + 1, "Missing spacing after \":\"", true)
                     if (autoCorrect) {
-                        (node as ASTNode).upsertWhitespaceAfterMe(" ")
+                        node.upsertWhitespaceAfterMe(" ")
                     }
                 }
             }
         }
     }
+
+    private inline val ASTNode.removeSpacingBefore: Boolean
+        get() =
+            psi
+                .parent
+                .let { psiParent ->
+                    psiParent !is KtClassOrObject &&
+                        psiParent !is KtConstructor<*> && // constructor : this/super
+                        psiParent !is KtTypeConstraint && // where T : S
+                        psiParent?.parent !is KtTypeParameterList
+                }
 }
 
 public val SPACING_AROUND_COLON_RULE_ID: RuleId = SpacingAroundColonRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.INDICES
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
@@ -21,8 +22,8 @@ import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
-import org.jetbrains.kotlin.psi.KtPsiFactory
 
 /**
  * Linting trailing comma for call site.
@@ -171,10 +172,12 @@ public class TrailingCommaOnCallSiteRule :
                         true,
                     )
                     if (autoCorrect) {
-                        val prevPsi = inspectNode.prevCodeSibling()!!.psi
-                        val parentPsi = prevPsi.parent
-                        val psiFactory = KtPsiFactory(prevPsi)
-                        parentPsi.addAfter(psiFactory.createComma(), prevPsi)
+                        inspectNode
+                            .prevCodeSibling()
+                            ?.nextSibling()
+                            ?.let { before ->
+                                before.treeParent.addChild(LeafPsiElement(COMMA, ","), before)
+                            }
                     }
                 }
             TrailingCommaState.REDUNDANT -> {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRuleTest.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class SpacingAroundColonRuleTest {
@@ -273,96 +274,141 @@ class SpacingAroundColonRuleTest {
             ).isFormattedAs(formattedCode)
     }
 
-    @Test
-    fun `Issue 1057 - Given some declaration with an unexpected newline before the colon`() {
-        val code =
-            """
-            fun test() {
+    @Nested
+    inner class `Issue 1057 - Given some declaration with an unexpected newline before the colon` {
+        @Test
+        fun `Property with colon on next line`() {
+            val code =
+                """
                 val v1
                     : Int = 1
 
-                val v2 // comment
+                val v2// comment
                     : Int = 1
 
-                val v3
+                val v3 // comment
+                    : Int = 1
+
+                val v4
                     // comment
                     : Int = 1
-
-                fun f1()
-                    : Int = 1
-
-                fun f2() // comment
-                    : Int = 1
-
-                fun f3()
-                    // comment
-                    : Int = 1
-
-                fun g1()
-                    : Int {
-                    return 1
-                }
-
-                fun g2() // comment
-                    : Int {
-                    return 1
-                }
-
-                fun g3()
-                    // comment
-                    : Int {
-                    return 1
-                }
-            }
-            """.trimIndent()
-        val formattedCode =
-            """
-            fun test() {
+                """.trimIndent()
+            val formattedCode =
+                """
                 val v1: Int =
                     1
 
-                val v2: Int = // comment
+                val v2: Int =// comment
                     1
 
-                val v3: Int =
+                val v3: Int = // comment
+                    1
+
+                val v4: Int =
                     // comment
                     1
+                """.trimIndent()
+            spacingAroundColonRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 7, "Unexpected newline before \":\""),
+                    LintViolation(4, 17, "Unexpected newline before \":\""),
+                    LintViolation(7, 18, "Unexpected newline before \":\""),
+                    LintViolation(11, 15, "Unexpected newline before \":\""),
+                ).isFormattedAs(formattedCode)
+        }
 
-                fun f1(): Int =
+        @Test
+        fun `Function with colon on next line followed by body expression`() {
+            val code =
+                """
+                fun foo1()
+                    : Int = 1
+
+                fun foo2()// comment
+                    : Int = 1
+
+                fun foo3() // comment
+                    : Int = 1
+
+                fun foo4()
+                    // comment
+                    : Int = 1
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo1(): Int =
                     1
 
-                fun f2(): Int = // comment
+                fun foo2(): Int =// comment
                     1
 
-                fun f3(): Int =
+                fun foo3(): Int = // comment
+                    1
+
+                fun foo4(): Int =
                     // comment
                     1
+                """.trimIndent()
+            spacingAroundColonRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Unexpected newline before \":\""),
+                    LintViolation(4, 21, "Unexpected newline before \":\""),
+                    LintViolation(7, 22, "Unexpected newline before \":\""),
+                    LintViolation(11, 15, "Unexpected newline before \":\""),
+                ).isFormattedAs(formattedCode)
+        }
 
-                fun g1(): Int {
-                    return 1
+        @Test
+        fun `Function with colon on next line followed by body block`() {
+            val code =
+                """
+                fun foo1()
+                    : Int {
+                    1
                 }
 
-                fun g2(): Int { // comment
-                    return 1
+                fun foo2()// comment
+                    : Int {
+                    1
                 }
 
-                fun g3(): Int {
+                fun foo3() // comment
+                    : Int {
+                    1
+                }
+
+                fun foo4()
                     // comment
-                    return 1
+                    : Int {
+                    1
                 }
-            }
-            """.trimIndent()
-        spacingAroundColonRuleAssertThat(code)
-            .hasLintViolations(
-                LintViolation(2, 11, "Unexpected newline before \":\""),
-                LintViolation(5, 22, "Unexpected newline before \":\""),
-                LintViolation(9, 19, "Unexpected newline before \":\""),
-                LintViolation(12, 13, "Unexpected newline before \":\""),
-                LintViolation(15, 24, "Unexpected newline before \":\""),
-                LintViolation(19, 19, "Unexpected newline before \":\""),
-                LintViolation(22, 13, "Unexpected newline before \":\""),
-                LintViolation(27, 24, "Unexpected newline before \":\""),
-                LintViolation(33, 19, "Unexpected newline before \":\""),
-            ).isFormattedAs(formattedCode)
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo1(): Int {
+                    1
+                }
+
+                fun foo2(): Int {// comment
+                    1
+                }
+
+                fun foo3(): Int { // comment
+                    1
+                }
+
+                fun foo4(): Int {
+                    // comment
+                    1
+                }
+                """.trimIndent()
+            spacingAroundColonRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Unexpected newline before \":\""),
+                    LintViolation(6, 21, "Unexpected newline before \":\""),
+                    LintViolation(11, 22, "Unexpected newline before \":\""),
+                    LintViolation(17, 15, "Unexpected newline before \":\""),
+                ).isFormattedAs(formattedCode)
+        }
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateRuleTest.kt
@@ -354,6 +354,17 @@ class StringTemplateRuleTest {
             .hasLintViolation(3, 21, "Redundant \"toString()\" call in string template")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a string template immediately followed by non-whitespace character`() {
+        val code =
+            """
+            fun test(foo: String, bar: String) {
+                println("${'$'}{foo}text:${'$'}bar")
+            }
+            """.trimIndent()
+        stringTemplateRuleAssertThat(code).hasNoLintViolations()
+    }
 }
 
 // Replace the "$." placeholder with an actual "$" so that string "$.{expression}" is transformed to a String template


### PR DESCRIPTION
## Description

In Kotlin 1.9 the extension points of the embedded kotlin compiler will change. Ktlint only uses the `org.jetbrains.kotlin.com.intellij.treeCopyHandler` extension point. This extension is not yet supported in 1.9, neither is it documented ([#KT-58704](https://youtrack.jetbrains.com/issue/KT-58704/Support-and-document-extension-point-org.jetbrains.kotlin.com.intellij.treeCopyHandler)). Without this extension point it might happen that your custom rules will throw exceptions during runtime. See [#1981](https://github.com/pinterest/ktlint/issues/1981).

In Ktlint, 7 out of 77 rules needed small and sometimes bigger changes to become independent of the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler`. The impact on your custom rules may vary dependent on the way the autocorrect has been implemented. When manipulating `ASTNode`s there seems to be no impact. When, manipulating `PsiElement`s, some functions consistently result in a runtime exception.

Based on the refactoring of the rules as provided by `ktlint-ruleset-standard` in Ktlint `0.49.x` the suggested refactoring is as follows:

* Replace `LeafElement.replaceWithText(String)` with `LeafElement.rawReplaceWithText(String)`.
* Replace `PsiElement.addAfter(PsiElement, PsiElement)` with `AstNode.addChild(AstNode, AstNode)`. Note that this method inserts the new node (first) argument *before* the second argument node and as of that is not a simple replacement of the `PsiElement.addAfter(PsiElement, PsiElement)`.
* Replace `PsiElement.replace(PsiElement)` with a sequence of `AstNode.addChild(AstNode, AstNode)` and `AstNode.removeChild(AstNode)`.

Be aware that your custom rules might use other functions which also throw exceptions when the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` is no longer supported.

In order to help you to analyse and fix the problems with your custom rules, ktlint temporarily supports to disable the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` using a flag. This flag is available in the Ktlint CLI and in the `KtlintRuleEngine`. By default, the extension point is enabled like it was in previous versions of ktlint.

At least you should analyse the problems by running your test suits by running ktlint and disabling the extension point. Next you can start with fixing and releasing the updated rules. All rules in this version of ktlint have already been refactored and are not dependent on the extension point anymore. In Ktlint CLI the flag is to be activated with parameter `--disable-kotlin-extension-point`. API Consumers that use the `KtlintRuleEngine` directly, have to set property `enableKotlinCompilerExtensionPoint` to `false`.

At this point in time, it is not yet decided what the next steps will be. Ktlint might drop the support of the extension points entirely. Or, if the extension point `org.jetbrains.kotlin.com.intellij.treeCopyHandler` is fully supported at the time that ktlint will be based on kotlin 1.9 it might be kept. In either case, the flag will be dropped in a next version of ktlint.
## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
