### PR TITLE
Fix indent of explicit constructor

### DIFF
--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -159,10 +159,11 @@ class ASTNodeExtensionTest {
                 """.trimIndent()
             val enumClass = code.transformAst(::toEnumClassSequence)
 
-            val actual = hasNewLineInClosedRange(
-                enumClass.first { it.isWhiteSpaceWithNewline() },
-                enumClass.last()
-            )
+            val actual =
+                hasNewLineInClosedRange(
+                    enumClass.first { it.isWhiteSpaceWithNewline() },
+                    enumClass.last(),
+                )
 
             assertThat(actual).isTrue
         }
@@ -193,10 +194,11 @@ class ASTNodeExtensionTest {
                 """.trimIndent()
             val enumBodyClass = code.transformAst(::toEnumClassBodySequence)
 
-            val actual = hasNewLineInClosedRange(
-                enumBodyClass.first(),
-                enumBodyClass.last { it.isWhiteSpaceWithNewline() }
-            )
+            val actual =
+                hasNewLineInClosedRange(
+                    enumBodyClass.first(),
+                    enumBodyClass.last { it.isWhiteSpaceWithNewline() },
+                )
 
             assertThat(actual).isTrue
         }
@@ -644,9 +646,9 @@ class ASTNodeExtensionTest {
     private open class DummyRule(
         val block: (node: ASTNode) -> Unit = {},
     ) : Rule(
-        ruleId = RuleId("test:dummy-rule"),
-        about = About(),
-    ) {
+            ruleId = RuleId("test:dummy-rule"),
+            about = About(),
+        ) {
         override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -52,6 +52,36 @@ class ASTNodeExtensionTest {
         )
     }
 
+    @Test
+    fun `Given an enum class body then get all leaves in the closed range of the class body`() {
+        val code =
+            """
+            enum class Shape {
+                FOO, FOOBAR, BAR
+            }
+            """.trimIndent()
+        val enumClassBody = code.transformAst(::toEnumClassBodySequence)
+
+        val actual =
+            leavesInClosedRange(enumClassBody.first(), enumClassBody.last())
+                .map { it.text }
+                .toList()
+
+        assertThat(actual).containsExactly(
+            "{",
+            "\n    ",
+            "FOO",
+            ",",
+            " ",
+            "FOOBAR",
+            ",",
+            " ",
+            "BAR",
+            "\n",
+            "}",
+        )
+    }
+
     @Nested
     inner class NoNewLineInOpenRange {
         @Test
@@ -111,14 +141,9 @@ class ASTNodeExtensionTest {
         fun `Given an enum class with no whitespace leaf containing a newline between the first and last enum entry`() {
             val code =
                 """
-                enum class Shape {
-                    FOO, FOOBAR, BAR
-                }
+                enum class Shape { FOO, FOOBAR, BAR }
                 """.trimIndent()
-            val enumEntries =
-                code
-                    .transformAst(::toEnumClassBodySequence)
-                    .filter { it.elementType == ENUM_ENTRY }
+            val enumEntries = code.transformAst(::toEnumClassBodySequence)
 
             val actual = hasNewLineInClosedRange(enumEntries.first(), enumEntries.last())
 
@@ -129,12 +154,15 @@ class ASTNodeExtensionTest {
         fun `Given a range of nodes starting with a whitespace leaf containing a newline but other whitespace leaves not containing a newline`() {
             val code =
                 """
-                enum class Shape {
-                    FOO, FOOBAR, BAR } // Malformed on purpose for test
+                enum class Shape
+                    { FOO, FOOBAR, BAR } // Malformed on purpose for test
                 """.trimIndent()
-            val enumClassBody = code.transformAst(::toEnumClassBodySequence)
+            val enumClass = code.transformAst(::toEnumClassSequence)
 
-            val actual = hasNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+            val actual = hasNewLineInClosedRange(
+                enumClass.first { it.isWhiteSpaceWithNewline() },
+                enumClass.last()
+            )
 
             assertThat(actual).isTrue
         }
@@ -163,9 +191,12 @@ class ASTNodeExtensionTest {
                 enum class Shape { FOO, FOOBAR, BAR
                 } // Malformed on purpose for test
                 """.trimIndent()
-            val enumClassBody = code.transformAst(::toEnumClassBodySequence)
+            val enumBodyClass = code.transformAst(::toEnumClassBodySequence)
 
-            val actual = hasNewLineInClosedRange(enumClassBody.first(), enumClassBody.last())
+            val actual = hasNewLineInClosedRange(
+                enumBodyClass.first(),
+                enumBodyClass.last { it.isWhiteSpaceWithNewline() }
+            )
 
             assertThat(actual).isTrue
         }
@@ -598,6 +629,12 @@ class ASTNodeExtensionTest {
         fileASTNode
             .findChildByType(CLASS)
             ?.findChildByType(CLASS_BODY)
+            ?.children()
+            .orEmpty()
+
+    private fun toEnumClassSequence(fileASTNode: FileASTNode) =
+        fileASTNode
+            .findChildByType(CLASS)
             ?.children()
             .orEmpty()
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/InternalRule.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/InternalRule.kt
@@ -19,8 +19,8 @@ public open class InternalRule internal constructor(
     override val visitorModifiers: Set<VisitorModifier> = emptySet(),
     override val usesEditorConfigProperties: Set<EditorConfigProperty<*>> = emptySet(),
 ) : Rule(
-    ruleId = RuleId("internal:$id"),
-    visitorModifiers = visitorModifiers,
-    usesEditorConfigProperties = usesEditorConfigProperties,
-    about = INTERNAL_RULE_ABOUT,
-)
+        ruleId = RuleId("internal:$id"),
+        visitorModifiers = visitorModifiers,
+        usesEditorConfigProperties = usesEditorConfigProperties,
+        about = INTERNAL_RULE_ABOUT,
+    )

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -473,9 +473,9 @@ class KtLintTest {
 private open class DummyRule(
     val block: (node: ASTNode) -> Unit = {},
 ) : Rule(
-    ruleId = RuleId("test:dummy"),
-    about = About(),
-) {
+        ruleId = RuleId("test:dummy"),
+        about = About(),
+    ) {
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -536,10 +536,10 @@ private class SimpleTestRule(
     private val stopTraversalInAfterVisitChildNodes: (ASTNode) -> Boolean = { false },
     private val stopTraversalInAfterLastNode: Boolean = false,
 ) : Rule(
-    ruleId = ruleId,
-    about = About(),
-    visitorModifiers,
-) {
+        ruleId = ruleId,
+        about = About(),
+        visitorModifiers,
+    ) {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         ruleExecutionCalls.add(RuleExecutionCall(ruleId, BEFORE_FIRST))
         if (stopTraversalInBeforeFirstNode) {

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
@@ -450,10 +450,10 @@ class RuleProviderSorterTest {
         ruleId: RuleId,
         visitorModifiers: Set<VisitorModifier> = emptySet(),
     ) : Rule(
-        ruleId = ruleId,
-        about = About(),
-        visitorModifiers,
-    ) {
+            ruleId = ruleId,
+            about = About(),
+            visitorModifiers,
+        ) {
         constructor(ruleId: RuleId, visitorModifier: VisitorModifier) : this(ruleId, setOf(visitorModifier))
 
         override fun beforeVisitChildNodes(

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilterTest.kt
@@ -43,10 +43,10 @@ class InternalRuleProvidersFilterTest {
         ruleId: RuleId,
         visitorModifiers: Set<VisitorModifier> = emptySet(),
     ) : Rule(
-        ruleId = ruleId,
-        about = About(),
-        visitorModifiers,
-    ) {
+            ruleId = ruleId,
+            about = About(),
+            visitorModifiers,
+        ) {
         override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
@@ -363,10 +363,10 @@ class RunAfterRuleFilterTest {
         ruleId: RuleId,
         visitorModifiers: Set<VisitorModifier> = emptySet(),
     ) : Rule(
-        ruleId = ruleId,
-        about = About(),
-        visitorModifiers,
-    ) {
+            ruleId = ruleId,
+            about = About(),
+            visitorModifiers,
+        ) {
         constructor(ruleId: RuleId, visitorModifier: VisitorModifier) : this(ruleId, setOf(visitorModifier))
 
         override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRule.kt
@@ -21,8 +21,8 @@ public open class StandardRule internal constructor(
     override val visitorModifiers: Set<VisitorModifier> = emptySet(),
     override val usesEditorConfigProperties: Set<EditorConfigProperty<*>> = emptySet(),
 ) : Rule(
-    ruleId = RuleId("${RuleSetId.STANDARD.value}:$id"),
-    visitorModifiers = visitorModifiers,
-    usesEditorConfigProperties = usesEditorConfigProperties,
-    about = STANDARD_RULE_ABOUT,
-)
+        ruleId = RuleId("${RuleSetId.STANDARD.value}:$id"),
+        visitorModifiers = visitorModifiers,
+        usesEditorConfigProperties = usesEditorConfigProperties,
+        about = STANDARD_RULE_ABOUT,
+    )

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -674,11 +674,12 @@ public class IndentationRule :
                     //             bar2
                     //         ),
                     //         BarFoo1
-                    val prevCodeLeaf = startIndentContext(
-                        fromAstNode = comma,
-                        toAstNode = superTypeList.lastChildLeafOrSelf(),
-                        childIndent = indentConfig.indent.repeat(2),
-                    ).prevCodeLeaf()
+                    val prevCodeLeaf =
+                        startIndentContext(
+                            fromAstNode = comma,
+                            toAstNode = superTypeList.lastChildLeafOrSelf(),
+                            childIndent = indentConfig.indent.repeat(2),
+                        ).prevCodeLeaf()
                     startIndentContext(
                         fromAstNode = primaryConstructor.getPrecedingLeadingCommentsAndWhitespaces(),
                         toAstNode = prevCodeLeaf,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -215,11 +215,7 @@ public class IndentationRule :
                 )
 
             node.elementType == SUPER_TYPE_CALL_ENTRY -> {
-                if (codeStyle == ktlint_official &&
-                    node
-                        .parent { it.elementType == CLASS }
-                        ?.findChildByType(PRIMARY_CONSTRUCTOR) != null
-                ) {
+                if (codeStyle == ktlint_official && node.isPartOfClassWithAMultilinePrimaryConstructor()) {
                     // Contrary to the default IntelliJ IDEA formatter, indent the super type call entry so that it looks better in case it
                     // is followed by another super type:
                     //      class Foo(
@@ -370,6 +366,11 @@ public class IndentationRule :
             }
         }
     }
+
+    private fun ASTNode.isPartOfClassWithAMultilinePrimaryConstructor() =
+        parent { it.elementType == CLASS }
+            ?.findChildByType(PRIMARY_CONSTRUCTOR)
+            ?.textContains('\n') == true
 
     private fun visitValueArgument(node: ASTNode) {
         if (codeStyle == ktlint_official) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5021,9 +5021,9 @@ internal class IndentationRuleTest {
                         foo1: Foo1,
                         foo2: Foo2,
                     ) : Foobar(
-                        "foobar1",
-                        "foobar2",
-                    ) {
+                            "foobar1",
+                            "foobar2",
+                        ) {
                     fun foo() = "foo"
                 }
                 """.trimIndent()
@@ -5035,9 +5035,9 @@ internal class IndentationRuleTest {
                     LintViolation(4, 1, "Unexpected indentation (4) (should be 8)"),
                     LintViolation(5, 1, "Unexpected indentation (4) (should be 8)"),
                     LintViolation(6, 1, "Unexpected indentation (0) (should be 4)"),
-                    LintViolation(7, 1, "Unexpected indentation (4) (should be 8)"),
-                    LintViolation(8, 1, "Unexpected indentation (4) (should be 8)"),
-                    LintViolation(9, 1, "Unexpected indentation (0) (should be 4)"),
+                    LintViolation(7, 1, "Unexpected indentation (4) (should be 12)"),
+                    LintViolation(8, 1, "Unexpected indentation (4) (should be 12)"),
+                    LintViolation(9, 1, "Unexpected indentation (0) (should be 8)"),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -5053,7 +5053,9 @@ internal class IndentationRuleTest {
                 ) : Foobar1(
                     "foobar1",
                     "foobar2",
-                ), FooBar2 {
+                ),
+                    FooBar2,
+                    FooBar3 {
                     fun foo() = "foo"
                 }
                 """.trimIndent()
@@ -5065,9 +5067,11 @@ internal class IndentationRuleTest {
                         foo1: Foo1,
                         foo2: Foo2,
                     ) : Foobar1(
-                        "foobar1",
-                        "foobar2",
-                    ), FooBar2 {
+                            "foobar1",
+                            "foobar2",
+                        ),
+                        FooBar2,
+                        FooBar3 {
                     fun foo() = "foo"
                 }
                 """.trimIndent()
@@ -5079,9 +5083,11 @@ internal class IndentationRuleTest {
                     LintViolation(4, 1, "Unexpected indentation (4) (should be 8)"),
                     LintViolation(5, 1, "Unexpected indentation (4) (should be 8)"),
                     LintViolation(6, 1, "Unexpected indentation (0) (should be 4)"),
-                    LintViolation(7, 1, "Unexpected indentation (4) (should be 8)"),
-                    LintViolation(8, 1, "Unexpected indentation (4) (should be 8)"),
-                    LintViolation(9, 1, "Unexpected indentation (0) (should be 4)"),
+                    LintViolation(7, 1, "Unexpected indentation (4) (should be 12)"),
+                    LintViolation(8, 1, "Unexpected indentation (4) (should be 12)"),
+                    LintViolation(9, 1, "Unexpected indentation (0) (should be 8)"),
+                    LintViolation(10, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(11, 1, "Unexpected indentation (4) (should be 8)"),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -5089,10 +5095,20 @@ internal class IndentationRuleTest {
         fun `Issue 2115 - Given a class without an explicit constructor and with a long super type list then do not indent the class body`() {
             val code =
                 """
-                class Foo(
+                class Foo1 :
+                    FooBar(
+                        "bar1",
+                        "bar2",
+                    ) {
+                    // body
+                }
+                class Foo2(
                     val bar1: Bar,
                     val bar2: Bar,
-                ) : FooBar(bar1, bar2),
+                ) : FooBar(
+                        bar1,
+                        bar2
+                    ),
                     BarFoo1,
                     BarFoo2 {
                     // body

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5118,6 +5118,21 @@ internal class IndentationRuleTest {
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasNoLintViolations()
         }
+
+        @Test
+        fun `Issue 2115 - xxx`() {
+            val code =
+                """
+                class Foo(bar: Bar) :
+                    FooBar(
+                        "foo",
+                        bar,
+                    )
+                """.trimIndent()
+            indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasNoLintViolations()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description

Follow-up on #2115. Fix indent of explicit constructor.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
