### PR TITLE
Repeat format run multiple times + fix for integration test bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Add new experimental rule `no-empty-file` for all code styles. A kotlin (script) file may not be empty ([#1074](https://github.com/pinterest/ktlint/issues/1074))
 * Add new experimental rule `statement-wrapping` which ensures function, class, or other blocks statement body doesn't start or end at starting or ending braces of the block ([#1938](https://github.com/pinterest/ktlint/issues/1938))
 * Add new experimental rule `blank-line-before-declaration`. This rule requires a blank line before class, function or property declarations ([#1939](https://github.com/pinterest/ktlint/issues/1939))
+* Wrap multiple statements on same line `wrapping` ([#1078](https://github.com/pinterest/ktlint/issues/1078))
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Update Kotlin development version to `1.8.22` and Kotlin version to `1.8.22`.
 * Update dependency io.github.detekt.sarif4k:sarif4k to v0.4.0
 * Update dependency org.jetbrains.dokka:dokka-gradle-plugin to v1.8.20
+* Run format up to 3 times in case formatting introduces changes which also can be autocorrected ([#2084](https://github.com/pinterest/ktlint/issues/2084))
 
 ## [0.49.1] - 2023-05-12
 

--- a/RELEASE_TESTING.MD
+++ b/RELEASE_TESTING.MD
@@ -40,7 +40,7 @@ Before releasing a new version of KtLint, the release candidate is tested on a s
    ```
 4. Create an alias or script to run the latest released version of ktlint (note that this script will print the version as reference to which version is used):
    ```shell
-   alias ktlint-prev="ktlint-0.47.1 $@" # Replace with the latest release version
+   alias ktlint-prev="ktlint-0.49.1 $@" # Replace with the latest release version
    ```
    Note that `~/git/ktlint` is the directory in which the ktlint project is checked out and that `~/git/ktlint/ktlint` refers to the `ktlint` CLI-module.
 5. Create an alias or script to run the latest development-version of ktlint (note that this script will print the version and the datetime of compilation as reference to which version is used):
@@ -80,27 +80,7 @@ Pre-requisites:
 
 Formatting projects in which ktlint is not used may result in a huge amount of fixes. The main focus of this test is to see what the effects are when upgrading ktlint in a project already formatted with latest released ktlint version.
 
-1. Format the sample projects with the *latest released* ktlint version:
-   ```shell
-   ktlint-prev -F --relative # Do not call this command via the "./exec-in-each-project.sh" script.
-   ```
-   Note: Ignore all output as this is the old version!
-2. Commit changes:
-   ```shell
-   ./exec-in-each-project.sh "git add --all && git commit -m \"Format with ktlint (xx.yy.zz) -F\""
-   ```
-   Repeat step 1 and 2 until no files are changed anymore.
-3. Create a new baseline file with the *latest released* ktlint version to ignore all lint violations that could not be autocorrected using the latest ktlint version:
-   ```shell
-   rm baseline.xml
-   ktlint-prev --baseline=baseline.xml --relative # Do not call this command via the "./exec-in-each-project.sh" script as we want one combined baseline.xml file for all projects.
-   ```
-4. Check that besides the `baseline.xml` no files are changed (in step 1 and 2 all violations which could be autocorrected have already been committed). Remaining violations which could not be autocorrected are saved in the `baseline.xml` which is stored outside the project directories.
-   ```shell
-   ./exec-in-each-project.sh "git status"
-   ```
-   The `baseline.xml` file should only contain errors which can not be autocorrected.
-5. Define `.editorconfig` in the integration test directory with content below. Also follow up the instructions mentioned:
+1. Define `.editorconfig` in the integration test directory with content below. Also follow up the instructions mentioned:
    ```editorconfig
    root = true
    [*.{kt,kts}]
@@ -112,6 +92,8 @@ Formatting projects in which ktlint is not used may result in a huge amount of f
    #        graphql
    #          ktlint_standard_import-ordering = disabled
    #          ktlint_standard_package-name = disabled
+   #   3) Replace removed property "disabled_rules" with "ktlint_standard_xxxx = disabled"
+   ktlint_code_style = ktlint_official
    ktlint_experimental = enabled
    ktlint_standard = enabled
    ktlint_standard_filename = disabled
@@ -119,14 +101,36 @@ Formatting projects in which ktlint is not used may result in a huge amount of f
    ktlint_standard_function-naming = disabled
    ktlint_standard_property-naming = disabled
    ```
-6. Commit changes:
+2. Commit changes:
    ```shell
    ./exec-in-each-project.sh "git add --all && git commit -m \"Update .editorconfig to fallback to integration test settings\""
    ```
+3. Format the sample projects with the *latest released* ktlint version:
+   ```shell
+   ktlint-prev -F --relative # Do not call this command via the "./exec-in-each-project.sh" script.
+   ```
+   Note: Ignore all output as this is the old version!
+4. Commit changes:
+   ```shell
+   ./exec-in-each-project.sh "git add --all && git commit -m \"Format with previous ktlint version -F\""
+   ```
+   Repeat step 1 and 2 until no files are changed anymore. Starting from 0.50, all changes should be resolved in one run as format internally reruns 3 times in case new violations are introduced which can be autocorrected as well.
+5. Create a new baseline file with the *latest released* ktlint version to ignore all lint violations that could not be autocorrected using the latest ktlint version:
+   ```shell
+   rm baseline.xml
+   ktlint-prev --baseline=baseline.xml --relative # Do not call this command via the "./exec-in-each-project.sh" script as we want one combined baseline.xml file for all projects.
+   ```
+6. Check that besides the `baseline.xml` no files are changed (in step 1 and 2 all violations which could be autocorrected have already been committed). Remaining violations which could not be autocorrected are saved in the `baseline.xml` which is stored outside the project directories.
+   ```shell
+   ./exec-in-each-project.sh "git status"
+   ```
+   The `baseline.xml` file should only contain errors which can not be autocorrected.
 7. Lint with *latest development* version:
    ```shell
    ktlint-dev --baseline=baseline.xml --relative # Do not call this command via the "./exec-in-each-project.sh" script as we want to use the one combined baseline.xml file for all projects.
-   # or when lots are violations are reported
+   ```
+   or when lots are violations are reported:
+   ```shell
    ktlint-dev --baseline=baseline.xml --relative --reporter=plain-summary # Do not call this command via the "./exec-in-each-project.sh" script as we want to use the one combined baseline.xml file for all projects.
    ```
    Inspect the output roughly (detailed inspection is done when formatting):

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -88,7 +88,7 @@ Requires a blank line before any class or function declaration. No blank line is
 Rule id: `blank-line-before-declaration` (`standard` rule set)
 
 !!! Note
-This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ## Discouraged comment location
 

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -516,6 +516,68 @@ class ASTNodeExtensionTest {
         )
     }
 
+    @Test
+    fun `Given some line containing identifiers at different indentation levels then check that all leaves on those line are found`() {
+        val code =
+            """
+            class Foo1 {
+                val foo2 = "foo2"
+
+                fun foo3() {
+                    val foo4 = "foo4"
+                }
+            }
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .firstChildLeafOrSelf()
+                .leaves()
+                .filter { it.elementType == IDENTIFIER }
+                .map { identifier ->
+                    identifier
+                        .leavesOnLine()
+                        .joinToString(separator = "") { it.text }
+                }.toList()
+
+        assertThat(actual).contains(
+            "class Foo1 {",
+            "\n    val foo2 = \"foo2\"",
+            "\n\n    fun foo3() {",
+            "\n        val foo4 = \"foo4\"",
+        )
+    }
+
+    @Test
+    fun `Given some line containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
+        val code =
+            """
+            class Foo1 {
+                val foo2 = "foo2"
+
+                fun foo3() {
+                    val foo4 = "foo4"
+                }
+            }
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .firstChildLeafOrSelf()
+                .leaves()
+                .filter { it.elementType == IDENTIFIER }
+                .map { newLine ->
+                    newLine.lineLengthWithoutNewlinePrefix()
+                }.toList()
+
+        assertThat(actual).contains(
+            "class Foo1 {".length,
+            "    val foo2 = \"foo2\"".length,
+            "    fun foo3() {".length,
+            "        val foo4 = \"foo4\"".length,
+        )
+    }
+
     private inline fun String.transformAst(block: FileASTNode.() -> Unit): FileASTNode =
         transformCodeToAST(this)
             .apply(block)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
@@ -23,6 +23,13 @@ public class Code private constructor(
             fileName.orEmpty()
         }
 
+    public fun filePathOrStdin(): String =
+        if (isStdIn) {
+            STDIN_FILE
+        } else {
+            filePath?.pathString.orEmpty()
+        }
+
     public companion object {
         /**
          * Create [Code] from a [file] containing valid Kotlin code or script. The '.editorconfig' files on the path to [file] are taken

--- a/ktlint-ruleset-standard/build.gradle.kts
+++ b/ktlint-ruleset-standard/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
     api(projects.ktlintRuleEngineCore)
 
     testImplementation(projects.ktlintTest)
+    testRuntimeOnly(libs.logback)
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
@@ -40,6 +41,7 @@ public class BlankLineBeforeDeclarationRule :
     ) {
         when (node.elementType) {
             CLASS,
+            CLASS_INITIALIZER,
             FUN,
             PROPERTY,
             PROPERTY_ACCESSOR,
@@ -110,10 +112,11 @@ public class BlankLineBeforeDeclarationRule :
             return
         }
 
-        (node.psi as KtDeclaration)
-            .firstChild
-            .node
-            .takeIf {
+        node
+            .takeIf { it.psi is KtDeclaration }
+//        (node.psi as KtDeclaration)
+//            .node
+            ?.takeIf {
                 val prevLeaf = it.prevLeaf()
                 prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))
             }?.let { insertBeforeNode ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -1,27 +1,33 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_ACCESSOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.psiUtil.siblings
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtFunctionLiteral
 
 /**
- * Insert a blank line before declarations. No blank line is inserted before between the class signature and the first declaration in the
- * class. Also, no blank lines are inserted between consecutive properties.
+ * Insert a blank line before declarations. No blank line is inserted before between a class or method signature and the first declaration
+ * in the class or method respectively. Also, no blank lines are inserted between consecutive properties.
  */
 public class BlankLineBeforeDeclarationRule :
     StandardRule("blank-line-before-declaration"),
@@ -47,9 +53,34 @@ public class BlankLineBeforeDeclarationRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        if (node == node.firstCodeSiblingInClassBodyOrNull()) {
-            // Allow missing blank line between class signature and first code sibling in class body:
-            //   Class Foo {
+        if (node.isFirstCodeSiblingInClassBody()) {
+            // No blank line between class signature and first declaration in class body:
+            //   class Foo {
+            //      fun bar() {}
+            //   }
+            //   class Foo {
+            //      class bar
+            //   }
+            return
+        }
+
+        if (node.isFirstCodeSiblingInBlock()) {
+            // No blank line between opening brace of block and first code sibling in class body:
+            //   fun foo() {
+            //      class Bar
+            //   }
+            //   val foo = {
+            //      fun bar() {}
+            //   }
+            return
+        }
+
+        if (node.isFirstCodeSiblingInBodyOfFunctionLiteral()) {
+            // No blank line between opening brace of function literal and declaration as first code sibling:
+            //   val foo = {
+            //      fun bar() {}
+            //   }
+            //   val foo = { _ ->
             //      fun bar() {}
             //   }
             return
@@ -71,29 +102,53 @@ public class BlankLineBeforeDeclarationRule :
             return
         }
 
-        node
-            .siblings(false)
-            .takeWhile { it.isWhiteSpace() || it.isPartOfComment() }
-            .lastOrNull()
-            ?.let { previous ->
-                when {
-                    !previous.isWhiteSpace() -> previous
-                    !previous.text.startsWith("\n\n") -> node
-                    else -> null
-                }?.let { insertBeforeNode ->
-                    emit(insertBeforeNode.startOffset, "Expected a blank line for this declaration", true)
-                    if (autoCorrect) {
-                        insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent()))
-                    }
+        if (node.elementType == PROPERTY && node.treeParent.elementType == WHEN) {
+            // Allow:
+            //   when(val foo = foo()) {
+            //       ...
+            //   }
+            return
+        }
+
+        (node.psi as KtDeclaration)
+            .firstChild
+            .node
+            .takeIf {
+                val prevLeaf = it.prevLeaf()
+                prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))
+            }?.let { insertBeforeNode ->
+                emit(insertBeforeNode.startOffset, "Expected a blank line for this declaration", true)
+                if (autoCorrect) {
+                    insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent()))
                 }
             }
     }
 
-    private fun ASTNode.firstCodeSiblingInClassBodyOrNull() =
-        treeParent
-            .takeIf { it.elementType == ElementType.CLASS_BODY }
-            ?.findChildByType(LBRACE)
-            ?.nextCodeSibling()
+    private fun ASTNode.isFirstCodeSiblingInClassBody() =
+        this ==
+            treeParent
+                .takeIf { it.elementType == CLASS_BODY }
+                ?.findChildByType(LBRACE)
+                ?.nextCodeSibling()
+
+    private fun ASTNode.isFirstCodeSiblingInBlock() =
+        this ==
+            treeParent
+                .takeIf { it.elementType == BLOCK }
+                ?.findChildByType(LBRACE)
+                ?.nextCodeSibling()
+
+    private fun ASTNode.isFirstCodeSiblingInBodyOfFunctionLiteral() =
+        this ==
+            treeParent
+                .takeIf { it.elementType == BLOCK && it.treeParent.elementType == FUNCTION_LITERAL }
+                ?.treeParent
+                ?.psi
+                ?.safeAs<KtFunctionLiteral>()
+                ?.bodyExpression
+                ?.node
+                ?.children()
+                ?.firstOrNull { !it.isWhiteSpace() && !it.isPartOfComment() }
 
     private fun ASTNode.isConsecutiveProperty() =
         takeIf { it.propertyRelated() }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -212,7 +212,7 @@ public class StringTemplateIndentRule :
                         }
                     if (currentIndent.contains(wrongIndentChar)) {
                         checkAndFixWrongIndentationChar(
-                            it = it,
+                            node = it,
                             oldIndent = currentIndent,
                             newIndent = newIndent,
                             newContent = currentContent,
@@ -249,15 +249,15 @@ public class StringTemplateIndentRule :
                 true,
             )
             if (autoCorrect) {
-                (firstNodeAfterOpeningQuotes as LeafPsiElement).rawReplaceWithText(
-                    "\n" + indent + firstNodeAfterOpeningQuotes.text,
+                (firstNodeAfterOpeningQuotes as LeafPsiElement).rawInsertBeforeMe(
+                    LeafPsiElement(REGULAR_STRING_PART, "\n" + indent),
                 )
             }
         }
     }
 
     private fun checkAndFixWrongIndentationChar(
-        it: ASTNode,
+        node: ASTNode,
         oldIndent: String,
         newIndent: String,
         newContent: String,
@@ -265,12 +265,12 @@ public class StringTemplateIndentRule :
         autoCorrect: Boolean,
     ) {
         emit(
-            it.startOffset + oldIndent.indexOf(wrongIndentChar),
+            node.startOffset + oldIndent.indexOf(wrongIndentChar),
             "Unexpected '$wrongIndentDescription' character(s) in margin of multiline string",
             true,
         )
         if (autoCorrect) {
-            (it.firstChildNode as LeafPsiElement).rawReplaceWithText(
+            (node.firstChildNode as LeafPsiElement).rawReplaceWithText(
                 newIndent + newContent,
             )
         }
@@ -316,8 +316,8 @@ public class StringTemplateIndentRule :
                 true,
             )
             if (autoCorrect) {
-                (lastNodeBeforeClosingQuotes as LeafPsiElement).rawReplaceWithText(
-                    lastNodeBeforeClosingQuotes.text + "\n" + indent,
+                (lastNodeBeforeClosingQuotes as LeafPsiElement).rawInsertAfterMe(
+                    LeafPsiElement(REGULAR_STRING_PART, "\n" + indent),
                 )
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -546,7 +546,18 @@ public class WrappingRule :
             return
         }
         if (noNewLineInClosedRange(previousCodeLeaf, nextCodeLeaf)) {
-            requireNewlineAfterLeaf(node, autoCorrect, emit, indent = previousCodeLeaf.indent())
+            requireNewlineAfterLeaf(node, autoCorrect, emit, previousCodeLeaf.indent())
+            node
+                .treeParent
+                .takeIf { it.elementType == BLOCK }
+                ?.let { block ->
+                    beforeVisitBlock(block, autoCorrect, emit)
+                    block
+                        .treeParent
+                        .takeIf { it.elementType == FUNCTION_LITERAL }
+                        ?.findChildByType(ARROW)
+                        ?.let { arrow -> rearrangeArrow(arrow, autoCorrect, emit) }
+                }
         }
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -54,6 +54,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.hasNewLineInClosedRange
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
@@ -151,52 +152,52 @@ public class WrappingRule :
     ) {
         require(node.elementType == BLOCK)
 
-        val startOfBlock = node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
-        if (startOfBlock?.elementType != LBRACE) {
+        val lbrace =
+            node
+                .getStartOfBlock()
+                ?.takeIf { it.elementType == LBRACE }
+                ?: return
+        if (lbrace.followedByNewline() ||
+            lbrace.followedByEolComment() ||
+            lbrace.isPartOf(LONG_STRING_TEMPLATE_ENTRY)
+        ) {
+            // String template inside raw string literal may exceed the maximum line length
             return
         }
-        val blockIsPrecededByWhitespaceContainingNewline = startOfBlock.nextLeaf().isWhiteSpaceWithNewline()
-        val endOfBlock = node.lastChildLeafOrSelf().nextLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
-        val blockIsFollowedByWhitespaceContainingNewline = endOfBlock?.prevLeaf().isWhiteSpaceWithNewline()
-        val wrapBlock =
-            when {
-                startOfBlock.isPartOf(LONG_STRING_TEMPLATE_ENTRY) -> {
-                    // String template inside raw string literal may exceed the maximum line length
-                    false
+
+        node
+            .takeUnless { it.firstChildLeafOrSelf().elementType == EOL_COMMENT }
+            ?.getEndOfBlock()
+            ?.takeIf { it.elementType == RBRACE }
+            ?.let { rbrace ->
+                if (hasNewLineInClosedRange(lbrace, rbrace)) {
+                    requireNewlineAfterLeaf(lbrace, autoCorrect, emit)
                 }
-                blockIsPrecededByWhitespaceContainingNewline -> false
-                node.textContains('\n') || blockIsFollowedByWhitespaceContainingNewline -> {
-                    // A multiline block should always be wrapped unless it starts with an EOL comment
-                    node.firstChildLeafOrSelf().elementType != EOL_COMMENT
-                }
-                maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF -> {
-                    val lengthUntilBeginOfLine =
-                        node
-                            .leaves(false)
-                            .takeWhile { !it.isWhiteSpaceWithNewline() }
-                            .sumOf { it.textLength }
-                    val lengthUntilEndOfLine =
-                        node
-                            .firstChildLeafOrSelf()
-                            .leavesIncludingSelf()
-                            .takeWhile { !it.isWhiteSpaceWithNewline() }
-                            .sumOf { it.textLength }
-                    lengthUntilBeginOfLine + lengthUntilEndOfLine > maxLineLength
-                }
-                else -> false
             }
-        if (wrapBlock) {
-            startOfBlock
-                .takeIf { !it.nextLeaf().isWhiteSpaceWithNewline() }
-                ?.let { leafNodeBeforeBlock ->
-                    requireNewlineAfterLeaf(
-                        leafNodeBeforeBlock,
-                        autoCorrect,
-                        emit,
-                    )
-                }
+
+        if (maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF) {
+            val lengthUntilBeginOfLine =
+                node
+                    .leaves(false)
+                    .takeWhile { !it.isWhiteSpaceWithNewline() }
+                    .sumOf { it.textLength }
+            val lengthUntilEndOfLine =
+                node
+                    .firstChildLeafOrSelf()
+                    .leavesIncludingSelf()
+                    .takeWhile { !it.isWhiteSpaceWithNewline() }
+                    .sumOf { it.textLength }
+            if (lengthUntilBeginOfLine + lengthUntilEndOfLine > maxLineLength) {
+                requireNewlineAfterLeaf(lbrace, autoCorrect, emit)
+            }
         }
     }
+
+    private fun ASTNode.followedByEolComment() =
+        null !=
+            leaves()
+                .takeWhile { it.isWhiteSpaceWithoutNewline() || it.elementType == EOL_COMMENT }
+                .firstOrNull { it.elementType == EOL_COMMENT }
 
     private fun rearrangeBlock(
         node: ASTNode,
@@ -670,27 +671,54 @@ public class WrappingRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         if (node.elementType == BLOCK) {
-            val startOfBlock = node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
-            if (startOfBlock?.elementType != LBRACE) {
-                return
-            }
-            val blockIsPrecededByWhitespaceContainingNewline = startOfBlock.nextLeaf().isWhiteSpaceWithNewline()
-            val endOfBlock = node.lastChildLeafOrSelf().nextLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
-            val blockIsFollowedByWhitespaceContainingNewline = endOfBlock?.prevLeaf().isWhiteSpaceWithNewline()
-            val wrapBlock =
-                !blockIsFollowedByWhitespaceContainingNewline && (
-                    blockIsPrecededByWhitespaceContainingNewline || node.textContains('\n')
-                    )
-            if (wrapBlock && endOfBlock != null) {
-                requireNewlineBeforeLeaf(
-                    endOfBlock,
-                    autoCorrect,
-                    emit,
-                    indentConfig.parentIndentOf(node),
-                )
-            }
+            val lbrace =
+                node
+                    .getStartOfBlock()
+                    ?.takeIf { it.elementType == LBRACE }
+                    ?: return
+            node
+                .getEndOfBlock()
+                ?.takeUnless { it.isPrecededByNewline() }
+                ?.let { rbrace ->
+                    if (hasNewLineInClosedRange(lbrace, rbrace)) {
+                        requireNewlineBeforeLeaf(
+                            rbrace,
+                            autoCorrect,
+                            emit,
+                            indentConfig.parentIndentOf(node),
+                        )
+                    }
+                }
         }
     }
+
+    private fun ASTNode.followedByNewline() = nextLeaf().isWhiteSpaceWithNewline()
+
+    private fun ASTNode.isPrecededByNewline() = prevLeaf().isWhiteSpaceWithNewline()
+
+    private fun ASTNode.getStartOfBlock() =
+        firstChildLeafOrSelf()
+            .let { node ->
+                if (node.elementType == LBRACE) {
+                    // WHEN-entry block have LBRACE and RBRACE as first and last elements
+                    node
+                } else {
+                    // Other blocks have LBRACE and RBRACE as siblings of the block
+                    node.prevLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+                }
+            }
+
+    private fun ASTNode.getEndOfBlock() =
+        lastChildLeafOrSelf()
+            .let { node ->
+                if (node.elementType == RBRACE && treeParent.elementType != FUNCTION_LITERAL) {
+                    // WHEN-entry block have LBRACE and RBRACE as first and last elements
+                    node
+                } else {
+                    // Other blocks have LBRACE and RBRACE as siblings of the block
+                    node.nextLeaf { !it.isPartOfComment() && !it.isWhiteSpace() }
+                }
+            }
 
     private companion object {
         private val LTOKEN_SET = TokenSet.create(LPAR, LBRACE, LBRACKET, LT)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -576,7 +576,7 @@ class ArgumentListWrappingRuleTest {
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code)
             // TODO:to be fixed by https://github.com/pinterest/ktlint/issues/1861
-            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 44)
+            .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 45)
             .hasNoLintViolations()
     }
 
@@ -838,5 +838,24 @@ class ArgumentListWrappingRuleTest {
                 LintViolation(8, 122, "Missing newline before \")\""),
             )
             .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a property assignment with a binary expression for which the left hand side operator is a function call`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER         $EOL_CHAR
+            val foo1 = foobar(foo * bar) + "foo"
+            val foo2 = foobar("foo", foo * bar) + "foo"
+            val foo3 = foobar("fooo", foo * bar) + "foo"
+            """.trimIndent()
+        argumentListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { BinaryExpressionWrappingRule() }
+            .addAdditionalRuleProvider { WrappingRule() }
+            // Although the argument-list-wrapping runs before binary-expression-wrapping, it may not wrap the argument values of a
+            // function call in case that call is part of a binary expression. It might be better to break the line at the operation
+            // reference instead.
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERT
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class BlankLineBeforeDeclarationRuleTest {
@@ -244,15 +245,77 @@ class BlankLineBeforeDeclarationRuleTest {
             .hasNoLintViolations()
     }
 
-    @Test
-    fun `Given a function as first code sibling inside a class body then do not insert a blank line between the class signature and this function`() {
-        val code =
-            """
-            class Foo {
-                fun Bar() {}
-            }
-            """.trimIndent()
-        blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+    @Nested
+    inner class `Given some nested declaration` {
+        @Test
+        fun `Given a class as first code sibling inside a class body then do not insert a blank line between the class signature and this function`() {
+            val code =
+                """
+                class Foo {
+                    class Bar
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function as first code sibling inside a class body then do not insert a blank line between the class signature and this function`() {
+            val code =
+                """
+                class Foo {
+                    fun bar() {}
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class as first code sibling inside a function body then do not insert a blank line between the class signature and this function`() {
+            val code =
+                """
+                fun foo() {
+                    class Bar
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function as first code sibling inside a function body then do not insert a blank line between the class signature and this function`() {
+            val code =
+                """
+                fun foo() {
+                    fun bar() {}
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function as first code sibling inside a function literal without parameters then do not insert a blank line the declaration`() {
+            val code =
+                """
+                val foo = {
+                    fun bar() {}
+
+                    bar()
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a function as first code sibling inside a function literal with parameters then do not insert a blank line the declaration`() {
+            val code =
+                """
+                val foo = { _ ->
+                    fun bar() {}
+
+                    bar()
+                }
+                """.trimIndent()
+            blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+        }
     }
 
     @Test
@@ -280,17 +343,6 @@ class BlankLineBeforeDeclarationRuleTest {
                 bar()
                 val bar = "bar"
             }
-            """.trimIndent()
-        blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `xx`() {
-        val code =
-            """
-            fun foo(
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-            ) {}
             """.trimIndent()
         blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
     }
@@ -342,5 +394,31 @@ class BlankLineBeforeDeclarationRuleTest {
                 LintViolation(10, 5, "Expected a blank line for this declaration"),
                 LintViolation(12, 5, "Expected a blank line for this declaration"),
             ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class followed by EOL comment followed by a class`() {
+        val code =
+            """
+            class Foo
+            // Some comment
+
+            class Bar
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a when statement with a property declaration `() {
+        val code =
+            """
+            val foo =
+                when (val foobar = FooBar()) {
+                    is Bar -> foobar.bar()
+                    is Foo -> foobar.foo()
+                    else -> foobar
+                }
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
@@ -409,7 +409,7 @@ class BlankLineBeforeDeclarationRuleTest {
     }
 
     @Test
-    fun `Given a when statement with a property declaration `() {
+    fun `Given a when statement with a property declaration`() {
         val code =
             """
             val foo =
@@ -420,5 +420,31 @@ class BlankLineBeforeDeclarationRuleTest {
                 }
             """.trimIndent()
         blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a class with a class initializer after another declaration`() {
+        val code =
+            """
+            class Foo {
+                val foo = "foo"
+                init {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo {
+                val foo = "foo"
+
+                init {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code)
+            .hasLintViolation(3, 5, "Expected a blank line for this declaration")
+            .isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
@@ -208,4 +208,34 @@ class IfElseWrappingRuleTest {
                 .hasLintViolationWithoutAutoCorrect(2, 26, "A single line if-statement should be kept simple. The 'ELSE' may not be wrapped in a block.")
         }
     }
+
+    @Test
+    fun `Given an if-else with empty branches`() {
+        val code =
+            """
+            val foo = if (true) {
+            } else {
+            }
+            """.trimIndent()
+        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an if-else statement inside a string template which is correctly indented then do not report a violation`() {
+        val code =
+            """
+            fun foo() {
+                logger.log(
+                    "<-- ${'$'}{if (true)
+                        ""
+                    else
+                        ' ' +
+                            "bar"}",
+                )
+            }
+            """.trimIndent()
+        @Suppress("ktlint:argument-list-wrapping", "ktlint:max-line-length")
+        ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -522,6 +522,20 @@ class ParameterListWrappingRuleTest {
         parameterListWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
+    @Test
+    fun `Given a multiline type argument list in a class property`() {
+        val code =
+            """
+            data class FooBar(
+                public val fooBar: List<
+                    Foo,
+                    Bar
+                    >,
+            )
+            """.trimIndent()
+        parameterListWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
     @Nested
     inner class `Issue 1255 - Given a variable declaration for nullable function type` {
         @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -2543,9 +2543,8 @@ internal class WrappingRuleTest {
             wrappingRuleAssertThat(code)
                 .addAdditionalRuleProvider { NoSemicolonsRule() }
                 .addAdditionalRuleProvider { IndentationRule() }
-                .hasLintViolations(
-                    LintViolation(3, 22, "Missing newline after \";\""),
-                ).isFormattedAs(formattedCode)
+                .hasLintViolation(3, 22, "Missing newline after \";\"")
+                .isFormattedAs(formattedCode)
         }
 
         @Test
@@ -2568,10 +2567,67 @@ internal class WrappingRuleTest {
             wrappingRuleAssertThat(code)
                 .addAdditionalRuleProvider { NoSemicolonsRule() }
                 .addAdditionalRuleProvider { IndentationRule() }
+                .hasLintViolation(3, 39, "Missing newline after \";\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line when entry block containing multiple statements then reformat block after wrapping the statement`() {
+            val code =
+                """
+                val foo =
+                    when (value) {
+                        0 -> { foo(); true }
+                        else -> { bar(); false }
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo =
+                    when (value) {
+                        0 -> {
+                            foo()
+                            true
+                        }
+                        else -> {
+                            bar()
+                            false
+                        }
+                    }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { NoSemicolonsRule() }
+                .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
-                    LintViolation(3, 39, "Missing newline after \";\""),
+                    LintViolation(3, 22, "Missing newline after \";\""),
+                    LintViolation(4, 25, "Missing newline after \";\""),
                 ).isFormattedAs(formattedCode)
         }
+    }
+
+    @Test
+    fun `Given a lambda expression containing a function literal`() {
+        val code =
+            """
+            val foo = {
+                Foo { "foo" }
+            }
+            """.trimIndent()
+        wrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `if else with comments after curly braces`() {
+        val code =
+            """
+            val foo =
+                if (true) { // comment 1
+                    "foo"
+                } else { // comment 2
+                    "bar"
+                }
+            """.trimIndent()
+        wrappingRuleAssertThat(code).hasNoLintViolations()
     }
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -2522,6 +2522,56 @@ internal class WrappingRuleTest {
                     .hasNoLintViolations()
             }
         }
+
+        @Test
+        fun `Given a single line block containing multiple statements then reformat block after wrapping the statement`() {
+            val code =
+                """
+                val fooBar =
+                    fooBar()
+                        .map { foo(); bar() }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val fooBar =
+                    fooBar()
+                        .map {
+                            foo()
+                            bar()
+                        }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { NoSemicolonsRule() }
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasLintViolations(
+                    LintViolation(3, 22, "Missing newline after \";\""),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line lambda expression containing multiple statements then reformat block after wrapping the statement`() {
+            val code =
+                """
+                val fooBar =
+                    fooBar()
+                        .map { foo, bar -> print(foo); print(bar) }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val fooBar =
+                    fooBar()
+                        .map { foo, bar ->
+                            print(foo)
+                            print(bar)
+                        }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { NoSemicolonsRule() }
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasLintViolations(
+                    LintViolation(3, 39, "Missing newline after \";\""),
+                ).isFormattedAs(formattedCode)
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Run format up to 3 times in case formatting introduces changes which also can be autocorrected

Closes #2084

The change above, resulted in the discovery of some problems wich are resolved as well:
* Do not require a blank line between the class/method signature and a nested declaration in rule blank-line-before-declaration.
* Allow branches with empty blocks in if-else.
* Emit violation which can not be autocorrected in case wrapping the operator reference in a binary expression would still violate the max-line-length.
* Only emit violation in if-else-wrapping rule in case a newline is missing. An incorrect indent should not lead to a violation about a missing newline.
* Swap the order in which the binary-expression-wrapping and argument-list-wrapping rules run. Binary expressions containing call expressions, or vice versa, are not autocorrected as it needs manual intervention whether it is better to wrap the operation reference or the argument value.

Integration test fixes:
* Fix a bug, introduced in #2050, causing an internal error. In #2050 a when entry condition was simplified as it was not triggered by unit tests. The method hasTypeParameterListInFront incorrectly checked whether a multiline parameter type list was associated with a function
* If a single line block or function literal contains multiple statements then wrap the first statement of that block or functional literal as well
* Fix wrapping of multiple statements on same line
-- Add reference to changelog for initial implementation
-- Wrap function literal containing multiple statements on same line
-- Wrap when entry blocks containing multiple statements on same line

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [X] KtLint has been applied on source code itself and violations are fixed
- [X] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
