### PR TITLE
Add property to disable ktlint for a glob in '.editorconfig'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Allow to disable ktlint in `.editorconfig` for a glob ([#2100](https://github.com/pinterest/ktlint/issues/2100))
+
 ### Changed
 
 ## [0.50.0] - 2023-06-29

--- a/documentation/release-latest/docs/faq.md
+++ b/documentation/release-latest/docs/faq.md
@@ -154,3 +154,16 @@ ij_formatter_on_tag = some-custom-on-tag # Defaults to '@formatter:on'
 ```
 
 When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags.
+
+# How do I disable ktlint for generated code?
+
+Running ktlint on generated code is not useful. Fixing lint and format errors on generated code is a waste of time as errors will be re-introduced once that code is generated again. Given that generated code is located in a separate directory, you can disable ktlint for such directory by adding a glob for that directory:
+```editorconfig
+[some/path/to/generated/code/**/*]
+ktlint = disabled
+```
+
+!!! warning
+    The `ec4j` library used by ktlint does not seem to work with globs starting with `**` followed by a chain of multiple directories (for example `**/path/to/generated/**/*`). But both `some/path/to/generated/**/*` and `**/generated/**/*` work fine.
+
+

--- a/documentation/snapshot/docs/faq.md
+++ b/documentation/snapshot/docs/faq.md
@@ -154,3 +154,16 @@ ij_formatter_on_tag = some-custom-on-tag # Defaults to '@formatter:on'
 ```
 
 When enabled, the ktlint rule checking is disabled for all code surrounded by the formatter tags.
+
+# How do I disable ktlint for generated code?
+
+Running ktlint on generated code is not useful. Fixing lint and format errors on generated code is a waste of time as errors will be re-introduced once that code is generated again. Given that generated code is located in a separate directory, you can disable ktlint for such directory by adding a glob for that directory:
+```editorconfig
+[some/path/to/generated/code/**/*]
+ktlint = disabled
+```
+
+!!! warning
+    The `ec4j` library used by ktlint does not seem to work with globs starting with `**` followed by a chain of multiple directories (for example `**/path/to/generated/**/*`). But both `some/path/to/generated/**/*` and `**/generated/**/*` work fine.
+
+

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/RuleExecutionEditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/RuleExecutionEditorConfigProperty.kt
@@ -20,6 +20,18 @@ public val RULE_EXECUTION_PROPERTY_TYPE: PropertyType.LowerCasingPropertyType<Ru
     )
 
 /**
+ * When disabled, no ktlint rules are executed. This property can be used to disable all rulesets (including internal rules) for a given
+ * glob in the '.editorconfig'.
+ */
+public val ALL_RULES_EXECUTION_PROPERTY: EditorConfigProperty<RuleExecution> =
+    EditorConfigProperty(
+        // Explicitly name the rule as multiple properties exists for this property type
+        name = "ktlint",
+        type = RULE_EXECUTION_PROPERTY_TYPE,
+        defaultValue = RuleExecution.enabled,
+    )
+
+/**
  * When enabled, a rule that implements interface "Rule.Experimental" is executed unless that rule itself is explicitly disabled.
  */
 public val EXPERIMENTAL_RULES_EXECUTION_PROPERTY: EditorConfigProperty<RuleExecution> =

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilter.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ALL_RULES_EXECUTION_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EXPERIMENTAL_RULES_EXECUTION_PROPERTY
@@ -24,16 +25,22 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 internal class RuleExecutionRuleFilter(
     private val editorConfig: EditorConfig,
 ) : RuleFilter {
-    override fun filter(ruleProviders: Set<RuleProvider>): Set<RuleProvider> {
-        val ruleExecutionFilter =
-            RuleExecutionFilter(
-                editorConfig.ruleExecutionProperties(ruleProviders),
-                editorConfig[CODE_STYLE_PROPERTY],
-            )
-        return ruleProviders
-            .filter { ruleExecutionFilter.isEnabled(it) }
-            .toSet()
-    }
+    override fun filter(ruleProviders: Set<RuleProvider>): Set<RuleProvider> =
+        if (disableKtlintEntirely()) {
+            emptySet()
+        } else {
+            val ruleExecutionFilter =
+                RuleExecutionFilter(
+                    editorConfig.ruleExecutionProperties(ruleProviders),
+                    editorConfig[CODE_STYLE_PROPERTY],
+                )
+            ruleProviders
+                .filter { ruleExecutionFilter.isEnabled(it) }
+                .toSet()
+        }
+
+    private fun disableKtlintEntirely() =
+        editorConfig.getEditorConfigValueOrNull(RULE_EXECUTION_PROPERTY_TYPE, ALL_RULES_EXECUTION_PROPERTY.name) == RuleExecution.disabled
 
     private fun EditorConfig.ruleExecutionProperties(ruleProviders: Set<RuleProvider>): Map<String, RuleExecution> {
         val ruleExecutionPropertyNames =

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ALL_RULES_EXECUTION_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RULE_EXECUTION_PROPERTY_TYPE
@@ -176,6 +177,21 @@ class RuleExecutionRuleFilterTest {
         assertThat(actual).containsExactly(KTLINT_SUPPRESSION_RULE_ID)
     }
 
+    @Test
+    fun `Given that ktlint is disabled entirely then the internal rule for migrating the ktlint-disable directives is disabled`() {
+        val actual =
+            runWithRuleExecutionRuleFilter(
+                RuleProvider { NormalRule(STANDARD_RULE_A) },
+                RuleProvider { KtlintSuppressionRule(listOf(STANDARD_RULE_A)) },
+                editorConfig =
+                    EditorConfig(
+                        ktLintDisableAllRuleExecutionEditorConfigProperty(),
+                    ),
+            ).toRuleIds()
+
+        assertThat(actual).isEmpty()
+    }
+
     /**
      * Create a [RuleExecutionRuleFilter] for a given set of [RuleProvider]s and an [EditorConfig].
      */
@@ -190,6 +206,14 @@ class RuleExecutionRuleFilterTest {
         )
 
     private fun Set<RuleProvider>.toRuleIds() = map { it.ruleId }
+
+    private fun ktLintDisableAllRuleExecutionEditorConfigProperty() =
+        Property
+            .builder()
+            .type(RULE_EXECUTION_PROPERTY_TYPE)
+            .name(ALL_RULES_EXECUTION_PROPERTY.name)
+            .value(RuleExecution.disabled.name)
+            .build()
 
     private fun ktLintRuleExecutionEditorConfigProperty(
         ktlintRuleExecutionPropertyName: String,


### PR DESCRIPTION
## Description

Add property to disable ktlint for a glob in '.editorconfig'

This property makes it convenient to disable ktlint entirely for generated code by setting the property on globs related to the generated code.

Closes #2100

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
