### PR TITLE
Fix indent when property value is wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ At this point in time, it is not yet decided what the next steps will be. Ktlint
 * Ignore property with name `serialVersionUID` in `property-naming` ([#2045](https://github.com/pinterest/ktlint/issues/2045))
 * Prevent incorrect reporting of violations in case a nullable function type reference exceeds the maximum line length `parameter-list-wrapping` ([#1324](https://github.com/pinterest/ktlint/issues/1324)) 
 * Prevent false negative on `else` branch when body contains only chained calls or binary expression ([#2057](https://github.com/pinterest/ktlint/issues/2057))
+* Fix indent when property value is wrapped to next line ([#2095](https://github.com/pinterest/ktlint/issues/2095)) 
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
@@ -146,7 +146,7 @@ public class PropertyWrappingRule :
         )
         LOGGER.trace { "$line: " + ((if (!autoCorrect) "would have " else "") + "inserted newline before ${node.text}") }
         if (autoCorrect) {
-            node.upsertWhitespaceBeforeMe(node.indent())
+            node.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
@@ -24,7 +24,6 @@ internal class PropertyWrappingRuleTest {
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolation(2, 34, "Missing newline after \":\"")
             .isFormattedAs(formattedCode)
     }
@@ -46,7 +45,6 @@ internal class PropertyWrappingRuleTest {
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolation(2, 30, "Missing newline before \"TypeWithALongName\"")
             .isFormattedAs(formattedCode)
     }
@@ -69,7 +67,6 @@ internal class PropertyWrappingRuleTest {
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolations(
                 LintViolation(2, 50, "Missing newline after \"=\""),
                 LintViolation(3, 49, "Missing newline before \"TypeWithALongName(123)\""),
@@ -93,7 +90,6 @@ internal class PropertyWrappingRuleTest {
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolation(2, 50, "Missing newline before \"TypeWithALongName(123)\"")
             .isFormattedAs(formattedCode)
     }


### PR DESCRIPTION
## Description

Fix indent when property value is wrapped

Closes #2095

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
