### PR TITLE
AstNodeExtensions && EditorConfig

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -385,8 +385,19 @@ public fun noNewLineInClosedRange(
     to: ASTNode,
 ): Boolean =
     !from.isWhiteSpaceWithNewline() &&
-        leavesInOpenRange(from, to).none { it.textContains('\n') } &&
+        noNewLineInOpenRange(from, to) &&
         !to.isWhiteSpaceWithNewline()
+
+/**
+ * Verifies that no leaf contains a newline in the open range [from] - [to]. This means that the boundary nodes are excluded from the range
+ * in case they would happen to be a leaf node. In case [from] is a [CompositeElement] than the first leaf node in the sequence is the first
+ * leaf node in this [CompositeElement]. In case [to] is a [CompositeElement] than the last node in the sequence is the last leaf node prior
+ * to this [CompositeElement].
+ */
+public fun noNewLineInOpenRange(
+    from: ASTNode,
+    to: ASTNode,
+): Boolean = leavesInOpenRange(from, to).none { it.textContains('\n') }
 
 /**
  * Creates a sequence of leaf nodes in the open range [from] - [to]. This means that the boundary nodes are excluded

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/IndentConfig.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.IndentStyle.TAB
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import org.ec4j.core.model.PropertyType
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 public data class IndentConfig(
     val indentStyle: IndentStyle,
@@ -78,6 +79,21 @@ public data class IndentConfig(
                 SPACE -> indentChar.toString().repeat(tabWidth)
             }
         }
+
+    /**
+     * Get the indentation including the newline character for a node at the next indent level compared to the given node.
+     */
+    public fun childIndentOf(node: ASTNode): String = node.indent().plus(indent)
+
+    /**
+     * Get the indentation including the newline character for a node at the same indent level as the given node.
+     */
+    public fun siblingIndentOf(node: ASTNode): String = parentIndentOf(node).plus(indent)
+
+    /**
+     * Get the indentation including the newline character for a node at the same indent level as the parent of the given node.
+     */
+    public fun parentIndentOf(node: ASTNode): String = node.treeParent.indent()
 
     /**
      * Converts [text] to a normalized indent. If [text] contains a new line, then only text after the last new line

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -137,11 +137,11 @@ public class AnnotationRule :
             val expectedIndent =
                 when {
                     node.elementType == ANNOTATED_EXPRESSION ->
-                        node.treeParent.indent().plus(indentConfig.indent)
+                        indentConfig.siblingIndentOf(node)
                     node.hasAnnotationBeforeConstructor() ->
-                        node.treeParent.treeParent.indent().plus(indentConfig.indent)
+                        indentConfig.siblingIndentOf(node.treeParent)
                     else ->
-                        node.treeParent.indent()
+                        indentConfig.parentIndentOf(node)
                 }
 
             node
@@ -264,7 +264,7 @@ public class AnnotationRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
         autoCorrect: Boolean,
     ) {
-        val expectedIndent = node.indent().plus(indentConfig.indent)
+        val expectedIndent = indentConfig.childIndentOf(node)
 
         node
             .children()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
@@ -22,7 +22,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
@@ -90,7 +89,7 @@ public class ChainWrappingRule :
                     // <prevLeaf><node="."><spaceBeforeComment><comment><nextLeaf="\n"> to
                     // <prevLeaf><delete space if any><spaceBeforeComment><comment><nextLeaf="\n"><node="."><space if needed>
                     if (node.elementType == ELVIS) {
-                        node.upsertWhitespaceBeforeMe(node.indent().plus(indentConfig.indent))
+                        node.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
                         node.upsertWhitespaceAfterMe(" ")
                     } else {
                         node.treeParent.removeChild(node)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -84,7 +84,7 @@ public class ContextReceiverWrappingRule :
                 if (autoCorrect) {
                     nodeAfterContextReceiver
                         .firstChildLeafOrSelf()
-                        .upsertWhitespaceBeforeMe(node.treeParent.indent())
+                        .upsertWhitespaceBeforeMe(indentConfig.parentIndentOf(node))
                 }
             }
 
@@ -104,7 +104,7 @@ public class ContextReceiverWrappingRule :
                     if (autoCorrect) {
                         it
                             .prevLeaf(includeEmpty = true)
-                            ?.upsertWhitespaceAfterMe(node.indent().plus(indentConfig.indent))
+                            ?.upsertWhitespaceAfterMe(indentConfig.childIndentOf(node))
                     }
                 }
             node
@@ -143,8 +143,7 @@ public class ContextReceiverWrappingRule :
                         true,
                     )
                     if (autoCorrect) {
-                        it
-                            .upsertWhitespaceBeforeMe(node.indent().plus(indentConfig.indent))
+                        it.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
                     }
                 }
             node
@@ -159,7 +158,7 @@ public class ContextReceiverWrappingRule :
                         // Ideally, the closing angle bracket should be de-indented to make it consistent with
                         // de-intentation of closing ")", "}" and "]". This however would be inconsistent with how the
                         // type argument lists are formatted by IntelliJ IDEA default formatter.
-                        gt.upsertWhitespaceBeforeMe(node.indent().plus(indentConfig.indent))
+                        gt.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
                     }
                 }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -345,7 +345,7 @@ public class FunctionSignatureRule :
             ?.takeIf { it.elementType == WHITE_SPACE }
             .let { whiteSpaceBeforeIdentifier ->
                 if (multiline) {
-                    val expectedParameterIndent = node.indent().plus(indentConfig.indent)
+                    val expectedParameterIndent = indentConfig.childIndentOf(node)
                     if (whiteSpaceBeforeIdentifier == null ||
                         whiteSpaceBeforeIdentifier.text != expectedParameterIndent
                     ) {
@@ -409,7 +409,7 @@ public class FunctionSignatureRule :
                     ?.takeIf { it.elementType == WHITE_SPACE }
                     .let { whiteSpaceBeforeIdentifier ->
                         if (multiline) {
-                            val expectedParameterIndent = node.indent().plus(indentConfig.indent)
+                            val expectedParameterIndent = indentConfig.childIndentOf(node)
                             if (whiteSpaceBeforeIdentifier == null ||
                                 whiteSpaceBeforeIdentifier.text != expectedParameterIndent
                             ) {
@@ -592,7 +592,7 @@ public class FunctionSignatureRule :
                         if (autoCorrect) {
                             functionBodyExpressionNodes
                                 .first()
-                                .upsertWhitespaceBeforeMe(node.indent().plus(indentConfig.indent))
+                                .upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
@@ -151,7 +151,7 @@ public class IfElseBracingRule :
             val previousChild = node.firstChildNode
             node.replaceChild(node.firstChildNode, this)
             addChild(LeafPsiElement(LBRACE, "{"))
-            addChild(PsiWhiteSpaceImpl(node.indent().plus(indentConfig.indent)))
+            addChild(PsiWhiteSpaceImpl(indentConfig.childIndentOf(node)))
             prevLeaves
                 .dropWhile { it.isWhiteSpace() }
                 .forEach(::addChild)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRule.kt
@@ -16,7 +16,6 @@ import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeLeaf
@@ -140,11 +139,7 @@ public class IfElseWrappingRule :
         }
 
         with(node.findFirstNodeInBlockToBeIndented() ?: node) {
-            val expectedIndent =
-                node
-                    .treeParent
-                    .indent()
-                    .plus(indentConfig.indent)
+            val expectedIndent = indentConfig.siblingIndentOf(node)
             if (text != expectedIndent) {
                 emit(startOffset, "Expected a newline", true)
                 if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
@@ -130,7 +130,7 @@ public class MultiLineIfElseRule :
             val previousChild = node.firstChildNode
             node.replaceChild(node.firstChildNode, this)
             addChild(LeafPsiElement(LBRACE, "{"))
-            addChild(PsiWhiteSpaceImpl(node.indent().plus(indentConfig.indent)))
+            addChild(PsiWhiteSpaceImpl(indentConfig.childIndentOf(node)))
             prevLeaves
                 .dropWhile { it.isWhiteSpace() }
                 .forEach(::addChild)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrapping.kt
@@ -30,7 +30,6 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
@@ -97,17 +96,12 @@ public class MultilineExpressionWrapping :
                     if (prevLeaf != null && !prevLeaf.textContains('\n')) {
                         emit(node.startOffset, "A multiline expression should start on a new line", true)
                         if (autoCorrect) {
-                            node.upsertWhitespaceBeforeMe(
-                                node
-                                    .treeParent
-                                    .indent()
-                                    .plus(indentConfig.indent),
-                            )
+                            node.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
                             node
                                 .lastChildLeafOrSelf()
                                 .nextLeaf { !it.isWhiteSpaceWithoutNewline() && !it.isPartOfComment() && it.elementType != COMMA }
                                 ?.takeIf { !it.isWhiteSpaceWithNewline() }
-                                ?.upsertWhitespaceBeforeMe(node.treeParent.indent())
+                                ?.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFirstLineInClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFirstLineInClassBodyRule.kt
@@ -7,7 +7,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.ruleset.standard.StandardRule
@@ -57,9 +56,7 @@ public class NoEmptyFirstLineInClassBodyRule :
                             true,
                         )
                         if (autoCorrect) {
-                            (whitespace as LeafPsiElement).rawReplaceWithText(
-                                node.indent().plus(indentConfig.indent),
-                            )
+                            (whitespace as LeafPsiElement).rawReplaceWithText(indentConfig.childIndentOf(node))
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
@@ -173,7 +173,7 @@ public class ParameterWrappingRule :
             "$line: " + (if (!autoCorrect) "would have " else "") + "inserted newline after ${nodeAfterWhichNewlineIsRequired.text}"
         }
         if (autoCorrect) {
-            nodeToFix.upsertWhitespaceAfterMe(nodeToFix.indent().plus(indentConfig.indent))
+            nodeToFix.upsertWhitespaceAfterMe(indentConfig.childIndentOf(nodeToFix))
         }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
@@ -165,7 +165,7 @@ public class PropertyWrappingRule :
             "$line: " + (if (!autoCorrect) "would have " else "") + "inserted newline after ${nodeAfterWhichNewlineIsRequired.text}"
         }
         if (autoCorrect) {
-            nodeToFix.upsertWhitespaceAfterMe(nodeToFix.indent().plus(indentConfig.indent))
+            nodeToFix.upsertWhitespaceAfterMe(indentConfig.childIndentOf(nodeToFix))
         }
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
@@ -13,7 +13,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
@@ -78,7 +77,7 @@ public class TryCatchFinallySpacingRule :
                 if (!nextSibling.text.startsWith("\n")) {
                     emit(lbrace.startOffset + 1, "Expected a newline after '{'", true)
                     if (autoCorrect) {
-                        lbrace.upsertWhitespaceAfterMe(node.treeParent.indent().plus(indentConfig.indent))
+                        lbrace.upsertWhitespaceAfterMe(indentConfig.siblingIndentOf(node))
                     }
                 }
             }
@@ -90,7 +89,7 @@ public class TryCatchFinallySpacingRule :
                 if (!prevSibling.text.startsWith("\n")) {
                     emit(rbrace.startOffset, "Expected a newline before '}'", true)
                     if (autoCorrect) {
-                        rbrace.upsertWhitespaceBeforeMe(node.treeParent.indent())
+                        rbrace.upsertWhitespaceBeforeMe(indentConfig.parentIndentOf(node))
                     }
                 }
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentListSpacingRule.kt
@@ -8,7 +8,6 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.findCompositeParentElementOfType
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfCompositeElementOfType
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
@@ -19,7 +18,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 
 /**
  * Lints and formats the spacing before and after the angle brackets of a type argument list.
@@ -98,11 +96,11 @@ public class TypeArgumentListSpacingRule :
     ) {
         val multiline = node.textContains('\n')
         val expectedIndent =
-            node
-                .indent()
-                .applyIf(multiline) {
-                    plus(indentConfig.indent)
-                }
+            if (multiline) {
+                indentConfig.childIndentOf(node)
+            } else {
+                indentConfig.siblingIndentOf(node)
+            }
 
         node
             .findChildByType(ElementType.LT)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -17,7 +17,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
@@ -92,7 +91,7 @@ public class TypeParameterListSpacingRule :
                     //    class Bar<T> constructor(...)
                     //    class Bar<T> actual constructor(...)
                     //    class Bar<T> @SomeAnnotation constructor(...)
-                    if (whiteSpace.text != " " && whiteSpace.text != node.indent().plus(indentConfig.indent)) {
+                    if (whiteSpace.text != " " && whiteSpace.text != indentConfig.childIndentOf(node)) {
                         emit(
                             whiteSpace.startOffset,
                             "Expected a single space or newline (with indent)",
@@ -176,7 +175,7 @@ public class TypeParameterListSpacingRule :
             ?.let {
                 val expectedWhitespace =
                     if (node.textContains('\n')) {
-                        node.indent().plus(indentConfig.indent)
+                        indentConfig.childIndentOf(node)
                     } else {
                         ""
                     }
@@ -190,7 +189,7 @@ public class TypeParameterListSpacingRule :
             ?.let {
                 val expectedWhitespace =
                     if (node.textContains('\n')) {
-                        node.indent().plus(indentConfig.indent)
+                        indentConfig.childIndentOf(node)
                     } else {
                         ""
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -269,7 +269,7 @@ public class WrappingRule :
             requireNewlineAfterLeaf(node, autoCorrect, emit)
         }
         if (!r.prevLeaf().isWhiteSpaceWithNewline()) {
-            requireNewlineBeforeLeaf(r, autoCorrect, emit, node.treeParent.indent())
+            requireNewlineBeforeLeaf(r, autoCorrect, emit, indentConfig.parentIndentOf(node))
         }
     }
 
@@ -404,9 +404,7 @@ public class WrappingRule :
                             if (prevSibling?.elementType == LT || prevSibling.isWhiteSpaceWithoutNewline()) {
                                 emit(typeProjection.startOffset, "A newline was expected before '${typeProjection.text}'", true)
                                 if (autoCorrect) {
-                                    typeProjection.upsertWhitespaceBeforeMe(
-                                        node.treeParent.indent().plus(indentConfig.indent),
-                                    )
+                                    typeProjection.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
                                 }
                             }
                         }
@@ -420,9 +418,7 @@ public class WrappingRule :
                     if (prevSibling?.elementType != WHITE_SPACE || prevSibling.isWhiteSpaceWithoutNewline()) {
                         emit(closingAngle.startOffset, "A newline was expected before '${closingAngle.text}'", true)
                         if (autoCorrect) {
-                            closingAngle.upsertWhitespaceBeforeMe(
-                                node.treeParent.indent().plus(indentConfig.indent),
-                            )
+                            closingAngle.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
                         }
                     }
                 }
@@ -566,7 +562,7 @@ public class WrappingRule :
             "$line: " + (if (!autoCorrect) "would have " else "") + "inserted newline after ${nodeAfterWhichNewlineIsRequired.text}"
         }
         if (autoCorrect) {
-            val tempIndent = indent ?: (nodeToFix.indent().plus(indentConfig.indent))
+            val tempIndent = indent ?: (indentConfig.childIndentOf(nodeToFix))
             nodeToFix.upsertWhitespaceAfterMe(tempIndent)
         }
     }
@@ -658,7 +654,7 @@ public class WrappingRule :
                     endOfBlock,
                     autoCorrect,
                     emit,
-                    node.treeParent.indent(),
+                    indentConfig.parentIndentOf(node),
                 )
             }
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -517,18 +517,28 @@ class ParameterListWrappingRuleTest {
         val code =
             """
             var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
+            fun foo() {
+                var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
+            }
             """.trimIndent()
         val formattedCode =
             """
             var changesListener: (
                 (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
             )? = null
+            fun foo() {
+                var changesListener: (
+                    (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
+                )? = null
+            }
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 80)
             .hasLintViolations(
                 LintViolation(1, 22, "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
                 LintViolation(1, 95, """Missing newline before ")""""),
+                LintViolation(3, 26, "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
+                LintViolation(3, 99, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
 


### PR DESCRIPTION
## Description

* Extract method noNewLineInOpenRange as counter partner for noNewLineInClosedRange
* Add methods `childIndentOf`, `siblingIndentOf` and `parentIndentOf` to `IndentConfig` to improve readability

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
