### PR TITLE
Remove misleading sample code

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -166,8 +166,7 @@ Enum entry names should be uppercase underscore-separated names.
     enum class Bar {
         FOO,
         Foo,
-        FOO_BAR,
-        Foo_Bar
+        FOO_BAR
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -166,8 +166,7 @@ Enum entry names should be uppercase underscore-separated names.
     enum class Bar {
         FOO,
         Foo,
-        FOO_BAR,
-        Foo_Bar
+        FOO_BAR
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"


### PR DESCRIPTION
Foo_Bar throws an error according to Rule id: enum-entry-name-case, but it is given as the example for allowed code.