### PR TITLE
Add new experimental rule `function-literal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fix spacing around colon in annotations `spacing-around-colon` ([#2093](https://github.com/pinterest/ktlint/issues/2093))
 * Do not wrap a binary expression after an elvis operator in case the max line length is exceeded ([#2128](https://github.com/pinterest/ktlint/issues/2128))
 * Fix indent of IS_EXPRESSION, PREFIX_EXPRESSION and POSTFIX_EXPRESSION in case it contains a linebreak `indent` [#2094](https://github.com/pinterest/ktlint/issues/2094)
+* Add new experimental rule `function-literal`. This rule enforces the parameter list of a function literal to be formatted consistently. `function-literal` [#2121](https://github.com/pinterest/ktlint/issues/2121)
 
 ### Changed
 

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -163,7 +163,6 @@ Consecutive EOL comments are always allowed as they are often used instead of a 
       * ... but a KDoc can not be followed by an EOL or a block comment or another KDoc
       */
     fun bar() = "bar"
-
     ```
 
 === "[:material-heart-off-outline:](#) Disallowed"
@@ -188,6 +187,73 @@ Rule id: `no-consecutive-comments` (`standard` rule set)
 
 !!! Note
     This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+
+## Function literal
+
+Enforces the parameters of a function literal and the arrow to be written on the same line as the opening brace if the maximum line length is not exceeded. In case the parameters are wrapped to multiple lines then this is respected.
+
+If the function literal contains multiple parameter and at least one parameter other than the first parameter starts on a new line than all parameters and the arrow are wrapped to separate lines.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+            val foobar1 = { foo + bar }
+            val foobar2 =
+                {
+                    foo + bar
+                }
+            val foobar3 =
+                { foo: Foo ->
+                    foo.repeat(2)
+                }
+            val foobar4 =
+                { foo: Foo, bar: Bar ->
+                    foo + bar
+                }
+            val foobar5 = { foo: Foo, bar: Bar -> foo + bar }
+            val foobar6 =
+                {
+                        foo: Foo,
+                        bar: Bar
+                    ->
+                    foo + bar
+                }
+
+    // Assume that the last allowed character is
+    // at the X character on the right           X
+    val foobar7 =
+        barrrrrrrrrrrrrr {
+                fooooooooooooooo: Foo
+            ->
+            foo.repeat(2)
+        }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val foobar3 =
+        {
+            foo: Foo ->
+            foo.repeat(2)
+        }
+    val foobar6 =
+        { foo: Foo,
+          bar: Bar ->
+            foo + bar
+        }
+    // Assume that the last allowed character is
+    // at the X character on the right           X
+    val foobar7 =
+        barrrrrrrrrrrrrr { fooooooooooooooo: Foo ->
+            foo.repeat(2)
+        }
+    ```
+
+Rule id: `function-literal` (`standard` rule set)
+
+!!! Note
+This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ## Function signature
 

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -24,6 +24,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun leavesIncludingSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Lkotlin/sequences/Sequence;
 	public static synthetic fun leavesIncludingSelf$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
 	public static final fun leavesOnLine (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun lineLengthWithoutNewlinePrefix (Lkotlin/sequences/Sequence;)I
 	public static final fun lineLengthWithoutNewlinePrefix (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun logStructure (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun nextCodeLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZZ)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -452,12 +452,21 @@ internal fun ASTNode.getLastLeafOnLineOrNull() = nextLeaf { it.textContains('\n'
  * Get the total length of all leaves on the same line as the given node including the whitespace indentation but excluding all leading
  * newline characters in the whitespace indentation.
  */
-public fun ASTNode.lineLengthWithoutNewlinePrefix(): Int =
-    leavesOnLine()
-        .joinToString(separator = "") { it.text }
+public fun ASTNode.lineLengthWithoutNewlinePrefix(): Int = leavesOnLine().lineLengthWithoutNewlinePrefix()
+
+/**
+ * Get the total length of all leaves in the sequence including the whitespace indentation but excluding all leading newline characters in
+ * the whitespace indentation. The first leaf node in the sequence must be a white space starting with at least one newline.
+ */
+public fun Sequence<ASTNode>.lineLengthWithoutNewlinePrefix(): Int {
+    require(first().text.startsWith('\n') || first().prevLeaf() == null) {
+        "First node in sequence must be a whitespace containing a newline"
+    }
+    return joinToString(separator = "") { it.text }
         // If a line is preceded by a blank line then the ident contains multiple newline chars
         .dropWhile { it == '\n' }
         // In case the last element on the line would contain a newline then only include chars before that newline. Note that this should
         // not occur if the AST is parsed correctly
         .takeWhile { it != '\n' }
         .length
+}

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -661,7 +661,7 @@ class ASTNodeExtensionTest {
     }
 
     @Test
-    fun `Given some line containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
+    fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
         val code =
             """
             class Foo1 {
@@ -678,15 +678,47 @@ class ASTNodeExtensionTest {
                 .firstChildLeafOrSelf()
                 .leaves()
                 .filter { it.elementType == IDENTIFIER }
-                .map { newLine ->
-                    newLine.lineLengthWithoutNewlinePrefix()
-                }.toList()
+                .map { identifier -> identifier.lineLengthWithoutNewlinePrefix() }
+                .toList()
 
         assertThat(actual).contains(
             "class Foo1 {".length,
             "    val foo2 = \"foo2\"".length,
             "    fun foo3() {".length,
             "        val foo4 = \"foo4\"".length,
+        )
+    }
+
+    @Test
+    fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters until and including the identifier`() {
+        val code =
+            """
+            class Foo1 {
+                val foo2 = "foo2"
+
+                fun foo3() {
+                    val foo4 = "foo4"
+                }
+            }
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .firstChildLeafOrSelf()
+                .leaves()
+                .filter { it.elementType == IDENTIFIER }
+                .map { identifier ->
+                    identifier
+                        .leavesOnLine()
+                        .takeWhile { it.prevLeaf() != identifier }
+                        .lineLengthWithoutNewlinePrefix()
+                }.toList()
+
+        assertThat(actual).contains(
+            "class Foo1".length,
+            "    val foo2".length,
+            "    fun foo3".length,
+            "        val foo4".length,
         )
     }
 

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -169,6 +169,16 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/FunKeywordSpacing
 	public static final fun getFUN_KEYWORD_SPACING_RULE ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralKt {
+	public static final fun getFUNCTION_LITERAL_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/Rule$Experimental {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/Rule$Experimental {
 	public fun <init> ()V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -20,6 +20,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.EnumWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.FilenameRule
 import com.pinterest.ktlint.ruleset.standard.rules.FinalNewlineRule
 import com.pinterest.ktlint.ruleset.standard.rules.FunKeywordSpacingRule
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionLiteralRule
 import com.pinterest.ktlint.ruleset.standard.rules.FunctionNamingRule
 import com.pinterest.ktlint.ruleset.standard.rules.FunctionReturnTypeSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule
@@ -104,6 +105,7 @@ public class StandardRuleSetProvider :
             RuleProvider { EnumWrappingRule() },
             RuleProvider { FilenameRule() },
             RuleProvider { FinalNewlineRule() },
+            RuleProvider { FunctionLiteralRule() },
             RuleProvider { FunctionNamingRule() },
             RuleProvider { FunctionReturnTypeSpacingRule() },
             RuleProvider { FunctionSignatureRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteral.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteral.kt
@@ -1,0 +1,331 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine
+import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * [Kotlin lang documentation](https://kotlinlang.org/docs/coding-conventions.html#lambdas):
+ *
+ * When declaring parameter names in a multiline lambda, put the names on the first line, followed by the arrow and the newline:
+ *
+ * ```
+ * appendCommaSeparated(properties) { prop ->
+ *     val propertyValue = prop.get(obj)  // ...
+ * }
+ * ```
+ *
+ * If the parameter list is too long to fit on a line, put the arrow on a separate line:
+ *
+ * ```
+ * foo {
+ *    context: Context,
+ *    environment: Env
+ *    ->
+ *    context.configureEnv(environment)
+ * }
+ * ```
+ */
+public class FunctionLiteralRule :
+    StandardRule(
+        id = "function-literal",
+        usesEditorConfigProperties =
+            setOf(
+                CODE_STYLE_PROPERTY,
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
+    ),
+    Rule.Experimental {
+    private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        codeStyle = editorConfig[CODE_STYLE_PROPERTY]
+        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+        if (indentConfig.disabled) {
+            stopTraversalOfAST()
+        }
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (node.elementType == FUNCTION_LITERAL) {
+            node
+                .findChildByType(VALUE_PARAMETER_LIST)
+                ?.let { visitValueParameterList(it, autoCorrect, emit) }
+            node
+                .findChildByType(BLOCK)
+                ?.let { visitBlock(it, autoCorrect, emit) }
+        }
+    }
+
+    private fun visitValueParameterList(
+        parameterList: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        val valueParameters =
+            parameterList
+                .children()
+                .filter { it.elementType == VALUE_PARAMETER }
+        if (valueParameters.count() > 1 || parameterList.wrapFirstParameterToNewline()) {
+            if (parameterList.textContains('\n') || parameterList.exceedsMaxLineLength()) {
+                rewriteToMultilineParameterList(parameterList, autoCorrect, emit)
+            } else {
+                rewriteToSingleFunctionLiteral(parameterList, emit, autoCorrect)
+            }
+        } else {
+            if (parameterList.textContains('\n')) {
+                // Allow:
+                //    val foo = {
+                //            bar:
+                //                @Baz("baz")
+                //                Bar
+                //        ->
+                //        bar()
+                //    }
+                Unit
+            } else {
+                // Disallow:
+                //    val foo = {
+                //            bar ->
+                //        bar()
+                //    }
+                //    val foo = { bar
+                //        ->
+                //        bar()
+                //    }
+                rewriteToSingleFunctionLiteral(parameterList, emit, autoCorrect)
+            }
+        }
+    }
+
+    private fun ASTNode.exceedsMaxLineLength() = lineLengthWithoutNewlinePrefix() > maxLineLength
+
+    private fun ASTNode.wrapFirstParameterToNewline() =
+        takeIf { it.treeParent.elementType == FUNCTION_LITERAL }
+            ?.treeParent
+            ?.takeIf { it.treeParent.elementType == LAMBDA_EXPRESSION }
+            ?.treeParent
+            ?.takeIf { it.treeParent.elementType == LAMBDA_ARGUMENT }
+            ?.let {
+                // Disallow when max line is exceeded:
+                //    val foo = someCallExpression { someLongParameterName ->
+                //        bar()
+                //    }
+                val stopAtLeaf =
+                    children()
+                        .first { it.elementType == VALUE_PARAMETER }
+                        .lastChildLeafOrSelf()
+                        .nextLeaf { !it.isWhiteSpaceWithoutNewline() && !it.isPartOfComment() }
+                leavesOnLine()
+                    .takeWhile { it.prevLeaf() != stopAtLeaf }
+                    .lineLengthWithoutNewlinePrefix()
+                    .let { it > maxLineLength }
+            }
+            ?: false
+
+    private fun rewriteToMultilineParameterList(
+        parameterList: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(parameterList.elementType == VALUE_PARAMETER_LIST)
+        parameterList
+            .children()
+            .filter { it.elementType == VALUE_PARAMETER }
+            .forEach { wrapValueParameter(it, autoCorrect, emit) }
+        parameterList
+            .treeParent
+            .findChildByType(ARROW)
+            ?.let { arrow -> wrapArrow(arrow, autoCorrect, emit) }
+        parameterList
+            .treeParent
+            .findChildByType(RBRACE)
+            ?.let { rbrace -> wrapBeforeRbrace(rbrace, autoCorrect, emit) }
+    }
+
+    private fun wrapValueParameter(
+        valueParameter: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(valueParameter.elementType == VALUE_PARAMETER)
+        valueParameter
+            .prevLeaf()
+            .takeIf { it.isWhiteSpace() }
+            .let { whitespaceBeforeValueParameter ->
+                if (whitespaceBeforeValueParameter == null ||
+                    !whitespaceBeforeValueParameter.textContains('\n')
+                ) {
+                    emit(valueParameter.startOffset, "Newline expected before parameter", true)
+                    if (autoCorrect) {
+                        valueParameter.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(valueParameter))
+                    }
+                }
+            }
+    }
+
+    private fun wrapArrow(
+        arrow: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        wrapBeforeArrow(arrow, emit, autoCorrect)
+        wrapAfterArrow(arrow, emit, autoCorrect)
+    }
+
+    private fun wrapBeforeArrow(
+        arrow: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        require(arrow.elementType == ARROW)
+        arrow
+            .prevLeaf()
+            .takeIf { it.isWhiteSpace() }
+            .let { whitespaceBeforeArrow ->
+                if (whitespaceBeforeArrow == null ||
+                    !whitespaceBeforeArrow.textContains('\n')
+                ) {
+                    emit(arrow.startOffset, "Newline expected before arrow", true)
+                    if (autoCorrect) {
+                        arrow.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(arrow))
+                    }
+                }
+            }
+    }
+
+    private fun wrapAfterArrow(
+        arrow: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        require(arrow.elementType == ARROW) {
+            Unit
+        }
+        arrow
+            .nextLeaf()
+            .takeIf { it.isWhiteSpace() }
+            .let { whitespaceAfterArrow ->
+                if (whitespaceAfterArrow == null ||
+                    !whitespaceAfterArrow.textContains('\n')
+                ) {
+                    emit(arrow.startOffset + arrow.textLength - 1, "Newline expected after arrow", true)
+                    if (autoCorrect) {
+                        arrow.upsertWhitespaceAfterMe(indentConfig.childIndentOf(arrow))
+                    }
+                }
+            }
+    }
+
+    private fun wrapBeforeRbrace(
+        rbrace: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(rbrace.elementType == RBRACE)
+        rbrace
+            .prevLeaf()
+            .takeIf { it.isWhiteSpace() }
+            .let { whitespaceBeforeRbrace ->
+                if (whitespaceBeforeRbrace == null ||
+                    !whitespaceBeforeRbrace.textContains('\n')
+                ) {
+                    emit(rbrace.startOffset, "Newline expected before closing brace", true)
+                    if (autoCorrect) {
+                        rbrace.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(rbrace))
+                    }
+                }
+            }
+    }
+
+    private fun rewriteToSingleFunctionLiteral(
+        parameterList: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        autoCorrect: Boolean,
+    ) {
+        require(parameterList.elementType == VALUE_PARAMETER_LIST)
+        parameterList
+            .prevSibling { it.isWhiteSpace() }
+            ?.takeIf { it.isWhiteSpaceWithNewline() }
+            ?.let { whitespaceBeforeParameterList ->
+                emit(parameterList.startOffset, "No newline expected before parameter", true)
+                if (autoCorrect) {
+                    whitespaceBeforeParameterList.upsertWhitespaceBeforeMe(" ")
+                }
+            }
+        parameterList
+            .nextSibling { it.isWhiteSpace() }
+            ?.takeIf { it.isWhiteSpaceWithNewline() }
+            ?.let { whitespaceAfterParameterList ->
+                emit(parameterList.startOffset + parameterList.textLength, "No newline expected after parameter", true)
+                if (autoCorrect) {
+                    whitespaceAfterParameterList.upsertWhitespaceAfterMe(" ")
+                }
+            }
+    }
+
+    private fun visitBlock(
+        block: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        require(block.elementType == BLOCK)
+        if (block.textContains('\n')) {
+            block
+                .prevCodeSibling()
+                ?.takeIf { it.elementType == ARROW }
+                ?.let { arrow -> wrapAfterArrow(arrow, emit, autoCorrect) }
+
+            block
+                .nextCodeSibling()
+                ?.takeIf { it.elementType == RBRACE }
+                ?.let { rbrace -> wrapBeforeRbrace(rbrace, autoCorrect, emit) }
+        }
+    }
+}
+
+public val FUNCTION_LITERAL_RULE_ID: RuleId = FunctionLiteralRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -1,0 +1,420 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Test
+
+class FunctionLiteralRuleTest {
+    private val functionLiteralRuleAssertThat =
+        assertThatRule(
+            provider = { FunctionLiteralRule() },
+            additionalRuleProviders =
+                setOf(
+                    RuleProvider { IndentationRule() },
+                ),
+        )
+
+    @Test
+    fun `Given a single line lambda without parameters`() {
+        val code =
+            """
+            val foobar = { foo + bar }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a multiline lambda without parameters`() {
+        val code =
+            """
+            val foobar =
+                {
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a lambda with a single parameter fitting on the first line`() {
+        val code =
+            """
+            val foobar =
+                { foo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a lambda with a single parameter not on same line as opening brace`() {
+        val code =
+            """
+            val foobar =
+                {
+                    foo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foobar =
+                { foo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolation(3, 9, "No newline expected before parameter")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with a single parameter and arrow on separate line`() {
+        val code =
+            """
+            val foobar =
+                { foo: Foo
+                    ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foobar =
+                { foo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolation(2, 15, "No newline expected after parameter")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with a single parameter not fitting on the first line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { fooooooooooooooo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a call expression followed by a lambda with a single parameter not fitting on the same line as the opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                barrrrrrrrrr { foooooooooooo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                barrrrrrrrrr {
+                        foooooooooooo: Foo
+                    ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 20, "Newline expected before parameter"),
+                LintViolation(3, 39, "Newline expected before arrow"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with multiple parameters fitting on the first line`() {
+        val code =
+            """
+            val foobar =
+                { foo: Foo, bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a lambda with multiple parameters but not fitting on the first line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { fooooo: Foo, bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                        fooooo: Foo,
+                        bar: Bar
+                    ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 7, "Newline expected before parameter"),
+                LintViolation(3, 20, "Newline expected before parameter"),
+                LintViolation(3, 29, "Newline expected before arrow"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with multiple parameters of which some are not fitting on line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { fooooooooooo: Foo, bar: Bar ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                        fooooooooooo: Foo,
+                        bar: Bar
+                    ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 7, "Newline expected before parameter"),
+                LintViolation(3, 26, "Newline expected before parameter"),
+                LintViolation(3, 35, "Newline expected before arrow"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with a multiline parameter list starting on same line as opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { foo: Foo,
+                  bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                        foo: Foo,
+                        bar: Bar
+                    ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 7, "Newline expected before parameter"),
+                LintViolation(4, 16, "Newline expected before arrow"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with a multiline parameter list starting on the next line below the opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                  foo: Foo,
+                  bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                        foo: Foo,
+                        bar: Bar
+                    ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(5, 16, "Newline expected before arrow")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line parameter list starting on the next line below the opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                {
+                  foo: Foo, bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { foo: Foo, bar: Bar ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(4, 7, "No newline expected before parameter")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line parameter list starting on the next line below the opening brace and arrow on separate line which can be merged to a single line after opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+            val foobar =
+                {
+                  foo: Foo, bar: Bar, baz: Baz
+                  ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+            val foobar =
+                { foo: Foo, bar: Bar, baz: Baz ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(4, 7, "No newline expected before parameter"),
+                LintViolation(4, 35, "No newline expected after parameter"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line parameter list starting on the next line below the opening brace and arrow on separate line which can not be merged to a single line after opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER         $EOL_CHAR
+            val foobar =
+                {
+                  foo: Foo, bar: Bar, baz: Baz
+                  ->
+                    foo + bar
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER         $EOL_CHAR
+            val foobar =
+                {
+                        foo: Foo,
+                        bar: Bar,
+                        baz: Baz
+                    ->
+                    foo + bar
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(4, 7, "No newline expected before parameter"),
+                LintViolation(4, 35, "No newline expected after parameter"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line function literal not exceeding the max line length and having a parameter list`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            val foobar = { foo: Foo, bar: Bar -> foo + bar }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line function literal exceeding the max line length and having a parameter list`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
+            val foobar = { foo: Foo, bar: Bar -> foo + bar }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
+            val foobar = {
+                    foo: Foo,
+                    bar: Bar
+                ->
+                foo + bar
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .addAdditionalRuleProvider { MultilineExpressionWrapping() }
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 16, "Newline expected before parameter"),
+                LintViolation(2, 26, "Newline expected before parameter"),
+                LintViolation(2, 35, "Newline expected before arrow"),
+                LintViolation(2, 36, "Newline expected after arrow"),
+                LintViolation(2, 48, "Newline expected before closing brace"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline code block starting on same line a arrow`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER               $EOL_CHAR
+            val foobar = { foo: Foo, bar: Bar -> foo +
+                bar
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER               $EOL_CHAR
+            val foobar = { foo: Foo, bar: Bar ->
+                foo +
+                    bar
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .addAdditionalRuleProvider { MultilineExpressionWrapping() }
+            .setMaxLineLength()
+            .hasLintViolation(2, 36, "Newline expected after arrow")
+            .isFormattedAs(formattedCode)
+    }
+}


### PR DESCRIPTION
## Description

This rule enforces the parameter list of a function literal to be formatted consistently

Closes #2121

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
