### PR TITLE
Fix false -ve on else with single line binary or chained call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Do not merge an annotated expression body with the function signature even if it fits on a single line ([#2043](https://github.com/pinterest/ktlint/issues/2043))
 * Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
 * Prevent incorrect reporting of violations in case a nullable function type reference exceeds the maximum line length `parameter-list-wrapping` ([#1324](https://github.com/pinterest/ktlint/issues/1324)) 
+* Prevent false negative on `else` branch when body contains only chained calls or binary expression ([#2057](https://github.com/pinterest/ktlint/issues/2057))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
@@ -64,7 +64,10 @@ public class MultiLineIfElseRule :
             return
         }
 
-        if (node.elementType == ELSE && node.firstChildNode?.elementType == BINARY_EXPRESSION) {
+        if (node.elementType == ELSE &&
+            node.firstChildNode?.elementType == BINARY_EXPRESSION &&
+            node.firstChildNode.firstChildNode?.elementType == IF
+        ) {
             // Allow
             //    val foo = if (bar1) {
             //       "bar1"
@@ -74,7 +77,10 @@ public class MultiLineIfElseRule :
             return
         }
 
-        if (node.elementType == ELSE && node.firstChildNode?.elementType == DOT_QUALIFIED_EXPRESSION) {
+        if (node.elementType == ELSE &&
+            node.firstChildNode?.elementType == DOT_QUALIFIED_EXPRESSION &&
+            node.firstChildNode.firstChildNode?.elementType == IF
+        ) {
             // Allow
             //    val foo = if (bar1) {
             //       "bar1"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
@@ -69,11 +69,13 @@ public class MultiLineIfElseRule :
             node.firstChildNode.firstChildNode?.elementType == IF
         ) {
             // Allow
-            //    val foo = if (bar1) {
-            //       "bar1"
-            //   } else {
-            //       null
-            //   } ?: "something-else"
+            // val foo2 = if (bar1) {
+            //     "bar1"
+            // } else if (bar2) {
+            //     null
+            // } else {
+            //     null
+            // } ?: "something-else"
             return
         }
 
@@ -82,11 +84,13 @@ public class MultiLineIfElseRule :
             node.firstChildNode.firstChildNode?.elementType == IF
         ) {
             // Allow
-            //    val foo = if (bar1) {
-            //       "bar1"
-            //   } else {
-            //       "bar2"
-            //   }.plus("foo")
+            // val foo = if (bar1) {
+            //     "bar1"
+            // } else if (bar2) {
+            //     "bar2"
+            // } else {
+            //     "bar3"
+            // }.plus("foo")
             return
         }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRuleTest.kt
@@ -574,7 +574,7 @@ class MultiLineIfElseRuleTest {
     fun `Issue 1904 - Given an nested if else statement followed by an elvis operator`() {
         val code =
             """
-            val foo = if (bar1) {
+            val foo1 = if (bar1) {
                 "bar1"
             } else {
                 null
@@ -617,13 +617,13 @@ class MultiLineIfElseRuleTest {
     fun `Issue 1904 - Given an nested if else statement and else which is part of a dot qualified expression`() {
         val code =
             """
-            val foo = if (bar1) {
+            val foo1 = if (bar1) {
                 "bar1"
             } else {
                 "bar2"
             }.plus("foo")
 
-            val foo = if (bar1) {
+            val foo2 = if (bar1) {
                 "bar1"
             } else if (bar2) {
                 "bar2"
@@ -638,13 +638,13 @@ class MultiLineIfElseRuleTest {
     fun `Issue 2057 - Given an else with chained condition`() {
         val code =
             """
-            val a = if (System.currentTimeMillis() % 2 == 0L) {
+            val foo = if (System.currentTimeMillis() % 2 == 0L) {
                 0
             } else System.currentTimeMillis().toInt()
             """.trimIndent()
         val formattedCode =
             """
-            val a = if (System.currentTimeMillis() % 2 == 0L) {
+            val foo = if (System.currentTimeMillis() % 2 == 0L) {
                 0
             } else {
                 System.currentTimeMillis().toInt()
@@ -660,14 +660,14 @@ class MultiLineIfElseRuleTest {
     fun `Issue 2057 - Given an if with chained condition`() {
         val code =
             """
-            val a = if (System.currentTimeMillis() % 2 == 0L) System.currentTimeMillis().toInt()
+            val foo = if (System.currentTimeMillis() % 2 == 0L) System.currentTimeMillis().toInt()
             else {
                 System.currentTimeMillis().toInt()
             }
             """.trimIndent()
         val formattedCode =
             """
-            val a = if (System.currentTimeMillis() % 2 == 0L) {
+            val foo = if (System.currentTimeMillis() % 2 == 0L) {
                 System.currentTimeMillis().toInt()
             } else {
                 System.currentTimeMillis().toInt()
@@ -675,7 +675,7 @@ class MultiLineIfElseRuleTest {
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 51, "Missing { ... }"),
+                LintViolation(1, 53, "Missing { ... }"),
             ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRuleTest.kt
@@ -579,14 +579,50 @@ class MultiLineIfElseRuleTest {
             } else {
                 null
             } ?: "something-else"
+
+            val foo2 = if (bar1) {
+                "bar1"
+            } else if (bar2) {
+                null
+            } else {
+                null
+            } ?: "something-else"
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2057 - Given an else condition with single line binary expression`() {
+        val code =
+            """
+            val foo = if (bar1) {
+                "bar1"
+            } else bar2 ?: "something-else"
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = if (bar1) {
+                "bar1"
+            } else {
+                bar2 ?: "something-else"
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 8, "Missing { ... }"),
+            ).isFormattedAs(formattedCode)
     }
 
     @Test
     fun `Issue 1904 - Given an nested if else statement and else which is part of a dot qualified expression`() {
         val code =
             """
+            val foo = if (bar1) {
+                "bar1"
+            } else {
+                "bar2"
+            }.plus("foo")
+
             val foo = if (bar1) {
                 "bar1"
             } else if (bar2) {
@@ -596,5 +632,50 @@ class MultiLineIfElseRuleTest {
             }.plus("foo")
             """.trimIndent()
         multiLineIfElseRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2057 - Given an else with chained condition`() {
+        val code =
+            """
+            val a = if (System.currentTimeMillis() % 2 == 0L) {
+                0
+            } else System.currentTimeMillis().toInt()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val a = if (System.currentTimeMillis() % 2 == 0L) {
+                0
+            } else {
+                System.currentTimeMillis().toInt()
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 8, "Missing { ... }"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2057 - Given an if with chained condition`() {
+        val code =
+            """
+            val a = if (System.currentTimeMillis() % 2 == 0L) System.currentTimeMillis().toInt()
+            else {
+                System.currentTimeMillis().toInt()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val a = if (System.currentTimeMillis() % 2 == 0L) {
+                System.currentTimeMillis().toInt()
+            } else {
+                System.currentTimeMillis().toInt()
+            }
+            """.trimIndent()
+        multiLineIfElseRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(1, 51, "Missing { ... }"),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description
Only ignore the chain or binary call when the parent of that call is `if`(when present inside `else if`). This solves the false -ve on those cases
This fixes https://github.com/pinterest/ktlint/issues/2057

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [x] PR description added
- [x] tests are added
- [x] KtLint has been applied on source code itself and violations are fixed
- [x] [documentation](https://pinterest.github.io/ktlint/) is updated: NA as no new rule is added
- [x] `CHANGELOG.md` is updated
