### PR TITLE
Fix solving problems in 3 consecutive runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Allow to disable ktlint in `.editorconfig` for a glob ([#2100](https://github.com/pinterest/ktlint/issues/2100))
 * Fix wrapping of nested function literals `wrapping` ([#2106](https://github.com/pinterest/ktlint/issues/2106))
 * Do not indent class body for classes having a long super type list in code style `ktlint_official` as it is inconsistent compared to other class bodies `indent` [#2115](https://github.com/pinterest/ktlint/issues/2115) 
+* Log message `Format was not able to resolve all violations which (theoretically) can be autocorrected in file ... in 3 consecutive runs of format` is now only displayed in case a new ktlint rule is actually needed. [#2129](https://github.com/pinterest/ktlint/issues/2129)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fix wrapping of nested function literals `wrapping` ([#2106](https://github.com/pinterest/ktlint/issues/2106))
 * Do not indent class body for classes having a long super type list in code style `ktlint_official` as it is inconsistent compared to other class bodies `indent` [#2115](https://github.com/pinterest/ktlint/issues/2115) 
 * Log message `Format was not able to resolve all violations which (theoretically) can be autocorrected in file ... in 3 consecutive runs of format` is now only displayed in case a new ktlint rule is actually needed. [#2129](https://github.com/pinterest/ktlint/issues/2129)
+* Fix wrapping of function signature in case the opening brace of the function body block exceeds the maximum line length. Fix upsert of whitespace into composite nodes. `function-signature` [#2130](https://github.com/pinterest/ktlint/issues/2130)
 
 ### Changed
 

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -245,11 +245,23 @@ public fun ASTNode.upsertWhitespaceBeforeMe(text: String) {
             }
         }
     } else {
-        val prevLeaf =
-            requireNotNull(prevLeaf()) {
-                "Can not upsert a whitespace if the first node is a non-leaf node"
+        when (val prevSibling = prevSibling()) {
+            null -> {
+                // Never insert a whitespace element as first child node in a composite node. Instead, upsert just before the composite node
+                treeParent.upsertWhitespaceBeforeMe(text)
             }
-        prevLeaf.upsertWhitespaceAfterMe(text)
+
+            is LeafElement -> {
+                prevSibling.upsertWhitespaceAfterMe(text)
+            }
+
+            else -> {
+                // Insert in between two composite nodes
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
+                    treeParent.addChild(psiWhiteSpace.node, this)
+                }
+            }
+        }
     }
 }
 
@@ -279,7 +291,23 @@ public fun ASTNode.upsertWhitespaceAfterMe(text: String) {
             }
         }
     } else {
-        lastChildLeafOrSelf().upsertWhitespaceAfterMe(text)
+        when (val nextSibling = nextSibling()) {
+            null -> {
+                // Never insert a whitespace element as last child node in a composite node. Instead, upsert just after the composite node
+                treeParent.upsertWhitespaceAfterMe(text)
+            }
+
+            is LeafElement -> {
+                nextSibling.upsertWhitespaceBeforeMe(text)
+            }
+
+            else -> {
+                // Insert in between two composite nodes
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
+                    treeParent.addChild(psiWhiteSpace.node, nextSibling)
+                }
+            }
+        }
     }
 }
 

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -2,13 +2,16 @@ package com.pinterest.ktlint.rule.engine.core.api
 
 import com.pinterest.ktlint.rule.engine.api.Code
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
@@ -303,7 +306,7 @@ class ASTNodeExtensionTest {
     @Nested
     inner class UpsertWhitespaceBeforeMe {
         @Test
-        fun `Given a whitespace node and upsert a whitespace before the node (RPAR) then replace the current whitespace element`() {
+        fun `Given an upsert of a whitespace based before another whitespace node then replace the existing whitespace element`() {
             val code =
                 """
                 fun foo( ) = 42
@@ -327,30 +330,7 @@ class ASTNodeExtensionTest {
         }
 
         @Test
-        fun `Given a node (RPAR) which is preceded by a non-whitespace leaf element (LPAR) and upsert a whitespace before the node (RPAR) then create a new whitespace element before the node (RPAR)`() {
-            val code =
-                """
-                fun foo() = 42
-                """.trimIndent()
-            val formattedCode =
-                """
-                fun foo(
-
-                ) = 42
-                """.trimIndent()
-
-            val actual =
-                code
-                    .transformAst {
-                        nextLeaf { it.elementType == RPAR }
-                            ?.upsertWhitespaceBeforeMe("\n\n")
-                    }.text
-
-            assertThat(actual).isEqualTo(formattedCode)
-        }
-
-        @Test
-        fun `Given a node (RPAR) which is preceded by a whitespace leaf element and upsert a whitespace before the node (RPAR) then replace the whitespace element before the node (RPAR)`() {
+        fun `Given an upsert of a whitespace before a non-whitespace node (RPAR) which is preceded by a whitespace leaf element (LPAR) then then replace the whitespace element`() {
             val code =
                 """
                 fun foo( ) = 42
@@ -373,7 +353,56 @@ class ASTNodeExtensionTest {
         }
 
         @Test
-        fun `Given a node (VALUE_PARAMETER) which is preceded by a non-whitespace leaf element (LPAR) and upsert a whitespace before the node (VALUE_PARAMETER) then create a new whitespace element before the node (VALUE_PARAMETER)`() {
+        fun `Given an upsert of a whitespace before a non-whitespace node (RPAR) which is preceded by another non-whitespace leaf element (LPAR) then create a new whitespace element`() {
+            val code =
+                """
+                fun foo() = 42
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo(
+
+                ) = 42
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        nextLeaf { it.elementType == RPAR }
+                            ?.upsertWhitespaceBeforeMe("\n\n")
+                    }.text
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given an upsert of a whitespace before a composite node (ANNOTATION_ENTRY) which is the first child of another composite element then create a new whitespace before (VALUE_PARAMETER)`() {
+            val code =
+                """
+                fun foo(@Bar string: String) = 42
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo(
+                    @Bar string: String) = 42
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(VALUE_PARAMETER)
+                            ?.findChildByType(MODIFIER_LIST)
+                            ?.findChildByType(ANNOTATION_ENTRY)
+                            ?.upsertWhitespaceBeforeMe("\n    ")
+                    }.text
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given an upsert of a whitespace before a composite node (VALUE_PARAMETER) which is preceded by a non-whitespace leaf element (LPAR) then create a new whitespace element before the node (VALUE_PARAMETER)`() {
             val code =
                 """
                 fun foo(string: String) = 42
@@ -397,25 +426,26 @@ class ASTNodeExtensionTest {
         }
 
         @Test
-        fun `Given a node (FUN bar) which is preceded by a composite element (FUN foo) and upsert a whitespace before the node (FUN bar) then create a new whitespace element before the node (FUN bar)`() {
+        fun `Given an upsert of a whitespace before a composite node (ANNOTATION_ENTRY) which is preceded by another composite node (ANNOTATION_ENTRY) then create a new whitespace between the ANNOTATION_ENTRIES`() {
             val code =
                 """
-                fun foo() = "foo"
-                fun bar() = "bar"
+                fun foo(@Bar@Foo string: String) = 42
                 """.trimIndent()
             val formattedCode =
                 """
-                fun foo() = "foo"
-
-                fun bar() = "bar"
+                fun foo(@Bar @Foo string: String) = 42
                 """.trimIndent()
 
             val actual =
                 code
                     .transformAst {
-                        children()
-                            .last { it.elementType == FUN }
-                            .upsertWhitespaceBeforeMe("\n\n")
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(VALUE_PARAMETER)
+                            ?.findChildByType(MODIFIER_LIST)
+                            ?.findChildByType(ANNOTATION_ENTRY)
+                            ?.nextSibling()
+                            ?.upsertWhitespaceBeforeMe(" ")
                     }.text
 
             assertThat(actual).isEqualTo(formattedCode)
@@ -425,30 +455,31 @@ class ASTNodeExtensionTest {
     @Nested
     inner class UpsertWhitespaceAfterMe {
         @Test
-        fun `Given a node (LPAR) which is followed by a non-whitespace leaf element (RPAR) and upsert a whitespace after the node (LPAR) then create a new whitespace element after the node (LPAR)`() {
+        fun `Given an upsert of a whitespace based after another whitespace node then replace the existing whitespace element`() {
             val code =
                 """
-                fun foo() = 42
+                fun foo( ) = 42
                 """.trimIndent()
             val formattedCode =
                 """
                 fun foo(
-
                 ) = 42
                 """.trimIndent()
 
             val actual =
                 code
                     .transformAst {
-                        nextLeaf { it.elementType == LPAR }
-                            ?.upsertWhitespaceAfterMe("\n\n")
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(WHITE_SPACE)
+                            ?.upsertWhitespaceAfterMe("\n")
                     }.text
 
             assertThat(actual).isEqualTo(formattedCode)
         }
 
         @Test
-        fun `Given a node (LPAR) which is followed by a whitespace leaf element and upsert a whitespace after the node (LPAR) then replace the whitespace element after the node (LPAR)`() {
+        fun `Given an upsert of a whitespace after a non-whitespace node (LPAR) which is followed by a whitespace leaf element (RPAR) then then replace the whitespace element`() {
             val code =
                 """
                 fun foo( ) = 42
@@ -471,7 +502,55 @@ class ASTNodeExtensionTest {
         }
 
         @Test
-        fun `Given a node (VALUE_PARAMETER) which is followed by a non-whitespace leaf element (RPAR) and upsert a whitespace after the node (VALUE_PARAMETER) then create a new whitespace element after the node (VALUE_PARAMETER)`() {
+        fun `Given an upsert of a whitespace after a non-whitespace node (LPAR) which is followed by another non-whitespace leaf element (RPAR) then create a new whitespace element`() {
+            val code =
+                """
+                fun foo() = 42
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo(
+
+                ) = 42
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        nextLeaf { it.elementType == LPAR }
+                            ?.upsertWhitespaceAfterMe("\n\n")
+                    }.text
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given an upsert of a whitespace after a composite node (ANNOTATION_ENTRY) which is the last child of another composite element then create a new whitespace after (VALUE_PARAMETER)`() {
+            val code =
+                """
+                fun foo(@Bar string: String) = 42
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo(@Bar string: String
+                ) = 42
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(VALUE_PARAMETER)
+                            ?.findChildByType(TYPE_REFERENCE)
+                            ?.upsertWhitespaceAfterMe("\n")
+                    }.text
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given an upsert of a whitespace after a composite node (VALUE_PARAMETER) which is followed by a non-whitespace leaf element (RPAR) then create a new whitespace element after the node (VALUE_PARAMETER)`() {
             val code =
                 """
                 fun foo(string: String) = 42
@@ -495,25 +574,25 @@ class ASTNodeExtensionTest {
         }
 
         @Test
-        fun `Given a node (FUN foo) which is followed by a composite element (FUN bar) and upsert a whitespace after the node (FUN foo) then create a new whitespace element after the node (FUN foo)`() {
+        fun `Given an upsert of a whitespace after a composite node (ANNOTATION_ENTRY) which is followed by another composite node (ANNOTATION_ENTRY) then create a new whitespace between the ANNOTATION_ENTRIES`() {
             val code =
                 """
-                fun foo() = "foo"
-                fun bar() = "bar"
+                fun foo(@Bar@Foo string: String) = 42
                 """.trimIndent()
             val formattedCode =
                 """
-                fun foo() = "foo"
-
-                fun bar() = "bar"
+                fun foo(@Bar @Foo string: String) = 42
                 """.trimIndent()
 
             val actual =
                 code
                     .transformAst {
-                        children()
-                            .first { it.elementType == FUN }
-                            .upsertWhitespaceAfterMe("\n\n")
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(VALUE_PARAMETER)
+                            ?.findChildByType(MODIFIER_LIST)
+                            ?.findChildByType(ANNOTATION_ENTRY)
+                            ?.upsertWhitespaceAfterMe(" ")
                     }.text
 
             assertThat(actual).isEqualTo(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -63,8 +63,13 @@ class FunctionSignatureRuleTest {
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { FunctionStartOfBodySpacingRule() }
-            .hasLintViolation(2, 38, "Expected a single space before body block")
-            .isFormattedAs(formattedCode)
+            .hasLintViolations(
+                LintViolation(2, 7, "Newline expected after opening parenthesis"),
+                LintViolation(2, 15, "Parameter should start on a newline"),
+                LintViolation(2, 23, "Parameter should start on a newline"),
+                LintViolation(2, 29, "Newline expected before closing parenthesis"),
+                LintViolation(2, 38, "Expected a single space before body block"),
+            ).isFormattedAs(formattedCode)
     }
 
     @Test


### PR DESCRIPTION
## Description

### False positive message 

Display log message `Format was not able to resolve all violations which (theoretically) can be autocorrected in file ... in 3 consecutive runs of format` only when after the third consecutive run still a violation exists that can be autocorrected.

Closes #2129

### Function signature wrapping

x wrapping of function signature in case the opening brace of the function body block exceeds the maximum line length. Fix upsert of whitespace into composite nodes.

Closes #2130

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
