### PR TITLE
Add example of suppressing a custom rule (documents that "ktlint:" pr…

### DIFF
--- a/documentation/snapshot/docs/faq.md
+++ b/documentation/snapshot/docs/faq.md
@@ -68,6 +68,10 @@ An error can be suppressed using:
     // Suppress all rules for the annotated construct
     @Suppress("ktlint")
     import foo.*
+
+    // Suppress a single custom rule for the annotated construct
+    @Suppress("ktlint:custom-ruleset-id:custom-rule")
+    import foo.*
     ```
 === "[:material-heart:](#) EOL comments"
 


### PR DESCRIPTION
…efix is required)

## Description

Add example of suppressing a custom rule to "How to suppres..." section of FAQ. It is done to document this feature and show that the "ktlint:" prefix is required.

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue. -->

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
