### PR TITLE
Add experimental rule `binary-expression-wrapping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* Add new experimental rule `binary-expression-wrapping`. This rule wraps a binary expression in case the max line length is exceeded ([#1940](https://github.com/pinterest/ktlint/issues/1940))
+
 ### Removed
 
 ### Fixed

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -8,6 +8,38 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](../configuration-ktlint/#disabled-rules).
 
+## Binary expression wrapping
+
+Wraps binary expression at the operator reference whenever the binary expression does not fit on the line. In case the binary expression is nested, the expression is evaluated from outside to inside. If the left and right hand sides of the binary expression, after wrapping, fit on a single line then the inner binary expressions will not be wrapped. If one or both inner binary expression still do not fit on a single after wrapping of the outer binary expression, then each of those inner binary expressions will be wrapped.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    fun foo() {
+        // Assume that the last allowed character is
+        // at the X character on the right                       X
+        if ((leftHandSideExpression && rightHandSideExpression) ||
+            (leftHandSideLongExpression &&
+                rightHandSideLongExpression)) {
+            // do something
+        }
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    fun foo() {
+        // Assume that the last allowed character is
+        // at the X character on the right                       X
+        if ((leftHandSideExpression && rightHandSideExpression) || (leftHandSideLongExpression && rightHandSideLongExpression)) {
+            // do something
+        }
+    }
+    ```
+
+Rule id: `binary-expression-wrapping` (`standard` rule set)
+
 ## Discouraged comment location
 
 Detect discouraged comment locations (no autocorrect).

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -268,7 +268,8 @@ internal class FileUtilsTest {
         LOGGER.info {
             val patterns = "src/main/kotlin"
             val dir = "/project1"
-            "`Given a (relative) directory path (but not a glob) from the workdir then find all files in that workdir and it subdirectories having the default kotlin extensions`\n" +
+            "`Given a (relative) directory path (but not a glob) from the workdir then find all files in that workdir and it " +
+                "subdirectories having the default kotlin extensions`\n" +
                 "\tpatterns = $patterns\n" +
                 "\trootDir = $dir"
         }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -25,6 +25,7 @@ import org.ec4j.core.Resource
 import org.ec4j.core.model.PropertyType.EndOfLineValue.crlf
 import org.ec4j.core.model.PropertyType.EndOfLineValue.lf
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.utils.addToStdlib.ifFalse
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
@@ -152,6 +153,13 @@ public class KtLintRuleEngine(
                             canBeAutoCorrected,
                         ),
                     )
+                    // In trace mode report the violation immediately. The order in which violations are actually found might be different
+                    // from the order in which they are reported. For debugging purposes it cn be helpful to know the exact order in which
+                    // violations are being solved.
+                    LOGGER.trace {
+                        "Format violation: ${code.fileNameOrStdin()}:$line:$col: $errorMessage (${rule.ruleId})" +
+                            canBeAutoCorrected.ifFalse { " [cannot be autocorrected]" }
+                    }
                 }
             }
         if (tripped) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 import com.pinterest.ktlint.ruleset.standard.rules.AnnotationRule
 import com.pinterest.ktlint.ruleset.standard.rules.AnnotationSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ArgumentListWrappingRule
+import com.pinterest.ktlint.ruleset.standard.rules.BinaryExpressionWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlockCommentInitialStarAlignmentRule
 import com.pinterest.ktlint.ruleset.standard.rules.ChainWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ClassNamingRule
@@ -88,6 +89,7 @@ public class StandardRuleSetProvider :
             RuleProvider { AnnotationRule() },
             RuleProvider { AnnotationSpacingRule() },
             RuleProvider { ArgumentListWrappingRule() },
