### PR TITLE
Add sample code for Rule id: wrapping

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -863,6 +863,25 @@ Rule id: `unnecessary-parentheses-before-trailing-lambda`
 
 Inserts missing newlines (for example between parentheses of a multi-line function call).
 
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val x = f(
+        a,
+        b,
+        c
+    )
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val x = f(
+        a,
+        b,
+        c)
+    ```
+
 Rule id: `wrapping`
 
 ### Comment wrapping

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -863,6 +863,25 @@ Rule id: `unnecessary-parentheses-before-trailing-lambda`
 
 Inserts missing newlines (for example between parentheses of a multi-line function call).
 
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val x = f(
+        a,
+        b,
+        c
+    )
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val x = f(
+        a,
+        b,
+        c)
+    ```
+
 Rule id: `wrapping`
 
 ### Comment wrapping


### PR DESCRIPTION
Added sample code for Rule id: wrapping in the standard.md file to enhance user comprehension of the rule.