### PR TITLE
Add rule to migrate away from ktlint-disable directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,10 @@ ktlint_experimental = enabled
 # Don't allow any wildcard imports
 ij_kotlin_packages_to_use_import_on_demand = unset
 
+# Prevent wildcard imports
+ij_kotlin_name_count_to_use_star_import = 99
+ij_kotlin_name_count_to_use_star_import_for_members = 99
+
 [*.md]
 trim_trailing_whitespace = false
 max_line_length = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
+max_line_length = 140
 
 end_of_line = lf
 charset = utf-8
@@ -28,6 +29,7 @@ ij_kotlin_packages_to_use_import_on_demand = unset
 
 [*.md]
 trim_trailing_whitespace = false
+max_line_length = unset
 
 [gradle/verification-metadata.xml]
 indent_size = 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Deprecation of ktlint-enable and ktlint-disable directives
+
+The `ktlint-disable` and `ktlint-enable` directives are no longer supported. Ktlint rules can now only be suppressed using the `@Suppress` or `@SuppressWarnings` annotations. A new rule, `ktlint-suppression`, is provided to replace the directives with annotations.
+
+It is recommended that API Consumers that do not provide the Ktlint `standard` rules at least provide the `DeprecatedRuleDirectiveRule` by default. If the rule is not provided, a log message will be printed for each `ktlint-disable` and `ktlint-enable` directive that is found and violations will not be suppressed.
+
+The `ktlint-suppression` rule can not be disabled via the `.editorconfig`.
+
 ### Custom Rule Providers need to prepare for Kotlin 1.9
 
 In Kotlin 1.9 the extension points of the embedded kotlin compiler will change. Ktlint only uses the `org.jetbrains.kotlin.com.intellij.treeCopyHandler` extension point. This extension is not yet supported in 1.9, neither is it documented ([#KT-58704](https://youtrack.jetbrains.com/issue/KT-58704/Support-and-document-extension-point-org.jetbrains.kotlin.com.intellij.treeCopyHandler)). Without this extension point it might happen that your custom rules will throw exceptions during runtime. See [#1981](https://github.com/pinterest/ktlint/issues/1981).
@@ -31,6 +39,7 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Add new experimental rule `no-empty-file` for all code styles. A kotlin (script) file may not be empty ([#1074](https://github.com/pinterest/ktlint/issues/1074))
 * Add new experimental rule `statement-wrapping` which ensures function, class, or other blocks statement body doesn't start or end at starting or ending braces of the block ([#1938](https://github.com/pinterest/ktlint/issues/1938))
 * Add new experimental rule `blank-line-before-declaration`. This rule requires a blank line before class, function or property declarations ([#1939](https://github.com/pinterest/ktlint/issues/1939))
+* Add new rule `ktlint-suppression` to replace the `ktlint-disable` and `ktlint-enable` directives with annotations. This rule can not be disabled via the `.editorconfig` ([#1947](https://github.com/pinterest/ktlint/issues/1947))
 
 ### Removed
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -251,6 +251,52 @@ Indentation formatting - respects `.editorconfig` `indent_size` with no continua
 
 Rule id: `indent` (`standard` rule set)
 
+## Ktlint-suppression rule
+
+The `ktlint-disable` and `ktlint-enable` directives are no longer supported as of ktlint version `0.50.0`. This rule migrates the directives to annotations. Identifiers in the @Suppress and @SuppressWarning annotations to suppress ktlint rules which are not prefixed with the rule set id are fixed. 
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    @file:Suppress("ktlint:standard:no-wildcard-imports")
+
+    class FooBar {
+        @Suppress("ktlint:standard:max-line-length")
+        val foo = "some longggggggggggggggggggg text"
+
+        fun bar() =
+            @Suppress("ktlint:standard:no-multi-spaces")
+            listOf(
+                "1   One", 
+                "10  Ten", 
+                "100 Hundred", 
+            )
+    }
+    ```
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    /* ktlint-disable standard:no-wildcard-imports */
+
+    class FooBar {
+        val foo = "some longggggggggggggggggggg text" // ktlint-disable standard:max-line-length
+
+        fun bar() =
+            listOf(
+                /* ktlint-disable standard:no-multi-spaces */
+                "1   One", 
+                "10  Ten", 
+                "100 Hundred", 
+                /* ktlint-enable standard:no-multi-spaces */
+            )
+    }
+    ```
+
+Rule id: `ktlint-suppression` (`standard` rule set)
+
+!!! note
+    This rule can not be disabled in the `.editorconfig`.
+
 ## Max line length
 
 Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to a comment that disables ktlint rules then that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.

--- a/ktlint-cli-reporter-checkstyle/src/test/kotlin/com/pinterest/ktlint/cli/reporter/checkstyle/CheckStyleReporterTest.kt
+++ b/ktlint-cli-reporter-checkstyle/src/test/kotlin/com/pinterest/ktlint/cli/reporter/checkstyle/CheckStyleReporterTest.kt
@@ -15,29 +15,29 @@ class CheckStyleReporterTest {
         val reporter = CheckStyleReporter(PrintStream(out, true))
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "<\"&'>", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 1, "rule-2", "And if you see my friend", FORMAT_IS_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 10, "rule-1", "I thought I would again", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 20, "rule-2", "A single thin straight line", LINT_CAN_BE_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/all-corrected.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "I thought we had more time", FORMAT_IS_AUTOCORRECTED),
         )
         reporter.afterAll()

--- a/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
+++ b/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
@@ -123,15 +123,15 @@ class FormatReporterTest {
     }
 
     companion object {
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "some-rule", "This error can be autocorrected", LINT_CAN_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_NOT_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", LINT_CAN_NOT_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         val SOME_FORMAT_ERROR_IS_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", FORMAT_IS_AUTOCORRECTED)
 

--- a/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
@@ -157,13 +157,13 @@ class HtmlReporterTest {
         val out = ByteArrayOutputStream()
         val reporter = HtmlReporter(PrintStream(out, true))
 
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
             KtlintCliError(1, 1, "rule-1", "Error message contains a generic type like List<Int> (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
         )
 
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
             KtlintCliError(2, 1, "rule-2", "Error message contains special html symbols like a<b>c\"d'e&f (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),

--- a/ktlint-cli-reporter-json/src/test/kotlin/com/pinterest/ktlint/cli/reporter/json/JsonReporterTest.kt
+++ b/ktlint-cli-reporter-json/src/test/kotlin/com/pinterest/ktlint/cli/reporter/json/JsonReporterTest.kt
@@ -15,29 +15,29 @@ class JsonReporterTest {
         val reporter = JsonReporter(PrintStream(out, true))
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "<\"&'>", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 1, "rule-2", "And if you see my friend", FORMAT_IS_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 10, "rule-1", "I thought I would again", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 20, "rule-2", "A single thin straight line", LINT_CAN_BE_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/all-corrected.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "I thought we had more time", FORMAT_IS_AUTOCORRECTED),
         )
         reporter.afterAll()

--- a/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
+++ b/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
@@ -19,29 +19,29 @@ class PlainSummaryReporterTest {
         ).apply {
             onLintError(
                 "file-1.kt",
-                @Suppress("ktlint:argument-list-wrapping")
+                @Suppress("ktlint:standard:argument-list-wrapping")
                 KtlintCliError(1, 1, "rule-1", "description-error-at-position-1:1 (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
             )
             onLintError(
                 "file-1.kt",
-                @Suppress("ktlint:argument-list-wrapping")
+                @Suppress("ktlint:standard:argument-list-wrapping")
                 KtlintCliError(2, 1, "rule-2", "description-error-at-position-2:1", FORMAT_IS_AUTOCORRECTED),
             )
 
             onLintError(
                 "file-2.kt",
-                @Suppress("ktlint:argument-list-wrapping")
+                @Suppress("ktlint:standard:argument-list-wrapping")
                 KtlintCliError(1, 10, "rule-1", "description-error-at-position-1:10 (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
             )
             onLintError(
                 "file-2.kt",
-                @Suppress("ktlint:argument-list-wrapping")
+                @Suppress("ktlint:standard:argument-list-wrapping")
                 KtlintCliError(2, 20, "rule-2", "description-error-at-position-2:20 (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
             )
 
             onLintError(
                 "file-3.kt",
-                @Suppress("ktlint:argument-list-wrapping")
+                @Suppress("ktlint:standard:argument-list-wrapping")
                 KtlintCliError(1, 1, "rule-1", "description-error-at-position-1:1", FORMAT_IS_AUTOCORRECTED),
             )
 
@@ -72,17 +72,17 @@ class PlainSummaryReporterTest {
         val reporter = PlainSummaryReporter(PrintStream(out, true))
         reporter.onLintError(
             "file-1.kt",
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
         reporter.onLintError(
             "file-2.kt",
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
         reporter.onLintError(
             "file-3.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(18, 51, "", "Something else", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.afterAll()

--- a/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
@@ -17,29 +17,29 @@ class PlainReporterTest {
         val reporter = PlainReporter(PrintStream(out, true))
         reporter.onLintError(
             "file-1.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "description-error-at-position-1:1", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "file-1.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 1, "rule-2", "description-error-at-position-2:1", FORMAT_IS_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "file-2.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 10, "rule-1", "description-error-at-position-1:10", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "file-2.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 20, "rule-2", "description-error-at-position-2:20", LINT_CAN_BE_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "file-3.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "description-error-at-position-1:1", FORMAT_IS_AUTOCORRECTED),
         )
 
@@ -65,17 +65,17 @@ class PlainReporterTest {
         val reporter = PlainReporter(PrintStream(out, true))
         reporter.onLintError(
             "file-1.kt",
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
         reporter.onLintError(
             "file-2.kt",
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
         reporter.onLintError(
             "file-3.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(18, 51, "", "Something else", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.afterAll()
@@ -106,7 +106,7 @@ class PlainReporterTest {
             )
         reporter.onLintError(
             File.separator + "one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "<\"&'>", LINT_CAN_BE_AUTOCORRECTED),
         )
         val outputString = String(out.toByteArray())
@@ -130,29 +130,29 @@ class PlainReporterTest {
         val reporter = PlainReporter(PrintStream(out, true), groupByFile = true)
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "<\"&'>", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/one-fixed-and-one-not.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 1, "rule-2", "And if you see my friend", FORMAT_IS_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 10, "rule-1", "I thought I would again", LINT_CAN_BE_AUTOCORRECTED),
         )
         reporter.onLintError(
             "/two-not-fixed.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(2, 20, "rule-2", "A single thin straight line", LINT_CAN_BE_AUTOCORRECTED),
         )
 
         reporter.onLintError(
             "/all-corrected.kt",
-            @Suppress("ktlint:argument-list-wrapping")
+            @Suppress("ktlint:standard:argument-list-wrapping")
             KtlintCliError(1, 1, "rule-1", "I thought we had more time", FORMAT_IS_AUTOCORRECTED),
         )
         reporter.after("/one-fixed-and-one-not.kt")

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
@@ -50,6 +50,7 @@ internal object SuppressionLocatorBuilder {
         )
     private val SUPPRESS_ANNOTATIONS = setOf("Suppress", "SuppressWarnings")
     private val SUPPRESS_ALL_KTLINT_RULES_RULE_ID = RuleId("ktlint:suppress-all-rules")
+    private val KTLINT_SUPPRESSION_RULE_ID = RuleId("standard:ktlint-suppression")
 
     /**
      * Builds [SuppressionLocator] for given [rootNode] of AST tree.
@@ -68,9 +69,15 @@ internal object SuppressionLocatorBuilder {
 
     private fun toSuppressedRegionsLocator(hintsList: List<SuppressionHint>): SuppressionLocator =
         { offset, ruleId ->
-            hintsList
-                .filter { offset in it.range }
-                .any { hint -> hint.disabledRuleIds.isEmpty() || hint.disabledRuleIds.contains(ruleId) }
+            if (ruleId == KTLINT_SUPPRESSION_RULE_ID) {
+                // The rule to detect deprecated rule directives may not be disabled itself as otherwise the directives
+                // will not be reported and fixed.
+                false
+            } else {
+                hintsList
+                    .filter { offset in it.range }
+                    .any { hint -> hint.disabledRuleIds.isEmpty() || hint.disabledRuleIds.contains(ruleId) }
+            }
         }
 
     private fun collect(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -30,6 +30,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.IfElseWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ImportOrderingRule
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import com.pinterest.ktlint.ruleset.standard.rules.KdocWrappingRule
+import com.pinterest.ktlint.ruleset.standard.rules.KtlintSuppressionRule
 import com.pinterest.ktlint.ruleset.standard.rules.MaxLineLengthRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierOrderRule
@@ -115,6 +116,7 @@ public class StandardRuleSetProvider :
             RuleProvider { ImportOrderingRule() },
             RuleProvider { IndentationRule() },
             RuleProvider { KdocWrappingRule() },
+            RuleProvider { KtlintSuppressionRule() },
             RuleProvider { MaxLineLengthRule() },
             RuleProvider { ModifierListSpacingRule() },
             RuleProvider { ModifierOrderRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
@@ -44,14 +44,14 @@ import org.jetbrains.kotlin.util.prefixIfNot
  * A ktlint-disable directive is replaced with an annotation on the closest parent declaration or expression, or as annotation on the file
  * level in case the directive is associated with a top level element.
  *
- * If the target element is annotated with a [Suppress], or if missing with a [SuppressWarnings] annotation then the ktlint-directive will
- * be matched against this annotation. If this annotation already contains a suppression for *all* ktlint rules, or for the specific rule
- * id, then it is not added to annotation as it would be redundant. In case a suppression identifier is added to an existing annotation then
- * all identifiers in the annotation are alphabetically sorted.
+ * If the target element is annotated with a [Suppress] (or, if missing, is annotated with a [SuppressWarnings] annotation) then the
+ * ktlint-directive will be matched against this annotation. If this annotation already contains a suppression for *all* ktlint rules, or
+ * for the specific rule id, then it is not added to annotation as it would be redundant. In case a suppression identifier is added to an
+ * existing annotation then all identifiers in the annotation are alphabetically sorted.
  *
  * If the target element is not annotated with [Suppress] or [SuppressWarnings] then a [Suppress] annotation is added.
  *
- * A ktlint-enable directive is removed as annotations have a scope in which the suppression will be active.
+ * Ktlint-enable directives are removed as annotations have a scope in which the suppression will be active.
  */
 public class KtlintSuppressionRule : StandardRule("ktlint-suppression") {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
@@ -1,0 +1,466 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isRoot
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import com.pinterest.ktlint.ruleset.standard.rules.KtlintSuppressionRule.SuppressAnnotationType.SUPPRESS
+import com.pinterest.ktlint.ruleset.standard.rules.KtlintSuppressionRule.SuppressAnnotationType.SUPPRESS_WARNINGS
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtDeclarationModifierList
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFileAnnotationList
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.psiUtil.children
+import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
+import org.jetbrains.kotlin.util.prefixIfNot
+
+/**
+ * Disallow usage of the old "ktlint-disable" and "ktlint-enable" directives.
+ *
+ * A ktlint-disable directive is replaced with an annotation on the closest parent declaration or expression, or as annotation on the file
+ * level in case the directive is associated with a top level element.
+ *
+ * If the target element is annotated with a [Suppress], or if missing with a [SuppressWarnings] annotation then the ktlint-directive will
+ * be matched against this annotation. If this annotation already contains a suppression for *all* ktlint rules, or for the specific rule
+ * id, then it is not added to annotation as it would be redundant. In case a suppression identifier is added to an existing annotation then
+ * all identifiers in the annotation are alphabetically sorted.
+ *
+ * If the target element is not annotated with [Suppress] or [SuppressWarnings] then a [Suppress] annotation is added.
+ *
+ * A ktlint-enable directive is removed as annotations have a scope in which the suppression will be active.
+ */
+public class KtlintSuppressionRule : StandardRule("ktlint-suppression") {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        node
+            .suppressionAnnotationTypeOrNull()
+            ?.visitSuppressAnnotation(node, emit, autoCorrect)
+
+        node
+            .removeCommentWithoutMarkersOrNull()
+            ?.let { commentWithoutMarkers ->
+                when {
+                    commentWithoutMarkers.startsWith(KTLINT_DISABLE) -> {
+                        if (node.elementType == EOL_COMMENT && node.prevLeaf().isWhiteSpaceWithNewline()) {
+                            removeDanglingEolCommentWithKtlintDisableDirective(node, autoCorrect, emit)
+                        } else {
+                            visitKtlintDisableDirective(node, autoCorrect, emit, commentWithoutMarkers)
+                        }
+                    }
+
+                    commentWithoutMarkers.startsWith(KTLINT_ENABLE) -> {
+                        removeKtlintEnableDirective(node, autoCorrect, emit)
+                    }
+
+                    else -> null
+                }
+            }
+    }
+
+    private fun SuppressAnnotationType.visitSuppressAnnotation(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        node
+            .findChildByType(VALUE_ARGUMENT_LIST)
+            ?.let { valueArgumentList ->
+                val suppressions =
+                    valueArgumentList
+                        .children()
+                        .filter { it.elementType == VALUE_ARGUMENT }
+                        .map { valueArgument ->
+                            valueArgument
+                                .text
+                                .prefixKtlintSuppressionWithRuleSetId()
+                                .also { prefixedSuppression ->
+                                    if (prefixedSuppression != valueArgument.text) {
+                                        emit(
+                                            valueArgument.startOffset + "\"ktlint:".length,
+                                            "Identifier to suppress ktlint rule must be fully qualified with the rule set id",
+                                            true,
+                                        )
+                                        // See below for autocorrect on entire value argument list
+                                    }
+                                }
+                        }.toSet()
+                if (autoCorrect) {
+                    node
+                        .psi
+                        .createSuppressAnnotation(this, suppressions)
+                        .node
+                        .findChildByType(VALUE_ARGUMENT_LIST)
+                        ?.let { newValueArgumentList ->
+                            if (valueArgumentList != newValueArgumentList) {
+                                valueArgumentList.replaceWith(newValueArgumentList)
+                            }
+                        }
+                }
+            }
+    }
+
+    private fun String.prefixKtlintSuppressionWithRuleSetId() =
+        takeIf { startsWith("\"ktlint:") }
+            ?.substringAfter("\"ktlint:")
+            ?.let { originalRuleId ->
+                RuleId
+                    .prefixWithStandardRuleSetIdWhenMissing(originalRuleId)
+                    .prefixIfNot("\"ktlint:")
+            }
+            ?: this
+
+    private fun ASTNode.removeCommentWithoutMarkersOrNull() =
+        when (elementType) {
+            EOL_COMMENT ->
+                text
+                    .removePrefix("//")
+                    .trim()
+
+            BLOCK_COMMENT ->
+                text
+                    .removePrefix("/*")
+                    .removeSuffix("*/")
+                    .trim()
+
+            else -> null
+        }
+
+    private fun removeDanglingEolCommentWithKtlintDisableDirective(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        emit(
+            node.ktlintDisableOffset(),
+            "Directive 'ktlint-disable' in EOL comment is ignored as it is not preceded by a code element",
+            true,
+        )
+        if (autoCorrect) {
+            node
+                .prevLeaf()
+                .takeIf { it.isWhiteSpace() }
+                ?.remove()
+            node.remove()
+        }
+    }
+
+    private fun ASTNode.ktlintDisableOffset() = startOffset + text.indexOf(KTLINT_DISABLE)
+
+    private fun visitKtlintDisableDirective(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        ktlintDisableDirective: String,
+    ) {
+        emit(
+            node.ktlintDisableOffset(),
+            "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation",
+            true,
+        )
+        if (autoCorrect) {
+            node
+                .findParentDeclarationOrExpression()
+                .addKtlintRuleSuppression(ktlintDisableDirective.toFullyQualifiedSuppressKtlintRuleIds())
+            if (node.elementType == EOL_COMMENT) {
+                node
+                    .prevLeaf()
+                    .takeIf { it.isWhiteSpace() }
+                    ?.remove()
+            } else {
+                if (node.nextLeaf().isWhiteSpaceWithNewline()) {
+                    node
+                        .nextLeaf()
+                        ?.remove()
+                } else {
+                    node
+                        .prevLeaf()
+                        .takeIf { it.isWhiteSpace() }
+                        ?.remove()
+                }
+            }
+            node.remove()
+        }
+    }
+
+    private fun ASTNode.findParentDeclarationOrExpression(): ASTNode {
+        var targetNode = this
+        while (
+            !targetNode.isRoot() &&
+            targetNode.psi !is KtDeclaration &&
+            (targetNode.psi !is KtExpression || targetNode.psi is KtBlockExpression)
+        ) {
+            targetNode = targetNode.treeParent
+        }
+        return targetNode
+    }
+
+    private fun ASTNode.remove() {
+        treeParent.removeChild(this)
+    }
+
+    private fun ASTNode.addKtlintRuleSuppression(ktlintRuleSuppressions: Set<String>) {
+        val suppressionAnnotations = findSuppressionAnnotations()
+        // Add ktlint rule suppressions:
+        //   - To the @Suppress annotation if found
+        //   - otherwise to the @SuppressWarnings annotation if found
+        //   - otherwise create a new @Suppress annotation
+        when {
+            suppressionAnnotations.containsKey(SUPPRESS) ->
+                ktlintRuleSuppressions.mergeInto(suppressionAnnotations.getValue(SUPPRESS), SUPPRESS)
+
+            suppressionAnnotations.containsKey(SUPPRESS_WARNINGS) ->
+                ktlintRuleSuppressions.mergeInto(suppressionAnnotations.getValue(SUPPRESS_WARNINGS), SUPPRESS_WARNINGS)
+
+            else -> {
+                psi
+                    .createSuppressAnnotation(SUPPRESS, ktlintRuleSuppressions)
+                    .node
+                    .let { annotation ->
+                        if (annotation.elementType == FILE_ANNOTATION_LIST) {
+                            require(isRoot()) { "File annotation list can only be created for root node" }
+                            // Should always be inserted into the first (root) code child regardless in which root node the ktlint directive
+                            // was actually found
+                            if (findChildByType(FILE_ANNOTATION_LIST) != null) {
+                                findChildByType(FILE_ANNOTATION_LIST)
+                                    ?.let { fileAnnotationList ->
+                                        fileAnnotationList.treeParent.addChild(annotation, fileAnnotationList)
+                                        fileAnnotationList.remove()
+                                    }
+                            } else {
+                                findChildByType(PACKAGE_DIRECTIVE)
+                                    ?.let { packageDirective ->
+                                        packageDirective
+                                            .treeParent
+                                            .addChild(annotation, packageDirective)
+                                        packageDirective
+                                            .treeParent
+                                            .addChild(PsiWhiteSpaceImpl("\n" + indent()), packageDirective)
+                                    }
+                            }
+                        } else {
+                            treeParent.addChild(annotation, this)
+                            treeParent.addChild(PsiWhiteSpaceImpl(indent()), this)
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun Set<String>.mergeInto(
+        annotationNode: ASTNode,
+        suppressType: SuppressAnnotationType,
+    ) {
+        annotationNode
+            .getExistingSuppressions()
+            .plus(this)
+            .let { suppressions ->
+                if (suppressions.contains("\"ktlint\"")) {
+                    // When all ktlint rules are to be suppressed, then ignore all suppressions for specific ktlint rules
+                    suppressions
+                        .filterNot { it.startsWith("\"ktlint:") }
+                        .toSet()
+                } else {
+                    suppressions
+                }
+            }.map { it.prefixKtlintSuppressionWithRuleSetId() }
+            .let { suppressions ->
+                annotationNode
+                    .treeParent
+                    .psi
+                    .createSuppressAnnotation(suppressType, suppressions)
+                    .node
+                    .let { newAnnotation ->
+                        if (annotationNode.treeParent.elementType == FILE_ANNOTATION_LIST) {
+                            annotationNode.treeParent.replaceWith(newAnnotation)
+                        } else {
+                            annotationNode.replaceWith(newAnnotation)
+                        }
+                    }
+            }
+    }
+
+    private fun ASTNode.findSuppressionAnnotations(): Map<SuppressAnnotationType, ASTNode> =
+        if (this.isRoot()) {
+            findChildByType(FILE_ANNOTATION_LIST)
+                ?.findSuppressionAnnotationsInModifierList()
+                .orEmpty()
+        } else {
+            findChildByType(MODIFIER_LIST)
+                ?.findSuppressionAnnotationsInModifierList()
+                .orEmpty()
+        }
+
+    private fun ASTNode.findSuppressionAnnotationsInModifierList(): Map<SuppressAnnotationType, ASTNode> =
+        children()
+            .mapNotNull { modifier ->
+                when (modifier.suppressionAnnotationTypeOrNull()) {
+                    SUPPRESS -> Pair(SUPPRESS, modifier)
+                    SUPPRESS_WARNINGS -> Pair(SUPPRESS_WARNINGS, modifier)
+                    else -> null
+                }
+            }.toMap()
+
+    private fun ASTNode.suppressionAnnotationTypeOrNull() =
+        takeIf { elementType == ANNOTATION || elementType == ANNOTATION_ENTRY }
+            ?.findChildByType(ElementType.CONSTRUCTOR_CALLEE)
+            ?.findChildByType(ElementType.TYPE_REFERENCE)
+            ?.findChildByType(ElementType.USER_TYPE)
+            ?.findChildByType(ElementType.REFERENCE_EXPRESSION)
+            ?.findChildByType(ElementType.IDENTIFIER)
+            ?.text
+            ?.let { SuppressAnnotationType.findByIdOrNull(it) }
+
+    private fun ASTNode.getExistingSuppressions() =
+        findChildByType(VALUE_ARGUMENT_LIST)
+            ?.children()
+            ?.filter { it.elementType == VALUE_ARGUMENT }
+            ?.map { it.text }
+            ?.toSet()
+            .orEmpty()
+
+    private fun PsiElement.createSuppressAnnotation(
+        suppressType: SuppressAnnotationType,
+        suppressions: Collection<String>,
+    ): PsiElement =
+        suppressions
+            .sorted()
+            .joinToString()
+            .let { sortedSuppressionsString ->
+                if (this is KtFile || this is KtFileAnnotationList) {
+                    createFileAnnotation(suppressType, sortedSuppressionsString)
+                } else {
+                    createDeclarationAnnotationEntry(suppressType, sortedSuppressionsString)
+                }
+            }
+
+    private fun PsiElement.createFileAnnotation(
+        suppressType: SuppressAnnotationType,
+        sortedSuppressionsString: String,
+    ): PsiElement =
+        "@file:${suppressType.annotationName}($sortedSuppressionsString)"
+            .let { annotation ->
+                PsiFileFactory
+                    .getInstance(project)
+                    .createFileFromText(KotlinLanguage.INSTANCE, annotation)
+                    ?.firstChild
+                    ?: throw IllegalStateException("Can not create annotation '$annotation'")
+            }
+
+    private fun PsiElement.createDeclarationAnnotationEntry(
+        suppressType: SuppressAnnotationType,
+        sortedSuppressionsString: String,
+    ): PsiElement =
+        "@${suppressType.annotationName}($sortedSuppressionsString)"
+            .let { annotation ->
+                PsiFileFactory
+                    .getInstance(project)
+                    .createFileFromText(
+                        KotlinLanguage.INSTANCE,
+                        // Create the annotation for a dummy declaration as the entire code block should be valid Kotlin code
+                        """
+                        $annotation
+                        fun foo() {}
+                        """.trimIndent(),
+                    ).getChildOfType<KtScript>()
+                    ?.getChildOfType<KtBlockExpression>()
+                    ?.getChildOfType<KtNamedFunction>()
+                    ?.getChildOfType<KtDeclarationModifierList>()
+                    ?.getChildOfType<KtAnnotationEntry>()
+                    ?: throw IllegalStateException("Can not create annotation '$annotation'")
+            }
+
+    private fun String.toFullyQualifiedSuppressKtlintRuleIds(): Set<String> =
+        removePrefix(KTLINT_DISABLE)
+            .trim()
+            .split(" ")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map {
+                it.prefixKtlintSuppressionWithRuleSetId()
+                RuleId
+                    .prefixWithStandardRuleSetIdWhenMissing(it)
+                    .prefixIfNot("ktlint:")
+            }.ifEmpty { listOf("ktlint") }
+            .map { it.surroundWith('"') }
+            .toSet()
+
+    private fun String.surroundWith(char: Char) =
+        char
+            .toString()
+            .let { string ->
+                removeSurrounding(string)
+                    .prefixIfNot(string)
+                    .plus(string)
+            }
+
+    private fun removeKtlintEnableDirective(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        emit(
+            node.startOffset + node.text.indexOf(KTLINT_ENABLE),
+            "Directive 'ktlint-enable' is obsolete after migrating to suppress annotations",
+            true,
+        )
+        if (autoCorrect) {
+            node
+                .prevLeaf()
+                .takeIf { it.isWhiteSpace() }
+                ?.remove()
+            node.remove()
+        }
+    }
+
+    private fun ASTNode.replaceWith(node: ASTNode) {
+        treeParent.addChild(node, this)
+        this.remove()
+    }
+
+    private enum class SuppressAnnotationType(val annotationName: String) {
+        SUPPRESS("Suppress"),
+        SUPPRESS_WARNINGS("SuppressWarnings"),
+        ;
+
+        companion object {
+            fun findByIdOrNull(id: String): SuppressAnnotationType? =
+                SuppressAnnotationType
+                    .values()
+                    .firstOrNull { it.annotationName == id }
+        }
+    }
+
+    private companion object {
+        const val KTLINT_DISABLE = "ktlint-disable"
+        const val KTLINT_ENABLE = "ktlint-enable"
+    }
+}
+
+public val KTLINT_SUPPRESSION_RULE_ID: RuleId = KtlintSuppressionRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRule.kt
@@ -100,8 +100,7 @@ public class KtlintSuppressionRule : StandardRule("ktlint-suppression") {
             }
     }
 
-    private fun ASTNode.isPartOfAnnotation() =
-        parent { it.elementType == ANNOTATION || it.elementType == ANNOTATION_ENTRY } != null
+    private fun ASTNode.isPartOfAnnotation() = parent { it.elementType == ANNOTATION || it.elementType == ANNOTATION_ENTRY } != null
 
     private fun visitKtlintSuppressionInAnnotation(
         node: ASTNode,
@@ -137,20 +136,19 @@ public class KtlintSuppressionRule : StandardRule("ktlint-suppression") {
             }
     }
 
-    private fun ASTNode.createLiteralStringTemplateEntry(
-        prefixedSuppression: String
-    ) = PsiFileFactory
-        .getInstance(psi.project)
-        .createFileFromText(KotlinLanguage.INSTANCE, "listOf(\"$prefixedSuppression\")")
-        .getChildOfType<KtScript>()
-        ?.getChildOfType<KtBlockExpression>()
-        ?.getChildOfType<KtScriptInitializer>()
-        ?.getChildOfType<KtCallExpression>()
-        ?.getChildOfType<KtValueArgumentList>()
-        ?.getChildOfType<KtValueArgument>()
-        ?.getChildOfType<KtStringTemplateExpression>()
-        ?.getChildOfType<KtLiteralStringTemplateEntry>()
-        ?.node
+    private fun ASTNode.createLiteralStringTemplateEntry(prefixedSuppression: String) =
+        PsiFileFactory
+            .getInstance(psi.project)
+            .createFileFromText(KotlinLanguage.INSTANCE, "listOf(\"$prefixedSuppression\")")
+            .getChildOfType<KtScript>()
+            ?.getChildOfType<KtBlockExpression>()
+            ?.getChildOfType<KtScriptInitializer>()
+            ?.getChildOfType<KtCallExpression>()
+            ?.getChildOfType<KtValueArgumentList>()
+            ?.getChildOfType<KtValueArgument>()
+            ?.getChildOfType<KtStringTemplateExpression>()
+            ?.getChildOfType<KtLiteralStringTemplateEntry>()
+            ?.node
 
     private fun String.prefixKtlintSuppressionWithRuleSetId(): String {
         val isPrefixedWithDoubleQuote = startsWith("\"")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -253,7 +253,7 @@ class AnnotationRuleTest {
                 val bar: Any
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         annotationRuleAssertThat(code)
             .hasLintViolation(3, 9, "Expected newline after last annotation")
             .isFormattedAs(formattedCode)
@@ -406,7 +406,7 @@ class AnnotationRuleTest {
 
                 package foo.bar
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .hasLintViolations(
                     LintViolation(1, 26, "Expected newline after last annotation"),
@@ -740,7 +740,7 @@ class AnnotationRuleTest {
                     String
                     > = FooBar()
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .addAdditionalRuleProvider { WrappingRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -29,7 +29,7 @@ class ArgumentListWrappingRuleTest {
                 c
             )
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         argumentListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 8, "Argument should be on a separate line (unless all arguments can fit a single line)")
             .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
@@ -33,7 +33,7 @@ class ClassNamingRuleTest {
                 """
                 class $className
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             classNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
         }
@@ -46,7 +46,7 @@ class ClassNamingRuleTest {
                     """
                     class `foo`
                     """.trimIndent()
-                @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
                 classNamingRuleAssertThat(code)
                     .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
@@ -73,7 +73,7 @@ class ClassNamingRuleTest {
         @ParameterizedTest(name = "Suppression annotation: {0}")
         @ValueSource(
             strings = [
-                "ktlint:class-naming",
+                "ktlint:standard:class-naming",
                 "ClassName", // IntelliJ IDEA suppression
             ],
         )
@@ -117,7 +117,7 @@ class ClassNamingRuleTest {
         @ParameterizedTest(name = "Suppression annotation: {0}")
         @ValueSource(
             strings = [
-                "ktlint:class-naming",
+                "ktlint:standard:class-naming",
                 "ClassName", // IntelliJ IDEA suppression
             ],
         )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
@@ -93,7 +93,7 @@ class CommentWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 17, "A block comment after any other element on the same line must be separated by a new line")
     }
@@ -104,7 +104,7 @@ class CommentWrappingRuleTest {
             """
             val foo /* some comment */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment in between other elements on the same line is disallowed")
     }
@@ -117,7 +117,7 @@ class CommentWrappingRuleTest {
             some comment
             */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment starting on same line as another element and ending on another line before another element is disallowed")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
@@ -29,7 +29,7 @@ class EnumEntryNameCaseRuleTest {
                 _FOO
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"")
     }
@@ -55,7 +55,7 @@ class EnumEntryNameCaseRuleTest {
                 Foo_Bar,
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
@@ -72,7 +72,7 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing a single declaration of a class type then the filename should match the class name`(code: String) {
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath("/some/path/$UNEXPECTED_FILE_NAME")
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
@@ -86,7 +86,7 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing one top level declaration then the file should be named after the identifier`(code: String) {
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'")
@@ -167,7 +167,7 @@ class FilenameRuleTest {
             class Foo
             $otherTopLevelDeclaration
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -39,7 +39,7 @@ class FunctionNamingRuleTest {
                 """
                 fun `Some name`() {}
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
         }
@@ -75,7 +75,7 @@ class FunctionNamingRuleTest {
                 """
                 fun do_something() {}
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
         }
@@ -117,7 +117,7 @@ class FunctionNamingRuleTest {
             """
             fun $functionName() = "foo"
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         functionNamingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -125,7 +125,7 @@ class FunctionNamingRuleTest {
     @ParameterizedTest(name = "Suppression annotation: {0}")
     @ValueSource(
         strings = [
-            "ktlint:function-naming",
+            "ktlint:standard:function-naming",
             "FunctionName", // IntelliJ IDEA suppression
         ],
     )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -516,6 +516,7 @@ class FunctionSignatureRuleTest {
     inner class CleanUpByRelatedRules {
         @Test
         fun `Given a nullable type with a space before the quest then remove this space`() {
+            @Suppress("ktlint:standard:string-template")
             val code =
                 """
                 fun String$UNEXPECTED_SPACES?.f1() = "some-result"
@@ -525,7 +526,7 @@ class FunctionSignatureRuleTest {
                 fun f5(): String$UNEXPECTED_SPACES? = "some-result"
                 fun f6(): List<String$UNEXPECTED_SPACES?> = listOf("some-result", null)
                 fun f7(): List<String>$UNEXPECTED_SPACES? = null
-                """.trimIndent() // ktlint-disable string-template
+                """.trimIndent()
             val formattedCode =
                 """
                 fun String?.f1() = "some-result"
@@ -608,7 +609,7 @@ class FunctionSignatureRuleTest {
                 fun f28(block: (T) -> String) = "some-result"
                 fun f29(block: (T) -> String) = "some-result"
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             functionSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProviders(
                     { NoMultipleSpacesRule() },

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
@@ -62,7 +62,7 @@ class IfElseBracingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(IF_ELSE_BRACING_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
@@ -138,7 +138,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(4, 12, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -237,7 +237,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -259,7 +259,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -282,7 +282,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -304,7 +304,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(7, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -325,7 +325,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(5, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -346,7 +346,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(3, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
@@ -190,7 +190,7 @@ class IfElseWrappingRuleTest {
                     if (true) { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(2, 15, "A single line if-statement should be kept simple. The 'THEN' may not be wrapped in a block.")
         }
@@ -203,7 +203,7 @@ class IfElseWrappingRuleTest {
                     if (true) bar() else { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(2, 26, "A single line if-statement should be kept simple. The 'ELSE' may not be wrapped in a block.")
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -3204,7 +3204,7 @@ internal class IndentationRuleTest {
                 ${TAB}line2
                     $MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             indentationRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 11, "Indentation of multiline string should not contain both tab(s) and space(s)")
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
@@ -64,7 +64,7 @@ class KdocWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         kdocWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 17, "A KDoc comment after any other element on the same line must be separated by a new line")
     }
@@ -87,7 +87,7 @@ class KdocWrappingRuleTest {
             some KDoc comment
             */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         kdocWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A KDoc comment starting on same line as another element and ending on another line before another element is disallowed")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintDocumentationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintDocumentationTest.kt
@@ -1,0 +1,11 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import org.junit.jupiter.api.Test
+
+/**
+ * Mark a unit test as a unit test for an example in the Ktlint documentation. For now the purpose is only to indicate that the code of the
+ * test is also used in the documentation. A future possible use it that the code samples in the documentation are extracted from the unit
+ * test directly which then will ensure that the code samples in the documentation actually provide the documented results.
+ */
+@Test
+annotation class KtlintDocumentationTest

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
@@ -1,0 +1,798 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class KtlintSuppressionRuleTest {
+    private val ktlintSuppressionRuleAssertThat =
+        KtLintAssertThat.assertThatRule { KtlintSuppressionRule() }
+
+    @Nested
+    inner class `Given a suppression annotation missing the rule set id prefix` {
+        @Test
+        fun `Given a @file Suppress annotation`() {
+            val code =
+                """
+                @file:Suppress("ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar")
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:Suppress("ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar")
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 24, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 61, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a @file SuppressWarnings annotation`() {
+            val code =
+                """
+                @file:SuppressWarnings("ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar")
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:SuppressWarnings("ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar")
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 32, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 69, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a Suppress annotation on a declaration`() {
+            val code =
+                """
+                @Suppress("ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar")
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 19, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 56, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a SuppressWarnings annotation on a declaration`() {
+            val code =
+                """
+                @SuppressWarnings("ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar")
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @SuppressWarnings("ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 27, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 64, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given an EOL comment with a ktlint-disable directive not preceded by code leaf on same line`() {
+        val code =
+            """
+            val foo = "foo"
+            // ktlint-disable
+            val bar = "bar"
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = "foo"
+            val bar = "bar"
+            """.trimIndent()
+        ktlintSuppressionRuleAssertThat(code)
+            .hasLintViolation(2, 4, "Directive 'ktlint-disable' in EOL comment is ignored as it is not preceded by a code element")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given an import statement` {
+        @Test
+        fun `Given an EOL comment with a ktlint-disable directive on an import`() {
+            val code =
+                """
+                import foo.bar
+                import foobar.* // ktlint-disable no-wildcard-imports
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:Suppress("ktlint:standard:no-wildcard-imports")
+
+                import foo.bar
+                import foobar.*
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given an EOL comment with a ktlint-disable directive on an import and an existing @file Suppress annotation`() {
+            val code =
+                """
+                @file:Suppress("aaa", "zzz")
+
+                import foo.bar
+                import foobar.* // ktlint-disable no-wildcard-imports
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:Suppress("aaa", "ktlint:standard:no-wildcard-imports", "zzz")
+
+                import foo.bar
+                import foobar.*
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(4, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given an EOL comment with a ktlint-disable directive on an import on a file starting with a (copyright) comment before the package statement`() {
+            val code =
+                """
+                /* Some copyright notice before package statement */
+                package foo
+
+                import foo.bar
+                import foobar.* // ktlint-disable no-wildcard-imports
+                """.trimIndent()
+            val formattedCode =
+                """
+                /* Some copyright notice before package statement */
+                @file:Suppress("ktlint:standard:no-wildcard-imports")
+
+                package foo
+
+                import foo.bar
+                import foobar.*
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(5, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given an EOL comment with a ktlint-disable directive on an import and an existing @file Suppress annotation  on a file starting with a (copyright) comment`() {
+            val code =
+                """
+                /* Some copyright notice before package statement */
+                @file:Suppress("aaa", "zzz")
+                package foo
+
+                import foo.bar
+                import foobar.* // ktlint-disable no-wildcard-imports
+                """.trimIndent()
+            val formattedCode =
+                """
+                /* Some copyright notice before package statement */
+                @file:Suppress("aaa", "ktlint:standard:no-wildcard-imports", "zzz")
+                package foo
+
+                import foo.bar
+                import foobar.*
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(6, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given an EOL comment with a ktlint-disable directive` {
+        @Test
+        fun `Given a ktlint-disable directive without rule-id`() {
+            val code =
+                """
+                val foo = "foo" // ktlint-disable
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id not prefixed with a rule set id`() {
+            val code =
+                """
+                val foo = "foo" // ktlint-disable some-rule-id
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:standard:some-rule-id")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id prefixed with a rule set id`() {
+            val code =
+                """
+                val foo = "foo" // ktlint-disable some-rule-set:some-rule-id
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set:some-rule-id")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Rules: {0}")
+        @ValueSource(
+            strings = [
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2",
+                // Redundant spaces between rule ids should not lead to suppressing all rules by adding "ktlint" as suppression id
+                "some-rule-set-1:some-rule-id-1   some-rule-set-2:some-rule-id-2",
+                // Duplicate rule ids are ignored
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+                // Unsorted rule ids are sorted
+                "some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+            ],
+        )
+        fun `Given a ktlint-disable directive with multiple rule-ids`(ruleIds: String) {
+            val code =
+                """
+                val foo = "foo" // ktlint-disable $ruleIds
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set-1:some-rule-id-1", "ktlint:some-rule-set-2:some-rule-id-2")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @Suppress then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                @Suppress("zzz", "aaa")
+                val foo = "foo" // ktlint-disable some-rule-set:some-rule-id
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @SuppressWarnings then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                @SuppressWarnings("aaa", "zzz")
+                val foo = "foo" // ktlint-disable some-rule-set:some-rule-id
+                """.trimIndent()
+            val formattedCode =
+                """
+                @SuppressWarnings("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with both @Suppress and @SuppressWarnings then add the ktlint suppression to the @Suppress`() {
+            val code =
+                """
+                @Suppress("aaa", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                val foo = "foo" // ktlint-disable some-rule-set:some-rule-id
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(3, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a top level block comment with a ktlint-disable directive` {
+        @Test
+        fun `Given a ktlint-disable directive without rule-id`() {
+            val code =
+                """
+                /* ktlint-disable */
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id not prefixed with a rule set id`() {
+            val code =
+                """
+                /* ktlint-disable some-rule-id */
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:standard:some-rule-id")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id prefixed with a rule set id`() {
+            val code =
+                """
+                /* ktlint-disable some-rule-set:some-rule-id */
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set:some-rule-id")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Rules: {0}")
+        @ValueSource(
+            strings = [
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2",
+                // Redundant spaces between rule ids should not lead to suppressing all rules by adding "ktlint" as suppression id
+                "some-rule-set-1:some-rule-id-1   some-rule-set-2:some-rule-id-2",
+                // Duplicate rule ids are ignored
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+                // Unsorted rule ids are sorted
+                "some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+            ],
+        )
+        fun `Given a ktlint-disable directive with multiple rule-ids`(ruleIds: String) {
+            val code =
+                """
+                /* ktlint-disable $ruleIds */
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set-1:some-rule-id-1", "ktlint:some-rule-set-2:some-rule-id-2")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @Suppress then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                /* ktlint-disable some-rule-set:some-rule-id */
+                @Suppress("zzz", "aaa")
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @SuppressWarnings then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                /* ktlint-disable some-rule-set:some-rule-id */
+                @SuppressWarnings("aaa", "zzz")
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @SuppressWarnings("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with both @Suppress and @SuppressWarnings then add the ktlint suppression to the @Suppress`() {
+            val code =
+                """
+                /* ktlint-disable some-rule-set:some-rule-id */
+                @Suppress("aaa", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a non-top level block comment with a ktlint-disable directive` {
+        @Test
+        fun `Given a ktlint-disable directive without rule-id`() {
+            val code =
+                """
+                fun foo() {
+                    /* ktlint-disable */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id not prefixed with a rule set id`() {
+            val code =
+                """
+                fun foo() {
+                    /* ktlint-disable some-rule-id */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:standard:some-rule-id")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive with rule-id prefixed with a rule set id`() {
+            val code =
+                """
+                fun foo() {
+                    /* ktlint-disable some-rule-set:some-rule-id */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set:some-rule-id")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Rules: {0}")
+        @ValueSource(
+            strings = [
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2",
+                // Redundant spaces between rule ids should not lead to suppressing all rules by adding "ktlint" as suppression id
+                "some-rule-set-1:some-rule-id-1   some-rule-set-2:some-rule-id-2",
+                // Duplicate rule ids are ignored
+                "some-rule-set-1:some-rule-id-1 some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+                // Unsorted rule ids are sorted
+                "some-rule-set-2:some-rule-id-2 some-rule-set-1:some-rule-id-1",
+            ],
+        )
+        fun `Given a ktlint-disable directive with multiple rule-ids`(ruleIds: String) {
+            val code =
+                """
+                fun foo() {
+                    /* ktlint-disable $ruleIds */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set-1:some-rule-id-1", "ktlint:some-rule-set-2:some-rule-id-2")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @Suppress then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                @Suppress("zzz", "aaa")
+                fun foo() {
+                    /* ktlint-disable some-rule-set:some-rule-id */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(3, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with @SuppressWarnings then add the ktlint suppression and sort all suppressions alphabetically`() {
+            val code =
+                """
+                @SuppressWarnings("aaa", "zzz")
+                fun foo() {
+                    /* ktlint-disable some-rule-set:some-rule-id */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @SuppressWarnings("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(3, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-disable directive for which the target element is already annotated with both @Suppress and @SuppressWarnings then add the ktlint suppression to the @Suppress`() {
+            val code =
+                """
+                @Suppress("aaa", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                fun foo() {
+                    /* ktlint-disable some-rule-set:some-rule-id */
+                    doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("aaa", "ktlint:some-rule-set:some-rule-id", "zzz")
+                @SuppressWarnings("bbb", "yyy")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(4, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a ktlint-enable directive` {
+        @Test
+        fun `Given a ktlint-enable directive matching with a ktlint-disable directive`() {
+            val code =
+                """
+                fun foo() {
+                    /* ktlint-disable some-rule-set:some-rule-id */
+                    doSomething()
+                    /* ktlint-enable some-rule-set:some-rule-id */
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:some-rule-set:some-rule-id")
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                    LintViolation(4, 8, "Directive 'ktlint-enable' is obsolete after migrating to suppress annotations"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a ktlint-enable directive not matching with a ktlint-disable directive`() {
+            val code =
+                """
+                fun foo() {
+                    doSomething()
+                    /* ktlint-enable some-rule-set:some-rule-id */
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo() {
+                    doSomething()
+                }
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(3, 8, "Directive 'ktlint-enable' is obsolete after migrating to suppress annotations")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a ktlint-disable directive for a specific rule on a declaration which already has suppression annotation for all ktlint rules`() {
+        val code =
+            """
+            @Suppress("ktlint")
+            fun foo() {
+                bar() // ktlint-disable some-rule-set:some-rule-id-1
+
+                /* ktlint-disable some-rule-set:some-rule-id-2 */
+                /* ktlint-disable some-rule-set:some-rule-id-3 */
+                bar()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            @Suppress("ktlint")
+            fun foo() {
+                bar()
+
+                bar()
+            }
+            """.trimIndent()
+        ktlintSuppressionRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 14, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(5, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(6, 8, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @KtlintDocumentationTest
+    fun `Documentation example`() {
+        val code =
+            """
+            /* ktlint-disable standard:no-wildcard-imports */
+
+            class FooBar {
+                val foo = "some longggggggggggggggggggg text" // ktlint-disable standard:max-line-length
+
+                fun bar() =
+                    listOf(
+                        /* ktlint-disable standard:no-multi-spaces */
+                        "1   One",
+                        "10  Ten",
+                        "100 Hundred",
+                        /* ktlint-enable standard:no-multi-spaces */
+                    )
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            @file:Suppress("ktlint:standard:no-wildcard-imports")
+
+            class FooBar {
+                @Suppress("ktlint:standard:max-line-length")
+                val foo = "some longggggggggggggggggggg text"
+
+                fun bar() =
+                    @Suppress("ktlint:standard:no-multi-spaces")
+                    listOf(
+                        "1   One",
+                        "10  Ten",
+                        "100 Hundred",
+                    )
+            }
+            """.trimIndent()
+        ktlintSuppressionRuleAssertThat(code)
+            .addAdditionalRuleProvider { ArgumentListWrappingRule() }
+            .hasLintViolations(
+                LintViolation(1, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(4, 54, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(8, 16, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(12, 16, "Directive 'ktlint-enable' is obsolete after migrating to suppress annotations"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "Suppression type: {0}")
+    @ValueSource(
+        strings = [
+            "Suppress",
+            "SuppressWarnings",
+        ],
+    )
+    fun `Given multiple ktlint-disable directives which have to merged into an existing @file Suppress annotation`(annotationName: String) {
+        val code =
+            """
+            @file:$annotationName("ktlint:standard:ccc", "ktlint:standard:ddd")
+
+            import foo // ktlint-disable foo
+            import bar // ktlint-disable bar
+
+            /* ktlint-disable fff */
+
+            val someFoo = foo.TEST
+            val someBar = bar.TEST
+
+            /* ktlint-disable aaa */
+            """.trimIndent()
+        val formattedCode =
+            """
+            @file:$annotationName("ktlint:standard:aaa", "ktlint:standard:bar", "ktlint:standard:ccc", "ktlint:standard:ddd", "ktlint:standard:fff", "ktlint:standard:foo")
+
+            import foo
+            import bar
+
+            val someFoo = foo.TEST
+            val someBar = bar.TEST
+            """.trimIndent()
+        ktlintSuppressionRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 15, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(4, 15, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(6, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+                LintViolation(11, 4, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation"),
+            ).isFormattedAs(formattedCode)
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
@@ -48,6 +48,42 @@ class KtlintSuppressionRuleTest {
         }
 
         @Test
+        fun `Given a @file array annotation with Suppress and SuppressWarnings annotations`() {
+            val code =
+                """
+                @file:[Suppress("ktlint:bar", "ktlint:standard:foo") SuppressWarnings("ktlint:foo-bar")]
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:[Suppress("ktlint:standard:bar", "ktlint:standard:foo") SuppressWarnings("ktlint:standard:foo-bar")]
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 25, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 79, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given an array annotation with Suppress and SuppressWarnings annotations`() {
+            val code =
+                """
+                @[Suppress("ktlint:bar", "ktlint:standard:foo") SuppressWarnings("ktlint:foo-bar")]
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @[Suppress("ktlint:standard:bar", "ktlint:standard:foo") SuppressWarnings("ktlint:standard:foo-bar")]
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 20, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 74, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
         fun `Given a Suppress annotation on a declaration`() {
             val code =
                 """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
@@ -84,6 +84,44 @@ class KtlintSuppressionRuleTest {
         }
 
         @Test
+        fun `Given a Suppress annotation with a named argument with an arrayOf initialization`() {
+            val code =
+                """
+                @Suppress(names = arrayOf("ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar"))
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress(names = arrayOf("ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar"))
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 35, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 72, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a Suppress annotation with a named argument with an array (squared brackets) initialization`() {
+            val code =
+                """
+                @Suppress(names = ["ktlint:bar", "ktlint:standard:foo", "ktlint:foo-bar"])
+                val foo = "foo"
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress(names = ["ktlint:standard:bar", "ktlint:standard:foo", "ktlint:standard:foo-bar"])
+                val foo = "foo"
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 28, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                    LintViolation(1, 65, "Identifier to suppress ktlint rule must be fully qualified with the rule set id"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
         fun `Given a Suppress annotation on a declaration`() {
             val code =
                 """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KtlintSuppressionRuleTest.kt
@@ -221,6 +221,25 @@ class KtlintSuppressionRuleTest {
         }
 
         @Test
+        fun `Given an EOL comment with a ktlint-disable directive on an import and an existing @file Suppress annotation without parameters`() {
+            val code =
+                """
+                @file:Suppress
+
+                import foobar.* // ktlint-disable no-wildcard-imports
+                """.trimIndent()
+            val formattedCode =
+                """
+                @file:Suppress("ktlint:standard:no-wildcard-imports")
+
+                import foobar.*
+                """.trimIndent()
+            ktlintSuppressionRuleAssertThat(code)
+                .hasLintViolation(3, 20, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
         fun `Given an EOL comment with a ktlint-disable directive on an import on a file starting with a (copyright) comment before the package statement`() {
             val code =
                 """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
@@ -52,7 +52,7 @@ class NoConsecutiveCommentsRuleTest {
             /** KDoc 1 */
             /* Block comment 2 */
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         noConsecutiveBlankLinesRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(NO_CONSECUTIVE_COMMENTS_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
@@ -118,7 +118,7 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
@@ -159,7 +159,7 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
@@ -200,7 +200,7 @@ class NoConsecutiveCommentsRuleTest {
                 // EOL comment
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by an EOL comment unless separated by a blank line")
@@ -226,7 +226,7 @@ class NoConsecutiveCommentsRuleTest {
                 /* Block comment */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a block comment unless separated by a blank line")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
@@ -91,7 +91,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 val foo = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 16, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)
@@ -107,7 +107,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 fun foo() = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 19, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PackageNameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PackageNameRuleTest.kt
@@ -67,7 +67,7 @@ class PackageNameRuleTest {
     @ParameterizedTest(name = "Suppression annotation: {0}")
     @ValueSource(
         strings = [
-            "ktlint:package-name",
+            "ktlint:standard:package-name",
             "PackageName", // IntelliJ IDEA suppression
         ],
     )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
@@ -331,10 +331,11 @@ class ParameterListSpacingRuleTest {
 
     @Test
     fun `Given a function signature with multiple parameters and at least one space before the comma separating the parameters then reformat`() {
+        @Suppress("ktlint:standard:string-template")
         val code =
             """
             fun foo(a: Any$TOO_MANY_SPACES, b: Any) = "some-result"
-            """.trimIndent() // ktlint-disable string-template
+            """.trimIndent()
         val formattedCode =
             """
             fun foo(a: Any, b: Any) = "some-result"
@@ -346,11 +347,12 @@ class ParameterListSpacingRuleTest {
 
     @Test
     fun `Given a function signature with multiple parameters and at least one newline before the comma separating the parameters then reformat`() {
+        @Suppress("ktlint:standard:string-template")
         val code =
             """
             fun foo(a: Any
             , b: Any) = "some-result"
-            """.trimIndent() // ktlint-disable string-template
+            """.trimIndent()
         val formattedCode =
             """
             fun foo(a: Any, b: Any) = "some-result"
@@ -377,10 +379,11 @@ class ParameterListSpacingRuleTest {
 
     @Test
     fun `Given a function signature with multiple parameters and too many spaces after the comma separating the parameters then reformat`() {
+        @Suppress("ktlint:standard:string-template")
         val code =
             """
             fun foo(a: Any,${TOO_MANY_SPACES}b: Any) = "some-result"
-            """.trimIndent() // ktlint-disable string-template
+            """.trimIndent()
         val formattedCode =
             """
             fun foo(a: Any, b: Any) = "some-result"
@@ -392,13 +395,14 @@ class ParameterListSpacingRuleTest {
 
     @Test
     fun `Given a function signature with multiple parameters and a newline after the comma separating the parameters then do not reformat`() {
+        @Suppress("ktlint:standard:string-template")
         val code =
             """
             fun foo(
                 a: Any,
                 b: Any
             ) = "some-result"
-            """.trimIndent() // ktlint-disable string-template
+            """.trimIndent()
         parameterListSpacingRuleAssertThat(code).hasNoLintViolations()
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -150,7 +150,7 @@ class ParameterListWrappingRuleTest {
                 c: Any
             )
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 13, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)
@@ -311,7 +311,7 @@ class ParameterListWrappingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(2, 11, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -43,7 +43,7 @@ class PropertyNamingRuleTest {
             const val FOO_BAR_2 = "foo-bar-2"
             const val ŸÈŠ_THÎS_IS_ALLOWED_123 = "Yes this is allowed"
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 11, "Property name should use the screaming snake case notation when the value can not be changed")
     }
@@ -55,7 +55,7 @@ class PropertyNamingRuleTest {
             val foo = Foo()
             val FOO_BAR = FooBar()
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 5, "Property name should use the screaming snake case notation when the value can not be changed")
     }
@@ -71,7 +71,7 @@ class PropertyNamingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(3, 13, "Property name should use the screaming snake case notation when the value can not be changed")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -161,7 +161,7 @@ class PropertyNamingRuleTest {
     @ParameterizedTest(name = "Suppression annotation: {0}")
     @ValueSource(
         strings = [
-            "ktlint:property-naming",
+            "ktlint:standard:property-naming",
             "PropertyName", // IntelliJ IDEA suppression
         ],
     )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
@@ -121,7 +121,7 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
             .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")
@@ -136,7 +136,7 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
             .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
@@ -38,7 +38,7 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
@@ -109,7 +109,7 @@ class ImportOrderingRuleIdeaTest {
             import android.view.ViewGroup
             import java.util.List
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
@@ -146,7 +146,7 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F // comment 3
             """.trimIndent()
-        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")


### PR DESCRIPTION
## Description

Add rule to migrate ktlint-disable directives from comments to @Suppress or @SuppressWarnings annotations

Note that the SuppressionLocatorBuilder never ignore this rule as otherwise the suppression hint to ignore *all* rules would also ignore the rule which has to migrate this suppression hint.

REVIEW suggestion:
* The functional change for #1947 is contained in [this commit](https://github.com/pinterest/ktlint/pull/2068/commits/428d52e637d931754b3756f8912f64cea884f8d5)
* Other commits are supportive to the change

Closes #1947

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
