### PR TITLE
Add rule `class-signature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* Add rule `class-signature`. This rule rewrites the class header to a consistent format. In code style `ktlint_official`, super types are always wrapped to a separate line. In other code styles, super types are only wrapped in classes having multiple super types. Especially for code style `ktlint_official` the class headers are rewritten in a more consistent format. See [examples in documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/#class-signature). `class-signature` [#875](https://github.com/pinterest/ktlint/issues/1349), [#1349](https://github.com/pinterest/ktlint/issues/875)
+
 ### Removed
 
 ### Fixed

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -90,6 +90,183 @@ Rule id: `blank-line-before-declaration` (`standard` rule set)
 !!! Note
     This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
+## Class signature
+
+Rewrites the class signature to a consistent format respecting the `.editorconfig` property `max_line_length` if set. In the `ktlint_official` code style all class parameters are wrapped by default. Set `.editorconfig` property `ktlint_class_signature_wrapping_rule_always_with_minimum_parameters` to a value greater than 1 to allow class with a few parameters to be placed on a single line.
+The other code styles allow an infinite amount of parameters on the same line (as long as the `max_line_length` is not exceeded) unless `.editorconfig` property `ktlint_class_signature_wrapping_rule_always_with_minimum_parameters` is set explicitly.
+
+=== "[:material-heart:](#) Ktlint (ktlint_official)"
+
+    ```kotlin
+    // Assume that max_line_length is not exceeded when written as single line
+    class Foo0
+    class Foo1(
+        a: Any
+    )
+    class Foo2(
+        a: Any,
+        b: Any
+    )
+    class Foo3(
+        @Foo a: Any,
+        b: Any,
+        c: Any
+    )
+    class Foo4(
+        a: Any,
+        b: Any,
+        c: Any
+    ) : FooBar(a, c)
+    class Foo5 :
+        FooBar(
+            "bar1",
+            "bar2",
+        ) {
+        // body
+    }
+    class Foo6(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+            bar1,
+            bar2
+        ) {
+        // body
+    }
+    class Foo7(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+            bar1,
+            bar2
+        ),
+        BarFoo1,
+        BarFoo2 {
+        // body
+    }
+    class Foo8
+        constructor(
+            val bar1: Bar,
+            val bar2: Bar,
+        ) : FooBar(bar1, bar2),
+            BarFoo1,
+            BarFoo2 {
+        // body
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed (ktlint_official)"
+
+    ```kotlin
+    // Assume that max_line_length is not exceeded when written as single line
+    class Foo0()
+    class Foo1(a: Any)
+    class Foo2(a: Any, b: Any)
+    class Foo3(@Foo a: Any, b: Any, c: Any)
+    class Foo4(a: Any, b: Any, c: Any) : FooBar(a, c)
+    class Foo5 : FooBar(
+        "bar1",
+        "bar2",
+    ) {
+        // body
+    }
+    class Foo6(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+        bar1,
+        bar2
+    ) {
+        // body
+    }
+    class Foo7(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+        bar1,
+        bar2
+    ),
+        BarFoo1,
+        BarFoo2 {
+        // body
+    }
+    class Foo8
+    constructor(
+        val bar1: Bar,
+        val bar2: Bar,
+    ) : FooBar(bar1, bar2),
+        BarFoo1,
+        BarFoo2 {
+        // body
+    }
+    ```
+
+=== "[:material-heart:](#) Ktlint (non ktlint_official)"
+
+    ```kotlin
+    // Assume that the last allowed character is
+    // at the X character on the right           X
+    class Foo0
+    class Foo1(
+        a: Any
+    )
+    class Foo2(a: Any)
+    class Foo3(
+        a: Any,
+        b: Any
+    )
+    class Foo4(a: Any, b: Any)
+    class Foo5(@Foo a: Any, b: Any, c: Any)
+    class Foo6(a: Any, b: Any, c: Any) :
+        FooBar(a, c)
+    class Foo7 : FooBar(
+        "bar1",
+        "bar2",
+    ) {
+        // body
+    }
+    class Foo8(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+        bar1,
+        bar2
+    ) {
+        // body
+    }
+    class Foo9(
+        val bar1: Bar,
+        val bar2: Bar
+    ) : FooBar(
+        bar1,
+        bar2
+    ),
+        BarFoo1,
+        BarFoo2 {
+        // body
+    }
+    class Foo10
+    constructor(
+        val bar1: Bar,
+        val bar2: Bar,
+    ) : FooBar(bar1, bar2),
+        BarFoo1,
+        BarFoo2 {
+        // body
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed (non ktlint_official)"
+
+    ```kotlin
+    // Assume that the last allowed character is
+    // at the X character on the right           X
+    class Foo0()
+    class Foo6(a: Any, b: Any, c: Any) : FooBar(a, c)
+    ```
+
+Rule id: `class-signature` (`standard` rule set)
+
 ## Discouraged comment location
 
 Detect discouraged comment locations (no autocorrect).

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/NoVarRule.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/NoVarRule.kt
@@ -5,10 +5,11 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class NoVarRule : Rule(
-    ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
-    about = About(),
-) {
+public class NoVarRule :
+    Rule(
+        ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
+        about = About(),
+    ) {
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/ApiTestRunner.kt
+++ b/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/ApiTestRunner.kt
@@ -14,7 +14,9 @@ import kotlin.io.path.relativeToOrSelf
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
-class ApiTestRunner(private val tempDir: Path) {
+class ApiTestRunner(
+    private val tempDir: Path,
+) {
     fun prepareTestProject(testProjectName: String): Path {
         val testProjectPath = TEST_PROJECTS_PATHS.resolve(testProjectName)
         assert(Files.exists(testProjectPath)) {

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
@@ -63,7 +63,9 @@ public class Baseline(
  */
 public fun loadBaseline(path: String): Baseline = BaselineLoader(path).load()
 
-private class BaselineLoader(private val path: String) {
+private class BaselineLoader(
+    private val path: String,
+) {
     var ruleReferenceWithoutRuleSetIdPrefix = 0
 
     fun load(): Baseline {

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
@@ -167,7 +167,8 @@ private class BaselineLoader(
                                 }
                             }
                     },
-            detail = "", // Not available in the baseline
+            // Detail is not available in the baseline
+            detail = "",
             status = BASELINE_IGNORED,
         )
 }

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineReporter.kt
@@ -6,7 +6,9 @@ import com.pinterest.ktlint.cli.reporter.core.api.ReporterV2
 import java.io.PrintStream
 import java.util.concurrent.ConcurrentHashMap
 
-public class BaselineReporter(private val out: PrintStream) : ReporterV2 {
+public class BaselineReporter(
+    private val out: PrintStream,
+) : ReporterV2 {
     private val acc = ConcurrentHashMap<String, MutableList<KtlintCliError>>()
 
     override fun onLintError(

--- a/ktlint-cli-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/cli/reporter/checkstyle/CheckStyleReporter.kt
+++ b/ktlint-cli-reporter-checkstyle/src/main/kotlin/com/pinterest/ktlint/cli/reporter/checkstyle/CheckStyleReporter.kt
@@ -7,7 +7,9 @@ import java.io.PrintStream
 import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 
-public class CheckStyleReporter(private val out: PrintStream) : ReporterV2 {
+public class CheckStyleReporter(
+    private val out: PrintStream,
+) : ReporterV2 {
     private val acc = ConcurrentHashMap<String, MutableList<KtlintCliError>>()
 
     override fun onLintError(

--- a/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/Color.kt
+++ b/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/Color.kt
@@ -3,7 +3,9 @@ package com.pinterest.ktlint.cli.reporter.format
 /**
  * Stripped down version of https://github.com/ziggy42/kolor (ziggy42/kolor#6).
  */
-public enum class Color(public val code: Int) {
+public enum class Color(
+    public val code: Int,
+) {
     BLACK(30),
     RED(31),
     GREEN(32),

--- a/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
+++ b/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
@@ -30,7 +30,9 @@ import com.pinterest.ktlint.cli.reporter.core.api.ReporterV2
 import java.io.PrintStream
 import java.util.concurrent.ConcurrentHashMap
 
-public class HtmlReporter(private val out: PrintStream) : ReporterV2 {
+public class HtmlReporter(
+    private val out: PrintStream,
+) : ReporterV2 {
     private val acc = ConcurrentHashMap<String, MutableList<KtlintCliError>>()
     private var issueCount = 0
     private var correctedCount = 0

--- a/ktlint-cli-reporter-json/src/main/kotlin/com/pinterest/ktlint/cli/reporter/json/JsonReporter.kt
+++ b/ktlint-cli-reporter-json/src/main/kotlin/com/pinterest/ktlint/cli/reporter/json/JsonReporter.kt
@@ -7,7 +7,9 @@ import java.io.PrintStream
 import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 
-public class JsonReporter(private val out: PrintStream) : ReporterV2 {
+public class JsonReporter(
+    private val out: PrintStream,
+) : ReporterV2 {
     private val acc = ConcurrentHashMap<String, MutableList<KtlintCliError>>()
 
     override fun onLintError(

--- a/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/Color.kt
+++ b/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/Color.kt
@@ -3,7 +3,9 @@ package com.pinterest.ktlint.cli.reporter.plain
 /**
  * Stripped down version of https://github.com/ziggy42/kolor (ziggy42/kolor#6).
  */
-public enum class Color(public val code: Int) {
+public enum class Color(
+    public val code: Int,
+) {
     BLACK(30),
     RED(31),
     GREEN(32),

--- a/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
+++ b/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
@@ -30,7 +30,9 @@ internal fun String.sanitize(): String =
             if (it.endsWith('/')) it else "$it/"
         }
 
-public class SarifReporter(private val out: PrintStream) : ReporterV2 {
+public class SarifReporter(
+    private val out: PrintStream,
+) : ReporterV2 {
     private val results: MutableList<Result> = mutableListOf()
     private var workingDirectory: File? = null
 

--- a/ktlint-cli-ruleset-core/src/main/kotlin/com/pinterest/ktlint/cli/ruleset/core/api/RuleSetProviderV3.kt
+++ b/ktlint-cli-ruleset-core/src/main/kotlin/com/pinterest/ktlint/cli/ruleset/core/api/RuleSetProviderV3.kt
@@ -10,7 +10,9 @@ import java.io.Serializable
  * `META-INF/services/com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3` (see `ktlint-ruleset-standard/src/main/resources`
  * for an example).
  */
-public abstract class RuleSetProviderV3(public val id: RuleSetId) : Serializable {
+public abstract class RuleSetProviderV3(
+    public val id: RuleSetId,
+) : Serializable {
     /**
      * Gets a group of related [RuleProvider]s. A provided rule is not guaranteed to be run as rules can be disabled,
      * for example via ".editorconfig" properties.

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/ReporterAggregator.kt
@@ -184,7 +184,9 @@ internal class ReporterAggregator(
         val output: String?,
     )
 
-    private class AggregatedReporter(val reporters: List<ReporterV2>) : ReporterV2 {
+    private class AggregatedReporter(
+        val reporters: List<ReporterV2>,
+    ) : ReporterV2 {
         override fun beforeAll() = reporters.forEach(ReporterV2::beforeAll)
 
         override fun before(file: String) = reporters.forEach { it.before(file) }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -24,7 +24,9 @@ import kotlin.io.path.relativeToOrSelf
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
-class CommandLineTestRunner(private val tempDir: Path) {
+class CommandLineTestRunner(
+    private val tempDir: Path,
+) {
     private val ktlintCli: String = System.getProperty("ktlint-cli")
 
     /**

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/environment/OsEnvironment.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/environment/OsEnvironment.kt
@@ -41,4 +41,5 @@ internal class OsEnvironment private constructor(
 }
 
 private class CaseInsensitiveMap<V : Any> :
-    TreeMap<String, V>(java.lang.String.CASE_INSENSITIVE_ORDER), MutableMap<String, V>
+    TreeMap<String, V>(java.lang.String.CASE_INSENSITIVE_ORDER),
+    MutableMap<String, V>

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -344,7 +344,8 @@ internal class FileUtilsTest {
                 patterns =
                     listOf(
                         pattern,
-                        "/some/non/existing/file", // This prevents the default patterns to be added
+                        // Prevents the default patterns to be added by specifying a file
+                        "/some/non/existing/file",
                     ),
                 rootDir = ktlintTestFileSystem.resolve("project1"),
             )
@@ -386,7 +387,8 @@ internal class FileUtilsTest {
                 patterns =
                     listOf(
                         pattern,
-                        "/some/non/existing/file", // This prevents the default patterns to be added
+                        // Prevents the default patterns to be added by specifying a file
+                        "/some/non/existing/file",
                     ),
                 rootDir = ktlintTestFileSystem.resolve("project1"),
             )

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -5,7 +5,9 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProper
 import com.pinterest.ktlint.rule.engine.core.internal.IdNamingPolicy
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public data class RuleId(public val value: String) {
+public data class RuleId(
+    public val value: String,
+) {
     init {
         IdNamingPolicy.enforceRuleIdNaming(value)
     }
@@ -26,7 +28,9 @@ public data class RuleId(public val value: String) {
     }
 }
 
-public data class RuleSetId(public val value: String) {
+public data class RuleSetId(
+    public val value: String,
+) {
     init {
         IdNamingPolicy.enforceRuleSetIdNaming(value)
     }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
@@ -47,7 +47,7 @@ public val CODE_STYLE_PROPERTY_TYPE: PropertyType.LowerCasingPropertyType<CodeSt
 public val CODE_STYLE_PROPERTY: EditorConfigProperty<CodeStyleValue> =
     EditorConfigProperty(
         type = CODE_STYLE_PROPERTY_TYPE,
-        /**
+        /*
          * Once the [CodeStyleValue.ktlint_official] is matured, it will become the default code style of ktlint. Until
          * then the [CodeStyleValue.intellij_idea] is used to remain backwards compatible.
          */

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig.kt
@@ -220,4 +220,6 @@ public data class EditorConfig(
         filterKeys { it in editorConfigProperties }
 }
 
-private class DeprecatedEditorConfigPropertyException(message: String) : RuntimeException(message)
+private class DeprecatedEditorConfigPropertyException(
+    message: String,
+) : RuntimeException(message)

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/SafeEnumValueParser.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/SafeEnumValueParser.kt
@@ -15,7 +15,9 @@ import java.util.Locale
  * @param <T> the type of the value <T>
  *
  */
-internal class SafeEnumValueParser<T : Enum<*>?>(enumType: Class<out T?>) : PropertyValueParser<T> {
+internal class SafeEnumValueParser<T : Enum<*>?>(
+    enumType: Class<out T?>,
+) : PropertyValueParser<T> {
     private val enumType: Class<out Enum<*>?>
 
     init {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoader.kt
@@ -17,7 +17,9 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 /**
  * Load all properties from an ".editorconfig" file without filtering on a glob.
  */
-internal class EditorConfigDefaultsLoader(private val editorConfigLoaderEc4j: EditorConfigLoaderEc4j) {
+internal class EditorConfigDefaultsLoader(
+    private val editorConfigLoaderEc4j: EditorConfigLoaderEc4j,
+) {
     /**
      * Loads properties from [path]. [path] may either locate a file (also allows specifying a file with a name other
      * than ".editorconfig") or a directory in which a file with name ".editorconfig" is expected to exist. Properties

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
@@ -19,7 +19,9 @@ import kotlin.system.measureTimeMillis
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
-internal class EditorConfigFinder(private val editorConfigLoaderEc4j: EditorConfigLoaderEc4j) {
+internal class EditorConfigFinder(
+    private val editorConfigLoaderEc4j: EditorConfigLoaderEc4j,
+) {
     /**
      * Finds all relevant ".editorconfig" files for the given path.
      */

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -5,7 +5,6 @@ import com.pinterest.ktlint.rule.engine.api.EditorConfigDefaults
 import com.pinterest.ktlint.rule.engine.api.EditorConfigDefaults.Companion.EMPTY_EDITOR_CONFIG_DEFAULTS
 import com.pinterest.ktlint.rule.engine.api.EditorConfigOverride
 import com.pinterest.ktlint.rule.engine.api.EditorConfigOverride.Companion.EMPTY_EDITOR_CONFIG_OVERRIDE
-import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.END_OF_LINE_PROPERTY
@@ -89,28 +88,28 @@ internal class EditorConfigLoader(
                 // Only add properties which are not related to rules but which are needed by the KtLint Rule Engine
                 EditorConfig(properties)
                     .addPropertiesWithDefaultValueIfMissing(
-                        /**
+                        /*
                          * Used in [EditorConfig] to determine the default value for a property when it is not specified in the
                          * [EditorConfig].
                          */
                         CODE_STYLE_PROPERTY,
-                        /**
+                        /*
                          * Used by [KtLintRuleEngine] to use correct line separator when writing the formatted output.
                          */
                         END_OF_LINE_PROPERTY,
-                        /**
+                        /*
                          * Used by [VisitorProvider] to determine whether experimental rules have to be executed.
                          */
                         EXPERIMENTAL_RULES_EXECUTION_PROPERTY,
-                        /**
+                        /*
                          * Used by [FormatterTags] to determine whether formatter tags should be respected.
                          */
                         FORMATTER_TAGS_ENABLED_PROPERTY,
-                        /**
+                        /*
                          * Used by [FormatterTags] to get the tag to disable the formatter.
                          */
                         FORMATTER_TAG_OFF_ENABLED_PROPERTY,
-                        /**
+                        /*
                          * Used by [FormatterTags] to get the tag to enable the formatter.
                          */
                         FORMATTER_TAG_ON_ENABLED_PROPERTY,

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
@@ -144,7 +144,9 @@ private fun MockProject.registerFormatPomModel() {
     registerService(PomModel::class.java, FormatPomModel())
 }
 
-private class FormatPomModel : UserDataHolderBase(), PomModel {
+private class FormatPomModel :
+    UserDataHolderBase(),
+    PomModel {
     override fun runTransaction(transaction: PomTransaction) {
         (transaction as PomTransactionBase).run()
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilter.kt
@@ -12,7 +12,9 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
  * Add internal [RuleProvider]s. These rule providers always have to run regardless of the rules providers which are provided by the API
  * consumer. In case the API consumer tries to provide a rule with the same rule id as an internal rule provider than it will be ignored.
  */
-internal class InternalRuleProvidersFilter(private val ktLintRuleEngine: KtLintRuleEngine) : RuleFilter {
+internal class InternalRuleProvidersFilter(
+    private val ktLintRuleEngine: KtLintRuleEngine,
+) : RuleFilter {
     private val internalRuleProviders =
         setOf(
             RuleProvider {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
@@ -211,9 +211,14 @@ internal class RunAfterRuleFilter : RuleFilter {
         }
     }
 
-    private data class RunAfterRuleRequiredButNotLoaded(val ruleId: RuleId, val runAfterRuleId: RuleId)
+    private data class RunAfterRuleRequiredButNotLoaded(
+        val ruleId: RuleId,
+        val runAfterRuleId: RuleId,
+    )
 
-    private enum class RunAfterRuleOrderModifier(val severity: Int) {
+    private enum class RunAfterRuleOrderModifier(
+        val severity: Int,
+    ) {
         /**
          *  This rule does not depend on any other rule which will be loaded, or it depends on rule which was already added to the new list
          *  of rule which will be loaded before the current rule.

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
@@ -89,7 +89,9 @@ private const val DOUBLE_QUOTE = "\""
  *
  * Ktlint-enable directives are removed as annotations have a scope in which the suppression will be active.
  */
-public class KtlintSuppressionRule(private val allowedRuleIds: List<RuleId>) : InternalRule("ktlint-suppression") {
+public class KtlintSuppressionRule(
+    private val allowedRuleIds: List<RuleId>,
+) : InternalRule("ktlint-suppression") {
     private val allowedRuleIdAsStrings = allowedRuleIds.map { it.value }
 
     private val ruleIdValidator: (String) -> Boolean = { ruleId -> allowedRuleIdAsStrings.contains(ruleId) }
@@ -550,7 +552,9 @@ public class KtlintSuppressionRule(private val allowedRuleIds: List<RuleId>) : I
         this.remove()
     }
 
-    private enum class SuppressAnnotationType(val annotationName: String) {
+    private enum class SuppressAnnotationType(
+        val annotationName: String,
+    ) {
         SUPPRESS("Suppress"),
         SUPPRESS_WARNINGS("SuppressWarnings"),
         ;
@@ -630,13 +634,17 @@ private data class KtLintDirective(
         }
     }
 
-    enum class KtlintDirectiveType(val id: String) {
+    enum class KtlintDirectiveType(
+        val id: String,
+    ) {
         KTLINT_DISABLE("ktlint-disable"),
         KTLINT_ENABLE("ktlint-enable"),
     }
 
     sealed class SuppressionIdChange {
-        class ValidSuppressionId(val suppressionId: String) : SuppressionIdChange()
+        class ValidSuppressionId(
+            val suppressionId: String,
+        ) : SuppressionIdChange()
 
         class InvalidSuppressionId(
             val originalRuleId: String,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/DisabledRulesTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/DisabledRulesTest.kt
@@ -56,10 +56,12 @@ class DisabledRulesTest {
         ).isEmpty()
     }
 
-    class NoVarRule(ruleId: RuleId) : Rule(
-        ruleId = ruleId,
-        about = About(),
-    ) {
+    class NoVarRule(
+        ruleId: RuleId,
+    ) : Rule(
+            ruleId = ruleId,
+            about = About(),
+        ) {
         override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -488,10 +488,11 @@ private open class DummyRule(
 /**
  * A dummy rule for testing
  */
-private class AutoCorrectErrorRule : Rule(
-    ruleId = AUTOCORRECT_ERROR_RULE_ID,
-    about = About(),
-) {
+private class AutoCorrectErrorRule :
+    Rule(
+        ruleId = AUTOCORRECT_ERROR_RULE_ID,
+        about = About(),
+    ) {
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -637,10 +638,11 @@ private data class CallbackResult(
 /**
  * This rule throws an exception when it is visited more than once.
  */
-private class WithStateRule : Rule(
-    ruleId = RuleId("test:with-state"),
-    about = About(),
-) {
+private class WithStateRule :
+    Rule(
+        ruleId = RuleId("test:with-state"),
+        about = About(),
+    ) {
     private var hasNotBeenVisitedYet = true
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigGeneratorTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigGeneratorTest.kt
@@ -168,15 +168,16 @@ internal class EditorConfigGeneratorTest {
             .contains("$PROPERTY_1_NAME = $rootEditorConfigPropertyValue1")
     }
 
-    private class TestRule : Rule(
-        ruleId = RuleId("test:test-rule"),
-        about = About(),
-        usesEditorConfigProperties =
-            setOf(
-                EDITOR_CONFIG_PROPERTY_2,
-                EDITOR_CONFIG_PROPERTY_1,
-            ),
-    )
+    private class TestRule :
+        Rule(
+            ruleId = RuleId("test:test-rule"),
+            about = About(),
+            usesEditorConfigProperties =
+                setOf(
+                    EDITOR_CONFIG_PROPERTY_2,
+                    EDITOR_CONFIG_PROPERTY_1,
+                ),
+        )
 
     private companion object {
         //language=

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
@@ -424,20 +424,28 @@ class RuleProviderSorterTest {
         val CUSTOM_RULE_SET_B_RULE_B = RuleId("$CUSTOM_RULE_SET_B:rule-b")
     }
 
-    private open class NormalRule(ruleId: RuleId) : R(ruleId)
+    private open class NormalRule(
+        ruleId: RuleId,
+    ) : R(ruleId)
 
-    private open class ExperimentalRule(ruleId: RuleId) : R(ruleId), Rule.Experimental
+    private open class ExperimentalRule(
+        ruleId: RuleId,
+    ) : R(ruleId),
+        Rule.Experimental
 
-    private class RunAsLateAsPossibleRule(ruleId: RuleId) : R(
-        ruleId = ruleId,
-        visitorModifiers =
-            setOf(
-                VisitorModifier.RunAsLateAsPossible,
-            ),
-    )
+    private class RunAsLateAsPossibleRule(
+        ruleId: RuleId,
+    ) : R(
+            ruleId = ruleId,
+            visitorModifiers =
+                setOf(
+                    VisitorModifier.RunAsLateAsPossible,
+                ),
+        )
 
-    private class RunAsLateAsPossibleExperimentalRule(ruleId: RuleId) :
-        R(
+    private class RunAsLateAsPossibleExperimentalRule(
+        ruleId: RuleId,
+    ) : R(
             ruleId = ruleId,
             visitorModifiers =
                 setOf(

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilderTest.kt
@@ -369,10 +369,12 @@ class SuppressionLocatorBuilderTest {
         assertThat(actual).isEqualTo(formattedCode)
     }
 
-    private class NoFooIdentifierRule(id: RuleId) : Rule(
-        ruleId = id,
-        about = About(),
-    ) {
+    private class NoFooIdentifierRule(
+        id: RuleId,
+    ) : Rule(
+            ruleId = id,
+            about = About(),
+        ) {
         override fun beforeVisitChildNodes(
             node: ASTNode,
             autoCorrect: Boolean,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCacheTest.kt
@@ -111,7 +111,9 @@ class ThreadSafeEditorConfigCacheTest {
         val EDIT_CONFIG_2: EditorConfig = createUniqueInstanceOfEditConfig("edit-config-2")
     }
 
-    private class EditorConfigLoaderMock(private var initial: EditorConfig) : EditorConfigLoader(null, null) {
+    private class EditorConfigLoaderMock(
+        private var initial: EditorConfig,
+    ) : EditorConfigLoader(null, null) {
         var loadCount = 0
 
         override fun load(configFile: Resource): EditorConfig {

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
@@ -217,14 +217,16 @@ class RuleExecutionRuleFilterTest {
         val CUSTOM_RULE_C = RuleId("$CUSTOM:rule-c")
     }
 
-    private open class NormalRule(ruleId: RuleId) :
-        Rule(
+    private open class NormalRule(
+        ruleId: RuleId,
+    ) : Rule(
             ruleId = ruleId,
             about = About(),
         )
 
-    private open class ExperimentalRule(ruleId: RuleId) :
-        Rule(
+    private open class ExperimentalRule(
+        ruleId: RuleId,
+    ) : Rule(
             ruleId = ruleId,
             about = About(),
         ),

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleFilterKtTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleFilterKtTest.kt
@@ -52,7 +52,9 @@ class RuleFilterKtTest {
         assertThat(actual).isEmpty()
     }
 
-    private class RuleIdRuleFilter(private val string: String) : RuleFilter {
+    private class RuleIdRuleFilter(
+        private val string: String,
+    ) : RuleFilter {
         override fun filter(ruleProviders: Set<RuleProvider>): Set<RuleProvider> =
             ruleProviders
                 .filter { it.ruleId.value.contains(string) }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
@@ -1366,4 +1366,6 @@ class KtlintSuppressionRuleTest {
     }
 }
 
-private class DummyRule(id: String) : Rule(RuleId(id), About())
+private class DummyRule(
+    id: String,
+) : Rule(RuleId(id), About())

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -85,6 +85,21 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleKt
 	public static final fun getCLASS_NAMING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/Rule$Experimental {
+	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule$Companion;
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule$Companion {
+	public final fun getFORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY ()Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleKt {
+	public static final fun getCLASS_SIGNATURE_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/CommentSpacingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public fun <init> ()V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -11,6 +11,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeDeclarationRul
 import com.pinterest.ktlint.ruleset.standard.rules.BlockCommentInitialStarAlignmentRule
 import com.pinterest.ktlint.ruleset.standard.rules.ChainWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ClassNamingRule
+import com.pinterest.ktlint.ruleset.standard.rules.ClassSignatureRule
 import com.pinterest.ktlint.ruleset.standard.rules.CommentSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.CommentWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ContextReceiverWrappingRule
@@ -84,8 +85,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.TypeParameterListSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.UnnecessaryParenthesesBeforeTrailingLambdaRule
 import com.pinterest.ktlint.ruleset.standard.rules.WrappingRule
 
-public class StandardRuleSetProvider :
-    RuleSetProviderV3(RuleSetId.STANDARD) {
+public class StandardRuleSetProvider : RuleSetProviderV3(RuleSetId.STANDARD) {
     override fun getRuleProviders(): Set<RuleProvider> =
         setOf(
             RuleProvider { AnnotationRule() },
@@ -96,6 +96,7 @@ public class StandardRuleSetProvider :
             RuleProvider { BlockCommentInitialStarAlignmentRule() },
             RuleProvider { ChainWrappingRule() },
             RuleProvider { ClassNamingRule() },
+            RuleProvider { ClassSignatureRule() },
             RuleProvider { CommentSpacingRule() },
             RuleProvider { CommentWrappingRule() },
             RuleProvider { ContextReceiverWrappingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -49,6 +49,10 @@ public class ArgumentListWrappingRule :
                     ruleId = WRAPPING_RULE_ID,
                     mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
                 ),
+                VisitorModifier.RunAfterRule(
+                    ruleId = CLASS_SIGNATURE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
             ),
         usesEditorConfigProperties =
             setOf(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -1,0 +1,741 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeLeaf
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.ec4j.core.model.PropertyType
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
+
+/**
+ * Formats the class signature according to https://kotlinlang.org/docs/coding-conventions.html#class-headers
+ *
+ * In code style `ktlint_official` class headers containing 2 or more parameters are formatted as multiline signature. As the Kotlin Coding
+ * conventions do not specify what is meant with a "few parameters", no default is set for other code styles.
+ */
+public class ClassSignatureRule :
+    StandardRule(
+        id = "class-signature",
+        visitorModifiers =
+            setOf(
+                // Run after wrapping and spacing rules
+                VisitorModifier.RunAsLateAsPossible,
+            ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+                FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY,
+            ),
+    ),
+    Rule.Experimental {
+    private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
+    private var indentConfig = DEFAULT_INDENT_CONFIG
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+    private var classSignatureWrappingMinimumParameters = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        codeStyle = editorConfig[CODE_STYLE_PROPERTY]
+        classSignatureWrappingMinimumParameters = editorConfig[FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY]
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType == CLASS) {
+            node
+                .classSignatureNodes(excludeSuperTypes = false)
+                .any { it.elementType == EOL_COMMENT || it.elementType == BLOCK_COMMENT }
+                .ifTrue {
+                    // Rewriting class signatures in a consistent manner is hard or sometimes even impossible. For example a multiline
+                    // signature which could fit on one line can not be rewritten in case it contains an EOL comment. Rewriting a single
+                    // line signature which exceeds the max line length to a multiline signature is hard when it contains block comments.
+                    // For now, it does not seem worth the effort to attempt it.
+                    // TODO: reconsider this as it is quite common to document class parameters
+                    return
+                }
+
+            visitPrimaryConstructor(node, emit, autoCorrect)
+        }
+    }
+
+    private fun ASTNode.classSignatureNodes(excludeSuperTypes: Boolean): List<ASTNode> {
+        // Find the nodes that are to be placed on the same line if no max line length is set
+        //     internal class Foo(bar: String) { // Class without super type
+        // or
+        //     public class Foo(bar: String) : Bar { // Class with exactly one super type
+        // or
+        //     private class Foo(bar: String) : // Class with multiple super types which have to be wrapped to next lines
+        val firstCodeChild = getFirstChildInSignature()
+        val lastNodeInPrimaryClassSignatureLine =
+            takeIf { excludeSuperTypes }
+                // When the class extends multiple super types or if the super type list contains a newline, all super types are wrapped
+                // on separate line
+                ?.findChildByType(COLON)
+                ?: findChildByType(CLASS_BODY)?.firstChildNode
+        return collectLeavesRecursively()
+            .childrenBetween(
+                startASTNodePredicate = { it == firstCodeChild },
+                endASTNodePredicate = { it == lastNodeInPrimaryClassSignatureLine },
+            )
+    }
+
+    private fun ASTNode.countSuperTypes() =
+        superTypes()
+            .orEmpty()
+            .count()
+
+    private fun ASTNode.superTypes() =
+        findChildByType(SUPER_TYPE_LIST)
+            ?.children()
+            ?.filterNot { it.isWhiteSpace() || it.isPartOfComment() || it.elementType == COMMA }
+
+    private fun ASTNode.hasMultilineSuperTypeList() = findChildByType(SUPER_TYPE_LIST)?.textContains('\n') == true
+
+    private fun ASTNode.getFirstChildInSignature(): ASTNode? {
+        findChildByType(MODIFIER_LIST)
+            ?.let { modifierList ->
+                val iterator = modifierList.children().iterator()
+                var currentNode: ASTNode
+                while (iterator.hasNext()) {
+                    currentNode = iterator.next()
+                    if (currentNode.elementType != ANNOTATION &&
+                        currentNode.elementType != ANNOTATION_ENTRY &&
+                        currentNode.elementType != WHITE_SPACE
+                    ) {
+                        return currentNode
+                    }
+                }
+                return modifierList.nextCodeSibling()
+            }
+        return nextCodeLeaf()
+    }
+
+    private fun visitPrimaryConstructor(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        require(node.elementType == CLASS)
+
+        val wrapPrimaryConstructorParameters =
+            node.hasMinimumNumberOfParameters() ||
+                node.containsMultilineParameter() ||
+                (codeStyle == ktlint_official && node.containsAnnotatedParameter())
+        val wrappedPrimaryConstructor =
+            if (isMaxLineLengthSet()) {
+                val multilinePrimaryConstructor =
+                    wrapPrimaryConstructorParameters ||
+                        calculateLengthOfClassSignatureExcludingSuperTypes(node, emit, autoCorrect) > maxLineLength
+                fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = multilinePrimaryConstructor, dryRun = false)
+                multilinePrimaryConstructor
+            } else {
+                // When max line length is not set then keep it as single line class signature only when the original signature already was a
+                // single line signature. Otherwise, rewrite the entire signature as a multiline signature.
+                val rewriteToSingleLineClassSignature =
+                    node
+                        .classSignatureNodes(excludeSuperTypes = false)
+                        .none { it.textContains('\n') }
+                if (!wrapPrimaryConstructorParameters && rewriteToSingleLineClassSignature) {
+                    fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = false)
+                } else {
+                    fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = true, dryRun = false)
+                }
+                rewriteToSingleLineClassSignature
+            }
+        val countSuperTypes = node.countSuperTypes()
+        val wrapFirstSuperType =
+            !wrappedPrimaryConstructor &&
+                (
+                    countSuperTypes > 1 ||
+                        node.hasMultilineSuperTypeList() ||
+                        // In case the class has exactly one super type, it may be placed on the same line if it fits
+                        (
+                            countSuperTypes == 1 &&
+                                !node.hasMultilineSuperTypeList() &&
+                                calculateLengthOfClassSignaturesIncludingFirstSuperType(node, emit, autoCorrect) > maxLineLength
+                            )
+                    )
+        fixWhitespacesInSuperTypeList(node, emit, autoCorrect, wrapFirstSuperType, dryRun = false)
+        fixClassBody(node, emit, autoCorrect)
+    }
+
+    private fun calculateLengthOfClassSignaturesIncludingFirstSuperType(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ): Int {
+        val actualClassSignatureLength = node.getClassSignatureLength(excludeSuperTypes = false)
+        // Calculate the length of the class signature in case it, including the super types, would be rewritten as single
+        // line (and without a maximum line length). The white space correction will be calculated via a dry run of the
+        // actual fix.
+        return actualClassSignatureLength +
+            // Calculate the white space correction in case the signature would be rewritten to a single line
+            fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = true) +
+            fixWhitespacesInSuperTypeList(
+                node,
+                emit,
+                autoCorrect,
+                wrapFirstSuperType = false,
+                dryRun = true,
+            )
+    }
+
+    private fun ASTNode.getClassSignatureLength(excludeSuperTypes: Boolean) =
+        indent(false).length + getClassSignatureNodesLength(excludeSuperTypes)
+
+    private fun ASTNode.getClassSignatureNodesLength(excludeSuperTypes: Boolean) =
+        classSignatureNodes(excludeSuperTypes)
+            .joinTextToString()
+            .length
+
+    private fun calculateLengthOfClassSignatureExcludingSuperTypes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ): Int {
+        val actualClassSignatureLength = node.getClassSignatureLength(excludeSuperTypes = true)
+        // Calculate the length of the class signature in case it, excluding the super types, would be rewritten as single
+        // line (and without a maximum line length). The white space correction will be calculated via a dry run of the
+        // actual fix.
+        return actualClassSignatureLength +
+            // Calculate the white space correction in case the signature would be rewritten to a single line
+            fixWhiteSpacesInValueParameterList(node, emit, autoCorrect, multiline = false, dryRun = true)
+    }
+
+    private fun ASTNode.containsMultilineParameter(): Boolean =
+        getPrimaryConstructorParameterListOrNull()
+            ?.children()
+            .orEmpty()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .any { it.textContains('\n') }
+
+    private fun ASTNode.containsAnnotatedParameter(): Boolean =
+        getPrimaryConstructorParameterListOrNull()
+            ?.children()
+            .orEmpty()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .any { it.isAnnotated() }
+
+    private fun ASTNode.isAnnotated() =
+        findChildByType(MODIFIER_LIST)
+            ?.children()
+            .orEmpty()
+            .any { it.elementType == ANNOTATION_ENTRY }
+
+    private fun fixWhiteSpacesInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = node.getPrimaryConstructorParameterListOrNull()
+        val firstParameterInList =
+            valueParameterList
+                ?.children()
+                .orEmpty()
+                .firstOrNull { it.elementType == VALUE_PARAMETER }
+
+        whiteSpaceCorrection +=
+            if (firstParameterInList == null) {
+                // Classes with comments in the value parameter list are excluded from processing before. So the parameter list at this
+                // point is empty or only contains a single whitespace element
+                fixWhiteSpacesInEmptyValueParameterList(node, emit, autoCorrect, dryRun)
+            } else {
+                fixWhiteSpacesBeforeFirstParameterInValueParameterList(node, emit, autoCorrect, multiline, dryRun) +
+                    fixWhiteSpacesBetweenParametersInValueParameterList(node, emit, autoCorrect, multiline, dryRun) +
+                    fixWhiteSpaceBeforeClosingParenthesis(node, emit, autoCorrect, multiline, dryRun)
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesInEmptyValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        node
+            .getPrimaryConstructorParameterListOrNull()
+            ?.let { parameterList ->
+                if (!dryRun) {
+                    emit(parameterList.startOffset, "No parenthesis expected", true)
+                }
+                if (autoCorrect && !dryRun) {
+                    parameterList.treeParent.removeChild(parameterList)
+                } else {
+                    whiteSpaceCorrection -= parameterList.textLength
+                }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesBeforeFirstParameterInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = node.getPrimaryConstructorParameterListOrNull()
+        val firstParameterInList =
+            valueParameterList
+                ?.children()
+                ?.first { it.elementType == VALUE_PARAMETER }
+                ?: return 0
+
+        val firstParameter = firstParameterInList.firstChildNode
+        firstParameter
+            ?.prevLeaf()
+            ?.takeIf { it.elementType == WHITE_SPACE }
+            .let { whiteSpaceBeforeIdentifier ->
+                if (multiline) {
+                    if (whiteSpaceBeforeIdentifier == null ||
+                        !whiteSpaceBeforeIdentifier.textContains('\n')
+                    ) {
+                        // Let indent rule determine the exact indent
+                        val expectedParameterIndent = indentConfig.childIndentOf(node)
+                        if (!dryRun) {
+                            emit(firstParameterInList.startOffset, "Newline expected after opening parenthesis", true)
+                        }
+                        if (autoCorrect && !dryRun) {
+                            valueParameterList.firstChildNode.upsertWhitespaceAfterMe(expectedParameterIndent)
+                        } else {
+                            whiteSpaceCorrection += expectedParameterIndent.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                        }
+                    }
+                } else {
+                    if (whiteSpaceBeforeIdentifier != null) {
+                        if (!dryRun) {
+                            emit(
+                                firstParameter!!.startOffset,
+                                "No whitespace expected between opening parenthesis and first parameter name",
+                                true,
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            whiteSpaceBeforeIdentifier.treeParent.removeChild(whiteSpaceBeforeIdentifier)
+                        } else {
+                            whiteSpaceCorrection -= whiteSpaceBeforeIdentifier.textLength
+                        }
+                    }
+                }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpacesBetweenParametersInValueParameterList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val valueParameterList = node.getPrimaryConstructorParameterListOrNull()
+        val firstParameterInList =
+            valueParameterList
+                ?.children()
+                ?.first { it.elementType == VALUE_PARAMETER }
+                ?: return 0
+
+        valueParameterList
+            .children()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .filter { it != firstParameterInList }
+            .forEach { valueParameter ->
+                val firstChildNodeInValueParameter = valueParameter.firstChildNode
+                firstChildNodeInValueParameter
+                    ?.prevLeaf()
+                    ?.takeIf { it.elementType == WHITE_SPACE }
+                    .let { whiteSpaceBeforeIdentifier ->
+                        if (multiline) {
+                            if (whiteSpaceBeforeIdentifier == null ||
+                                !whiteSpaceBeforeIdentifier.textContains('\n')
+                            ) {
+                                // Let IndentationRule determine the exact indent
+                                val expectedParameterIndent = indentConfig.childIndentOf(node)
+                                if (!dryRun) {
+                                    emit(valueParameter.startOffset, "Parameter should start on a newline", true)
+                                }
+                                if (autoCorrect && !dryRun) {
+                                    firstChildNodeInValueParameter.upsertWhitespaceBeforeMe(expectedParameterIndent)
+                                } else {
+                                    whiteSpaceCorrection += expectedParameterIndent.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                }
+                            }
+                        } else {
+                            if (whiteSpaceBeforeIdentifier == null || whiteSpaceBeforeIdentifier.text != " ") {
+                                if (!dryRun) {
+                                    emit(
+                                        firstChildNodeInValueParameter!!.startOffset,
+                                        "Single whitespace expected before parameter",
+                                        true,
+                                    )
+                                }
+                                if (autoCorrect && !dryRun) {
+                                    firstChildNodeInValueParameter.upsertWhitespaceBeforeMe(" ")
+                                } else {
+                                    whiteSpaceCorrection += 1 - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                }
+                            }
+                        }
+                    }
+            }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhiteSpaceBeforeClosingParenthesis(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        multiline: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val closingParenthesisPrimaryConstructor =
+            node
+                .getPrimaryConstructorParameterListOrNull()
+                ?.findChildByType(RPAR)
+        closingParenthesisPrimaryConstructor
+            ?.prevSibling()
+            ?.takeIf { it.elementType == WHITE_SPACE }
+            .let { whiteSpaceBeforeClosingParenthesis ->
+                if (multiline) {
+                    if (whiteSpaceBeforeClosingParenthesis == null ||
+                        !whiteSpaceBeforeClosingParenthesis.textContains('\n')
+                    ) {
+                        // Let IndentationRule determine the exact indent
+                        val expectedParameterIndent = node.indent()
+                        if (!dryRun) {
+                            emit(
+                                closingParenthesisPrimaryConstructor!!.startOffset,
+                                "Newline expected before closing parenthesis",
+                                true,
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            closingParenthesisPrimaryConstructor!!.upsertWhitespaceBeforeMe(expectedParameterIndent)
+                        } else {
+                            whiteSpaceCorrection += expectedParameterIndent.length - (whiteSpaceBeforeClosingParenthesis?.textLength ?: 0)
+                        }
+                    }
+                } else {
+                    if (whiteSpaceBeforeClosingParenthesis != null &&
+                        whiteSpaceBeforeClosingParenthesis.nextLeaf()?.elementType == RPAR
+                    ) {
+                        if (!dryRun) {
+                            emit(
+                                whiteSpaceBeforeClosingParenthesis.startOffset,
+                                "No whitespace expected between last parameter and closing parenthesis",
+                                true,
+                            )
+                        }
+                        if (autoCorrect && !dryRun) {
+                            whiteSpaceBeforeClosingParenthesis.treeParent.removeChild(whiteSpaceBeforeClosingParenthesis)
+                        } else {
+                            whiteSpaceCorrection -= whiteSpaceBeforeClosingParenthesis.textLength
+                        }
+                    }
+                }
+            }
+        return whiteSpaceCorrection
+    }
+
+    private fun fixWhitespacesInSuperTypeList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+        wrapFirstSuperType: Boolean,
+        dryRun: Boolean,
+    ): Int {
+        var whiteSpaceCorrection = 0
+
+        val superTypes = node.superTypes() ?: return 0
+
+        if (superTypes.first().elementType != SUPER_TYPE_CALL_ENTRY) {
+            superTypes
+                .firstOrNull { it.elementType == SUPER_TYPE_CALL_ENTRY }
+                ?.let { superTypeCallEntry ->
+                    if (!dryRun) {
+                        emit(superTypeCallEntry.startOffset, "Super type call must be first super type", true)
+                        if (autoCorrect) {
+                            val superTypeList = node.findChildByType(SUPER_TYPE_LIST) ?: return 0
+                            val originalFirstSuperType = superTypes.first()
+                            val commaBeforeSuperTypeCall = requireNotNull(superTypeCallEntry.prevSibling { it.elementType == COMMA })
+
+                            // Remove the whitespace before the super type call and do not insert a new whitespace as it will be fixed later
+                            superTypeCallEntry
+                                .prevSibling()
+                                ?.takeIf { it.elementType == WHITE_SPACE }
+                                ?.let { whitespaceBeforeSuperTypeCallEntry ->
+                                    superTypeList.removeChild(whitespaceBeforeSuperTypeCallEntry)
+                                }
+
+                            superTypeList.addChild(superTypeCallEntry, superTypes.first())
+                            superTypeList.addChild(commaBeforeSuperTypeCall, originalFirstSuperType)
+                        }
+                    }
+                }
+        }
+
+        if (superTypes.count() == 1) {
+            superTypes
+                .first()
+                .firstChildNode
+                .let { superTypeFirstChildNode ->
+                    superTypeFirstChildNode
+                        ?.prevLeaf()
+                        ?.takeIf { it.elementType == WHITE_SPACE }
+                        .let { whiteSpaceBeforeIdentifier ->
+                            if (wrapFirstSuperType && !node.hasMultilinePrimaryConstructor()) {
+                                if (whiteSpaceBeforeIdentifier == null ||
+                                    !whiteSpaceBeforeIdentifier.textContains('\n')
+                                ) {
+                                    // Let IndentationRule determine the exact indent
+                                    val expectedWhitespace = indentConfig.childIndentOf(node)
+                                    if (dryRun) {
+                                        whiteSpaceCorrection += expectedWhitespace.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                    } else {
+                                        emit(superTypeFirstChildNode.startOffset, "Super type should start on a newline", true)
+                                        if (autoCorrect) {
+                                            superTypeFirstChildNode.upsertWhitespaceBeforeMe(expectedWhitespace)
+                                        }
+                                    }
+                                }
+                            } else {
+                                val expectedWhitespace = " "
+                                if (whiteSpaceBeforeIdentifier == null ||
+                                    whiteSpaceBeforeIdentifier.text != expectedWhitespace
+                                ) {
+                                    if (dryRun) {
+                                        whiteSpaceCorrection += expectedWhitespace.length - (whiteSpaceBeforeIdentifier?.textLength ?: 0)
+                                    } else {
+                                        emit(superTypeFirstChildNode.startOffset, "Expected single space before the super type", true)
+                                        if (autoCorrect) {
+                                            superTypeFirstChildNode.upsertWhitespaceBeforeMe(expectedWhitespace)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                }
+        } else {
+            superTypes
+                .forEachIndexed { index, superType ->
+                    val firstChildNodeInSuperType = superType.firstChildNode
+                    firstChildNodeInSuperType
+                        ?.prevLeaf()
+                        ?.takeIf { it.elementType == WHITE_SPACE }
+                        .let { whiteSpaceBeforeIdentifier ->
+                            if (index == 0 && node.hasMultilinePrimaryConstructor()) {
+                                val expectedWhitespace = " "
+                                if (whiteSpaceBeforeIdentifier == null ||
+                                    whiteSpaceBeforeIdentifier.text != expectedWhitespace
+                                ) {
+                                    if (!dryRun) {
+                                        emit(
+                                            firstChildNodeInSuperType.startOffset,
+                                            "Expected single space before the first super type",
+                                            true,
+                                        )
+                                        if (autoCorrect) {
+                                            firstChildNodeInSuperType.upsertWhitespaceBeforeMe(expectedWhitespace)
+                                        }
+                                    }
+                                }
+                            } else {
+                                if (whiteSpaceBeforeIdentifier == null ||
+                                    !whiteSpaceBeforeIdentifier.textContains('\n')
+                                ) {
+                                    // Let IndentationRule determine the exact indent
+                                    val expectedWhitespace = indentConfig.childIndentOf(node)
+                                    if (!dryRun) {
+                                        emit(firstChildNodeInSuperType.startOffset, "Super type should start on a newline", true)
+                                        if (autoCorrect) {
+                                            firstChildNodeInSuperType.upsertWhitespaceBeforeMe(expectedWhitespace)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                }
+        }
+
+        return whiteSpaceCorrection
+    }
+
+    private fun ASTNode.hasMultilinePrimaryConstructor() =
+        findChildByType(PRIMARY_CONSTRUCTOR)
+            ?.findChildByType(VALUE_PARAMETER_LIST)
+            ?.findChildByType(RPAR)
+            ?.prevLeaf { !it.isPartOfComment() }
+            .isWhiteSpaceWithNewline()
+
+    private fun fixClassBody(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        node
+            .findChildByType(CLASS_BODY)
+            ?.let { classBody ->
+                if (classBody.prevLeaf()?.text != " ") {
+                    emit(classBody.startOffset, "Expected a single space before class body", true)
+                    if (autoCorrect) {
+                        classBody
+                            .prevLeaf(true)
+                            ?.upsertWhitespaceAfterMe(" ")
+                    }
+                }
+            }
+    }
+
+    private fun isMaxLineLengthSet() = maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF
+
+    private fun List<ASTNode>.collectLeavesRecursively(): List<ASTNode> = flatMap { it.collectLeavesRecursively() }
+
+    private fun ASTNode.collectLeavesRecursively(): List<ASTNode> =
+        if (psi is LeafElement) {
+            listOf(this)
+        } else {
+            children()
+                .flatMap { it.collectLeavesRecursively() }
+                .toList()
+        }
+
+    private fun List<ASTNode>.childrenBetween(
+        startASTNodePredicate: (ASTNode) -> Boolean,
+        endASTNodePredicate: (ASTNode) -> Boolean,
+    ): List<ASTNode> {
+        val iterator = iterator()
+        var currentNode: ASTNode
+        val childrenBetween: MutableList<ASTNode> = mutableListOf()
+
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            if (startASTNodePredicate(currentNode)) {
+                childrenBetween.add(currentNode)
+                break
+            }
+        }
+
+        while (iterator.hasNext()) {
+            currentNode = iterator.next()
+            childrenBetween.add(currentNode)
+            if (endASTNodePredicate(currentNode)) {
+                break
+            }
+        }
+
+        return childrenBetween
+    }
+
+    private fun List<ASTNode>.joinTextToString(): String = collectLeavesRecursively().joinToString(separator = "") { it.text }
+
+    private fun ASTNode.hasMinimumNumberOfParameters(): Boolean = countParameters() >= classSignatureWrappingMinimumParameters
+
+    private fun ASTNode.countParameters() =
+        getPrimaryConstructorParameterListOrNull()
+            ?.children()
+            .orEmpty()
+            .count { it.elementType == VALUE_PARAMETER }
+
+    private fun ASTNode.getPrimaryConstructorParameterListOrNull() =
+        findChildByType(PRIMARY_CONSTRUCTOR)?.findChildByType(VALUE_PARAMETER_LIST)
+
+    public companion object {
+        private const val FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET = Int.MAX_VALUE
+        public val FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY: EditorConfigProperty<Int> =
+            EditorConfigProperty(
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        "ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than",
+                        "Force wrapping the parameters of the class signature in case it contains at least the specified " +
+                            "number of parameters even in case the entire Class signature would fit on a single line. " +
+                            "By default this parameter is not enabled.",
+                        PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+                        setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
+                    ),
+                defaultValue = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET,
+                ktlintOfficialCodeStyleDefaultValue = 1,
+                propertyMapper = { property, _ ->
+                    if (property?.isUnset == true) {
+                        FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET
+                    } else {
+                        property?.getValueAs<Int>()
+                    }
+                },
+                propertyWriter = { property ->
+                    if (property == FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET) {
+                        "unset"
+                    } else {
+                        property.toString()
+                    }
+                },
+            )
+    }
+}
+
+public val CLASS_SIGNATURE_RULE_ID: RuleId = ClassSignatureRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -289,11 +289,11 @@ public class ClassSignatureRule :
                     if (whiteSpaceBeforeIdentifier == null ||
                         !whiteSpaceBeforeIdentifier.textContains('\n')
                     ) {
-                        // Let indent rule determine the exact indent
-                        val expectedParameterIndent = indentConfig.childIndentOf(node)
                         if (!dryRun) {
                             emit(firstParameterInList.startOffset, "Newline expected after opening parenthesis", true)
                         }
+                        // Let indent rule determine the exact indent
+                        val expectedParameterIndent = indentConfig.childIndentOf(node)
                         if (autoCorrect && !dryRun) {
                             valueParameterList.firstChildNode.upsertWhitespaceAfterMe(expectedParameterIndent)
                         } else {
@@ -351,11 +351,11 @@ public class ClassSignatureRule :
                             if (whiteSpaceBeforeIdentifier == null ||
                                 !whiteSpaceBeforeIdentifier.textContains('\n')
                             ) {
-                                // Let IndentationRule determine the exact indent
-                                val expectedParameterIndent = indentConfig.childIndentOf(node)
                                 if (!dryRun) {
                                     emit(valueParameter.startOffset, "Parameter should start on a newline", true)
                                 }
+                                // Let IndentationRule determine the exact indent
+                                val expectedParameterIndent = indentConfig.childIndentOf(node)
                                 if (autoCorrect && !dryRun) {
                                     firstChildNodeInValueParameter.upsertWhitespaceBeforeMe(expectedParameterIndent)
                                 } else {
@@ -365,11 +365,7 @@ public class ClassSignatureRule :
                         } else {
                             if (whiteSpaceBeforeIdentifier == null || whiteSpaceBeforeIdentifier.text != " ") {
                                 if (!dryRun) {
-                                    emit(
-                                        firstChildNodeInValueParameter!!.startOffset,
-                                        "Single whitespace expected before parameter",
-                                        true,
-                                    )
+                                    emit(firstChildNodeInValueParameter!!.startOffset, "Single whitespace expected before parameter", true)
                                 }
                                 if (autoCorrect && !dryRun) {
                                     firstChildNodeInValueParameter.upsertWhitespaceBeforeMe(" ")
@@ -405,15 +401,11 @@ public class ClassSignatureRule :
                     if (whiteSpaceBeforeClosingParenthesis == null ||
                         !whiteSpaceBeforeClosingParenthesis.textContains('\n')
                     ) {
+                        if (!dryRun) {
+                            emit(closingParenthesisPrimaryConstructor!!.startOffset, "Newline expected before closing parenthesis", true)
+                        }
                         // Let IndentationRule determine the exact indent
                         val expectedParameterIndent = node.indent()
-                        if (!dryRun) {
-                            emit(
-                                closingParenthesisPrimaryConstructor!!.startOffset,
-                                "Newline expected before closing parenthesis",
-                                true,
-                            )
-                        }
                         if (autoCorrect && !dryRun) {
                             closingParenthesisPrimaryConstructor!!.upsertWhitespaceBeforeMe(expectedParameterIndent)
                         } else {
@@ -524,11 +516,7 @@ public class ClassSignatureRule :
                                 if (whiteSpaceBeforeIdentifier == null ||
                                     whiteSpaceBeforeIdentifier.text != expectedWhitespace
                                 ) {
-                                    emit(
-                                        firstChildNodeInSuperType.startOffset,
-                                        "Expected single space before the first super type",
-                                        true,
-                                    )
+                                    emit(firstChildNodeInSuperType.startOffset, "Expected single space before the first super type", true)
                                     if (autoCorrect) {
                                         firstChildNodeInSuperType.upsertWhitespaceBeforeMe(expectedWhitespace)
                                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/DiscouragedCommentLocationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/DiscouragedCommentLocationRule.kt
@@ -1,15 +1,27 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ELSE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ELSE_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.THEN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
@@ -53,6 +65,12 @@ public class DiscouragedCommentLocationRule :
             ) {
                 emit(node.startOffset, "No comment expected at this location", false)
             }
+            when (node.treeParent.elementType) {
+                VALUE_ARGUMENT, VALUE_PARAMETER, TYPE_PROJECTION, TYPE_PARAMETER ->
+                    visitListElement(node, emit)
+                VALUE_ARGUMENT_LIST, VALUE_PARAMETER_LIST, TYPE_ARGUMENT_LIST, TYPE_PARAMETER_LIST ->
+                    visitList(node, emit)
+            }
         }
     }
 
@@ -64,6 +82,104 @@ public class DiscouragedCommentLocationRule :
         afterElementType: IElementType,
         beforeElementType: IElementType,
     ) = afterNodeOfElementType(afterElementType) && beforeNodeOfElementType(beforeElementType)
+
+    private fun visitListElement(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        when (node.elementType) {
+            EOL_COMMENT, BLOCK_COMMENT -> {
+                // Disallow a comment inside a VALUE_PARAMETER. Note that an EOL comment which is placed on a separate line is a direct
+                // child of the list.
+                //      class Foo(
+                //         val bar:
+                //             // some comment
+                //             Bar,
+                //     )
+                // or
+                //      class Foo(
+                //         val bar: Bar // some comment
+                //     )
+                // Although the last example looks ok it is not accepted because it can mess up a lot of things when trailing commas are
+                // enabled and/or multiple arguments are used in the class.
+                // It seems not to be possible to create a comment in a VALUE_ARGUMENT, TYPE_PROJECTION or TYPE_PARAMETER as a direct child
+                // of that type. However, if it would be possible, it is ok to emit the error analog to the VALUE_ARGUMENT
+                emit(
+                    node.startOffset,
+                    "A comment in a '${node.treeParentElementTypeName()}' is only allowed when placed on a new line before this element",
+                    false,
+                )
+            }
+            KDOC -> {
+                if (node.treeParent.elementType == VALUE_PARAMETER) {
+                    // Contrary to other comments, a kdoc which is placed on a separate line before the val keyword is part of the
+                    // VALUE_PARAMETER ast node and is to be allowed.
+                    if (node != node.treeParent.firstChildNode) {
+                        // Disallow a kdoc inside a VALUE_PARAMETER.
+                        //      class Foo(
+                        //         val bar:
+                        //             /** some comment */
+                        //             Bar,
+                        //     )
+                        // or
+                        //      class Foo(
+                        //         val bar: Bar /** some comment */
+                        //     )
+                        emit(
+                            node.startOffset,
+                            "A kdoc in a '${node.treeParentElementTypeName()}' is only allowed when placed on a new line before this " +
+                                "element",
+                            false,
+                        )
+                    }
+                } else {
+                    emit(
+                        node.startOffset,
+                        "A KDoc is not allowed on a '${node.treeParentElementTypeName()}",
+                        false,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun ASTNode.treeParentElementTypeName() =
+        treeParent
+            .elementType
+            .toString()
+            .lowercase()
+
+    private fun visitList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        when (node.elementType) {
+            EOL_COMMENT, BLOCK_COMMENT -> {
+                if (!node.prevLeaf().isWhiteSpaceWithNewline()) {
+                    // Disallow
+                    //     class Foo(
+                    //         val bar1: Bar, // some comment 1
+                    //         // some comment 2
+                    //         val bar2: Bar,
+                    //     )
+                    // It is not clear whether "some comment 2" belongs to bar1 as a continuation of "some comment 1" or that is belongs to
+                    // bar2.
+                    emit(
+                        node.startOffset,
+                        "A comment in a '${node.treeParentElementTypeName()}' is only allowed when placed on a separate line",
+                        false,
+                    )
+                }
+            }
+            KDOC -> {
+                emit(
+                    node.startOffset,
+                    "A KDoc is not allowed on a '${node.treeParentElementTypeName()}'",
+                    false,
+                )
+            }
+        }
+    }
 }
 
 public val DISCOURAGED_COMMENT_LOCATION_RULE_ID: RuleId = DiscouragedCommentLocationRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -447,10 +447,11 @@ public class IndentationRule :
                         toAstNode = nextToAstNode,
                     ).prevCodeLeaf()
             }
+        // No indent for the RPAR
         startIndentContext(
             fromAstNode = node,
             toAstNode = nextToAstNode,
-            lastChildIndent = "", // No indent for the RPAR
+            lastChildIndent = "",
         )
     }
 
@@ -531,8 +532,10 @@ public class IndentationRule :
 
     private fun visitLparBeforeCondition(node: ASTNode) {
         startIndentContext(
-            fromAstNode = requireNotNull(node.nextLeaf()), // Allow to pickup whitespace before condition
-            toAstNode = requireNotNull(node.nextCodeSibling()).lastChildLeafOrSelf(), // Ignore whitespace after condition but before rpar
+            // Allow to pickup whitespace before condition
+            fromAstNode = requireNotNull(node.nextLeaf()),
+            // Ignore whitespace after condition but before rpar
+            toAstNode = requireNotNull(node.nextCodeSibling()).lastChildLeafOrSelf(),
             nodeIndent = currentIndent() + indentConfig.indent,
             childIndent = "",
         )

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -133,6 +133,10 @@ public class IndentationRule :
             setOf(
                 VisitorModifier.RunAsLateAsPossible,
                 VisitorModifier.RunAfterRule(
+                    ruleId = CLASS_SIGNATURE_RULE_ID,
+                    mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
+                ),
+                VisitorModifier.RunAfterRule(
                     ruleId = FUNCTION_SIGNATURE_RULE_ID,
                     mode = REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED,
                 ),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -14,10 +14,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CATCH
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLOSING_QUOTE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONDITION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_DELEGATION_CALL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_KEYWORD
@@ -65,8 +63,6 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SECONDARY_CONSTRUCTOR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SHORT_STRING_TEMPLATE_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_ENTRY
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.THEN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TRY
@@ -211,8 +207,7 @@ public class IndentationRule :
                 visitNewLineIndentation(node, autoCorrect, emit)
             }
 
-            node.elementType == CLASS_BODY ||
-                node.elementType == CONTEXT_RECEIVER_LIST ||
+            node.elementType == CONTEXT_RECEIVER_LIST ||
                 node.elementType == LONG_STRING_TEMPLATE_ENTRY ||
                 node.elementType == STRING_TEMPLATE ||
                 node.elementType == VALUE_ARGUMENT_LIST ->
@@ -221,7 +216,7 @@ public class IndentationRule :
                     lastChildIndent = "",
                 )
 
-            node.elementType == SUPER_TYPE_CALL_ENTRY -> {
+            node.elementType == SUPER_TYPE_LIST -> {
                 if (codeStyle == ktlint_official && node.isPartOfClassWithAMultilinePrimaryConstructor()) {
                     // Contrary to the default IntelliJ IDEA formatter, indent the super type call entry so that it looks better in case it
                     // is followed by another super type:
@@ -235,13 +230,7 @@ public class IndentationRule :
                     //          BarFoo,
                     startIndentContext(
                         fromAstNode = node,
-                        childIndent = indentConfig.indent,
                         activated = true,
-                    )
-                } else {
-                    startIndentContext(
-                        fromAstNode = node,
-                        lastChildIndent = "",
                     )
                 }
             }
@@ -264,7 +253,6 @@ public class IndentationRule :
                 }
 
             node.elementType == BINARY_WITH_TYPE ||
-                node.elementType == SUPER_TYPE_ENTRY ||
                 node.elementType == TYPE_ARGUMENT_LIST ||
                 node.elementType == TYPE_PARAMETER_LIST ||
                 node.elementType == USER_TYPE ->
@@ -647,9 +635,9 @@ public class IndentationRule :
                     requireNotNull(
                         where.nextCodeSibling(),
                     ) { "Can not find code sibling after WHERE in CLASS" }
-                require(
-                    typeConstraintList.elementType == TYPE_CONSTRAINT_LIST,
-                ) { "Code sibling after WHERE in CLASS is not a TYPE_CONSTRAINT_LIST" }
+                require(typeConstraintList.elementType == TYPE_CONSTRAINT_LIST) {
+                    "Code sibling after WHERE in CLASS is not a TYPE_CONSTRAINT_LIST"
+                }
                 nextToAstNode =
                     startIndentContext(
                         fromAstNode = where.getPrecedingLeadingCommentsAndWhitespaces(),
@@ -660,53 +648,12 @@ public class IndentationRule :
         val primaryConstructor = node.findChildByType(PRIMARY_CONSTRUCTOR)
         val containsConstructorKeyword = primaryConstructor?.findChildByType(CONSTRUCTOR_KEYWORD) != null
         if (codeStyle == ktlint_official && primaryConstructor != null && containsConstructorKeyword) {
-            // Contrary to the default IntelliJ IDEA formatter, ident both constructor and super type list as follows:
-            //     class Foo
-            //        @Bar1 @Bar2
-            //        constructor(
-            //            foo1: Foo1,
-            //            foo2: Foo2,
-            //        ) : Foobar1(
-            //                "foobar1",
-            //                "foobar2",
-            //            ),
-            //            FooBar2,
-            val superTypeList = node.findChildByType(SUPER_TYPE_LIST)
             nextToAstNode =
                 startIndentContext(
                     fromAstNode = primaryConstructor.getPrecedingLeadingCommentsAndWhitespaces(),
-                    toAstNode =
-                        superTypeList
-                            ?.lastChildLeafOrSelf()
-                            ?: nextToAstNode,
+                    toAstNode = nextToAstNode,
+//                    activated = true,
                 ).prevCodeLeaf()
-
-            superTypeList
-                ?.findChildByType(COMMA)
-                ?.let { comma ->
-                    // In case of a multiline primary constructor the first super type is merged with the closing parenthesis of the
-                    // constructor. The start of the super type list does not activate the indent because it is not preceded by a newline.
-                    // To fix this, the super type entries on the next line (e.g. after the comma) have to be double indented.
-                    // Allow:
-                    //     class Foo(
-                    //         val bar1: Bar,
-                    //         val bar2: Bar,
-                    //     ) : FooBar(
-                    //             bar1,
-                    //             bar2
-                    //         ),
-                    //         BarFoo1
-                    val prevCodeLeaf =
-                        startIndentContext(
-                            fromAstNode = comma,
-                            toAstNode = superTypeList.lastChildLeafOrSelf(),
-                            childIndent = indentConfig.indent.repeat(2),
-                        ).prevCodeLeaf()
-                    startIndentContext(
-                        fromAstNode = primaryConstructor.getPrecedingLeadingCommentsAndWhitespaces(),
-                        toAstNode = prevCodeLeaf,
-                    ).prevCodeLeaf()
-                }
         } else {
             node
                 .findChildByType(SUPER_TYPE_LIST)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -166,7 +166,9 @@ private data class ParsedLine(
     }
 }
 
-internal class RangeTree(seq: List<Int> = emptyList()) {
+internal class RangeTree(
+    seq: List<Int> = emptyList(),
+) {
     private var emptyArrayView = ArrayView(0, 0)
     private var arr: IntArray = seq.toIntArray()
 
@@ -219,7 +221,10 @@ internal class RangeTree(seq: List<Int> = emptyList()) {
 
     fun isEmpty(): Boolean = arr.isEmpty()
 
-    inner class ArrayView(private var l: Int, private val r: Int) {
+    inner class ArrayView(
+        private var l: Int,
+        private val r: Int,
+    ) {
         val size: Int = r - l
 
         fun get(i: Int): Int {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRule.kt
@@ -9,7 +9,9 @@ import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class NoEmptyFileRule : StandardRule(id = "no-empty-file"), Rule.Experimental {
+public class NoEmptyFileRule :
+    StandardRule(id = "no-empty-file"),
+    Rule.Experimental {
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -259,7 +259,10 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
 
     private fun String.removeBackticksAndTrim() = replace("`", "").trim()
 
-    private data class Reference(val text: String, val inDotQualifiedExpression: Boolean)
+    private data class Reference(
+        val text: String,
+        val inDotQualifiedExpression: Boolean,
+    )
 
     private companion object {
         val COMPONENT_N_REGEX = Regex("^component\\d+$")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRule.kt
@@ -89,7 +89,7 @@ public class NoWildcardImportsRule :
                         "Defines allowed wildcard imports",
                         PACKAGES_TO_USE_ON_DEMAND_IMPORT_PROPERTY_PARSER,
                     ),
-                /**
+                /*
                  * Default IntelliJ IDEA style: Use wildcard imports for packages in "java.util", "kotlin.android.synthetic" and
                  * it's subpackages.
                  *

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProviderTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProviderTest.kt
@@ -2,7 +2,8 @@ package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.test.RuleSetProviderTest
 
-class StandardRuleSetProviderTest : RuleSetProviderTest(
-    rulesetClass = StandardRuleSetProvider::class.java,
-    packageName = "com.pinterest.ktlint.ruleset.standard.rules",
-)
+class StandardRuleSetProviderTest :
+    RuleSetProviderTest(
+        rulesetClass = StandardRuleSetProvider::class.java,
+        packageName = "com.pinterest.ktlint.ruleset.standard.rules",
+    )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -887,6 +887,7 @@ class ArgumentListWrappingRuleTest {
         argumentListWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { ClassSignatureRule() }
+            .addAdditionalRuleProvider { DiscouragedCommentLocationRule() }
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
             .hasLintViolationForAdditionalRule(5, 37, "Super type should start on a newline")
             .hasLintViolations(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.ClassSignatureRule.Companion.FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
@@ -855,5 +856,43 @@ class ArgumentListWrappingRuleTest {
             // function call in case that call is part of a binary expression. It might be better to break the line at the operation
             // reference instead.
             .hasNoLintViolationsExceptInAdditionalRules()
+    }
+
+    @Test
+    fun `Given a super type call entry with arguments which after wrapping to the next line does not fit on that line then keep start of body on same line as end of super type call entry`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            // Note that the super type call does not fit the line after it has been wrapped
+            // ...Foo(a: Any, b: Any, c: Any) :
+            //  FooBar(a, "longggggggggggggggggggggggggggggggggggg")
+            class Foo(a: Any, b: Any, c: Any) : FooBar(a, "longggggggggggggggggggggggggggggggggggg") {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            // Note that the super type call does not fit the line after it has been wrapped
+            // ...Foo(a: Any, b: Any, c: Any) :
+            //  FooBar(a, "longggggggggggggggggggggggggggggggggggg")
+            class Foo(a: Any, b: Any, c: Any) :
+                FooBar(
+                    a,
+                    "longggggggggggggggggggggggggggggggggggg"
+                ) {
+                // body
+            }
+            """.trimIndent()
+        argumentListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { ClassSignatureRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
+            .hasLintViolationForAdditionalRule(5, 37, "Super type should start on a newline")
+            .hasLintViolations(
+                LintViolation(5, 44, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(5, 47, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(5, 88, "Missing newline before \")\""),
+            ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1228,9 +1228,10 @@ class ClassSignatureRuleTest {
                     ) : FooBar(bar1, bar2),
                         BarFoo1,
                         BarFoo2 {
-                    // body
-                }
+                        // body
+                    }
                 """.trimIndent()
+
             classSignatureWrappingRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .addAdditionalRuleProvider { IndentationRule() }
@@ -1272,8 +1273,8 @@ class ClassSignatureRuleTest {
                     ) : FooBar(bar1, bar2),
                         BarFoo1,
                         BarFoo2 {
-                    // body
-                }
+                        // body
+                    }
                 """.trimIndent()
             val formattedCodeNonKtlintOfficial =
                 """
@@ -1639,6 +1640,33 @@ class ClassSignatureRuleTest {
 
             assertThat(actual).isEqualTo(expectedOutputValue)
         }
+    }
+
+    @Test
+    fun `Given a single line primary constructor which needs to be wrapped followed by a super type on the next line then merge supertype with line containing the closing parenthesis of the constructor`() {
+        val code =
+            """
+            class Foo(bar: Bar) :
+                FooBar(bar) {
+                    fun doSomething() {}
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo(
+                bar: Bar
+            ) : FooBar(bar) {
+                fun doSomething() {}
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+            .hasLintViolations(
+                LintViolation(1, 11, "Newline expected after opening parenthesis"),
+                LintViolation(1, 19, "Newline expected before closing parenthesis"),
+                LintViolation(2, 5, "Expected single space before the super type"),
+            ).isFormattedAs(formattedCode)
     }
 
     private companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
@@ -21,7 +22,11 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class ClassSignatureRuleTest {
-    private val classSignatureWrappingRuleAssertThat = assertThatRule { ClassSignatureRule() }
+    private val classSignatureWrappingRuleAssertThat =
+        assertThatRule(
+            provider = { ClassSignatureRule() },
+            additionalRuleProviders = setOf(RuleProvider { DiscouragedCommentLocationRule() }),
+        )
 
     @Nested
     inner class `Given a class with a body` {
@@ -1483,170 +1488,6 @@ class ClassSignatureRuleTest {
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
             .hasLintViolation(5, 37, "Super type should start on a newline")
             .isFormattedAs(formattedCode)
-    }
-
-    @Nested
-    inner class `Given a comment or kdoc in the class header` {
-        @Test
-        fun `Given an EOL comment in the class parameter list then allow to rewrite the class signature`() {
-            // EOL comments in the parameter list are siblings of the value parameters
-            val code =
-                """
-                class Foo(
-                    // before first value parameter
-                    foo: Any,
-                    // between value parameters
-                    bar: Any
-                    // after last value parameter
-                ) : FooBar1, FooBar2
-                """.trimIndent()
-            val formattedCode =
-                """
-                class Foo(
-                    // before first value parameter
-                    foo: Any,
-                    // between value parameters
-                    bar: Any
-                    // after last value parameter
-                ) : FooBar1,
-                    FooBar2
-                """.trimIndent()
-            classSignatureWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(7, 14, "Super type should start on a newline")
-                .isFormattedAs(formattedCode)
-        }
-
-        @Test
-        fun `Given a block comment in the class parameter list then allow to rewrite the class signature`() {
-            // Block comments in the parameter list are siblings of the value parameters
-            val code =
-                """
-                class Foo(
-                    /* before first value parameter */
-                    foo: Any,
-                    /* between value parameters */
-                    bar: Any
-                    /* after last value parameter */
-                ) : FooBar1, FooBar2
-                """.trimIndent()
-            val formattedCode =
-                """
-                class Foo(
-                    /* before first value parameter */
-                    foo: Any,
-                    /* between value parameters */
-                    bar: Any
-                    /* after last value parameter */
-                ) : FooBar1,
-                    FooBar2
-                """.trimIndent()
-            classSignatureWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(7, 14, "Super type should start on a newline")
-                .isFormattedAs(formattedCode)
-        }
-
-        @Test
-        fun `Given a KDoc in the class parameter list then allow to rewrite the class signature`() {
-            // KDoc before a value parameter is contained as inner node in the VALUE_PARAMETER. A KDoc after the last value parameter is a
-            // siblings of the value parameters
-            val code =
-                """
-                class Foo(
-                    /** before first value parameter */
-                    foo: Any,
-                    /** between value parameters */
-                    bar: Any
-                    /** after last value parameter */
-                ) : FooBar1, FooBar2
-                """.trimIndent()
-            val formattedCode =
-                """
-                class Foo(
-                    /** before first value parameter */
-                    foo: Any,
-                    /** between value parameters */
-                    bar: Any
-                    /** after last value parameter */
-                ) : FooBar1,
-                    FooBar2
-                """.trimIndent()
-            classSignatureWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(7, 14, "Super type should start on a newline")
-                .isFormattedAs(formattedCode)
-        }
-
-        @ParameterizedTest(name = "{0}")
-        @ValueSource(
-            strings = [
-                """
-                class // some comment
-                    Foo: FooBar1, FooBar2
-                """,
-                """
-                class /* some comment */ Foo: FooBar1, FooBar2
-                """,
-                """
-                class /** some kdoc */ Foo: FooBar1, FooBar2
-                """,
-                """
-                class Foo // some comment
-                    : FooBar1, FooBar2
-                """,
-                """
-                class Foo /* some comment */ : FooBar1, FooBar2
-                """,
-                """
-                class Foo /** some kdoc */ : FooBar1, FooBar2
-                """,
-                """
-                class Foo : // some comment
-                    FooBar1, FooBar2
-                """,
-                """
-                class Foo : /* some comment */ FooBar1, FooBar2
-                """,
-                """
-                class Foo : /** some kdoc */ FooBar1, FooBar2
-                """,
-                """
-                class Foo : FooBar1 // some comment
-                    , FooBar2
-                """,
-                """
-                class Foo : FooBar1 /* some comment */, FooBar2
-                """,
-                """
-                class Foo : FooBar1 /* some comment */, FooBar2
-                """,
-                """
-                class Foo : FooBar1, // some comment
-                    FooBar2
-                """,
-                """
-                class Foo : FooBar1, /* some comment */ FooBar2
-                """,
-                """
-                class Foo : FooBar1, /* some comment */ FooBar2
-                """,
-                """
-                class Foo : FooBar1, FooBar2 // some comment
-                """,
-                """
-                class Foo : FooBar1,  FooBar2 /* some comment */
-                """,
-                """
-                class Foo : FooBar1,  FooBar2 /* some comment */
-                """,
-            ],
-        )
-        fun `Given a comment or kdoc at an unexpected location then do not rewrite the class signature`(code: String) {
-            classSignatureWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(7, 14, "Super type should start on a newline")
-        }
     }
 
     @Nested

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1486,6 +1486,170 @@ class ClassSignatureRuleTest {
     }
 
     @Nested
+    inner class `Given a comment or kdoc in the class header` {
+        @Test
+        fun `Given an EOL comment in the class parameter list then allow to rewrite the class signature`() {
+            // EOL comments in the parameter list are siblings of the value parameters
+            val code =
+                """
+                class Foo(
+                    // before first value parameter
+                    foo: Any,
+                    // between value parameters
+                    bar: Any
+                    // after last value parameter
+                ) : FooBar1, FooBar2
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    // before first value parameter
+                    foo: Any,
+                    // between value parameters
+                    bar: Any
+                    // after last value parameter
+                ) : FooBar1,
+                    FooBar2
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(7, 14, "Super type should start on a newline")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a block comment in the class parameter list then allow to rewrite the class signature`() {
+            // Block comments in the parameter list are siblings of the value parameters
+            val code =
+                """
+                class Foo(
+                    /* before first value parameter */
+                    foo: Any,
+                    /* between value parameters */
+                    bar: Any
+                    /* after last value parameter */
+                ) : FooBar1, FooBar2
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    /* before first value parameter */
+                    foo: Any,
+                    /* between value parameters */
+                    bar: Any
+                    /* after last value parameter */
+                ) : FooBar1,
+                    FooBar2
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(7, 14, "Super type should start on a newline")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a KDoc in the class parameter list then allow to rewrite the class signature`() {
+            // KDoc before a value parameter is contained as inner node in the VALUE_PARAMETER. A KDoc after the last value parameter is a
+            // siblings of the value parameters
+            val code =
+                """
+                class Foo(
+                    /** before first value parameter */
+                    foo: Any,
+                    /** between value parameters */
+                    bar: Any
+                    /** after last value parameter */
+                ) : FooBar1, FooBar2
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    /** before first value parameter */
+                    foo: Any,
+                    /** between value parameters */
+                    bar: Any
+                    /** after last value parameter */
+                ) : FooBar1,
+                    FooBar2
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolation(7, 14, "Super type should start on a newline")
+                .isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(
+            strings = [
+                """
+                class // some comment
+                    Foo: FooBar1, FooBar2
+                """,
+                """
+                class /* some comment */ Foo: FooBar1, FooBar2
+                """,
+                """
+                class /** some kdoc */ Foo: FooBar1, FooBar2
+                """,
+                """
+                class Foo // some comment
+                    : FooBar1, FooBar2
+                """,
+                """
+                class Foo /* some comment */ : FooBar1, FooBar2
+                """,
+                """
+                class Foo /** some kdoc */ : FooBar1, FooBar2
+                """,
+                """
+                class Foo : // some comment
+                    FooBar1, FooBar2
+                """,
+                """
+                class Foo : /* some comment */ FooBar1, FooBar2
+                """,
+                """
+                class Foo : /** some kdoc */ FooBar1, FooBar2
+                """,
+                """
+                class Foo : FooBar1 // some comment
+                    , FooBar2
+                """,
+                """
+                class Foo : FooBar1 /* some comment */, FooBar2
+                """,
+                """
+                class Foo : FooBar1 /* some comment */, FooBar2
+                """,
+                """
+                class Foo : FooBar1, // some comment
+                    FooBar2
+                """,
+                """
+                class Foo : FooBar1, /* some comment */ FooBar2
+                """,
+                """
+                class Foo : FooBar1, /* some comment */ FooBar2
+                """,
+                """
+                class Foo : FooBar1, FooBar2 // some comment
+                """,
+                """
+                class Foo : FooBar1,  FooBar2 /* some comment */
+                """,
+                """
+                class Foo : FooBar1,  FooBar2 /* some comment */
+                """,
+            ],
+        )
+        fun `Given a comment or kdoc at an unexpected location then do not rewrite the class signature`(code: String) {
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolationWithoutAutoCorrect(7, 14, "Super type should start on a newline")
+        }
+    }
+
+    @Nested
     inner class `Property ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` {
         val propertyMapper = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.propertyMapper!!
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1,0 +1,1587 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
+import com.pinterest.ktlint.ruleset.standard.rules.ClassSignatureRule.Companion.FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class ClassSignatureRuleTest {
+    private val classSignatureWrappingRuleAssertThat = assertThatRule { ClassSignatureRule() }
+
+    @Nested
+    inner class `Given a class with a body` {
+        @Test
+        fun `Given a single line class signature which is smaller than or equal to the max line length, and the class is followed by a body block, then do not change the signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a single line class signature without parameters but exceeding the max line length then do not change the signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+                class Foooooooooooooooooooooo {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a single line class signature which is equal to the max line length but missing a space before the opening brace of the body block then reformat to a multiline signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any){
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+                class Foo(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                ) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .addAdditionalRuleProvider { FunctionStartOfBodySpacingRule() }
+                .hasLintViolation(2, 34, "Expected a single space before class body")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line class signature which is greater then the max line length then reformat to a multiline signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+                class Foo(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                ) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 19, "Parameter should start on a newline"),
+                    LintViolation(2, 27, "Parameter should start on a newline"),
+                    LintViolation(2, 33, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a single line class signature, without class body, which is greater then the max line length then reformat to a multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any)
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(2, 19, "Parameter should start on a newline"),
+                LintViolation(2, 27, "Parameter should start on a newline"),
+                LintViolation(2, 33, "Newline expected before closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given a single line class signature and max-line-length is not set` {
+        @Test
+        fun `Given the ktlint code style`() {
+            val code =
+                """
+                // No max line length marker!
+                class Foo1(a: Any)
+                class Foo2(a: Any, b: Any)
+                class Foo3(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            val formattedCode =
+                """
+                // No max line length marker!
+                class Foo1(
+                    a: Any
+                )
+                class Foo2(
+                    a: Any,
+                    b: Any
+                )
+                class Foo3(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolations(
+                    LintViolation(2, 12, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 18, "Newline expected before closing parenthesis"),
+                    LintViolation(3, 12, "Newline expected after opening parenthesis"),
+                    LintViolation(3, 20, "Parameter should start on a newline"),
+                    LintViolation(3, 26, "Newline expected before closing parenthesis"),
+                    LintViolation(4, 12, "Newline expected after opening parenthesis"),
+                    LintViolation(4, 20, "Parameter should start on a newline"),
+                    LintViolation(4, 28, "Parameter should start on a newline"),
+                    LintViolation(4, 34, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(
+            value = CodeStyleValue::class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = ["ktlint_official"],
+        )
+        fun `Given non-ktlint_official code style`(codeStyle: CodeStyleValue) {
+            val code =
+                """
+                // No max line length marker!
+                class Foo1(a: Any)
+                class Foo2(a: Any, b: Any)
+                class Foo3(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
+                .hasNoLintViolations()
+        }
+    }
+
+    @Test
+    fun `Given a single line class signature and first parameter is annotated and class signature has a length greater than the max line length then reformat to multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            class Foo(@Foo a: Any, b: Any, c: Any)
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            class Foo(
+                @Foo a: Any,
+                b: Any,
+                c: Any
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(2, 24, "Parameter should start on a newline"),
+                LintViolation(2, 32, "Parameter should start on a newline"),
+                LintViolation(2, 38, "Newline expected before closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Disabled
+    @Test
+    fun `Given some class signatures containing at least one comment then do not reformat although the max line length is exceeded`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            private /* some comment */ class Foo1(a: Any, b: Any)
+            private class /* some comment */ Foo2(a: Any, b: Any)
+            private class Foo3 /* some comment */ (a: Any, b: Any)
+            private class Foo4( /* some comment */ a: Any, b: Any)
+            private class Foo5(a /* some comment */ : Any, b: Any)
+            private class Foo6(a: /* some comment */ Any, b: Any)
+            private class Foo7(a: Any /* some comment */, b: Any)
+            private class Foo8(a: Any, b: Any) /* some comment */
+            private class Foo9(
+                a: Any, // some-comment
+                b: Any
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a class signature with a newline between the last parameter in the parameter list and the closing parenthesis, but which does not fit on a single line then reformat to a proper multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(2, 19, "Parameter should start on a newline"),
+                LintViolation(2, 27, "Parameter should start on a newline"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class without parameters but with parenthesis then reformat to a proper single line signature`() {
+        val code =
+            """
+            class Foo()
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 10, "No parenthesis expected")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class without parameters but with at least one space between the parenthesis then reformat to a proper single line signature`() {
+        val code =
+            """
+            class Foo( )
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 10, "No parenthesis expected")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class without parameters but with at least one newline between the parenthesis then reformat to a proper single line signature`() {
+        val code =
+            """
+            class Foo(
+
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 10, "No parenthesis expected")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class without parameters but containing an EOL-comment in the parameter list then do not reformat the class signature`() {
+        val code =
+            """
+            class Foo(
+                // some comment
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a multiline class signature which actually fits on a single line then reformat the signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 5, "No whitespace expected between opening parenthesis and first parameter name"),
+                LintViolation(4, 5, "Single whitespace expected before parameter"),
+                LintViolation(5, 5, "Single whitespace expected before parameter"),
+                LintViolation(5, 11, "No whitespace expected between last parameter and closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line class signature with a body starting on next line as it does not fit on same line then reformat to a multiline class signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any)
+            {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            ) {
+                // body
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(2, 19, "Parameter should start on a newline"),
+                LintViolation(2, 27, "Parameter should start on a newline"),
+                LintViolation(2, 33, "Newline expected before closing parenthesis"),
+                LintViolation(3, 1, "Expected a single space before class body"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given a custom setting for the minimum number of parameters which enforces a multiline signature` {
+        @Test
+        fun `Given a single line class signature which is smaller than or equal to the max line length and not having too many parameters then do not reformat to a multiline signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a single line class signature which is smaller than or equal to the max line length but having too many parameters then do reformat as multiline signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                class Foo(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 3)
+                .hasLintViolations(
+                    LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 19, "Parameter should start on a newline"),
+                    LintViolation(2, 27, "Parameter should start on a newline"),
+                    LintViolation(2, 33, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a single line class signature and max line length not set but having too many parameters then do reformat as multiline signature`() {
+            val code =
+                """
+                class Foo(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 3)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Newline expected after opening parenthesis"),
+                    LintViolation(1, 19, "Parameter should start on a newline"),
+                    LintViolation(1, 27, "Parameter should start on a newline"),
+                    LintViolation(1, 33, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given the ktlint_official code style then avoid wrapping of parameters by overriding property ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`() {
+            val code =
+                """
+                class Foo(a: Any, b: Any, c: Any)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasNoLintViolations()
+        }
+    }
+
+    @Test
+    fun `Given an abstract class declaration`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR                                                                                                       $EOL_CHAR
+            abstract class Foo(a: Any, b: Any)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    // The ClassSignatureWrappingRule depends on a lot of different rules to do an initial clean up. The tests below ensure that those rules
+    // effectively clean up so that the FunctionSignatureWrappingRule does not need to check for it at all.
+    @Nested
+    inner class CleanUpByRelatedRules {
+        @Test
+        fun `Given a nullable type with a space before the quest then remove this space`() {
+            @Suppress("ktlint:standard:string-template")
+            val code =
+                """
+                class Foo1<B : Bar$UNEXPECTED_SPACES?>(b: B)
+                class Foo2<B : List<Bar$UNEXPECTED_SPACES?>>(b: B)
+                class Foo3<B : List<Bar>$UNEXPECTED_SPACES?>(b: B)
+                class Foo4(b: B$UNEXPECTED_SPACES?)
+                class Foo5(b: List<B$UNEXPECTED_SPACES?>)
+                class Foo6(b: List<B>$UNEXPECTED_SPACES?)
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo1<B : Bar?>(b: B)
+                class Foo2<B : List<Bar?>>(b: B)
+                class Foo3<B : List<Bar>?>(b: B)
+                class Foo4(b: B?)
+                class Foo5(b: List<B?>)
+                class Foo6(b: List<B>?)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { NullableTypeSpacingRule() }
+                .hasNoLintViolationsExceptInAdditionalRules()
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class signature contains redundant spaces then ensure that those are removed before running the class signature rule`() {
+            val code =
+                """
+                private${UNEXPECTED_SPACES}class Foo1(a: Any)
+                class Foo2$UNEXPECTED_SPACES(a: Any)
+                class Foo3(${UNEXPECTED_SPACES}a: Any)
+                class Foo4(a$UNEXPECTED_SPACES: Any)
+                class Foo5(a:${UNEXPECTED_SPACES}Any)
+                class Foo6(a: Any$UNEXPECTED_SPACES, b: Any)
+                class Foo7(a: Any,${UNEXPECTED_SPACES}b: Any)
+                class Foo8(a: Any, b: Any$UNEXPECTED_SPACES)
+                class Foo9(${UNEXPECTED_SPACES}vararg a: Any)
+                class Foo10(vararg${UNEXPECTED_SPACES}a: Any)
+                class Foo11$UNEXPECTED_SPACES{}
+                class Foo12$UNEXPECTED_SPACES: Bar()
+                class Foo13 :${UNEXPECTED_SPACES}Bar()
+                class Foo14<${UNEXPECTED_SPACES}Any>
+                class Foo15<Any${UNEXPECTED_SPACES}>
+                class Foo16<A${UNEXPECTED_SPACES}: Any>
+                class Foo17<A :${UNEXPECTED_SPACES}Any>
+                class Foo18<Any${UNEXPECTED_SPACES}, Any>
+                class Foo19<Any,${UNEXPECTED_SPACES}Any>
+                class Foo20<Any, Any${UNEXPECTED_SPACES}>
+                class Foo21<M : Map<${UNEXPECTED_SPACES}Any, Any>>(map: M)
+                class Foo22<M : Map<Any${UNEXPECTED_SPACES}, Any>>(map: M)
+                class Foo23<M : Map<Any,${UNEXPECTED_SPACES}Any>>(map: M)
+                class Foo24<M : Map<Any, Any${UNEXPECTED_SPACES}>>(map: M)
+                """.trimIndent()
+            val formattedCode =
+                """
+                private class Foo1(a: Any)
+                class Foo2(a: Any)
+                class Foo3(a: Any)
+                class Foo4(a: Any)
+                class Foo5(a: Any)
+                class Foo6(a: Any, b: Any)
+                class Foo7(a: Any, b: Any)
+                class Foo8(a: Any, b: Any)
+                class Foo9(vararg a: Any)
+                class Foo10(vararg a: Any)
+                class Foo11 {}
+                class Foo12 : Bar()
+                class Foo13 : Bar()
+                class Foo14<Any>
+                class Foo15<Any>
+                class Foo16<A : Any>
+                class Foo17<A : Any>
+                class Foo18<Any, Any>
+                class Foo19<Any, Any>
+                class Foo20<Any, Any>
+                class Foo21<M : Map<Any, Any>>(map: M)
+                class Foo22<M : Map<Any, Any>>(map: M)
+                class Foo23<M : Map<Any, Any>>(map: M)
+                class Foo24<M : Map<Any, Any>>(map: M)
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            classSignatureWrappingRuleAssertThat(code)
+                .addAdditionalRuleProviders(
+                    { NoMultipleSpacesRule() },
+                    { SpacingAroundAngleBracketsRule() },
+                    { SpacingAroundParensRule() },
+                    { SpacingAroundCommaRule() },
+                    { SpacingAroundColonRule() },
+                ).hasLintViolations(
+                    LintViolation(3, 14, "No whitespace expected between opening parenthesis and first parameter name"),
+                    LintViolation(7, 21, "Single whitespace expected before parameter"),
+                    LintViolation(8, 26, "No whitespace expected between last parameter and closing parenthesis"),
+                    LintViolation(9, 14, "No whitespace expected between opening parenthesis and first parameter name"),
+                    LintViolation(11, 14, "Expected a single space before class body"),
+                    LintViolation(13, 16, "Expected single space before the super type"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class signature missing required spaces then ensure that those are added before running the class signature rule`() {
+            val code =
+                """
+                class Foo1(a:${NO_SPACE}Any)
+                class Foo2(a: Any,${NO_SPACE}b: Any)
+                class Foo3$NO_SPACE: Bar()
+                class Foo4 :${NO_SPACE}Bar()
+                class Foo5<A${NO_SPACE}: Any>
+                class Foo6<A :${NO_SPACE}Any>
+                class Foo7<Any,${NO_SPACE}Any>
+                class Foo8<M : Map<Any,${NO_SPACE}Any>>(map: M)
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo1(a: Any)
+                class Foo2(a: Any, b: Any)
+                class Foo3 : Bar()
+                class Foo4 : Bar()
+                class Foo5<A : Any>
+                class Foo6<A : Any>
+                class Foo7<Any, Any>
+                class Foo8<M : Map<Any, Any>>(map: M)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .addAdditionalRuleProviders(
+                    { TypeParameterListSpacingRule() },
+                    { FunctionStartOfBodySpacingRule() },
+                    { FunctionTypeReferenceSpacingRule() },
+                    { SpacingAroundColonRule() },
+                    { SpacingAroundCommaRule() },
+                    { SpacingAroundOperatorsRule() },
+                ).hasLintViolations(
+                    LintViolation(2, 19, "Single whitespace expected before parameter"),
+                    LintViolation(4, 13, "Expected single space before the super type"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Given a single line class signature with an annotated parameter` {
+        @Test
+        fun `Given ktlint_official code style`() {
+            val code =
+                """
+                class Foo1(a: Int, bar: String, b: Int)
+                class Foo2(a: Int, @Bar bar: String, b: Int)
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo1(a: Int, bar: String, b: Int)
+                class Foo2(
+                    a: Int,
+                    @Bar bar: String,
+                    b: Int
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to Int.MAX_VALUE)
+                .hasLintViolations(
+                    LintViolation(2, 12, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 20, "Parameter should start on a newline"),
+                    LintViolation(2, 38, "Parameter should start on a newline"),
+                    LintViolation(2, 44, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(
+            value = CodeStyleValue::class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = ["ktlint_official"],
+        )
+        fun `Given non-ktlint_official code style`(codeStyle: CodeStyleValue) {
+            val code =
+                """
+                class Foo(a: Int, @Bar bar: String, b: Int)
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to Int.MAX_VALUE)
+                .hasNoLintViolations()
+        }
+    }
+
+    @Test
+    fun `Given a class signature with an annotated parameter and the annotation is on a separate line then reformat it as a multiline signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+            class Foo(@Bar
+                bar: String)
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                $EOL_CHAR
+            class Foo(
+                @Bar
+                bar: String
+            )
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(3, 16, "Newline expected before closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class preceded by an annotation array`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER              $EOL_CHAR
+            internal class Foo1(foo1: Foo, foo2: Foo)
+
+            @Bar
+            internal class Foo2(foo1: Foo, foo2: Foo)
+
+            @[Bar]
+            internal class Foo2(foo1: Foo, foo2: Foo)
+
+            @[Bar1 Bar2 Bar3 Bar4 Bar5 Bar6 Bar7 Bar8 Bar9]
+            internal class Foo2(foo1: Foo, foo2: Foo)
+
+            @[Bar1 // some comment
+            Bar2]
+            internal class Foo2(foo1: Foo, foo2: Foo)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line class signature extending another class, the primary constructor fitting on a single line but not together with the super type then wrap the super type`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) : FooBar(a, c)
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) :
+                FooBar(a, c)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 37, "Super type should start on a newline")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given a class declaration` {
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(
+            strings = [
+                """
+                class Foo {
+                    // body
+                }
+                """,
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) {
+                    // body
+                }
+                """,
+                """
+                class Foo : FooBar("bar") {
+                    // body
+                }
+                """,
+                """
+                class Foo : FooBar("bar1", "bar2") {
+                    // body
+                }
+                """,
+                """
+                class Foo :
+                    FooBar(
+                        "bar1",
+                        "bar2",
+                    ) {
+                    // body
+                }
+                """,
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) : FooBar(bar1) {
+                    // body
+                }
+                """,
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) : FooBar(bar1, bar2) {
+                    // body
+                }
+                """,
+                """
+                class Foo :
+                    FooBar(
+                        "bar1",
+                        "bar2",
+                    ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """,
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) : FooBar(bar1, bar2),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """,
+            ],
+        )
+        fun `Given some correctly formatted class`(code: String) {
+            classSignatureWrappingRuleAssertThat(code.trimIndent())
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+            classSignatureWrappingRuleAssertThat(code.trimIndent())
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class with an empty primary constructor only`() {
+            val code =
+                """
+                class Foo() {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class with primary constructor only`() {
+            val code =
+                """
+                class Foo(val bar1: Bar) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    val bar1: Bar
+                ) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class without primary constructor and multiline super type call entry starting on same line as class keyword`() {
+            val code =
+                """
+                class Foo : FooBar(
+                    "bar1",
+                    "bar2",
+                ) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo :
+                    FooBar(
+                        "bar1",
+                        "bar2",
+                    ) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class with primary constructor and single line super type call entry on same line as class keyword`() {
+            val code =
+                """
+                class Foo(val bar1: Bar) : FooBar(bar1) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo(
+                    val bar1: Bar
+                ) : FooBar(bar1) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class with a multiline primary constructor and multiline super type call entry starting on same line as closing parenthesis of primary constructor`() {
+            val code =
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar
+                ) : FooBar(
+                    bar1,
+                    bar2
+                ) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCodeKtlintOfficialCodeStyle =
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar
+                ) : FooBar(
+                        bar1,
+                        bar2
+                    ) {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCodeKtlintOfficialCodeStyle)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class with a multiline primary constructor and multiline super type call entry starting on same line as closing parenthesis of primary constructor and followed by other super type entries`() {
+            val code =
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar
+                ) : FooBar(
+                    bar1,
+                    bar2
+                ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCodeKtlintOfficialCodeStyle =
+                """
+                class Foo(
+                    val bar1: Bar,
+                    val bar2: Bar
+                ) : FooBar(
+                        bar1,
+                        bar2
+                    ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCodeKtlintOfficialCodeStyle)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class without primary constructor, a super type call entry with a single parameter, and multiple super type entries on a single line`() {
+            val code =
+                """
+                class Foo : FooBar("bar"), BarFoo1, BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo :
+                    FooBar("bar"),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class without primary constructor, a super type call entry with a multiple parameters, and multiple super type entries on a single line`() {
+            val code =
+                """
+                class Foo : FooBar("bar1", "bar2"), BarFoo1, BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo :
+                    FooBar("bar1", "bar2"),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class without primary constructor, a multiline super type call entry starting on the same line as the class keyword and at least one other super type entry`() {
+            val code =
+                """
+                class Foo : FooBar(
+                    "bar1",
+                    "bar2"
+                ), BarFoo1, BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo :
+                    FooBar(
+                        "bar1",
+                        "bar2"
+                    ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class without primary constructor, a multiline super type call entry starting on a separate line but indented as non-ktlint_official and at least one other super type entry`() {
+            val code =
+                """
+                class Foo : FooBar(
+                    "bar1",
+                    "bar2"
+                ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo :
+                    FooBar(
+                        "bar1",
+                        "bar2"
+                    ),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given a class explicit constructor, a multiline super type call entry starting on a separate line but indented as non-ktlint_official and at least one other super type entry`() {
+            val code =
+                """
+                class Foo
+                constructor(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) : FooBar(bar1, bar2),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo
+                    constructor(
+                        val bar1: Bar,
+                        val bar2: Bar,
+                    ) : FooBar(bar1, bar2),
+                        BarFoo1,
+                        BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .hasNoLintViolations()
+        }
+    }
+
+    @Test
+    fun `Given a multiline class signature extending another class but fitting on a single line then format as single line signature`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            ) : FooBar(a, c)
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) : FooBar(a, c)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 5, "No whitespace expected between opening parenthesis and first parameter name"),
+                LintViolation(4, 5, "Single whitespace expected before parameter"),
+                LintViolation(5, 5, "Single whitespace expected before parameter"),
+                LintViolation(5, 11, "No whitespace expected between last parameter and closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Given a single line class signature extending another class and some interfaces and fitting on a single line` {
+        @Test
+        fun `Given that the super type call is the first super type`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) : Bar1(a, c), Bar2, Bar3 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) :
+                    Bar1(a, c),
+                    Bar2,
+                    Bar3 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 37, "Super type should start on a newline"),
+                    LintViolation(2, 49, "Super type should start on a newline"),
+                    LintViolation(2, 55, "Super type should start on a newline"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given that the super type call is not the first or last super type`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) : Bar1, Bar2(a, c), Bar3 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) :
+                    Bar2(a, c),
+                    Bar1,
+                    Bar3 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 37, "Super type should start on a newline"),
+                    LintViolation(2, 43, "Super type call must be first super type"),
+                    LintViolation(2, 43, "Super type should start on a newline"),
+                    LintViolation(2, 55, "Super type should start on a newline"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given that the super type call is the last super type`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) : Bar1, Bar2, Bar3(a, c) {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+                class Foo(a: Any, b: Any, c: Any) :
+                    Bar3(a, c),
+                    Bar1,
+                    Bar2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 37, "Super type should start on a newline"),
+                    LintViolation(2, 43, "Super type should start on a newline"),
+                    LintViolation(2, 49, "Super type call must be first super type"),
+                    LintViolation(2, 49, "Super type should start on a newline"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Test
+    fun `Given a single line class signature having a super type by delegate which does not fit on a single line then wrap the super type`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo(bar: Bar) : Bar by bar {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo(bar: Bar) :
+                Bar by bar {
+                // body
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(2, 23, "Super type should start on a newline")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a class having a multiline super type list`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER             $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) : Bar(
+                a,
+                c
+            ) {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER             $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) :
+                Bar(
+                    a,
+                    c
+                ) {
+                // body
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolation(2, 37, "Super type should start on a newline")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given that the primary constructor parameters have to be wrapped and that the class has a multiline super type call entry then keep start of body on same line as end of super type call entry`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                          $EOL_CHAR
+            class Foo(a: Any, b: Any, c: Any) : Bar(
+                a,
+                c
+            ) {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                          $EOL_CHAR
+            class Foo(
+                a: Any,
+                b: Any,
+                c: Any
+            ) : Bar(
+                a,
+                c
+            ) {
+                // body
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 3)
+            .hasLintViolations(
+                LintViolation(2, 11, "Newline expected after opening parenthesis"),
+                LintViolation(2, 19, "Parameter should start on a newline"),
+                LintViolation(2, 27, "Parameter should start on a newline"),
+                LintViolation(2, 33, "Newline expected before closing parenthesis"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a super type call entry with arguments which after wrapping to the next line does not fit on that line then keep start of body on same line as end of super type call entry`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            // Note that the super type call does not fit the line after it has been wrapped
+            // ...Foo(a: Any, b: Any, c: Any) :
+            //  FooBar(a, "longggggggggggggggggggggggggggggggggggg")
+            class Foo(a: Any, b: Any, c: Any) : FooBar(a, "longggggggggggggggggggggggggggggggggggg") {
+                // body
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            // Note that the super type call does not fit the line after it has been wrapped
+            // ...Foo(a: Any, b: Any, c: Any) :
+            //  FooBar(a, "longggggggggggggggggggggggggggggggggggg")
+            class Foo(a: Any, b: Any, c: Any) :
+                FooBar(
+                    a,
+                    "longggggggggggggggggggggggggggggggggggg"
+                ) {
+                // body
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { ArgumentListWrappingRule() }
+            .addAdditionalRuleProvider { WrappingRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
+            .hasLintViolation(5, 37, "Super type should start on a newline")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Nested
+    inner class `Property ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` {
+        val propertyMapper = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.propertyMapper!!
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a null property then the property mapper returns null`(codeStyleValue: CodeStyleValue) {
+            val actual = propertyMapper(null, codeStyleValue)
+
+            assertThat(actual).isNull()
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a property which is unset then the property mapper returns max integer which is set as the default value`(
+            codeStyleValue: CodeStyleValue,
+        ) {
+            val property = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.toPropertyWithValue("unset")
+
+            val actual = propertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(Int.MAX_VALUE)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a valid string value then the property mapper returns the integer value`(codeStyleValue: CodeStyleValue) {
+            val someValue = 123
+            val property = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.toPropertyWithValue(someValue.toString())
+
+            val actual = propertyMapper(property, codeStyleValue)
+
+            assertThat(actual).isEqualTo(someValue)
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a negative value then the property mapper throws and exception`(codeStyleValue: CodeStyleValue) {
+            val someNegativeValue = "-1"
+            val property = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.toPropertyWithValue(someNegativeValue)
+
+            assertThatExceptionOfType(RuntimeException::class.java)
+                .isThrownBy { propertyMapper(property, codeStyleValue) }
+                .withMessage(
+                    "Property 'ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than' expects a " +
+                        "positive integer; found '$someNegativeValue'",
+                )
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a value bigger than max integer then the property mapper throws and exception`(codeStyleValue: CodeStyleValue) {
+            val someValueBiggerThanMaxInt = (1L + Int.MAX_VALUE).toString()
+            val property =
+                FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.toPropertyWithValue(someValueBiggerThanMaxInt)
+
+            assertThatExceptionOfType(RuntimeException::class.java)
+                .isThrownBy { propertyMapper(property, codeStyleValue) }
+                .withMessage(
+                    "Property 'ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than' expects an " +
+                        "integer. The parsed '$someValueBiggerThanMaxInt' is not an integer.",
+                )
+        }
+
+        @ParameterizedTest(name = "Code style: {0}")
+        @EnumSource(CodeStyleValue::class)
+        fun `Given a invalid string value then the property mapper returns the integer value`(codeStyleValue: CodeStyleValue) {
+            val property =
+                FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.toPropertyWithValue("some-invalid-value")
+
+            assertThatExceptionOfType(RuntimeException::class.java)
+                .isThrownBy { propertyMapper(property, codeStyleValue) }
+                .withMessage(
+                    "Property 'ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than' expects an " +
+                        "integer. The parsed 'some-invalid-value' is not an integer.",
+                )
+        }
+
+        @ParameterizedTest(name = "Input value: {0}, output value: {1}")
+        @CsvSource(
+            value = [
+                "1, 1",
+                "${Int.MAX_VALUE}, unset",
+            ],
+        )
+        fun `Given a property with an integer value than write that property`(
+            inputValue: Int,
+            expectedOutputValue: String,
+        ) {
+            val actual = FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.propertyWriter(inputValue)
+
+            assertThat(actual).isEqualTo(expectedOutputValue)
+        }
+    }
+
+    private companion object {
+        const val UNEXPECTED_SPACES = "  "
+        const val NO_SPACE = ""
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1206,7 +1206,7 @@ class ClassSignatureRuleTest {
         }
 
         @Test
-        fun `Given a class explicit constructor, a multiline super type call entry starting on a separate line but indented as non-ktlint_official and at least one other super type entry`() {
+        fun `Given a class with an explicit multiline constructor, a multiline super type call entry starting on a separate line but indented as non-ktlint_official and at least one other super type entry`() {
             val code =
                 """
                 class Foo
@@ -1246,6 +1246,62 @@ class ClassSignatureRuleTest {
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a class with an explicit multiline constructor, a multiline super type call entry starting on a separate line below the colon and at least one other super type entry`() {
+            val code =
+                """
+                class Foo
+                constructor(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) :
+                    FooBar(bar1, bar2),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCodeKtlintOfficial =
+                """
+                class Foo
+                    constructor(
+                        val bar1: Bar,
+                        val bar2: Bar,
+                    ) : FooBar(bar1, bar2),
+                        BarFoo1,
+                        BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            val formattedCodeNonKtlintOfficial =
+                """
+                class Foo
+                constructor(
+                    val bar1: Bar,
+                    val bar2: Bar,
+                ) : FooBar(bar1, bar2),
+                    BarFoo1,
+                    BarFoo2 {
+                    // body
+                }
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCodeKtlintOfficial)
+
+            // non-ktlint_official code style
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 1)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCodeNonKtlintOfficial)
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCodeNonKtlintOfficial)
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/DiscouragedCommentLocationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/DiscouragedCommentLocationRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -348,6 +349,392 @@ class DiscouragedCommentLocationRuleTest {
                 """.trimIndent()
             discouragedCommentLocationRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(5, 5, "No comment expected at this location")
+        }
+    }
+
+    @Nested
+    inner class `Given a value argument list ast node` {
+        @Test
+        fun `Given a kdoc as child of value argument list`() {
+            val code =
+                """
+                val foo = foo(
+                    /** some comment */
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed on a 'value_argument_list'")
+        }
+
+        @Test
+        fun `Given a comment as only child of value argument list`() {
+            val code =
+                """
+                val foo1 = foo(
+                    // some comment
+                )
+                val foo2 = foo(
+                    /* some comment */
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment on separate line before value argument ast node`() {
+            val code =
+                """
+                val foo1 = foo(
+                    // some comment
+                    "bar"
+                )
+                val foo2 = foo(
+                    /* some comment */
+                    "bar"
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment as last node of value argument ast node`() {
+            val code =
+                """
+                val foo1 = foo(
+                    "bar" // some comment
+                )
+                val foo2 = foo(
+                    "bar" /* some comment */
+                )
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 11, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
+                    LintViolation(5, 11, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment after a comma on the same line as an value argument ast node`() {
+            val code =
+                """
+                val foo1 = foo(
+                    "bar", // some comment
+                )
+                val foo2 = foo(
+                    "bar", /* some comment */
+                )
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 12, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
+                    LintViolation(5, 12, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment as last node of value argument list`() {
+            val code =
+                """
+                val foo1 = foo(
+                    "bar"
+                    // some comment
+                )
+                val foo1 = foo(
+                    "bar"
+                    /* some comment */
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a value parameter list ast node` {
+        @Test
+        fun `Given a kdoc as child of value parameter list`() {
+            val code =
+                """
+                class Foo(
+                    /** some comment */
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed on a 'value_parameter_list'")
+        }
+
+        @Test
+        fun `Given a kdoc as only child of value parameter list`() {
+            val code =
+                """
+                class Foo1(
+                    // some comment
+                )
+                class Foo2(
+                    /* some comment */
+                )
+
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment as only child of value parameter list`() {
+            val code =
+                """
+                class Foo1(
+                    // some comment
+                )
+                class Foo2(
+                    /* some comment */
+                )
+
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment on separate line before value parameter ast node`() {
+            val code =
+                """
+                class Foo1(
+                    // some comment
+                    val bar: Bar
+                )
+                class Foo2(
+                    /* some comment */
+                    val bar: Bar
+                )
+                class Foo3(
+                    /** some comment */
+                    val bar: Bar
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment inside value parameter ast node`() {
+            val code =
+                """
+                class Foo1(
+                    val bar:
+                        // some comment
+                        Bar
+                )
+                class Foo2(
+                    val bar: /* some comment */ Bar
+                )
+                class Foo3(
+                    val bar: /** some comment */ Bar
+                )
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(3, 9, "A comment in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                    LintViolation(7, 14, "A comment in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                    LintViolation(10, 14, "A kdoc in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                )
+        }
+
+        @Test
+        fun `Given a comment as last node of value parameter ast node`() {
+            val code =
+                """
+                class Foo1(
+                    val bar: Bar // some comment
+                )
+                class Foo2(
+                    val bar: Bar /* some comment */
+                )
+                class Foo3(
+                    val bar: Bar /* some comment */
+                )
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 18, "A comment in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                    LintViolation(5, 18, "A comment in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                    LintViolation(8, 18, "A comment in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                )
+        }
+
+        @Test
+        fun `Given a comment after a comma on the same line as an value parameter ast node`() {
+            val code =
+                """
+                class Foo1(
+                    val bar: Bar, // some comment
+                )
+                class Foo2(
+                    val bar: Bar, /* some comment */
+                )
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 19, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line"),
+                    LintViolation(5, 19, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment as last node of value parameter list`() {
+            val code =
+                """
+                class Foo(
+                    val bar: Bar
+                    // some comment
+                )
+                class Foo(
+                    val bar: Bar
+                    /* some comment */
+                )
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a type parameter list ast node` {
+        @Test
+        fun `Given a kdoc as child of type parameter list`() {
+            val code =
+                """
+                class Foo<
+                    /** some comment */
+                    Bar>
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed on a 'type_parameter_list'")
+        }
+
+        @Test
+        fun `Given a comment on separate line before type parameter ast node`() {
+            val code =
+                """
+                class Foo1<
+                    // some comment
+                    Bar>
+                class Foo2<
+                    /* some comment */
+                    Bar>
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment after, but on the same line as an type parameter ast node`() {
+            val code =
+                """
+                class Foo1<
+                    Bar // some comment
+                    >
+                class Foo2<Bar /* some comment */ >
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 9, "A comment in a 'type_parameter_list' is only allowed when placed on a separate line"),
+                    LintViolation(4, 16, "A comment in a 'type_parameter_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment after a comma on the same line as an type parameter ast node`() {
+            val code =
+                """
+                class FooBar1<
+                    Foo, // some comment
+                    Bar>
+                class FooBar2<Foo, /* some comment */ Bar>
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 10, "A comment in a 'type_parameter_list' is only allowed when placed on a separate line"),
+                    LintViolation(4, 20, "A comment in a 'type_parameter_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment as last node of type parameter list`() {
+            val code =
+                """
+                class FooBar1<
+                    Foo
+                    // some comment
+                    >
+                class FooBar2<
+                    Foo
+                    /* some comment */
+                    >
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a type argument list ast node` {
+        @Test
+        fun `Given a kdoc as child of type argument list`() {
+            val code =
+                """
+                val fooBar: FooBar<
+                    /** some comment */
+                    Foo, Bar>
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed on a 'type_argument_list'")
+        }
+
+        @Test
+        fun `Given a comment on separate line before type projection ast node`() {
+            val code =
+                """
+                val fooBar1: FooBar<
+                    // some comment
+                    Foo, Bar>
+                val fooBar2: FooBar<
+                    /* some comment */
+                    Foo, Bar>
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a comment after a comma on the same line as an type projection ast node`() {
+            val code =
+                """
+                val fooBar1: FooBar<Foo, // some comment
+                    Bar>
+                val fooBar2: FooBar<Foo, /* some comment */
+                    Bar>
+                """.trimIndent()
+            @Suppress("ktlint:standard:parameter-list-wrapping", "ktlint:standard:max-line-length")
+            discouragedCommentLocationRuleAssertThat(code)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(1, 26, "A comment in a 'type_argument_list' is only allowed when placed on a separate line"),
+                    LintViolation(3, 26, "A comment in a 'type_argument_list' is only allowed when placed on a separate line"),
+                )
+        }
+
+        @Test
+        fun `Given a comment as last node of type argument list`() {
+            val code =
+                """
+                val fooBar: FooBar<Foo, Bar
+                    // some comment
+                >
+                val fooBar: FooBar<Foo, Bar
+                    /* some comment */
+                >
+                """.trimIndent()
+            discouragedCommentLocationRuleAssertThat(code).hasNoLintViolations()
         }
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -4585,6 +4585,11 @@ internal class IndentationRuleTest {
     fun `Given an object declaration with a super type list`() {
         val code =
             """
+            class FooBar :
+                Foox,
+                Bar {
+                // Do something
+            }
             class Foo {
                 companion object FooBar :
                     Foo,
@@ -4986,6 +4991,7 @@ internal class IndentationRuleTest {
                 """.trimIndent()
             indentationRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .isFormattedAs(formattedCode)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 4)"),
@@ -5024,8 +5030,8 @@ internal class IndentationRuleTest {
                             "foobar1",
                             "foobar2",
                         ) {
-                    fun foo() = "foo"
-                }
+                        fun foo() = "foo"
+                    }
                 """.trimIndent()
             indentationRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
@@ -5038,6 +5044,8 @@ internal class IndentationRuleTest {
                     LintViolation(7, 1, "Unexpected indentation (4) (should be 12)"),
                     LintViolation(8, 1, "Unexpected indentation (4) (should be 12)"),
                     LintViolation(9, 1, "Unexpected indentation (0) (should be 8)"),
+                    LintViolation(10, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(11, 1, "Unexpected indentation (0) (should be 4)"),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -5072,11 +5080,12 @@ internal class IndentationRuleTest {
                         ),
                         FooBar2,
                         FooBar3 {
-                    fun foo() = "foo"
-                }
+                        fun foo() = "foo"
+                    }
                 """.trimIndent()
             indentationRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .isFormattedAs(formattedCode)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 4)"),
@@ -5088,28 +5097,36 @@ internal class IndentationRuleTest {
                     LintViolation(9, 1, "Unexpected indentation (0) (should be 8)"),
                     LintViolation(10, 1, "Unexpected indentation (4) (should be 8)"),
                     LintViolation(11, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(12, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(13, 1, "Unexpected indentation (0) (should be 4)"),
                 ).isFormattedAs(formattedCode)
         }
 
         @Test
-        fun `Issue 2115 - Given a class without an explicit constructor and with a long super type list then do not indent the class body`() {
+        fun `Issue 2115 - Given a class without an explicit constructor and with a multiline super type call entry then do not indent the class body`() {
             val code =
                 """
-                class Foo1 :
+                class Foo :
                     FooBar(
                         "bar1",
                         "bar2",
                     ) {
                     // body
                 }
-                class Foo2(
+                """.trimIndent()
+            indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2115 - Given a class without an explicit constructor and with a long super type list then do not indent the class body`() {
+            val code =
+                """
+                class Foo1(
                     val bar1: Bar,
                     val bar2: Bar,
-                ) : FooBar(
-                        bar1,
-                        bar2
-                    ),
-                    BarFoo1,
+                ) : BarFoo1,
                     BarFoo2 {
                     // body
                 }
@@ -5120,17 +5137,19 @@ internal class IndentationRuleTest {
         }
 
         @Test
-        fun `Issue 2115 - xxx`() {
+        fun `Given a class preceded by a multiline comment and with an explicit constructor on same line as class keyword`() {
             val code =
                 """
-                class Foo(bar: Bar) :
-                    FooBar(
-                        "foo",
-                        bar,
-                    )
+                /**
+                 *  Some kdoc
+                 */
+                class Foo internal constructor(
+                    private val bar: Bar
+                ): FooBar {
+                    fun bar()
+                }
                 """.trimIndent()
             indentationRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasNoLintViolations()
         }
     }
@@ -5395,6 +5414,73 @@ internal class IndentationRuleTest {
         indentationRuleAssertThat(code)
             .hasLintViolation(3, 1, "Unexpected indentation (4) (should be 8)")
             .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given ktlint_official code style, a class with an explicit constructor and a super type entry`() {
+        val code =
+            """
+            class Foo
+            constructor(
+                private val bar: Bar,
+            ) : FooBar {
+                fun baz()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+                constructor(
+                    private val bar: Bar,
+                ) : FooBar {
+                    fun baz()
+                }
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+            .isFormattedAs(formattedCode)
+            .hasLintViolations(
+                LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
+                LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(4, 1, "Unexpected indentation (0) (should be 4)"),
+                LintViolation(5, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(6, 1, "Unexpected indentation (0) (should be 4)"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given ktlint_official code style, a class with an explicit constructor and multiple super types entry`() {
+        val code =
+            """
+            class Foo
+            constructor(
+                private val bar: Bar
+            ) : FooBar1,
+                FooBar2 {
+                fun baz()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+                constructor(
+                    private val bar: Bar
+                ) : FooBar1,
+                    FooBar2 {
+                    fun baz()
+                }
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+            .isFormattedAs(formattedCode)
+            .hasLintViolations(
+                LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
+                LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(4, 1, "Unexpected indentation (0) (should be 4)"),
+                LintViolation(5, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(6, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(7, 1, "Unexpected indentation (0) (should be 4)"),
+            ).isFormattedAs(formattedCode)
     }
 
     private companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -941,7 +941,7 @@ class TrailingCommaOnDeclarationSiteRuleTest {
                 additionalRuleProviders =
                     setOf(
                         RuleProvider { TrailingCommaOnDeclarationSiteRule() },
-                        RuleProvider { WrappingRule() }, // Required for TrailingCommaOnDeclarationSiteRule
+                        RuleProvider { WrappingRule() },
                     ),
             )
 

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
@@ -6,8 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 
 internal val CUSTOM_RULE_SET_ID = "custom-rule-set-id"
 
-public class CustomRuleSetProvider :
-    RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
+public class CustomRuleSetProvider : RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
     override fun getRuleProviders(): Set<RuleProvider> =
         setOf(
             RuleProvider { NoVarRule() },

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -5,15 +5,16 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class NoVarRule : Rule(
-    ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
-    about =
-        About(
-            maintainer = "Your name",
-            repositoryUrl = "https://github.com/your/project/",
-            issueTrackerUrl = "https://github.com/your/project/issues",
-        ),
-) {
+public class NoVarRule :
+    Rule(
+        ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
+        about =
+            About(
+                maintainer = "Your name",
+                repositoryUrl = "https://github.com/your/project/",
+                issueTrackerUrl = "https://github.com/your/project/issues",
+            ),
+    ) {
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -648,13 +648,14 @@ public class KtLintAssertThatAssertable(
     )
 }
 
-internal class MissingEolMarker : RuntimeException(
-    """
-    The first line of the provide code sample should contain text '$MAX_LINE_LENGTH_MARKER' which is provided by the
-    constant '${::MAX_LINE_LENGTH_MARKER.name}' and ends with the EOL_CHAR'$EOL_CHAR' provided by the constant
-    '${::EOL_CHAR.name}' which indicates the last position that is allowed.
-    """.trimIndent(),
-)
+internal class MissingEolMarker :
+    RuntimeException(
+        """
+        The first line of the provide code sample should contain text '$MAX_LINE_LENGTH_MARKER' which is provided by the
+        constant '${::MAX_LINE_LENGTH_MARKER.name}' and ends with the EOL_CHAR'$EOL_CHAR' provided by the constant
+        '${::EOL_CHAR.name}' which indicates the last position that is allowed.
+        """.trimIndent(),
+    )
 
 /**
  * Expectation of the [LintError]. Contrary to the [LintError] it does not contain the ruleId. The ruleId will be


### PR DESCRIPTION
## Description

Add rule `class-signature`. This rule rewrites the class header to a consistent format. In code style `ktlint_official`, super types are always wrapped to a separate line. In other code styles, super types are only wrapped in classes having multiple super types. Especially for code style `ktlint_official` the class headers are rewritten in a more consistent format.

Closes #875
Closes #1349

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
