### PR TITLE
Function type in nullable type exceeding max line length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Do not flag a (potential) mutable extension property in case the getter is annotated or prefixed with a modifier `property-naming` ([#2024](https://github.com/pinterest/ktlint/issues/2024))
 * Do not merge an annotated expression body with the function signature even if it fits on a single line ([#2043](https://github.com/pinterest/ktlint/issues/2043))
 * Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
+* Prevent incorrect reporting of violations in case a nullable function type reference exceeds the maximum line length `parameter-list-wrapping` ([#1324](https://github.com/pinterest/ktlint/issues/1324)) 
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -115,7 +115,7 @@ public class ParameterListWrappingRule :
                         emit(
                             rpar.startOffset,
                             "Expected new line after function type as it does not fit on a single line",
-                            true
+                            true,
                         )
                         if (autoCorrect) {
                             rpar.upsertWhitespaceBeforeMe("\n")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -22,7 +22,8 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PR
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
-import com.pinterest.ktlint.rule.engine.core.api.parent
+import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevSibling
@@ -89,37 +90,45 @@ public class ParameterListWrappingRule :
         require(node.elementType == NULLABLE_TYPE)
         node
             .takeUnless {
-                // skip when max line length is not exceedd
+                // skip when max line length is not exceeded
                 (node.column - 1 + node.textLength) <= maxLineLength
-            }?.findChildByType(FUNCTION_TYPE)
-            ?.findChildByType(VALUE_PARAMETER_LIST)
-            ?.takeIf { it.findChildByType(VALUE_PARAMETER) != null }
-            ?.takeUnless { it.textContains('\n') }
-            ?.let {
-                node
-                    .children()
-                    .forEach {
-                        when (it.elementType) {
-                            LPAR -> {
-                                emit(
-                                    it.startOffset,
-                                    "Parameter of nullable type should be on a separate line (unless the type fits on a single line)",
-                                    true,
-                                )
-                                if (autoCorrect) {
-                                    it.upsertWhitespaceAfterMe("\n${indentConfig.indent}")
-                                }
-                            }
-                            RPAR -> {
-                                emit(it.startOffset, errorMessage(it), true)
-                                if (autoCorrect) {
-                                    it.upsertWhitespaceBeforeMe("\n")
-                                }
-                            }
+            }?.takeUnless { it.textContains('\n') }
+            ?.takeIf { it.isFunctionTypeWithNonEmptyValueParameterList() }
+            ?.let { nullableType ->
+                nullableType
+                    .findChildByType(LPAR)
+                    ?.takeUnless { it.nextLeaf()?.isWhiteSpaceWithNewline() == true }
+                    ?.let { lpar ->
+                        emit(
+                            lpar.startOffset + 1,
+                            "Expected new line before function type as it does not fit on a single line",
+                            true,
+                        )
+                        if (autoCorrect) {
+                            lpar.upsertWhitespaceAfterMe("\n${indentConfig.indent}")
+                        }
+                    }
+                nullableType
+                    .findChildByType(RPAR)
+                    ?.takeUnless { it.prevLeaf()?.isWhiteSpaceWithNewline() == true }
+                    ?.let { rpar ->
+                        emit(
+                            rpar.startOffset,
+                            "Expected new line after function type as it does not fit on a single line",
+                            true
+                        )
+                        if (autoCorrect) {
+                            rpar.upsertWhitespaceBeforeMe("\n")
                         }
                     }
             }
     }
+
+    private fun ASTNode.isFunctionTypeWithNonEmptyValueParameterList() =
+        null !=
+            findChildByType(FUNCTION_TYPE)
+                ?.findChildByType(VALUE_PARAMETER_LIST)
+                ?.findChildByType(VALUE_PARAMETER)
 
     private fun ASTNode.needToWrapParameterList() =
         when {
@@ -127,10 +136,9 @@ public class ParameterListWrappingRule :
             codeStyle != ktlint_official && isPartOfFunctionLiteralInNonKtlintOfficialCodeStyle() -> false
             codeStyle == ktlint_official && isPartOfFunctionLiteralStartingOnSameLineAsClosingParenthesisOfPrecedingReferenceExpression() ->
                 false
-            isFunctionTypeWrappedInNullableType() -> false
             textContains('\n') -> true
             codeStyle == ktlint_official && containsAnnotatedParameter() -> true
-            exceedsMaxLineLength() -> true
+            isOnLineExceedingMaxLineLength() -> true
             else -> false
         }
 
@@ -158,11 +166,6 @@ public class ParameterListWrappingRule :
                     ?.none { it.isWhiteSpaceWithNewline() }
                     ?: false
             }
-    }
-
-    private fun ASTNode.isFunctionTypeWrappedInNullableType(): Boolean {
-        require(elementType == VALUE_PARAMETER_LIST)
-        return treeParent.elementType == FUNCTION_TYPE && treeParent?.treeParent?.elementType == NULLABLE_TYPE
     }
 
     private fun ASTNode.containsAnnotatedParameter(): Boolean {
@@ -222,10 +225,12 @@ public class ParameterListWrappingRule :
         when (child.elementType) {
             LPAR -> {
                 val prevLeaf = child.prevLeaf()
-                if (prevLeaf is PsiWhiteSpace && prevLeaf.textContains('\n')) {
+                if (!child.treeParent.isValueParameterListInFunctionType() &&
+                    prevLeaf.isWhiteSpaceWithNewline()
+                ) {
                     emit(child.startOffset, errorMessage(child), true)
                     if (autoCorrect) {
-                        prevLeaf.delete()
+                        (prevLeaf as PsiWhiteSpace).delete()
                     }
                 }
             }
@@ -271,7 +276,24 @@ public class ParameterListWrappingRule :
         }
     }
 
-    private fun ASTNode.exceedsMaxLineLength() = (column - 1 + textLength) > maxLineLength && !textContains('\n')
+    private fun ASTNode.isValueParameterListInFunctionType() =
+        FUNCTION_TYPE ==
+            takeIf { it.elementType == VALUE_PARAMETER_LIST }
+                ?.treeParent
+                ?.elementType
+
+    private fun ASTNode.isOnLineExceedingMaxLineLength(): Boolean {
+        val stopLeaf = nextLeaf { it.textContains('\n') }?.nextLeaf()
+        val lineContent =
+            prevLeaf { it.textContains('\n') }
+                ?.leavesIncludingSelf()
+                ?.takeWhile { it.prevLeaf() != stopLeaf }
+                ?.joinToString(separator = "") { it.text }
+                ?.substringAfter('\n')
+                ?.substringBefore('\n')
+                .orEmpty()
+        return lineContent.length > maxLineLength
+    }
 
     private fun errorMessage(node: ASTNode) =
         when (node.elementType) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -4,7 +4,8 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Nested
@@ -51,10 +52,12 @@ class ParameterListWrappingRuleTest {
     fun `Given a single line class header which exceeds the maximum line length`() {
         val code =
             """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
             class ClassA(paramA: String, paramB: String, paramC: String)
             """.trimIndent()
         val formattedCode =
             """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
             class ClassA(
                 paramA: String,
                 paramB: String,
@@ -62,12 +65,12 @@ class ParameterListWrappingRuleTest {
             )
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
+            .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(1, 14, "Parameter should start on a newline"),
-                LintViolation(1, 30, "Parameter should start on a newline"),
-                LintViolation(1, 46, "Parameter should start on a newline"),
-                LintViolation(1, 60, """Missing newline before ")""""),
+                LintViolation(2, 14, "Parameter should start on a newline"),
+                LintViolation(2, 30, "Parameter should start on a newline"),
+                LintViolation(2, 46, "Parameter should start on a newline"),
+                LintViolation(2, 60, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -75,10 +78,11 @@ class ParameterListWrappingRuleTest {
     fun `Given a class header with a very long name and without parameters which exceeds the maximum line length then do not change the class header`() {
         val code =
             """
-            class ClassAWithALongName()
+            // $MAX_LINE_LENGTH_MARKER    $EOL_CHAR
+            class ClassAWithALoooooongName()
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
+            .setMaxLineLength()
             .hasNoLintViolations()
     }
 
@@ -130,7 +134,7 @@ class ParameterListWrappingRuleTest {
     }
 
     @Test
-    fun `Given a multiline function with parameters wheren some parameters are on the same line then start each parameter and closing parenthesis on a separate line`() {
+    fun `Given a multiline function with parameters where some parameters are on the same line then start each parameter and closing parenthesis on a separate line`() {
         val code =
             """
             fun f(
@@ -156,11 +160,13 @@ class ParameterListWrappingRuleTest {
     fun `Given a single line function which exceeds the maximum line length then start each parameter and the closing parenthesis on a separate line`() {
         val code =
             """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
             fun f(a: Any, b: Any, c: Any) {
             }
             """.trimIndent()
         val formattedCode =
             """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
             fun f(
                 a: Any,
                 b: Any,
@@ -169,12 +175,12 @@ class ParameterListWrappingRuleTest {
             }
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
+            .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(1, 7, "Parameter should start on a newline"),
-                LintViolation(1, 15, "Parameter should start on a newline"),
-                LintViolation(1, 23, "Parameter should start on a newline"),
-                LintViolation(1, 29, """Missing newline before ")""""),
+                LintViolation(2, 7, "Parameter should start on a newline"),
+                LintViolation(2, 15, "Parameter should start on a newline"),
+                LintViolation(2, 23, "Parameter should start on a newline"),
+                LintViolation(2, 29, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -248,6 +254,7 @@ class ParameterListWrappingRuleTest {
     fun `Given a function with annotated parameters then start each parameter on a separate line but preserve spacing between annotation and parameter name`() {
         val code =
             """
+            // $MAX_LINE_LENGTH_MARKER    $EOL_CHAR
             class A {
                 fun f(@Annotation
                       a: Any,
@@ -259,6 +266,7 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         val formattedCode =
             """
+            // $MAX_LINE_LENGTH_MARKER    $EOL_CHAR
             class A {
                 fun f(
                     @Annotation
@@ -272,11 +280,11 @@ class ParameterListWrappingRuleTest {
             }
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
+            .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(2, 11, "Parameter should start on a newline"),
-                LintViolation(6, 19, "Parameter should start on a newline"),
-                LintViolation(6, 37, """Missing newline before ")""""),
+                LintViolation(3, 11, "Parameter should start on a newline"),
+                LintViolation(7, 19, "Parameter should start on a newline"),
+                LintViolation(7, 37, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -344,10 +352,12 @@ class ParameterListWrappingRuleTest {
     fun `Given a single line function with nested declarations which exceeds the maximum line length then format each parameter and closing parenthesis on a separate line`() {
         val code =
             """
+            // $MAX_LINE_LENGTH_MARKER                                                      $EOL_CHAR
             fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {}
             """.trimIndent()
         val formattedCode =
             """
+            // $MAX_LINE_LENGTH_MARKER                                                      $EOL_CHAR
             fun visit(
                 node: ASTNode,
                 autoCorrect: Boolean,
@@ -359,16 +369,16 @@ class ParameterListWrappingRuleTest {
             ) {}
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 10)
+            .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(1, 11, "Parameter should start on a newline"),
-                LintViolation(1, 26, "Parameter should start on a newline"),
-                LintViolation(1, 48, "Parameter should start on a newline"),
-                LintViolation(1, 55, "Parameter should start on a newline"),
-                LintViolation(1, 68, "Parameter should start on a newline"),
-                LintViolation(1, 90, "Parameter should start on a newline"),
-                LintViolation(1, 117, "Missing newline before \")\""),
-                LintViolation(1, 126, "Missing newline before \")\""),
+                LintViolation(2, 11, "Parameter should start on a newline"),
+                LintViolation(2, 26, "Parameter should start on a newline"),
+                LintViolation(2, 48, "Parameter should start on a newline"),
+                LintViolation(2, 55, "Parameter should start on a newline"),
+                LintViolation(2, 68, "Parameter should start on a newline"),
+                LintViolation(2, 90, "Parameter should start on a newline"),
+                LintViolation(2, 117, "Missing newline before \")\""),
+                LintViolation(2, 126, "Missing newline before \")\""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -512,24 +522,85 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
-    @Test
-    fun `Issue 1255 - Given a variable declaration for nullable function type which exceeds the max-line-length then wrap the function type to a new line`() {
-        val code =
-            """
-            var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
-            """.trimIndent()
-        val formattedCode =
-            """
-            var changesListener: (
-                (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
-            )? = null
-            """.trimIndent()
-        parameterListWrappingRuleAssertThat(code)
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 80)
-            .hasLintViolations(
-                LintViolation(1, 22, "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
-                LintViolation(1, 95, """Missing newline before ")""""),
-            ).isFormattedAs(formattedCode)
+    @Nested
+    inner class `Issue 1255 - Given a variable declaration for nullable function type` {
+        @Test
+        fun `Given a nullable function type for which the function type fits on a single line after wrapping the nullable type`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+                var foo1: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null
+                var foo2: (
+                    (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
+                )? = null
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+                var foo1: (
+                    (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
+                )? = null
+                var foo2: (
+                    (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
+                )? = null
+                """.trimIndent()
+            parameterListWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    // Some violations below are only reported during linting but not on formatting. After wrapping the
+                    // nullable type, there is no need to wrap the parameters.
+                    LintViolation(2, 12, "Expected new line before function type as it does not fit on a single line"),
+                    LintViolation(2, 13, "Parameter should start on a newline"),
+                    LintViolation(2, 24, "Parameter should start on a newline"),
+                    LintViolation(2, 35, "Parameter should start on a newline"),
+                    LintViolation(2, 44, "Missing newline before \")\""),
+                    LintViolation(2, 53, "Expected new line after function type as it does not fit on a single line"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a nullable function type for which the function type fits does not fit on a single line after wrapping the nullable type`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+                var foo1: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null
+                var foo2: (
+                    (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
+                )? = null
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+                var foo1: (
+                    (
+                        bar1: Bar,
+                        bar2: Bar,
+                        bar3: Bar
+                    ) -> Unit
+                )? = null
+                var foo2: (
+                    (
+                        bar1: Bar,
+                        bar2: Bar,
+                        bar3: Bar
+                    ) -> Unit
+                )? = null
+                """.trimIndent()
+            parameterListWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 12, "Expected new line before function type as it does not fit on a single line"),
+                    LintViolation(2, 13, "Parameter should start on a newline"),
+                    LintViolation(2, 24, "Parameter should start on a newline"),
+                    LintViolation(2, 35, "Parameter should start on a newline"),
+                    LintViolation(2, 44, "Missing newline before \")\""),
+                    LintViolation(2, 53, "Expected new line after function type as it does not fit on a single line"),
+                    LintViolation(4, 6, "Parameter should start on a newline"),
+                    LintViolation(4, 17, "Parameter should start on a newline"),
+                    LintViolation(4, 28, "Parameter should start on a newline"),
+                    LintViolation(4, 37, "Missing newline before \")\""),
+                ).isFormattedAs(formattedCode)
+        }
     }
 
     @Nested

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -4,7 +4,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
@@ -604,26 +603,34 @@ class ParameterListWrappingRuleTest {
         }
 
         @Test
-        fun `Given a fucntion containing a nullable function type for which the function type fits does not fit on a single line after wrapping the nullable type`() {
+        fun `Given a function containing a nullable function type for which the function type fits does not fit on a single line after wrapping the nullable type`() {
             val code =
                 """
+                // $MAX_LINE_LENGTH_MARKER                      $EOL_CHAR
                 fun foo() {
-                    var changesListener: ((width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit)? = null
+                    var changesListener: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null
                 }
                 """.trimIndent()
             val formattedCode =
                 """
+                // $MAX_LINE_LENGTH_MARKER                      $EOL_CHAR
                 fun foo() {
                     var changesListener: (
-                        (width: Double?, depth: Double?, length: Double?, area: Double?) -> Unit
+                        (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
                     )? = null
                 }
                 """.trimIndent()
             parameterListWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 80)
+                .setMaxLineLength()
                 .hasLintViolations(
-                    LintViolation(2, 26, "Parameter of nullable type should be on a separate line (unless the type fits on a single line)"),
-                    LintViolation(2, 99, """Missing newline before ")""""),
+                    // Some violations below are only reported during linting but not on formatting. After wrapping the
+                    // nullable type, there is no need to wrap the parameters.
+                    LintViolation(3, 27, "Expected new line before function type as it does not fit on a single line"),
+                    LintViolation(3, 28, "Parameter should start on a newline"),
+                    LintViolation(3, 39, "Parameter should start on a newline"),
+                    LintViolation(3, 50, "Parameter should start on a newline"),
+                    LintViolation(3, 59, "Missing newline before \")\""),
+                    LintViolation(3, 68, "Expected new line after function type as it does not fit on a single line"),
                 ).isFormattedAs(formattedCode)
         }
     }


### PR DESCRIPTION
## Description

Prevent incorrect reporting of violations in case a nullable function type reference exceeds the maximum line length `parameter-list-wrapping`

Closes #1324

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
