### PR TITLE
Change default code style to `ktlint_official`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+* Change default code style to `ktlint_official` ([#2143](https://github.com/pinterest/ktlint/pull/2143))
 * Update dependency gradle to v8.2.1 ([#2122](https://github.com/pinterest/ktlint/pull/2122))
 * Update dependency org.codehaus.janino:janino to v3.1.10  ([#2110](https://github.com/pinterest/ktlint/pull/2110))
 * Update dependency com.google.jimfs:jimfs to v1.3.0 ([#2112](https://github.com/pinterest/ktlint/pull/2112))

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigProperty.kt
@@ -37,9 +37,8 @@ public enum class CodeStyleValue {
 public val CODE_STYLE_PROPERTY_TYPE: PropertyType.LowerCasingPropertyType<CodeStyleValue> =
     PropertyType.LowerCasingPropertyType(
         "ktlint_code_style",
-        "The code style ('intellij_idea', 'android_studio' or 'ktlint_official') to be applied. Currently, the " +
-            "value is defaulted to 'intellij_idea' when not set. However, in the future the default code style " +
-            "will be changed to 'ktlint_official'.",
+        "The code style ('ktlint_official', 'intellij_idea' or 'android_studio') to be applied. By default the 'ktlint_official' code " +
+            "style is used",
         SafeEnumValueParser(CodeStyleValue::class.java),
         CodeStyleValue.values().map { it.name }.toSet(),
     )
@@ -47,11 +46,7 @@ public val CODE_STYLE_PROPERTY_TYPE: PropertyType.LowerCasingPropertyType<CodeSt
 public val CODE_STYLE_PROPERTY: EditorConfigProperty<CodeStyleValue> =
     EditorConfigProperty(
         type = CODE_STYLE_PROPERTY_TYPE,
-        /*
-         * Once the [CodeStyleValue.ktlint_official] is matured, it will become the default code style of ktlint. Until
-         * then the [CodeStyleValue.intellij_idea] is used to remain backwards compatible.
-         */
-        defaultValue = CodeStyleValue.intellij_idea,
+        defaultValue = CodeStyleValue.ktlint_official,
         androidStudioCodeStyleDefaultValue = CodeStyleValue.android_studio,
         intellijIdeaCodeStyleDefaultValue = CodeStyleValue.intellij_idea,
         ktlintOfficialCodeStyleDefaultValue = CodeStyleValue.ktlint_official,

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigTest.kt
@@ -36,8 +36,7 @@ class EditorConfigTest {
 
         val actual = editorConfig[SOME_EDITOR_CONFIG_PROPERTY]
 
-        // Note that IntelliJ IDEA is the default code style for now, this will change to KTLINT_OFFICIAL in the future
-        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_INTELLIJ_IDEA)
+        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_KTLINT_OFFICIAL)
     }
 
     @ParameterizedTest(name = "Code style: {0}, expected result: {1}")
@@ -45,7 +44,7 @@ class EditorConfigTest {
         value = [
             "android_studio, $SOME_PROPERTY_VALUE_ANDROID_STUDIO",
             "intellij_idea, $SOME_PROPERTY_VALUE_INTELLIJ_IDEA",
-            "ktlint_official, $SOME_PROPERTY_VALUE_OFFICIAL",
+            "ktlint_official, $SOME_PROPERTY_VALUE_KTLINT_OFFICIAL",
         ],
     )
     fun `Given an EditorConfig with a defined code style and add a property with default value then the default value can be retrieved for the default code style`(
@@ -119,8 +118,8 @@ class EditorConfigTest {
         val editorConfig =
             EditorConfig()
                 .addPropertiesWithDefaultValueIfMissing(
-                    SOME_EDITOR_CONFIG_PROPERTY.copy(name = propertyName1, intellijIdeaCodeStyleDefaultValue = propertyValue1),
-                    SOME_EDITOR_CONFIG_PROPERTY.copy(name = propertyName2, intellijIdeaCodeStyleDefaultValue = propertyValue2),
+                    SOME_EDITOR_CONFIG_PROPERTY.copy(name = propertyName1, ktlintOfficialCodeStyleDefaultValue = propertyValue1),
+                    SOME_EDITOR_CONFIG_PROPERTY.copy(name = propertyName2, ktlintOfficialCodeStyleDefaultValue = propertyValue2),
                 )
 
         val actual = editorConfig.map { property -> property.name.uppercase() to property.sourceValue.uppercase() }
@@ -198,7 +197,7 @@ class EditorConfigTest {
         val editorConfigPropertyWithPropertyMapper =
             SOME_EDITOR_CONFIG_PROPERTY
                 .copy(
-                    propertyMapper = { _, _ -> SOME_PROPERTY_VALUE_OFFICIAL },
+                    propertyMapper = { _, _ -> SOME_PROPERTY_VALUE_KTLINT_OFFICIAL },
                     defaultValue = SOME_PROPERTY_VALUE,
                     androidStudioCodeStyleDefaultValue = null,
                     intellijIdeaCodeStyleDefaultValue = null,
@@ -208,7 +207,7 @@ class EditorConfigTest {
 
         val actual = editorConfig[editorConfigPropertyWithPropertyMapper]
 
-        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_OFFICIAL)
+        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_KTLINT_OFFICIAL)
     }
 
     @Test
@@ -220,7 +219,7 @@ class EditorConfigTest {
 
         val actual = editorConfig[SOME_EDITOR_CONFIG_PROPERTY]
 
-        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_INTELLIJ_IDEA)
+        assertThat(actual).isEqualTo(SOME_PROPERTY_VALUE_KTLINT_OFFICIAL)
     }
 
     @Test
@@ -324,7 +323,7 @@ class EditorConfigTest {
         const val SOME_PROPERTY_VALUE_ANDROID_STUDIO = "some-property-value-android"
         const val SOME_PROPERTY_VALUE_DEFAULT = "some-property-value-default"
         const val SOME_PROPERTY_VALUE_INTELLIJ_IDEA = "some-property-value-intellij-idea"
-        const val SOME_PROPERTY_VALUE_OFFICIAL = "some-property-value-official"
+        const val SOME_PROPERTY_VALUE_KTLINT_OFFICIAL = "some-property-value-ktlint-official"
         val SOME_EDITOR_CONFIG_PROPERTY =
             EditorConfigProperty(
                 name = SOME_PROPERTY_NAME,
@@ -337,7 +336,7 @@ class EditorConfigTest {
                     ),
                 defaultValue = SOME_PROPERTY_VALUE_DEFAULT,
                 androidStudioCodeStyleDefaultValue = SOME_PROPERTY_VALUE_ANDROID_STUDIO,
-                ktlintOfficialCodeStyleDefaultValue = SOME_PROPERTY_VALUE_OFFICIAL,
+                ktlintOfficialCodeStyleDefaultValue = SOME_PROPERTY_VALUE_KTLINT_OFFICIAL,
                 intellijIdeaCodeStyleDefaultValue = SOME_PROPERTY_VALUE_INTELLIJ_IDEA,
             )
     }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -229,7 +229,7 @@ internal class EditorConfigLoaderTest {
                             "ij_formatter_tags_enabled = false",
                             "ij_formatter_off_tag = @formatter:off",
                             "ij_formatter_on_tag = @formatter:on",
-                            "ktlint_code_style = intellij_idea",
+                            "ktlint_code_style = ktlint_official",
                             "ktlint_experimental = disabled",
                         )
                 }
@@ -306,7 +306,7 @@ internal class EditorConfigLoaderTest {
                             "ij_formatter_tags_enabled = false",
                             "ij_formatter_off_tag = @formatter:off",
                             "ij_formatter_on_tag = @formatter:on",
-                            "ktlint_code_style = intellij_idea",
+                            "ktlint_code_style = ktlint_official",
                             "ktlint_experimental = disabled",
                         )
                 }
@@ -357,7 +357,7 @@ internal class EditorConfigLoaderTest {
                             "ij_formatter_tags_enabled = false",
                             "ij_formatter_off_tag = @formatter:off",
                             "ij_formatter_on_tag = @formatter:on",
-                            "ktlint_code_style = intellij_idea",
+                            "ktlint_code_style = ktlint_official",
                             "ktlint_experimental = disabled",
                         )
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -151,7 +151,7 @@ public class ClassSignatureRule :
         require(node.elementType == CLASS)
 
         val wrapPrimaryConstructorParameters =
-            node.hasMinimumNumberOfParameters() ||
+            node.hasTooManyParameters() ||
                 node.containsMultilineParameter() ||
                 (codeStyle == ktlint_official && node.containsAnnotatedParameter()) ||
                 (isMaxLineLengthSet() && classSignatureExcludingSuperTypesExceedsMaxLineLength(node, emit, autoCorrect)) ||
@@ -648,7 +648,7 @@ public class ClassSignatureRule :
 
     private fun List<ASTNode>.joinTextToString(): String = collectLeavesRecursively().joinToString(separator = "") { it.text }
 
-    private fun ASTNode.hasMinimumNumberOfParameters(): Boolean = countParameters() >= classSignatureWrappingMinimumParameters
+    private fun ASTNode.hasTooManyParameters(): Boolean = countParameters() >= classSignatureWrappingMinimumParameters
 
     private fun ASTNode.countParameters() =
         getPrimaryConstructorParameterListOrNull()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
@@ -806,12 +807,14 @@ class AnnotationRuleTest {
     @Nested
     inner class `Given a class with a primary constructor` {
         @Test
-        fun `Issue 628 - Given an annotation followed by other modifier before the primary constructor (non ktlint_official code style)`() {
+        fun `Issue 628 - Given a non-ktlint_official code style and an annotation followed by other modifier before the primary constructor (non ktlint_official code style)`() {
             val code =
                 """
                 class Foo @Inject internal constructor()
                 """.trimIndent()
-            annotationRuleAssertThat(code).hasNoLintViolations()
+            annotationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.intellij_idea)
+                .hasNoLintViolations()
         }
 
         @Nested

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -41,6 +41,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasNoLintViolations()
         }
 
@@ -81,6 +82,7 @@ class ClassSignatureRuleTest {
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
                 .addAdditionalRuleProvider { FunctionStartOfBodySpacingRule() }
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasLintViolation(2, 34, "Expected a single space before class body")
                 .isFormattedAs(formattedCode)
         }
@@ -357,6 +359,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
                 LintViolation(3, 5, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(4, 5, "Single whitespace expected before parameter"),
@@ -485,6 +488,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 
@@ -515,6 +519,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProvider { NullableTypeSpacingRule() }
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasNoLintViolationsExceptInAdditionalRules()
                 .isFormattedAs(formattedCode)
         }
@@ -583,7 +588,8 @@ class ClassSignatureRuleTest {
                     { SpacingAroundParensRule() },
                     { SpacingAroundCommaRule() },
                     { SpacingAroundColonRule() },
-                ).hasLintViolations(
+                ).withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasLintViolations(
                     LintViolation(3, 14, "No whitespace expected between opening parenthesis and first parameter name"),
                     LintViolation(7, 21, "Single whitespace expected before parameter"),
                     LintViolation(8, 26, "No whitespace expected between last parameter and closing parenthesis"),
@@ -625,7 +631,8 @@ class ClassSignatureRuleTest {
                     { SpacingAroundColonRule() },
                     { SpacingAroundCommaRule() },
                     { SpacingAroundOperatorsRule() },
-                ).hasLintViolations(
+                ).withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasLintViolations(
                     LintViolation(2, 19, "Single whitespace expected before parameter"),
                     LintViolation(4, 13, "Expected single space before the super type"),
                 ).isFormattedAs(formattedCode)
@@ -725,6 +732,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 
@@ -743,6 +751,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolation(2, 37, "Super type should start on a newline")
             .isFormattedAs(formattedCode)
     }
@@ -1324,6 +1333,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
                 LintViolation(3, 5, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(4, 5, "Single whitespace expected before parameter"),
@@ -1355,6 +1365,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasLintViolations(
                     LintViolation(2, 37, "Super type should start on a newline"),
                     LintViolation(2, 49, "Super type should start on a newline"),
@@ -1383,6 +1394,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasLintViolations(
                     LintViolation(2, 37, "Super type should start on a newline"),
                     LintViolation(2, 43, "Super type call must be first super type"),
@@ -1412,6 +1424,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .hasLintViolations(
                     LintViolation(2, 37, "Super type should start on a newline"),
                     LintViolation(2, 43, "Super type should start on a newline"),
@@ -1440,6 +1453,7 @@ class ClassSignatureRuleTest {
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolation(2, 23, "Super type should start on a newline")
             .isFormattedAs(formattedCode)
     }
@@ -1470,6 +1484,7 @@ class ClassSignatureRuleTest {
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { IndentationRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolation(2, 37, "Super type should start on a newline")
             .isFormattedAs(formattedCode)
     }
@@ -1494,9 +1509,9 @@ class ClassSignatureRuleTest {
                 b: Any,
                 c: Any
             ) : Bar(
-                a,
-                c
-            ) {
+                    a,
+                    c
+                ) {
                 // body
             }
             """.trimIndent()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -35,6 +35,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 
@@ -96,6 +97,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
                 LintViolation(2, 7, "Newline expected after opening parenthesis"),
                 LintViolation(2, 15, "Parameter should start on a newline"),
@@ -263,6 +265,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolation(2, 32, "Newline expected before expression body")
             .isFormattedAs(formattedCode)
     }
@@ -282,6 +285,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolation(2, 32, "First line of body expression fits on same line as function signature")
             .isFormattedAs(formattedCode)
     }
@@ -379,6 +383,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
                 LintViolation(5, 5, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(6, 5, "Single whitespace expected before parameter"),
@@ -415,6 +420,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
                 LintViolation(6, 9, "No whitespace expected between opening parenthesis and first parameter name"),
                 LintViolation(7, 9, "Single whitespace expected before parameter"),
@@ -497,6 +503,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 
@@ -511,6 +518,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 
@@ -623,7 +631,8 @@ class FunctionSignatureRuleTest {
                     { SpacingAroundDotRule() },
                     { SpacingAroundCommaRule() },
                     { SpacingAroundColonRule() },
-                ).hasLintViolations(
+                ).withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasLintViolations(
                     LintViolation(3, 10, "No whitespace expected between opening parenthesis and first parameter name"),
                     LintViolation(7, 17, "Single whitespace expected before parameter"),
                     LintViolation(8, 22, "No whitespace expected between last parameter and closing parenthesis"),
@@ -669,7 +678,8 @@ class FunctionSignatureRuleTest {
                     { SpacingAroundColonRule() },
                     { SpacingAroundCommaRule() },
                     { SpacingAroundOperatorsRule() },
-                ).hasLintViolation(2, 15, "Single whitespace expected before parameter")
+                ).withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasLintViolation(2, 15, "Single whitespace expected before parameter")
                 .isFormattedAs(formattedCode)
         }
     }
@@ -692,6 +702,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .hasNoLintViolations()
         }
@@ -717,6 +728,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolation(2, 33, "Newline expected before expression body")
@@ -746,6 +758,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolation(2, 33, "Newline expected before expression body")
@@ -780,6 +793,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
@@ -814,6 +828,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
@@ -851,6 +866,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
@@ -886,6 +902,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
@@ -923,6 +940,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
                 .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
@@ -1097,6 +1115,7 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasNoLintViolations()
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -1494,7 +1494,7 @@ internal class IndentationRuleTest {
     @Nested
     inner class `Given a nested conditional` {
         @Test
-        fun `Given a simple nested conditional`() {
+        fun `Given a non-ktlint_official code style and a simple nested conditional`() {
             val code =
                 """
                 val foo =
@@ -1514,6 +1514,7 @@ internal class IndentationRuleTest {
                             )
                 """.trimIndent()
             indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 8)"),
@@ -1524,7 +1525,7 @@ internal class IndentationRuleTest {
         }
 
         @Test
-        fun `Given a method chain combined with nested conditionals`() {
+        fun `Given a non-ktlint_official code style and a method chain combined with nested conditionals`() {
             val code =
                 """
                 val foo =
@@ -1558,6 +1559,7 @@ internal class IndentationRuleTest {
                         false
                 """.trimIndent()
             indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 8)"),
@@ -1575,7 +1577,7 @@ internal class IndentationRuleTest {
         }
 
         @Test
-        fun `Given a while statement with method chain combined with nested conditionals`() {
+        fun `Given a non-ktlint_official code style and a while statement with method chain combined with nested conditionals`() {
             val code =
                 """
                 fun foo() {
@@ -1619,6 +1621,7 @@ internal class IndentationRuleTest {
                 }
                 """.trimIndent()
             indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 8)"),
@@ -1640,7 +1643,7 @@ internal class IndentationRuleTest {
         }
 
         @Test
-        fun `Given an if-statement with method chain combined with nested conditionals`() {
+        fun `Given a non-ktlint_official code style and an if-statement with method chain combined with nested conditionals`() {
             val code =
                 """
                 fun foo() {
@@ -1684,6 +1687,7 @@ internal class IndentationRuleTest {
                 }
                 """.trimIndent()
             indentationRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .hasLintViolations(
                     LintViolation(2, 1, "Unexpected indentation (0) (should be 4)"),
                     LintViolation(3, 1, "Unexpected indentation (0) (should be 8)"),
@@ -2171,7 +2175,7 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun `Given if-else-statement for which branches are wrapped between parenthesis`() {
+    fun `Given non-ktlint_official code style and if-else-statement for which branches are wrapped between parenthesis`() {
         val code =
             """
             val foo = if (true) (
@@ -2180,7 +2184,9 @@ internal class IndentationRuleTest {
                 3 + 4
                 ) // IDEA quirk
             """.trimIndent()
-        indentationRuleAssertThat(code).hasNoLintViolations()
+        indentationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -3579,7 +3585,7 @@ internal class IndentationRuleTest {
     }
 
     @Test
-    fun `Issue 1003 - Given multiple interfaces`() {
+    fun `Issue 1003 - Given non-ktlint_official code style and multiple interfaces`() {
         val code =
             """
             abstract class Parent(a: Int, b: Int)
@@ -3595,7 +3601,9 @@ internal class IndentationRuleTest {
             ),
                 Parent2
             """.trimIndent()
-        indentationRuleAssertThat(code).hasNoLintViolations()
+        indentationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+            .hasNoLintViolations()
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.ruleset.standard.rules.NoWildcardImportsRule.Companion.IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoWildcardImportsRuleTest.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.ruleset.standard.rules.NoWildcardImportsRule.Companion.IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
@@ -12,9 +14,9 @@ class NoWildcardImportsRuleTest {
     private val noWildcardImportsRuleAssertThat = assertThatRule { NoWildcardImportsRule() }
 
     @Nested
-    inner class `Given that editorconfig property packagesToUseImportOnDemandProperty is not set` {
+    inner class `Given that editorconfig property ij_kotlin_packages_to_use_import_on_demand is not set` {
         @Test
-        fun `Wildcard imports are detected`() {
+        fun `Given the ktlint_official codestyle then the default wildcard imports allowed in other code styles are no longer allowed`() {
             val code =
                 """
                 import a
@@ -22,29 +24,44 @@ class NoWildcardImportsRuleTest {
                 import a.b.c
                 import a.d.*
                 import foo.bar.`**`
+                import java.util.*
+                import kotlinx.android.synthetic.*
                 """.trimIndent()
             noWildcardImportsRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 1, "Wildcard import"),
+                    LintViolation(4, 1, "Wildcard import"),
+                    LintViolation(6, 1, "Wildcard import"),
+                    LintViolation(7, 1, "Wildcard import"),
+                )
+        }
+
+        @Test
+        fun `Given a non-ktlint_official codestyle then the default wildcard imports allowed in other code styles are no longer allowed`() {
+            val code =
+                """
+                import a
+                import a.b.*
+                import a.b.c
+                import a.d.*
+                import foo.bar.`**`
+                import java.util.*
+                import kotlinx.android.synthetic.*
+                """.trimIndent()
+            noWildcardImportsRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .hasLintViolationsWithoutAutoCorrect(
                     LintViolation(2, 1, "Wildcard import"),
                     LintViolation(4, 1, "Wildcard import"),
                 )
         }
-
-        @Test
-        fun `Wildcard imports on packages which are accepted by IntelliJ Default are not detected`() {
-            val code =
-                """
-                import a.b
-                import kotlinx.android.synthetic.main.layout_name.*
-                """.trimIndent()
-            noWildcardImportsRuleAssertThat(code).hasNoLintViolations()
-        }
     }
 
     @Nested
-    inner class `Given that editorconfig property packagesToUseImportOnDemandProperty is set` {
+    inner class `Given that editorconfig property ij_kotlin_packages_to_use_import_on_demand is set` {
         @Test
-        fun `Given that the property is set with value 'unset' then packages which are accepted by IntelliJ Default are not detected`() {
+        fun `Given ktlint_official code style and the property is set with value 'unset' then packages which are accepted by IntelliJ Default are detected`() {
             val code =
                 """
                 import a.b
@@ -53,6 +70,26 @@ class NoWildcardImportsRuleTest {
                 import react.dom.*
                 """.trimIndent()
             noWildcardImportsRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .withEditorConfigOverride(IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND to "unset")
+                .hasLintViolationsWithoutAutoCorrect(
+                    LintViolation(2, 1, "Wildcard import"),
+                    LintViolation(3, 1, "Wildcard import"),
+                    LintViolation(4, 1, "Wildcard import"),
+                )
+        }
+
+        @Test
+        fun `Given non-ktlint_official code style and the property is set with value 'unset' then packages which are accepted by IntelliJ Default are not detected`() {
+            val code =
+                """
+                import a.b
+                import kotlinx.android.synthetic.main.layout_name.*
+                import react.*
+                import react.dom.*
+                """.trimIndent()
+            noWildcardImportsRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 .withEditorConfigOverride(IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND to "unset")
                 .hasLintViolationsWithoutAutoCorrect(
                     LintViolation(3, 1, "Wildcard import"),
@@ -99,20 +136,5 @@ class NoWildcardImportsRuleTest {
                 .withEditorConfigOverride(IJ_KOTLIN_PACKAGES_TO_USE_IMPORT_ON_DEMAND to "")
                 .hasLintViolationWithoutAutoCorrect(2, 1, "Wildcard import")
         }
-    }
-
-    @Test
-    fun `Given the ktlint_official codestyle then the default wildcard imports allowed in other code styles are no longer allowed`() {
-        val code =
-            """
-            import java.util.*
-            import kotlinx.android.synthetic.*
-            """.trimIndent()
-        noWildcardImportsRuleAssertThat(code)
-            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
-            .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(1, 1, "Wildcard import"),
-                LintViolation(2, 1, "Wildcard import"),
-            )
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
@@ -22,17 +22,15 @@ internal class ParameterWrappingRuleTest {
             )
             """.trimIndent()
         val formattedCode =
-            // TODO: fix test when changing the default code style to 'ktlint_official'. The variable type is not indented for the
-            //  current default code style.
             """
             // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
             class Bar(
                 val foooooooooooooooooTooLong:
-                Foo,
+                    Foo,
             )
             fun bar(
                 foooooooooooooooooooooTooLong:
-                Foo,
+                    Foo,
             )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
@@ -59,18 +57,16 @@ internal class ParameterWrappingRuleTest {
             )
             """.trimIndent()
         val formattedCode =
-            // TODO: fix test when changing the default code style to 'ktlint_official'. The variable type is not indented for the
-            //  current default code style.
             """
             // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
             class Bar(
                 val foooooooooooooooooTooLong:
-                Foo,
+                    Foo,
                 val foooooooooooooNotTooLong: Foo,
             )
             fun bar(
                 foooooooooooooooooooooTooLong:
-                Foo,
+                    Foo,
                 foooooooooooooooooNotTooLong: Foo,
             )
             """.trimIndent()


### PR DESCRIPTION
## Description

Change default code style to `ktlint_official`

Closes #2143

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
