### PR TITLE
Do not wrap a binary expression after an elvis operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Log message `Format was not able to resolve all violations which (theoretically) can be autocorrected in file ... in 3 consecutive runs of format` is now only displayed in case a new ktlint rule is actually needed. [#2129](https://github.com/pinterest/ktlint/issues/2129)
 * Fix wrapping of function signature in case the opening brace of the function body block exceeds the maximum line length. Fix upsert of whitespace into composite nodes. `function-signature` [#2130](https://github.com/pinterest/ktlint/issues/2130)
 * Fix spacing around colon in annotations `spacing-around-colon` ([#2093](https://github.com/pinterest/ktlint/issues/2093))
+* Do not wrap a binary expression after an elvis operator in case the max line length is exceeded ([#2128](https://github.com/pinterest/ktlint/issues/2128))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
@@ -176,9 +176,9 @@ class BinaryExpressionWrappingRuleTest {
                 // When linting, a violation is reported for each operation reference. While when formatting, the nested binary expression
                 // is evaluated (working from outside to inside). After wrapping an outer binary expression, the inner binary expressions
                 // are evaluated and only wrapped again at the operation reference when needed.
+                LintViolation(3, 1, "Line is exceeding max line length", canBeAutoCorrected = false),
                 LintViolation(3, 35, "Line is exceeding max line length. Break line after operator in binary expression"),
                 LintViolation(3, 63, "Line is exceeding max line length. Break line after operator in binary expression"),
-                LintViolation(3, 92, "Line is exceeding max line length", canBeAutoCorrected = false),
             ).isFormattedAs(formattedCode)
     }
 
@@ -194,7 +194,7 @@ class BinaryExpressionWrappingRuleTest {
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasLintViolationWithoutAutoCorrect(3, 36, "Line is exceeding max line length")
+            .hasLintViolationWithoutAutoCorrect(3, 1, "Line is exceeding max line length")
     }
 
     @Test
@@ -211,10 +211,9 @@ class BinaryExpressionWrappingRuleTest {
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasLintViolationsWithoutAutoCorrect(
+            .hasLintViolations(
+                LintViolation(2, 1, "Line is exceeding max line length", canBeAutoCorrected = false),
                 LintViolation(2, 12, "Line is exceeding max line length. Break line between assignment and expression"),
-                LintViolation(2, 20, "Line is exceeding max line length. Break line after operator in binary expression"),
-                LintViolation(2, 36, "Line is exceeding max line length"),
             )
     }
 
@@ -307,6 +306,23 @@ class BinaryExpressionWrappingRuleTest {
             .setMaxLineLength()
             .addAdditionalRuleProvider { ArgumentListWrappingRule() }
             .addAdditionalRuleProvider { WrappingRule() }
-            .hasLintViolationWithoutAutoCorrect(3, 17, "Line is exceeding max line length")
+            .hasLintViolationWithoutAutoCorrect(3, 1, "Line is exceeding max line length")
+    }
+
+    @Test
+    fun `Issue 2128 - Given an elvis expression exceeding the line length`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            val foo =
+                bar
+                    ?: throw UnsupportedOperationException("foobar")
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { ArgumentListWrappingRule() }
+            .addAdditionalRuleProvider { WrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolationWithoutAutoCorrect(4, 1, "Line is exceeding max line length")
     }
 }

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -76,8 +76,8 @@ public class KtLintAssertThat(
      */
     private val code: String,
     /**
-     * Providers of rules which have to be executed in addition to the main rule when linting/formatting the code. Note
-     * that lint errors for those rules are suppressed.
+     * Providers of rules which have to be executed in addition to the main rule when linting/formatting the code. Note that lint errors for
+     * those rules are suppressed.
      */
     private val additionalRuleProviders: MutableSet<RuleProvider>,
     /**
@@ -89,8 +89,8 @@ public class KtLintAssertThat(
     private var kotlinScript = false
 
     /**
-     * Set the [EditorConfigOverride] properties to be used by the rule. This function can be called multiple times.
-     * Properties which have been set before, are silently overwritten with the new vale.
+     * Set the [EditorConfigOverride] properties to be used by the rule. This function can be called multiple times. Properties which have
+     * been set before, are silently overwritten with the new vale.
      */
     public fun withEditorConfigOverride(vararg properties: Pair<EditorConfigProperty<*>, *>): KtLintAssertThat {
         editorConfigProperties.addAll(properties)
@@ -99,9 +99,8 @@ public class KtLintAssertThat(
     }
 
     /**
-     * Set the [EditorConfigOverride] "max_line_length" property based on the EOL Marker which is places at the first
-     * line of the code sample. If the property has been set before via [withEditorConfigOverride] then that value is
-     * silently overwritten.
+     * Set the [EditorConfigOverride] "max_line_length" property based on the EOL Marker which is places at the first line of the code
+     * sample. If the property has been set before via [withEditorConfigOverride] then that value is silently overwritten.
      *
      * Example of usage:
      * ```
@@ -145,16 +144,15 @@ public class KtLintAssertThat(
     }
 
     /**
-     * Adds a single provider of an additional rule to be executed when linting/formatting the code. This can to be used
-     * to unit test rules which are best to be tested in conjunction with other rules, for example wrapping and
-     * indenting.
+     * Adds a single provider of an additional rule to be executed when linting/formatting the code. This can to be used to unit test rules
+     * which are best to be tested in conjunction with other rules, for example wrapping and indenting.
      *
      * Caution:
-     * An additional rule provider for a rule which actually is executed before the rule under test, might result in
-     * unexpected [LintViolation] in case that additional rule is modifying the AST. During the [lint] phase, all rules
-     * are executed in parallel and as of that both the rule under test and the additional rule are using the exact same
-     * version of the AST. When, in the [format] stage the additional rule is run first, and if it modifies the AST,
-     * this could result in a [LintViolation] for the rule under test which is executed later than the additional rule.
+     * An additional rule provider for a rule which actually is executed before the rule under test, might result in unexpected
+     * [LintViolation] in case that additional rule is modifying the AST. During the [lint] phase, all rules are executed in parallel and as
+     * of that both the rule under test and the additional rule are using the exact same version of the AST. When, in the [format] stage the
+     * additional rule is run first, and if it modifies the AST, this could result in a [LintViolation] for the rule under test which is
+     * executed later than the additional rule.
      *
      * Prefer to use [addAdditionalRuleProviders] when adding multiple providers of rules.
      */
@@ -165,16 +163,15 @@ public class KtLintAssertThat(
     }
 
     /**
-     * Adds a single provider of an additional rule to be executed when linting/formatting the code. This can to be used
-     * to unit test rules which are best to be tested in conjunction with other rules, for example wrapping and
-     * indenting.
+     * Adds a single provider of an additional rule to be executed when linting/formatting the code. This can to be used to unit test rules
+     * which are best to be tested in conjunction with other rules, for example wrapping and indenting.
      *
      * Caution:
-     * An additional rule provider for a rule which actually is executed before the rule under test, might result in
-     * unexpected [LintViolation] in case that additional rule is modifying the AST. During the [lint] phase, all rules
-     * are executed in parallel and as of that both the rule under test and the additional rule are using the exact same
-     * version of the AST. When, in the [format] stage the additional rule is run first, and if it modifies the AST,
-     * this could result in a [LintViolation] for the rule under test which is executed later than the additional rule.
+     * An additional rule provider for a rule which actually is executed before the rule under test, might result in unexpected
+     * [LintViolation] in case that additional rule is modifying the AST. During the [lint] phase, all rules are executed in parallel and as
+     * of that both the rule under test and the additional rule are using the exact same version of the AST. When, in the [format] stage the
+     * additional rule is run first, and if it modifies the AST, this could result in a [LintViolation] for the rule under test which is
+     * executed later than the additional rule.
      *
      * Prefer to use [addAdditionalRuleProvider] when only a singe provider of a rule is to be added.
      */
@@ -208,8 +205,8 @@ public class KtLintAssertThat(
         ktLintAssertThatAssertable().hasNoLintViolationsExceptInAdditionalRules()
 
     /**
-     * Asserts that the code does contain given [LintViolation] which automatically can be corrected. This is a sugar
-     * coated version of [hasLintViolations] for the case that the code contains exactly one lint violation.
+     * Asserts that the code does contain given [LintViolation] which automatically can be corrected. This is a sugar-coated version of
+     * [hasLintViolations] for the case that the code contains exactly one lint violation.
      */
     public fun hasLintViolation(
         line: Int,
@@ -218,16 +215,15 @@ public class KtLintAssertThat(
     ): KtLintAssertThatAssertable = ktLintAssertThatAssertable().hasLintViolation(line, col, detail)
 
     /**
-     * Asserts that the code does contain given [LintViolation]s which can be automatically corrected. Note that tests
-     * resulting in only one (type of) [LintViolation] are usually easier to comprehend.
+     * Asserts that the code does contain given [LintViolation]s which can be automatically corrected. Note that tests resulting in only one
+     * (type of) [LintViolation] are usually easier to comprehend.
      */
     public fun hasLintViolations(vararg expectedErrors: LintViolation): KtLintAssertThatAssertable =
         ktLintAssertThatAssertable().hasLintViolations(*expectedErrors)
 
     /**
-     * Asserts that the code does contain given [LintViolation] caused by an additional rule which automatically can be
-     * corrected. This is a sugar coated version of [hasLintViolations] for the case that the code contains exactly one
-     * lint violation.
+     * Asserts that the code does contain given [LintViolation] caused by an additional rule which automatically can be corrected. This is a
+     * sugar-coated version of [hasLintViolations] for the case that the code contains exactly one lint violation.
      */
     public fun hasLintViolationForAdditionalRule(
         line: Int,
@@ -236,9 +232,8 @@ public class KtLintAssertThat(
     ): KtLintAssertThatAssertable = ktLintAssertThatAssertable().hasLintViolationForAdditionalRule(line, col, detail)
 
     /**
-     * Asserts that the code does contain given [LintViolation]s caused by an additional rules which can be
-     * automatically corrected. Note that tests resulting in only one (type of) [LintViolation] are usually easier to
-     * comprehend.
+     * Asserts that the code does contain given [LintViolation]s caused by an additional rules which can be automatically corrected. Note
+     * that tests resulting in only one (type of) [LintViolation] are usually easier to comprehend.
      */
     public fun hasLintViolationsForAdditionalRule(vararg expectedErrors: LintViolation): KtLintAssertThatAssertable =
         ktLintAssertThatAssertable().hasLintViolationsForAdditionalRules(*expectedErrors)
@@ -258,8 +253,8 @@ public class KtLintAssertThat(
     ): Unit = ktLintAssertThatAssertable().hasLintViolationWithoutAutoCorrect(line, col, detail)
 
     /**
-     * Asserts that the code does contain the given [LintViolation]s which can not be automatically corrected. Note that
-     * tests resulting in only one [LintViolation] are usually easier to comprehend.
+     * Asserts that the code does contain the given [LintViolation]s which can not be automatically corrected. Note that tests resulting in
+     * only one [LintViolation] are usually easier to comprehend.
      */
     public fun hasLintViolationsWithoutAutoCorrect(vararg expectedErrors: LintViolation): Unit =
         ktLintAssertThatAssertable().hasLintViolationsWithoutAutocorrect(*expectedErrors)
@@ -292,17 +287,17 @@ public class KtLintAssertThat(
 
     public companion object {
         /**
-         * Creates an assertThat assertion function for the rule provided by [provider]. This assertion function has
-         * extensions specifically for testing KtLint rules.
+         * Creates an assertThat assertion function for the rule provided by [provider]. This assertion function has extensions specifically
+         * for testing KtLint rules.
          */
         public fun assertThatRule(provider: () -> Rule): (String) -> KtLintAssertThat = RuleProvider { provider() }.assertThat()
 
         /**
-         * Creates an assertThat assertion function for the rule provided by [provider]. This assertion function has
-         * extensions specifically for testing KtLint rules. The rules provided via [additionalRuleProviders] are only
-         * executed during the format phase of the test. This means that the unit test only has to check the lint
-         * violations thrown by the rule for which the assertThat is created. But the code is formatted by both the rule
-         * and the rules provided by [additionalRuleProviders] in the order as defined by the rule definitions.
+         * Creates an assertThat assertion function for the rule provided by [provider]. This assertion function has extensions specifically
+         * for testing KtLint rules. The rules provided via [additionalRuleProviders] are only executed during the format phase of the test.
+         * This means that the unit test only has to check the lint violations thrown by the rule for which the assertThat is created. But
+         * the code is formatted by both the rule and the rules provided by [additionalRuleProviders] in the order as defined by the rule
+         * definitions.
          */
 
         public fun assertThatRule(
@@ -353,9 +348,8 @@ public class KtLintAssertThat(
 }
 
 /**
- * Immutable assertable. Once the first assertion is made on [KtLintAssertThat] it is converted to the
- * [KtLintAssertThatAssertable] which allows no further modifications of the internal state. This guarantees that all
- * assertions operate on the same state.
+ * Immutable assertable. Once the first assertion is made on [KtLintAssertThat] it is converted to the [KtLintAssertThatAssertable] which
+ * allows no further modifications of the internal state. This guarantees that all assertions operate on the same state.
  */
 public class KtLintAssertThatAssertable(
     /** The provider of the rule which is the subject of the test, e.g. the rule for which the AssertThat is created. */
@@ -371,8 +365,7 @@ public class KtLintAssertThatAssertable(
     private val ruleId = ruleProvider.createNewRuleInstance().ruleId
 
     /**
-     * Asserts that the code does not contain any [LintViolation]s caused by the rule associated with the
-     * KtLintAssertThat.
+     * Asserts that the code does not contain any [LintViolation]s caused by the rule associated with the KtLintAssertThat.
      *
      * Note: When linting succeeds without errors, formatting is also checked.
      */
@@ -428,13 +421,11 @@ public class KtLintAssertThatAssertable(
     /**
      * Asserts that the code does not contain any [LintViolation]s except in the additional formatting rules.
      *
-     * Note that this method can and should be chained with [isFormattedAs] to verify whether the code is correctly
-     * formatted.
+     * Note that this method can and should be chained with [isFormattedAs] to verify whether the code is correctly formatted.
      *
-     * This method can be used when the rule which is associated with the KtLintAssertThat is not violated by the sample
-     * code, but the code is reformatted by the additional formatting rules. In case that rules are dependent on each
-     * other, a unit test cal still verify that code is formatted correctly even when the rule under test is not
-     * violated.
+     * This method can be used when the rule which is associated with the KtLintAssertThat is not violated by the sample code, but the code
+     * is reformatted by the additional formatting rules. In case that rules are dependent on each other, a unit test cal still verify that
+     * code is formatted correctly even when the rule under test is not violated.
      */
     public fun hasNoLintViolationsExceptInAdditionalRules(): KtLintAssertThatAssertable {
         check(additionalRuleProviders.isNotEmpty()) {
@@ -449,8 +440,8 @@ public class KtLintAssertThatAssertable(
     }
 
     /**
-     * Asserts that the code does contain given [LintViolation]. This is a sugar coated version of
-     * [hasLintViolation] for the case that the code contains exactly one lint violation.
+     * Asserts that the code does contain given [LintViolation]. This is a sugar-coated version of [hasLintViolation] for the case that the
+     * code contains exactly one lint violation.
      */
     public fun hasLintViolation(
         line: Int,
@@ -466,8 +457,8 @@ public class KtLintAssertThatAssertable(
         )
 
     /**
-     * Asserts that the code does contain given [LintViolation] caused by an additional rule. This is a sugar coated
-     * version of [hasLintViolationsForAdditionalRules] for the case that the code contains exactly one lint violation.
+     * Asserts that the code does contain given [LintViolation] caused by an additional rule. This is a sugar-coated version of
+     * [hasLintViolationsForAdditionalRules] for the case that the code contains exactly one lint violation.
      */
     public fun hasLintViolationForAdditionalRule(
         line: Int,
@@ -499,8 +490,7 @@ public class KtLintAssertThatAssertable(
     }
 
     /**
-     * Asserts that the code does contain given [LintViolation]s caused by additional rules and which can be
-     * automatically corrected.
+     * Asserts that the code does contain given [LintViolation]s caused by additional rules and which can be automatically corrected.
      */
     public fun hasLintViolationsForAdditionalRules(vararg expectedErrors: LintViolation): KtLintAssertThatAssertable {
         check(expectedErrors.isNotEmpty())
@@ -550,8 +540,7 @@ public class KtLintAssertThatAssertable(
         )
 
     /**
-     * Asserts that the code does contain the given [LintViolation]s and that those violations can not be automatically
-     * corrected.
+     * Asserts that the code does contain the given [LintViolation]s and that those violations can not be automatically corrected.
      */
     public fun hasLintViolationsWithoutAutocorrect(vararg expectedLintViolations: LintViolation) {
         check(expectedLintViolations.isNotEmpty())
@@ -591,14 +580,15 @@ public class KtLintAssertThatAssertable(
                 detail = it.detail,
                 canBeAutoCorrected = it.canBeAutoCorrected,
             )
-        }.toTypedArray()
+        }.distinct()
+            .toTypedArray()
     }
 
-    private fun List<LintError>.filterAdditionalRulesOnly() = filter { it.ruleId != ruleId }
+    private fun Set<LintError>.filterAdditionalRulesOnly() = filter { it.ruleId != ruleId }.toSet()
 
-    private fun List<LintError>.filterCurrentRuleOnly() = filter { it.ruleId == ruleId }
+    private fun Set<LintError>.filterCurrentRuleOnly() = filter { it.ruleId == ruleId }.toSet()
 
-    private fun List<LintError>.toLintViolationsFields(): Array<LintViolationFields> =
+    private fun Set<LintError>.toLintViolationsFields(): Array<LintViolationFields> =
         map {
             LintViolationFields(
                 line = it.line,
@@ -606,13 +596,14 @@ public class KtLintAssertThatAssertable(
                 detail = it.detail,
                 canBeAutoCorrected = it.canBeAutoCorrected,
             )
-        }.toTypedArray()
+        }.distinct()
+            .toTypedArray()
 
     private fun createKtLintRuleEngine(): KtLintRuleEngine {
         val ruleProviders =
             setOf(ruleProvider)
-                // Also run the additional rules as the main rule might have a VisitorModifier which requires one or more of
-                // the additional rules to be loaded and enabled as well.
+                // Also run the additional rules as the main rule might have a VisitorModifier which requires one or more of the additional
+                // rules to be loaded and enabled as well.
                 .plus(additionalRuleProviders)
         val editorConfigOverride =
             editorConfigOverride
@@ -625,20 +616,21 @@ public class KtLintAssertThatAssertable(
         )
     }
 
-    private fun lint(): List<LintError> {
-        val lintErrors = ArrayList<LintError>()
+    private fun lint(): Set<LintError> {
+        val lintErrors = mutableSetOf<LintError>()
         createKtLintRuleEngine().lint(code) { lintError -> lintErrors.add(lintError) }
         return lintErrors
     }
 
-    private fun format(): Pair<String, List<LintError>> {
-        val lintErrors = ArrayList<LintError>()
+    private fun format(): Pair<String, Set<LintError>> {
+        val lintErrors = mutableSetOf<LintError>()
         val formattedCode = createKtLintRuleEngine().format(code) { lintError, _ -> lintErrors.add(lintError) }
         return Pair(formattedCode, lintErrors)
     }
 
-    /* Representation of the field of the [LintError] that should be identical. Note that no comparison can be made
-     * against the original [LintError] as the [canBeAutoCorrected] flag is excluded from the hashcode.
+    /**
+     * Representation of the field of the [LintError] that should be identical. Note that no comparison can be made against the original
+     * [LintError] as the [canBeAutoCorrected] flag is excluded from the hashcode.
      */
     private data class LintViolationFields(
         val line: Int,
@@ -657,8 +649,8 @@ internal class MissingEolMarker : RuntimeException(
 )
 
 /**
- * Expectation of the [LintError]. Contrary to the [LintError] it does not contain the ruleId. The ruleId will be
- * derived from the rule for which the AssertThat was created.
+ * Expectation of the [LintError]. Contrary to the [LintError] it does not contain the ruleId. The ruleId will be derived from the rule for
+ * which the AssertThat was created.
  */
 public data class LintViolation(
     val line: Int,
@@ -668,8 +660,7 @@ public data class LintViolation(
 )
 
 /**
- * Enables the rule sets for the given set of [ruleProviders] unless the rule execution of that rule set was already
- * provided.
+ * Enables the rule sets for the given set of [ruleProviders] unless the rule execution of that rule set was already provided.
  */
 private fun EditorConfigOverride.extendWithRuleSetRuleExecutionsFor(ruleProviders: Set<RuleProvider>): EditorConfigOverride {
     val ruleSetRuleExecutions =


### PR DESCRIPTION
## Description

Do not wrap a binary expression after an elvis operator in case the max line length is exceeded

Use sets internally in KtlintAssertThat rather than lists for storage and comparing of LintViolations. Like the KtlintRuleEngine duplicate violations are to be ignored.

Closes #2128

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