+            RuleProvider { BinaryExpressionWrappingRule() },
             RuleProvider { BlockCommentInitialStarAlignmentRule() },
             RuleProvider { ChainWrappingRule() },
             RuleProvider { ClassNamingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -42,10 +42,13 @@ public class ArgumentListWrappingRule :
         id = "argument-list-wrapping",
         visitorModifiers =
             setOf(
+                // ArgumentListWrapping should only be used in case the max_line_length is still violated after running rules below:
                 VisitorModifier.RunAfterRule(
-                    // ArgumentListWrapping should only be used in case after normal wrapping the max_line_length is still
-                    // violated
                     ruleId = WRAPPING_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAfterRule(
+                    ruleId = BINARY_EXPRESSION_WRAPPING_RULE_ID,
                     mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
                 ),
             ),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -1,0 +1,153 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EQ
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.noNewLineInClosedRange
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+
+/**
+ * Wraps a binary expression whenever the expression does not fit on the line. Wrapping a binary expression should take precedence before
+ * argument of function calls inside that binary expression are wrapped.
+ */
+public class BinaryExpressionWrappingRule :
+    StandardRule(
+        id = "binary-expression-wrapping",
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
+    ),
+    Rule.Experimental {
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        when (node.elementType) {
+            BINARY_EXPRESSION -> visitExpression(node, emit, autoCorrect)
+        }
+    }
+
+    private fun visitExpression(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        require(node.elementType == BINARY_EXPRESSION)
+
+        // First check whether the entire expression has to be pushed to the next line after and assignment in a property or function
+        node
+            .takeIf { it.treeParent.elementType.anyOf(PROPERTY, FUN) }
+            ?.takeIf { binaryExpression ->
+                binaryExpression
+                    .prevSibling { it.elementType == EQ }
+                    ?.let { noNewLineInClosedRange(it, binaryExpression.firstChildLeafOrSelf()) }
+                    ?: false
+            }?.takeIf { textLengthWithoutNewlinePrefix(it.getFirstLeafOnLineOrSelf(), it.getLastLeafOnLineOrNull()) > maxLineLength }
+            ?.let { expression ->
+                emit(
+                    expression.startOffset,
+                    "Line is exceeding max line length. Break line between assignment and expression",
+                    true,
+                )
+                if (autoCorrect) {
+                    expression.upsertWhitespaceBeforeMe(expression.indent().plus(indentConfig.indent))
+                }
+            }
+
+        node
+            .findChildByType(OPERATION_REFERENCE)
+            ?.let { operationReference -> visitOperationReference(operationReference, emit, autoCorrect) }
+    }
+
+    private fun visitOperationReference(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        node
+            .takeIf { it.elementType == OPERATION_REFERENCE }
+            ?.takeIf { it.treeParent.elementType == BINARY_EXPRESSION }
+            ?.takeIf { textLengthWithoutNewlinePrefix(it.getFirstLeafOnLineOrSelf(), it.getLastLeafOnLineOrNull()) > maxLineLength }
+            ?.let { operationReference ->
+                if (cannotBeWrappedAtOperationReference(operationReference)) {
+                    // Wrapping after operation reference won't work as the left hand side still does not fit on a single line
+                    emit(operationReference.startOffset, "Line is exceeding max line length", false)
+                } else {
+                    operationReference
+                        .nextSibling()
+                        ?.let { nextSibling ->
+                            emit(
+                                nextSibling.startOffset,
+                                "Line is exceeding max line length. Break line after operator of binary expression",
+                                true,
+                            )
+                            if (autoCorrect) {
+                                nextSibling.upsertWhitespaceBeforeMe(operationReference.indent().plus(indentConfig.indent))
+                            }
+                        }
+                }
+            }
+    }
+
+    private fun cannotBeWrappedAtOperationReference(operationReference: ASTNode) =
+        operationReference
+            .takeUnless { it.prevCodeSibling()?.elementType == BINARY_EXPRESSION }
+            ?.let { textLengthWithoutNewlinePrefix(it.getFirstLeafOnLineOrSelf(), it.lastChildLeafOrSelf()) > maxLineLength }
+            ?: false
+
+    private fun textLengthWithoutNewlinePrefix(
+        fromNode: ASTNode,
+        toNode: ASTNode?,
+    ) = fromNode
+        .leavesIncludingSelf()
+        .takeWhile { it.prevLeaf() != toNode }
+        .joinToString(separator = "") { it.text }
+        .removePrefix("\n")
+        .length
+
+    private fun ASTNode.getLastLeafOnLineOrNull() = nextLeaf { it.isWhiteSpaceWithNewline() }?.prevLeaf()
+
+    private fun ASTNode.getFirstLeafOnLineOrSelf() = prevLeaf { it.isWhiteSpaceWithNewline() || it.prevLeaf() == null }!!
+}
+
+private fun IElementType.anyOf(vararg elementType: IElementType): Boolean = elementType.contains(this)
+
+public val BINARY_EXPRESSION_WRAPPING_RULE_ID: RuleId = BinaryExpressionWrappingRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
@@ -1,0 +1,198 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Test
+
+class BinaryExpressionWrappingRuleTest {
+    private val binaryExpressionWrappingRuleAssertThat = KtLintAssertThat.assertThatRule { BinaryExpressionWrappingRule() }
+
+    @Test
+    fun `Given a property with a binary expression on same line as equals, and it exceeds the max line length then wrap before the expression`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
+            val bar = leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
+            val bar =
+                leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Line is exceeding max line length. Break line between assignment and expression"),
+                // Next violation only happens during linting. When formatting the violation does not occur because fix of previous
+                // violation prevent that the remainder of the line exceeds the maximum
+                LintViolation(2, 36, "Line is exceeding max line length. Break line after operator of binary expression"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a property with a binary expression not on same line as equals, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                         $EOL_CHAR
+            val bar =
+                leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                         $EOL_CHAR
+            val bar =
+                leftHandSideExpression &&
+                    rightHandSideExpression
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(3, 30, "Line is exceeding max line length. Break line after operator of binary expression")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a return with a binary expression, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
+            fun foo() {
+                return leftHandSideExpression && rightHandSideExpression
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
+            fun foo() {
+                return leftHandSideExpression &&
+                    rightHandSideExpression
+            }
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(3, 37, "Line is exceeding max line length. Break line after operator of binary expression")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with a binary body expression on same line as function signature, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+            fun foo() = leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+            fun foo() =
+                leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 13, "Line is exceeding max line length. Break line between assignment and expression"),
+                // Next violation only happens during linting. When formatting the violation does not occur because fix of previous
+                // violation prevent that the remainder of the line exceeds the maximum
+                LintViolation(2, 38, "Line is exceeding max line length. Break line after operator of binary expression"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with a binary body expression not on same line as function signature, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                         $EOL_CHAR
+            fun foo() =
+                leftHandSideExpression && rightHandSideExpression
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                         $EOL_CHAR
+            fun foo() =
+                leftHandSideExpression &&
+                    rightHandSideExpression
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(3, 30, "Line is exceeding max line length. Break line after operator of binary expression")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given an if-statement with a binary expression condition, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
+            fun foo() {
+                if (leftHandSideExpression && rightHandSideExpression) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
+            fun foo() {
+                if (leftHandSideExpression &&
+                    rightHandSideExpression) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(3, 34, "Line is exceeding max line length. Break line after operator of binary expression")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given an if-statement with a nested binary expression condition, and it exceeds the max line length then wrap the expression at the operator`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                   $EOL_CHAR
+            fun foo() {
+                if ((leftHandSideExpression && rightHandSideExpression) || (leftHandSideLongExpression && rightHandSideLongExpression)) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                   $EOL_CHAR
+            fun foo() {
+                if ((leftHandSideExpression && rightHandSideExpression) ||
+                    (leftHandSideLongExpression &&
+                        rightHandSideLongExpression)) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                // When linting, a violation is reported for each operation reference. While when formatting, the nested binary expression
+                // is evaluated (working from outside to inside). After wrapping an outer binary expression, the inner binary expressions
+                // are evaluated and only when needed wrapped again at the operation reference.
+                LintViolation(3, 35, "Line is exceeding max line length. Break line after operator of binary expression"),
+                LintViolation(3, 63, "Line is exceeding max line length. Break line after operator of binary expression"),
+                LintViolation(3, 92, "Line is exceeding max line length", canBeAutoCorrected = false),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a binary expression for which the left hand side including the operation reference is exceeding the max line length`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            fun foo(): String {
+                return "some longgggggggg txt" +
+                    "more text"
+            }
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolationWithoutAutoCorrect(3, 36, "Line is exceeding max line length")
+    }
+}

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -494,7 +494,7 @@ public class KtLintAssertThatAssertable(
                 .toLintViolationsFields()
         assertThat(actualLintViolationFields)
             .describedAs("Lint errors which can be automatically corrected")
-            .containsExactlyInAnyOrder(*expectedErrors.toLintViolationsFields(canBeAutoCorrected = true))
+            .containsExactlyInAnyOrder(*expectedErrors.toLintViolationsFields())
         return this
     }
 
@@ -511,7 +511,7 @@ public class KtLintAssertThatAssertable(
                 .toLintViolationsFields()
         assertThat(actualLintViolationFields)
             .describedAs("Lint errors which can be automatically corrected")
-            .containsExactlyInAnyOrder(*expectedErrors.toLintViolationsFields(canBeAutoCorrected = true))
+            .containsExactlyInAnyOrder(*expectedErrors.toLintViolationsFields())
         return this
     }
 
@@ -559,20 +559,37 @@ public class KtLintAssertThatAssertable(
         val actualLintViolationFields =
             lint()
                 .filterCurrentRuleOnly()
-                .toLintViolationsFields()
+                .map {
+                    LintViolationFields(
+                        line = it.line,
+                        col = it.col,
+                        detail = it.detail,
+                        canBeAutoCorrected = false,
+                    )
+                }.toTypedArray()
+        val expectedLintViolationFields =
+            expectedLintViolations
+                .map {
+                    LintViolationFields(
+                        line = it.line,
+                        col = it.col,
+                        detail = it.detail,
+                        canBeAutoCorrected = false,
+                    )
+                }
 
         assertThat(actualLintViolationFields)
             .describedAs("Lint errors which can not be automatically corrected")
-            .containsExactlyInAnyOrder(*expectedLintViolations.toLintViolationsFields(canBeAutoCorrected = false))
+            .containsExactlyInAnyOrder(*expectedLintViolationFields.toTypedArray())
     }
 
-    private fun Array<out LintViolation>.toLintViolationsFields(canBeAutoCorrected: Boolean): Array<LintViolationFields> {
+    private fun Array<out LintViolation>.toLintViolationsFields(): Array<LintViolationFields> {
         return map {
             LintViolationFields(
                 line = it.line,
                 col = it.col,
                 detail = it.detail,
-                canBeAutoCorrected = canBeAutoCorrected,
+                canBeAutoCorrected = it.canBeAutoCorrected,
             )
         }.toTypedArray()
     }
@@ -647,6 +664,7 @@ public data class LintViolation(
     val line: Int,
     val col: Int,
     val detail: String,
+    val canBeAutoCorrected: Boolean = true,
 )
 
 /**


### PR DESCRIPTION
## Description

Add experimental rule `binary-expression-wrapping`. This rule wraps a binary expression in case the max line length is exceeded.

Closes #1940

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
