### PR TITLE
Fix indent of IS_EXPRESSION, PREFIX_EXPRESSION and POSTFIX_EXPRESSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 * Allow to disable ktlint in `.editorconfig` for a glob ([#2100](https://github.com/pinterest/ktlint/issues/2100))
 * Fix wrapping of nested function literals `wrapping` ([#2106](https://github.com/pinterest/ktlint/issues/2106))
-* Do not indent class body for classes having a long super type list in code style `ktlint_official` as it is inconsistent compared to other class bodies `indent` [#2115](https://github.com/pinterest/ktlint/issues/2115) 
+* Do not indent class body for classes having a long super type list in code style `ktlint_official` as it is inconsistent compared to other class bodies `indent` [#2115](https://github.com/pinterest/ktlint/issues/2115)
+* Fix indent of IS_EXPRESSION, PREFIX_EXPRESSION and POSTFIX_EXPRESSION in case it contains a linebreak `indent` [#2094](https://github.com/pinterest/ktlint/issues/2094)
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -35,6 +35,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC_END
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC_LEADING_ASTERISK
@@ -50,6 +51,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_DECLARATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPEN_QUOTE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PARENTHESIZED
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_ACCESSOR
@@ -254,6 +257,11 @@ public class IndentationRule :
                 node.elementType == TYPE_ARGUMENT_LIST ||
                 node.elementType == TYPE_PARAMETER_LIST ||
                 node.elementType == USER_TYPE ->
+                startIndentContext(node)
+
+            node.elementType == IS_EXPRESSION ||
+                node.elementType == PREFIX_EXPRESSION ||
+                node.elementType == POSTFIX_EXPRESSION ->
                 startIndentContext(node)
 
             node.elementType == DELEGATED_SUPER_TYPE_ENTRY ||

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5322,6 +5322,63 @@ internal class IndentationRuleTest {
             .isFormattedAs(formattedCode)
     }
 
+    @Test
+    fun `Issue 2094 - Given a malformed IS_EXPRESSION`() {
+        val code =
+            """
+            fun foo(any: Any) =
+                any is
+                Foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(any: Any) =
+                any is
+                    Foo
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Unexpected indentation (4) (should be 8)")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2094 - Given a malformed PREFIX_EXPRESSION`() {
+        val code =
+            """
+            fun foo(value: Int) =
+                ++
+                value
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(value: Int) =
+                ++
+                    value
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Unexpected indentation (4) (should be 8)")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2094 - Given a malformed POSTFIX_EXPRESSION`() {
+        val code =
+            """
+            fun foo(value: Int) =
+                --
+                value
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(value: Int) =
+                --
+                    value
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Unexpected indentation (4) (should be 8)")
+            .isFormattedAs(formattedCode)
+    }
+
     private companion object {
         val INDENT_STYLE_TAB =
             INDENT_STYLE_PROPERTY to PropertyType.IndentStyleValue.tab

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingTest.kt
@@ -574,12 +574,11 @@ class MultilineExpressionWrappingTest {
             fun foo(any: Any) = any is
                 Foo
             """.trimIndent()
-        // TODO: https://github.com/pinterest/ktlint/issues/2094 Fix formatting by indent rule
         val formattedCode =
             """
             fun foo(any: Any) =
                 any is
-                Foo
+                    Foo
             """.trimIndent()
         multilineExpressionWrappingAssertThat(code)
             .addAdditionalRuleProvider { IndentationRule() }
@@ -615,12 +614,11 @@ class MultilineExpressionWrappingTest {
             fun foo(any: Int) = ++
                 42
             """.trimIndent()
-        // TODO: https://github.com/pinterest/ktlint/issues/2094 Fix formatting by indent rule
         val formattedCode =
             """
             fun foo(any: Int) =
                 ++
-                42
+                    42
             """.trimIndent()
         multilineExpressionWrappingAssertThat(code)
             .addAdditionalRuleProvider { IndentationRule() }


### PR DESCRIPTION
## Description

Fix indent of IS_EXPRESSION, PREFIX_EXPRESSION and POSTFIX_EXPRESSION in case it contains a linebreak

Closes #2094

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
