### PR TITLE
Split workflow for pull request with(out) code

### DIFF
--- a/.github/workflows/pull-request-with-code.yml
+++ b/.github/workflows/pull-request-with-code.yml
@@ -1,10 +1,20 @@
-name: Build pull request
+# name must be identical to name of 'pull-request-without-code'
+name: Pull request
 
 on:
   push:
     branches: ['master']
-    paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/*.properties'
+      - '**/*.toml'
   pull_request:
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/*.properties'
+      - '**/*.toml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pull-request-without-code.yml
+++ b/.github/workflows/pull-request-without-code.yml
@@ -1,0 +1,26 @@
+# name must be identical to name of 'pull-request-with-code'
+name: Pull request
+
+on:
+  push:
+    branches: ['master']
+    paths:
+      - '**/*'
+      - '!**/*.kt'
+      - '!**/*.kts'
+      - '!**/*.properties'
+      - '!**/*.toml'
+  pull_request:
+    paths:
+      - '**/*'
+      - '!**/*.kt'
+      - '!**/*.kts'
+      - '!**/*.properties'
+      - '!**/*.toml'
+
+# Add a dummy job that return true so that a PR not containing any code can be merged to master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Description

Rename 'build-pull-request.yml'  to 'pull-request-with-code.yml' and add 'pull-request-without-code.yml' to make it possible that PR with and without code have distinct workflows. Important: they need to share the same "name".

Solution is based on https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
