### PR TITLE
Clarify property naming documentation, add examples of backing properties

### DIFF
--- a/documentation/release-latest/docs/rules/experimental.md
+++ b/documentation/release-latest/docs/rules/experimental.md
@@ -326,6 +326,11 @@ Enforce naming of property.
 
         val foo2 = "foo"
         val fooBar2 = "foo-bar"
+
+        // Backing property
+        private val _elementList = mutableListOf<Element>()
+        val elementList: List<Element>
+            get() = _elementList
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"
@@ -342,6 +347,14 @@ Enforce naming of property.
 
         val FOO2 = "foo"
         val FOO_BAR_2 = "foo-bar"
+
+        // Incomplete backing property as public property 'elementList1' is missing
+        private val _elementList1 = mutableListOf<Element>()
+
+        // Invalid backing property as '_elementList2' is not a private property
+        val _elementList2 = mutableListOf<Element>()
+        val elementList2: List<Element>
+            get() = _elementList2
     }
     ```
 

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -408,6 +408,11 @@ Enforce naming of property.
 
         val foo2 = "foo"
         val fooBar2 = "foo-bar"
+
+        // Backing property
+        private val _elementList = mutableListOf<Element>()
+        val elementList: List<Element>
+            get() = _elementList
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"
@@ -424,6 +429,14 @@ Enforce naming of property.
 
         val FOO2 = "foo"
         val FOO_BAR_2 = "foo-bar"
+
+        // Incomplete backing property as public property 'elementList1' is missing
+        private val _elementList1 = mutableListOf<Element>()
+
+        // Invalid backing property as '_elementList2' is not a private property
+        val _elementList2 = mutableListOf<Element>()
+        val elementList2: List<Element>
+            get() = _elementList2
     }
     ```
 


### PR DESCRIPTION
## Description

Clarify property naming documentation, add examples of backing properties

Closes #2078

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [ ] PR description added
- [ ] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [ ] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
