### PR TITLE
Change rule description

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -158,7 +158,7 @@ Rule id: `class-naming` (`standard` rule set)
 
 ## Enum entry
 
-Enum entry names should be uppercase underscore-separated names.
+Enum entry names should be uppercase underscore-separated or upper camel-case separated.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -166,7 +166,8 @@ Enum entry names should be uppercase underscore-separated or upper camel-case se
     enum class Bar {
         FOO,
         Foo,
-        FOO_BAR
+        FOO_BAR,
+        FooBar
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -158,7 +158,7 @@ Rule id: `class-naming` (`standard` rule set)
 
 ## Enum entry
 
-Enum entry names should be uppercase underscore-separated names.
+Enum entry names should be uppercase underscore-separated or upper camel-case separated.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -166,7 +166,8 @@ Enum entry names should be uppercase underscore-separated or upper camel-case se
     enum class Bar {
         FOO,
         Foo,
-        FOO_BAR
+        FOO_BAR,
+        FooBar
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"


### PR DESCRIPTION
Changed the rule description of Rule id: enum-entry-name-case. 
The rule allows to have upper camel-case separated enum names, but not mentioned in the documentation. Hence, added that for clear understanding for the users. 