### PR TITLE
Fixes/2017/ignore serial version UI d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 * Do not flag a (potential) mutable extension property in case the getter is annotated or prefixed with a modifier `property-naming` ([#2024](https://github.com/pinterest/ktlint/issues/2024))
 * Do not merge an annotated expression body with the function signature even if it fits on a single line ([#2043](https://github.com/pinterest/ktlint/issues/2043))
+* Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
 
 ### Changed
 
@@ -39,7 +40,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Extract rule `no-single-line-block-comment` from `comment-wrapping` rule. The `no-single-line-block-comment` rule is added as experimental rule to the `ktlint_official` code style, but it can be enabled explicitly for the other code styles as well. ([#1980](https://github.com/pinterest/ktlint/issues/1980))
 * Clean-up unwanted logging dependencies ([#1998](https://github.com/pinterest/ktlint/issues/1998))
 * Fix directory traversal for patterns referring to paths outside of current working directory or any of it child directories ([#2002](https://github.com/pinterest/ktlint/issues/2002))
-* Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Extract rule `no-single-line-block-comment` from `comment-wrapping` rule. The `no-single-line-block-comment` rule is added as experimental rule to the `ktlint_official` code style, but it can be enabled explicitly for the other code styles as well. ([#1980](https://github.com/pinterest/ktlint/issues/1980))
 * Clean-up unwanted logging dependencies ([#1998](https://github.com/pinterest/ktlint/issues/1998))
 * Fix directory traversal for patterns referring to paths outside of current working directory or any of it child directories ([#2002](https://github.com/pinterest/ktlint/issues/2002))
+* Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -81,7 +81,13 @@ public class PropertyNamingRule :
     ) {
         identifier
             .text
-            .takeUnless { it == SERIAL_VERSION_UID_PROPERTY_NAME }
+            .takeUnless {
+                // Allow
+                // object Foo {
+                //     private const val serialVersionUID: Long = 123
+                // }
+                it == SERIAL_VERSION_UID_PROPERTY_NAME
+            }
             ?.takeUnless { it.matches(SCREAMING_SNAKE_CASE_REGEXP) }
             ?.let {
                 emit(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -81,7 +81,8 @@ public class PropertyNamingRule :
     ) {
         identifier
             .text
-            .takeUnless { it.matches(SCREAMING_SNAKE_CASE_REGEXP) }
+            .takeUnless { it == SERIAL_VERSION_UID_PROPERTY_NAME }
+            ?.takeUnless { it.matches(SCREAMING_SNAKE_CASE_REGEXP) }
             ?.let {
                 emit(
                     identifier.startOffset,
@@ -142,6 +143,7 @@ public class PropertyNamingRule :
     private companion object {
         val LOWER_CAMEL_CASE_REGEXP = "[a-z][a-zA-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
         val SCREAMING_SNAKE_CASE_REGEXP = "[A-Z][_A-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
+        const val SERIAL_VERSION_UID_PROPERTY_NAME = "serialVersionUID"
         val BACKING_PROPERTY_LOWER_CAMEL_CASE_REGEXP = "_[a-z][a-zA-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -87,8 +87,7 @@ public class PropertyNamingRule :
                 //     private const val serialVersionUID: Long = 123
                 // }
                 it == SERIAL_VERSION_UID_PROPERTY_NAME
-            }
-            ?.takeUnless { it.matches(SCREAMING_SNAKE_CASE_REGEXP) }
+            }?.takeUnless { it.matches(SCREAMING_SNAKE_CASE_REGEXP) }
             ?.let {
                 emit(
                     identifier.startOffset,
@@ -149,8 +148,8 @@ public class PropertyNamingRule :
     private companion object {
         val LOWER_CAMEL_CASE_REGEXP = "[a-z][a-zA-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
         val SCREAMING_SNAKE_CASE_REGEXP = "[A-Z][_A-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
-        const val SERIAL_VERSION_UID_PROPERTY_NAME = "serialVersionUID"
         val BACKING_PROPERTY_LOWER_CAMEL_CASE_REGEXP = "_[a-z][a-zA-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
+        const val SERIAL_VERSION_UID_PROPERTY_NAME = "serialVersionUID"
     }
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -187,16 +187,8 @@ class PropertyNamingRuleTest {
                 }
                 class Foo2 {
                     companion object {
-                        private val serialVersionUID: Long = 123
+                        private const val serialVersionUID = 123L
                     }
-                }
-                class Foo3 {
-                    companion object {
-                        @JvmStatic private val serialVersionUID: Long = 123
-                    }
-                }
-                class Foo4 {
-                    private val serialVersionUID: Long = 123
                 }
                 """.trimIndent()
             propertyNamingRuleAssertThat(code).hasNoLintViolations()
@@ -210,10 +202,7 @@ class PropertyNamingRuleTest {
                     private const val serialVersionUID: Long = 123
                 }
                 object Foo2 {
-                    private val serialVersionUID: Long = 123
-                }
-                object Foo3 {
-                    @JvmStatic private val serialVersionUID: Long = 123
+                    private const val serialVersionUID = 123L
                 }
                 """.trimIndent()
             propertyNamingRuleAssertThat(code).hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -171,5 +172,51 @@ class PropertyNamingRuleTest {
             val foo = Foo()
             """.trimIndent()
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Nested
+    inner class `Given property is serialVersionUID` {
+        @Test
+        fun `Given property is present in companion object`() {
+            val code =
+                """
+                class Foo1 {
+                    companion object {
+                        private const val serialVersionUID: Long = 123
+                    }
+                }
+                class Foo2 {
+                    companion object {
+                        private val serialVersionUID: Long = 123
+                    }
+                }
+                class Foo3 {
+                    companion object {
+                        @JvmStatic private val serialVersionUID: Long = 123
+                    }
+                }
+                class Foo4 {
+                    private val serialVersionUID: Long = 123
+                }
+                """.trimIndent()
+            propertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given property defined object is private const`() {
+            val code =
+                """
+                object Foo1 {
+                    private const val serialVersionUID: Long = 123
+                }
+                object Foo2 {
+                    private val serialVersionUID: Long = 123
+                }
+                object Foo3 {
+                    @JvmStatic private val serialVersionUID: Long = 123
+                }
+                """.trimIndent()
+            propertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -175,7 +175,7 @@ class PropertyNamingRuleTest {
     }
 
     @Nested
-    inner class `Given property is serialVersionUID` {
+    inner class `Issue 2017 - Given property is serialVersionUID` {
         @Test
         fun `Given property is present in companion object`() {
             val code =


### PR DESCRIPTION
## Description
Filter the `serialversionUID` from the analysis
Fixes https://github.com/pinterest/ktlint/issues/2017

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated
- [x] `CHANGELOG.md` is updated
