### PR TITLE
Mark `BlockCommentInitialStarAlignmentRule` and `StringTemplateIndentRule` as `RunAsLateAsPossible`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlockCommentInitialStarAlignmentRule.kt
@@ -23,6 +23,7 @@ public class BlockCommentInitialStarAlignmentRule :
                     ruleId = INDENTATION_RULE_ID,
                     mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
                 ),
+                VisitorModifier.RunAsLateAsPossible,
             ),
     ) {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -38,6 +38,7 @@ public class StringTemplateIndentRule :
                 // the string template is relative to the opening quotes. Running this rule before the IndentationRule results in a wrong
                 // indentation whenever the indent level of the root of the string template is changed.
                 VisitorModifier.RunAfterRule(INDENTATION_RULE_ID, ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED),
+                VisitorModifier.RunAsLateAsPossible,
             ),
         usesEditorConfigProperties =
             setOf(


### PR DESCRIPTION
## Description

`BlockCommentInitialStarAlignmentRule` and `StringTemplateIndentRule` have to run after `IndentationRule`. And `IndentationRule` is marked as `RunAsLateAsPossible`.

`BlockCommentInitialStarAlignmentRule` and `StringTemplateIndentRule` should better be marked as `RunAsLateAsPossible`. This is to make the algorithm implementation to infer the run order to be easy to reason about

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
