### PR TITLE
Inform user about using `--format` option of KtLint CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Add new experimental rule `statement-wrapping` which ensures function, class, or other blocks statement body doesn't start or end at starting or ending braces of the block ([#1938](https://github.com/pinterest/ktlint/issues/1938))
 * Add new experimental rule `blank-line-before-declaration`. This rule requires a blank line before class, function or property declarations ([#1939](https://github.com/pinterest/ktlint/issues/1939))
 * Wrap multiple statements on same line `wrapping` ([#1078](https://github.com/pinterest/ktlint/issues/1078))
-
+* Inform user about using `--format` option of KtLint CLI when finding a violation that can be autocorrected ([#1071](https://github.com/pinterest/ktlint/issues/1071))
 
 ### Removed
 

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -79,6 +79,24 @@ class SimpleCLITest {
     }
 
     @Test
+    fun `Given some code with an error then return from lint with the error exit code and warning to use --format`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                "too-many-empty-lines",
+                listOf("**/*.test"),
+            ) {
+                SoftAssertions().apply {
+                    assertErrorExitCode()
+                    assertThat(normalOutput)
+                        .containsLineMatching(Regex(".* WARN .* Lint has found errors than can be autocorrected using 'ktlint --format'"))
+                }.assertAll()
+            }
+    }
+
+    @Test
     fun `Given some code with an error but a glob which does not select the file`(
         @TempDir
         tempDir: Path,


### PR DESCRIPTION
## Description

Inform user about using `--format` option of KtLint CLI when finding a violation that can be autocorrected

Closes #1071

## Checklist

<!-- Following checklist may be skipped in some cases -->
- [X] PR description added
- [X] tests are added
- [ ] KtLint has been applied on source code itself and violations are fixed
- [ ] [documentation](https://pinterest.github.io/ktlint/) is updated
- [X] `CHANGELOG.md` is updated

In case of adding a new rule:
- [ ] Rule is added to [rules documentation](https://pinterest.github.io/ktlint/rules/standard/)
