### PR TITLE
Restrict build pull request workflow to PR's containing code

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -5,6 +5,8 @@ on:
     branches: ['master']
     paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
   pull_request:
+    branches: ['master']
+    paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

Restrict build pull request workflow to PR's containing code. In this way a PR with only a documentation change will not trigger a build of the snapshot.

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
