### PR TITLE
Provide convenience API for rule providers

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -1,14 +1,10 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.visitor.NodeVisitor
 import com.pinterest.ktlint.rule.engine.core.internal.IdNamingPolicy
-import com.pinterest.ktlint.rule.engine.core.util.safeAs
-import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtWhenExpression
 
 public data class RuleId(
     public val value: String,
@@ -81,7 +77,7 @@ public open class Rule(
      * Set of [EditorConfigProperty]'s that are to provided to the rule. Only specify the properties that are actually used by the rule.
      */
     public open val usesEditorConfigProperties: Set<EditorConfigProperty<*>> = emptySet(),
-) {
+) : NodeVisitor() {
     private var traversalState = TraversalState.NOT_STARTED
 
     /**
@@ -89,114 +85,6 @@ public open class Rule(
      * before processing of nodes starts.
      */
     public open fun beforeFirstNode(editorConfig: EditorConfig) {}
-
-    /**
-     * This method is called on a node in AST before visiting the child nodes. This is repeated recursively for the child nodes resulting in
-     * a depth first traversal of the AST. If the node can be transformed to a known Kt-type (for example [KtIfExpression], the call is
-     * dispatched to the visit method [beforeIfExpression] for that specific type. Otherwise, the node is dispatched to the default handler
-     * [beforeVisitChildNodes].
-     *
-     * This method is not `open` as it dispatches the visit of a node based on its element type.
-     *
-     * @param node AST node
-     * @param autoCorrect indicates whether rule should attempt autocorrection
-     * @param emit a way for rule to notify about a violation (lint error)
-     */
-    public fun beforeNode(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ) {
-        when(node.elementType) {
-            IF ->
-                node.psi.safeAs<KtIfExpression>()?.let { return beforeIfExpression(it, autoCorrect, emit) }
-            WHEN ->
-                node.psi.safeAs<KtWhenExpression>()?.let { return beforeWhen(it, autoCorrect, emit) }
-        }
-        // In case no mapping exists for the element type, or if the PSI of the node could not safely be cast to the Kt-type, then fall back
-        // on the generic handler.
-        beforeVisitChildNodes(node, autoCorrect, emit)
-    }
-
-    /**
-     * This method is called on a node in AST before visiting the child nodes. This is repeated recursively for the child nodes resulting in
-     * a depth first traversal of the AST. Note: this method won't be called for a node for which the visit method of the type of that node
-     * has been overridden in the rule.
-     *
-     * ```
-     * class ExampleRule(...) {
-     *     override fun beforeIfExpression(
-     *         ktIfExpression: KtIfExpression,
-     *         autoCorrect: Boolean,
-     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-     *     ) {
-     *         // Only called for nodes having element type 'IF'
-     *     }
-
-     *     override fun beforeWhenExpression(...) {
-     *         // Only called for nodes having element type 'WHEN'
-     *     }
-     *
-     *     override fun beforeVisitChildNodes(
-     *         node: ASTNode,
-     *         autoCorrect: Boolean,
-     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-     *     ) {
-     *         // Called for nodes of other types than 'IF' and 'WHEN' because the 'beforeIfExpression' and 'beforeWhenExpression' are
-     *         // overridden.
-     *     }
-     * }
-     * ```
-     *
-     * @param node AST node
-     * @param autoCorrect indicates whether rule should attempt autocorrection
-     * @param emit a way for rule to notify about a violation (lint error)
-     */
-    public open fun beforeVisitChildNodes(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ) {}
-
-    /**
-     * This method is called on a node of element type 'IF' in the AST before visiting the child nodes.
-     *
-     * @param ktIfExpression the [KtIfExpression] of a node with element type 'WHEN'
-     * @param autoCorrect indicates whether rule should attempt autocorrection
-     * @param emit a way for rule to notify about a violation (lint error)
-     */
-    @Suppress("unused")
-    public open fun beforeIfExpression(
-        ktIfExpression: KtIfExpression,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ): Unit =
-        beforeVisitChildNodes(ktIfExpression.node, autoCorrect, emit)
-
-    /**
-     * This method is called on a node of element type 'WHEN' in the AST before visiting the child nodes.
-     *
-     * @param ktWhenExpression the [KtWhenExpression] of a node with element type 'WHEN'
-     * @param autoCorrect indicates whether rule should attempt autocorrection
-     * @param emit a way for rule to notify about a violation (lint error)
-     */
-    @Suppress("unused")
-    public open fun beforeWhen(
-        ktWhenExpression: KtWhenExpression,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ): Unit =
-        beforeVisitChildNodes(ktWhenExpression.node, autoCorrect, emit)
-
-    /**
-     * This method is called on a node in AST after all its child nodes have been visited.
-     */
-    @Suppress("unused")
-    public open fun afterVisitChildNodes(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ) {}
 
     /**
      * This method is called once after the last node in the AST is visited. It can be used for teardown of the state

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/AfterNodeVisitor.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/AfterNodeVisitor.kt
@@ -1,0 +1,1263 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
+import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtContinueExpression
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
+import org.jetbrains.kotlin.psi.KtDoWhileExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtDynamicType
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtForExpression
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtImportAlias
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtInitializerList
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.KtScriptInitializer
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeConstraintList
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeParameterList
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtWhenConditionInRange
+import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
+import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.KtWhileExpression
+
+public interface AfterNodeVisitor {
+    /**
+     * This method is called on a node in AST after visiting the child nodes. This is repeated recursively for the child nodes resulting in
+     * a depth first traversal of the AST. Note: this method won't be called for a node for which the visit method of the type of that node
+     * has been overridden in the rule.
+     *
+     * ```
+     * class ExampleRule(...) {
+     *     override fun afterIfExpression(
+     *         ktIfExpression: KtIfExpression,
+     *         autoCorrect: Boolean,
+     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+     *     ) {
+     *         // Only called for nodes having element type 'IF'
+     *     }
+
+     *     override fun afterWhenExpression(...) {
+     *         // Only called for nodes having element type 'WHEN'
+     *     }
+     *
+     *     override fun afterVisitChildNodes(
+     *         node: ASTNode,
+     *         autoCorrect: Boolean,
+     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+     *     ) {
+     *         // Called for nodes of other types than 'IF' and 'WHEN' because the 'afterIfExpression' and 'afterWhenExpression' are
+     *         // overridden.
+     *     }
+     * }
+     * ```
+     *
+     * @param node AST node
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {}
+
+    /**
+     * This method is called on a node of element type 'CLASS' in the AST after visiting the child nodes.
+     *
+     * @param ktClass the [KtClass] of a node with element type 'CLASS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterClass(
+        ktClass: KtClass,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktClass.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SECONDARY_CONSTRUCTOR' in the AST after visiting the child nodes.
+     *
+     * @param ktSecondaryConstructor the [KtSecondaryConstructor] of a node with element type 'SECONDARY_CONSTRUCTOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSecondaryConstructor(
+        ktSecondaryConstructor: KtSecondaryConstructor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSecondaryConstructor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PRIMARY_CONSTRUCTOR' in the AST after visiting the child nodes.
+     *
+     * @param ktPrimaryConstructor the [KtPrimaryConstructor] of a node with element type 'PRIMARY_CONSTRUCTOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPrimaryConstructor(
+        ktPrimaryConstructor: KtPrimaryConstructor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPrimaryConstructor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY' in the AST after visiting the child nodes.
+     *
+     * @param ktProperty the [KtProperty] of a node with element type 'PROPERTY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterProperty(
+        ktProperty: KtProperty,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktProperty.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPEALIAS' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeAlias the [KtTypeAlias] of a node with element type 'TYPEALIAS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeAlias(
+        ktTypeAlias: KtTypeAlias,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeAlias.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DESTRUCTURING_DECLARATION' in the AST after visiting the child nodes.
+     *
+     * @param ktDestructuringDeclaration the [KtDestructuringDeclaration] of a node with element type 'DESTRUCTURING_DECLARATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDestructuringDeclaration(
+        ktDestructuringDeclaration: KtDestructuringDeclaration,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDestructuringDeclaration.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DESTRUCTURING_DECLARATION_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktDestructuringDeclarationEntry the [KtDestructuringDeclarationEntry] of a node with element type 'DESTRUCTURING_DECLARATION_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDestructuringDeclarationEntry(
+        ktDestructuringDeclarationEntry: KtDestructuringDeclarationEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDestructuringDeclarationEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'kotlin.FILE' in the AST after visiting the child nodes.
+     *
+     * @param ktFile the [KtFile] of a node with element type 'kotlin.FILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterFile(
+        ktFile: KtFile,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktFile.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SCRIPT' in the AST after visiting the child nodes.
+     *
+     * @param ktScript the [KtScript] of a node with element type 'SCRIPT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterScript(
+        ktScript: KtScript,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktScript.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_ALIAS' in the AST after visiting the child nodes.
+     *
+     * @param ktImportAlias the [KtImportAlias] of a node with element type 'IMPORT_ALIAS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterImportAlias(
+        ktImportAlias: KtImportAlias,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktImportAlias.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_DIRECTIVE' in the AST after visiting the child nodes.
+     *
+     * @param ktImportDirective the [KtImportDirective] of a node with element type 'IMPORT_DIRECTIVE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterImportDirective(
+        ktImportDirective: KtImportDirective,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktImportDirective.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktImportList the [KtImportList] of a node with element type 'IMPORT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterImportList(
+        ktImportList: KtImportList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktImportList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_BODY' in the AST after visiting the child nodes.
+     *
+     * @param ktClassBody the [KtClassBody] of a node with element type 'CLASS_BODY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterClassBody(
+        ktClassBody: KtClassBody,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktClassBody.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'MODIFIER_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktModifierList the [KtModifierList] of a node with element type 'MODIFIER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterModifierList(
+        ktModifierList: KtModifierList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktModifierList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATION' in the AST after visiting the child nodes.
+     *
+     * @param ktAnnotation the [KtAnnotation] of a node with element type 'ANNOTATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterAnnotation(
+        ktAnnotation: KtAnnotation,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktAnnotation.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATION_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktAnnotationEntry the [KtAnnotationEntry] of a node with element type 'ANNOTATION_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterAnnotationEntry(
+        ktAnnotationEntry: KtAnnotationEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktAnnotationEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONSTRUCTOR_CALLEE' in the AST after visiting the child nodes.
+     *
+     * @param ktConstructorCalleeExpression the [KtConstructorCalleeExpression] of a node with element type 'CONSTRUCTOR_CALLEE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterConstructorCalleeExpression(
+        ktConstructorCalleeExpression: KtConstructorCalleeExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktConstructorCalleeExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PARAMETER_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeParameterList the [KtTypeParameterList] of a node with element type 'TYPE_PARAMETER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeParameterList(
+        ktTypeParameterList: KtTypeParameterList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeParameterList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PARAMETER' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeParameter the [KtTypeParameter] of a node with element type 'TYPE_PARAMETER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeParameter(
+        ktTypeParameter: KtTypeParameter,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeParameter.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ENUM_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktEnumEntry the [KtEnumEntry] of a node with element type 'ENUM_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterEnumEntry(
+        ktEnumEntry: KtEnumEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktEnumEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_PARAMETER_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktParameterList the [KtParameterList] of a node with element type 'VALUE_PARAMETER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterParameterList(
+        ktParameterList: KtParameterList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktParameterList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_PARAMETER' in the AST after visiting the child nodes.
+     *
+     * @param ktParameter the [KtParameter] of a node with element type 'VALUE_PARAMETER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterParameter(
+        ktParameter: KtParameter,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktParameter.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktSuperTypeList the [KtSuperTypeList] of a node with element type 'SUPER_TYPE_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSuperTypeList(
+        ktSuperTypeList: KtSuperTypeList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSuperTypeList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DELEGATED_SUPER_TYPE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktDelegatedSuperTypeEntry the [KtDelegatedSuperTypeEntry] of a node with element type 'DELEGATED_SUPER_TYPE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDelegatedSuperTypeEntry(
+        ktDelegatedSuperTypeEntry: KtDelegatedSuperTypeEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDelegatedSuperTypeEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_CALL_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktSuperTypeCallEntry the [KtSuperTypeCallEntry] of a node with element type 'SUPER_TYPE_CALL_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSuperTypeCallEntry(
+        ktSuperTypeCallEntry: KtSuperTypeCallEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSuperTypeCallEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktSuperTypeEntry the [KtSuperTypeEntry] of a node with element type 'SUPER_TYPE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSuperTypeEntry(
+        ktSuperTypeEntry: KtSuperTypeEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSuperTypeEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONTEXT_RECEIVER_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktContextReceiverList the [KtContextReceiverList] of a node with element type 'CONTEXT_RECEIVER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterContextReceiverList(
+        ktContextReceiverList: KtContextReceiverList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktContextReceiverList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONSTRUCTOR_DELEGATION_CALL' in the AST after visiting the child nodes.
+     *
+     * @param ktConstructorDelegationCall the [KtConstructorDelegationCall] of a node with element type 'CONSTRUCTOR_DELEGATION_CALL'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterConstructorDelegationCall(
+        ktConstructorDelegationCall: KtConstructorDelegationCall,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktConstructorDelegationCall.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY_DELEGATE' in the AST after visiting the child nodes.
+     *
+     * @param ktPropertyDelegate the [KtPropertyDelegate] of a node with element type 'PROPERTY_DELEGATE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPropertyDelegate(
+        ktPropertyDelegate: KtPropertyDelegate,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPropertyDelegate.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_REFERENCE' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeReference the [KtTypeReference] of a node with element type 'TYPE_REFERENCE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeReference(
+        ktTypeReference: KtTypeReference,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeReference.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_ARGUMENT_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktValueArgumentList the [KtValueArgumentList] of a node with element type 'VALUE_ARGUMENT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterValueArgumentList(
+        ktValueArgumentList: KtValueArgumentList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktValueArgumentList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_ARGUMENT' in the AST after visiting the child nodes.
+     *
+     * @param ktValueArgument the [KtValueArgument] of a node with element type 'VALUE_ARGUMENT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterValueArgument(
+        ktValueArgument: KtValueArgument,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktValueArgument.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'REFERENCE_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktReferenceExpression the [KtReferenceExpression] of a node with element type 'REFERENCE_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterReferenceExpression(
+        ktReferenceExpression: KtReferenceExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktReferenceExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LABELED_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktLabeledExpression the [KtLabeledExpression] of a node with element type 'LABELED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterLabeledExpression(
+        ktLabeledExpression: KtLabeledExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktLabeledExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PREFIX_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktPrefixExpression the [KtPrefixExpression] of a node with element type 'PREFIX_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPrefixExpression(
+        ktPrefixExpression: KtPrefixExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPrefixExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'POSTFIX_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktPostfixExpression the [KtPostfixExpression] of a node with element type 'POSTFIX_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPostfixExpression(
+        ktPostfixExpression: KtPostfixExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPostfixExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BINARY_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktBinaryExpression the [KtBinaryExpression] of a node with element type 'BINARY_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterBinaryExpression(
+        ktBinaryExpression: KtBinaryExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktBinaryExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'THROW' in the AST after visiting the child nodes.
+     *
+     * @param ktThrowExpression the [KtThrowExpression] of a node with element type 'THROW'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterThrowExpression(
+        ktThrowExpression: KtThrowExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktThrowExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BREAK' in the AST after visiting the child nodes.
+     *
+     * @param ktBreakExpression the [KtBreakExpression] of a node with element type 'BREAK'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterBreakExpression(
+        ktBreakExpression: KtBreakExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktBreakExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONTINUE' in the AST after visiting the child nodes.
+     *
+     * @param ktContinueExpression the [KtContinueExpression] of a node with element type 'CONTINUE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterContinueExpression(
+        ktContinueExpression: KtContinueExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktContinueExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IF' in the AST after visiting the child nodes.
+     *
+     * @param ktIfExpression the [KtIfExpression] of a node with element type 'IF'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterIfExpression(
+        ktIfExpression: KtIfExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktIfExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN' in the AST after visiting the child nodes.
+     *
+     * @param ktWhenExpression the [KtWhenExpression] of a node with element type 'WHEN'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhenExpression(
+        ktWhenExpression: KtWhenExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhenExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'COLLECTION_LITERAL_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktCollectionLiteralExpression the [KtCollectionLiteralExpression] of a node with element type 'COLLECTION_LITERAL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterCollectionLiteralExpression(
+        ktCollectionLiteralExpression: KtCollectionLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktCollectionLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TRY' in the AST after visiting the child nodes.
+     *
+     * @param ktTryExpression the [KtTryExpression] of a node with element type 'TRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTryExpression(
+        ktTryExpression: KtTryExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTryExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FOR' in the AST after visiting the child nodes.
+     *
+     * @param ktForExpression the [KtForExpression] of a node with element type 'FOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterForExpression(
+        ktForExpression: KtForExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktForExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHILE' in the AST after visiting the child nodes.
+     *
+     * @param ktWhileExpression the [KtWhileExpression] of a node with element type 'WHILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhileExpression(
+        ktWhileExpression: KtWhileExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhileExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DO_WHILE' in the AST after visiting the child nodes.
+     *
+     * @param ktDoWhileExpression the [KtDoWhileExpression] of a node with element type 'DO_WHILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDoWhileExpression(
+        ktDoWhileExpression: KtDoWhileExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDoWhileExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LAMBDA_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktLambdaExpression the [KtLambdaExpression] of a node with element type 'LAMBDA_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterLambdaExpression(
+        ktLambdaExpression: KtLambdaExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktLambdaExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATED_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktAnnotatedExpression the [KtAnnotatedExpression] of a node with element type 'ANNOTATED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterAnnotatedExpression(
+        ktAnnotatedExpression: KtAnnotatedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktAnnotatedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CALL_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktCallExpression the [KtCallExpression] of a node with element type 'CALL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterCallExpression(
+        ktCallExpression: KtCallExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktCallExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ARRAY_ACCESS_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktArrayAccessExpression the [KtArrayAccessExpression] of a node with element type 'ARRAY_ACCESS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterArrayAccessExpression(
+        ktArrayAccessExpression: KtArrayAccessExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktArrayAccessExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CALLABLE_REFERENCE_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktCallableReferenceExpression the [KtCallableReferenceExpression] of a node with element type 'CALLABLE_REFERENCE_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterCallableReferenceExpression(
+        ktCallableReferenceExpression: KtCallableReferenceExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktCallableReferenceExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_LITERAL_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktClassLiteralExpression the [KtClassLiteralExpression] of a node with element type 'CLASS_LITERAL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterClassLiteralExpression(
+        ktClassLiteralExpression: KtClassLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktClassLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DOT_QUALIFIED_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktDotQualifiedExpression the [KtDotQualifiedExpression] of a node with element type 'DOT_QUALIFIED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDotQualifiedExpression(
+        ktDotQualifiedExpression: KtDotQualifiedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDotQualifiedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SAFE_ACCESS_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktSafeQualifiedExpression the [KtSafeQualifiedExpression] of a node with element type 'SAFE_ACCESS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSafeQualifiedExpression(
+        ktSafeQualifiedExpression: KtSafeQualifiedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSafeQualifiedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'OBJECT_LITERAL' in the AST after visiting the child nodes.
+     *
+     * @param ktObjectLiteralExpression the [KtObjectLiteralExpression] of a node with element type 'OBJECT_LITERAL'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterObjectLiteralExpression(
+        ktObjectLiteralExpression: KtObjectLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktObjectLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BLOCK' in the AST after visiting the child nodes.
+     *
+     * @param ktBlockExpression the [KtBlockExpression] of a node with element type 'BLOCK'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterBlockExpression(
+        ktBlockExpression: KtBlockExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktBlockExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CATCH' in the AST after visiting the child nodes.
+     *
+     * @param ktCatchClause the [KtCatchClause] of a node with element type 'CATCH'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterCatchClause(
+        ktCatchClause: KtCatchClause,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktCatchClause.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FINALLY' in the AST after visiting the child nodes.
+     *
+     * @param ktFinallySection the [KtFinallySection] of a node with element type 'FINALLY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterFinallySection(
+        ktFinallySection: KtFinallySection,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktFinallySection.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_ARGUMENT_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeArgumentList the [KtTypeArgumentList] of a node with element type 'TYPE_ARGUMENT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeArgumentList(
+        ktTypeArgumentList: KtTypeArgumentList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeArgumentList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'THIS_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktThisExpression the [KtThisExpression] of a node with element type 'THIS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterThisExpression(
+        ktThisExpression: KtThisExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktThisExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktSuperExpression the [KtSuperExpression] of a node with element type 'SUPER_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSuperExpression(
+        ktSuperExpression: KtSuperExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSuperExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PARENTHESIZED' in the AST after visiting the child nodes.
+     *
+     * @param ktParenthesizedExpression the [KtParenthesizedExpression] of a node with element type 'PARENTHESIZED'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterParenthesizedExpression(
+        ktParenthesizedExpression: KtParenthesizedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktParenthesizedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'INITIALIZER_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktInitializerList the [KtInitializerList] of a node with element type 'INITIALIZER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterInitializerList(
+        ktInitializerList: KtInitializerList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktInitializerList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SCRIPT_INITIALIZER' in the AST after visiting the child nodes.
+     *
+     * @param ktScriptInitializer the [KtScriptInitializer] of a node with element type 'SCRIPT_INITIALIZER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterScriptInitializer(
+        ktScriptInitializer: KtScriptInitializer,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktScriptInitializer.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_INITIALIZER' in the AST after visiting the child nodes.
+     *
+     * @param ktClassInitializer the [KtClassInitializer] of a node with element type 'CLASS_INITIALIZER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterClassInitializer(
+        ktClassInitializer: KtClassInitializer,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktClassInitializer.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY_ACCESSOR' in the AST after visiting the child nodes.
+     *
+     * @param ktPropertyAccessor the [KtPropertyAccessor] of a node with element type 'PROPERTY_ACCESSOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPropertyAccessor(
+        ktPropertyAccessor: KtPropertyAccessor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPropertyAccessor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_CONSTRAINT_LIST' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeConstraintList the [KtTypeConstraintList] of a node with element type 'TYPE_CONSTRAINT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeConstraintList(
+        ktTypeConstraintList: KtTypeConstraintList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeConstraintList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_CONSTRAINT' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeConstraint the [KtTypeConstraint] of a node with element type 'TYPE_CONSTRAINT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeConstraint(
+        ktTypeConstraint: KtTypeConstraint,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeConstraint.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'USER_TYPE' in the AST after visiting the child nodes.
+     *
+     * @param ktUserType the [KtUserType] of a node with element type 'USER_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterUserType(
+        ktUserType: KtUserType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktUserType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DYNAMIC_TYPE' in the AST after visiting the child nodes.
+     *
+     * @param ktDynamicType the [KtDynamicType] of a node with element type 'DYNAMIC_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterDynamicType(
+        ktDynamicType: KtDynamicType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktDynamicType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FUNCTION_TYPE' in the AST after visiting the child nodes.
+     *
+     * @param ktFunctionType the [KtFunctionType] of a node with element type 'FUNCTION_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterFunctionType(
+        ktFunctionType: KtFunctionType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktFunctionType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BINARY_WITH_TYPE' in the AST after visiting the child nodes.
+     *
+     * @param ktBinaryExpressionWithTypeRHS the [KtBinaryExpressionWithTypeRHS] of a node with element type 'BINARY_WITH_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterBinaryExpressionWithTypeRHS(
+        ktBinaryExpressionWithTypeRHS: KtBinaryExpressionWithTypeRHS,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktBinaryExpressionWithTypeRHS.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'STRING_TEMPLATE' in the AST after visiting the child nodes.
+     *
+     * @param ktStringTemplateExpression the [KtStringTemplateExpression] of a node with element type 'STRING_TEMPLATE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterStringTemplateExpression(
+        ktStringTemplateExpression: KtStringTemplateExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktStringTemplateExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'NULLABLE_TYPE' in the AST after visiting the child nodes.
+     *
+     * @param ktNullableType the [KtNullableType] of a node with element type 'NULLABLE_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterNullableType(
+        ktNullableType: KtNullableType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktNullableType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PROJECTION' in the AST after visiting the child nodes.
+     *
+     * @param ktTypeProjection the [KtTypeProjection] of a node with element type 'TYPE_PROJECTION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterTypeProjection(
+        ktTypeProjection: KtTypeProjection,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktTypeProjection.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktWhenEntry the [KtWhenEntry] of a node with element type 'WHEN_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhenEntry(
+        ktWhenEntry: KtWhenEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhenEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IS_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktIsExpression the [KtIsExpression] of a node with element type 'IS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterIsExpression(
+        ktIsExpression: KtIsExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktIsExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_IS_PATTERN' in the AST after visiting the child nodes.
+     *
+     * @param ktWhenConditionIsPattern the [KtWhenConditionIsPattern] of a node with element type 'WHEN_CONDITION_IS_PATTERN'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhenConditionIsPattern(
+        ktWhenConditionIsPattern: KtWhenConditionIsPattern,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhenConditionIsPattern.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_IN_RANGE' in the AST after visiting the child nodes.
+     *
+     * @param ktWhenConditionInRange the [KtWhenConditionInRange] of a node with element type 'WHEN_CONDITION_IN_RANGE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhenConditionInRange(
+        ktWhenConditionInRange: KtWhenConditionInRange,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhenConditionInRange.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_WITH_EXPRESSION' in the AST after visiting the child nodes.
+     *
+     * @param ktWhenConditionWithExpression the [KtWhenConditionWithExpression] of a node with element type 'WHEN_CONDITION_WITH_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterWhenConditionWithExpression(
+        ktWhenConditionWithExpression: KtWhenConditionWithExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktWhenConditionWithExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'OBJECT_DECLARATION' in the AST after visiting the child nodes.
+     *
+     * @param ktObjectDeclaration the [KtObjectDeclaration] of a node with element type 'OBJECT_DECLARATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterObjectDeclaration(
+        ktObjectDeclaration: KtObjectDeclaration,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktObjectDeclaration.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LONG_STRING_TEMPLATE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktBlockStringTemplateEntry the [KtBlockStringTemplateEntry] of a node with element type 'LONG_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterBlockStringTemplateEntry(
+        ktBlockStringTemplateEntry: KtBlockStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktBlockStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SHORT_STRING_TEMPLATE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktSimpleNameStringTemplateEntry the [KtSimpleNameStringTemplateEntry] of a node with element type 'SHORT_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterSimpleNameStringTemplateEntry(
+        ktSimpleNameStringTemplateEntry: KtSimpleNameStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktSimpleNameStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LITERAL_STRING_TEMPLATE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktLiteralStringTemplateEntry the [KtLiteralStringTemplateEntry] of a node with element type 'LITERAL_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterLiteralStringTemplateEntry(
+        ktLiteralStringTemplateEntry: KtLiteralStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktLiteralStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ESCAPE_STRING_TEMPLATE_ENTRY' in the AST after visiting the child nodes.
+     *
+     * @param ktEscapeStringTemplateEntry the [KtEscapeStringTemplateEntry] of a node with element type 'ESCAPE_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterEscapeStringTemplateEntry(
+        ktEscapeStringTemplateEntry: KtEscapeStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktEscapeStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PACKAGE_DIRECTIVE' in the AST after visiting the child nodes.
+     *
+     * @param ktPackageDirective the [KtPackageDirective] of a node with element type 'PACKAGE_DIRECTIVE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterPackageDirective(
+        ktPackageDirective: KtPackageDirective,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = afterVisitChildNodes(ktPackageDirective.node, autoCorrect, emit)
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/BeforeNodeVisitor.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/BeforeNodeVisitor.kt
@@ -1,0 +1,1263 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
+import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtContinueExpression
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
+import org.jetbrains.kotlin.psi.KtDoWhileExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtDynamicType
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtForExpression
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtImportAlias
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtInitializerList
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.KtScriptInitializer
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeConstraintList
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeParameterList
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtWhenConditionInRange
+import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
+import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.KtWhileExpression
+
+public interface BeforeNodeVisitor {
+    /**
+     * This method is called on a node in AST before visiting the child nodes. This is repeated recursively for the child nodes resulting in
+     * a depth first traversal of the AST. Note: this method won't be called for a node for which the visit method of the type of that node
+     * has been overridden in the rule.
+     *
+     * ```
+     * class ExampleRule(...) {
+     *     override fun beforeIfExpression(
+     *         ktIfExpression: KtIfExpression,
+     *         autoCorrect: Boolean,
+     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+     *     ) {
+     *         // Only called for nodes having element type 'IF'
+     *     }
+
+     *     override fun beforeWhenExpression(...) {
+     *         // Only called for nodes having element type 'WHEN'
+     *     }
+     *
+     *     override fun beforeVisitChildNodes(
+     *         node: ASTNode,
+     *         autoCorrect: Boolean,
+     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+     *     ) {
+     *         // Called for nodes of other types than 'IF' and 'WHEN' because the 'beforeIfExpression' and 'beforeWhenExpression' are
+     *         // overridden.
+     *     }
+     * }
+     * ```
+     *
+     * @param node AST node
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {}
+
+    /**
+     * This method is called on a node of element type 'CLASS' in the AST before visiting the child nodes.
+     *
+     * @param ktClass the [KtClass] of a node with element type 'CLASS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeClass(
+        ktClass: KtClass,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktClass.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SECONDARY_CONSTRUCTOR' in the AST before visiting the child nodes.
+     *
+     * @param ktSecondaryConstructor the [KtSecondaryConstructor] of a node with element type 'SECONDARY_CONSTRUCTOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSecondaryConstructor(
+        ktSecondaryConstructor: KtSecondaryConstructor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSecondaryConstructor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PRIMARY_CONSTRUCTOR' in the AST before visiting the child nodes.
+     *
+     * @param ktPrimaryConstructor the [KtPrimaryConstructor] of a node with element type 'PRIMARY_CONSTRUCTOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePrimaryConstructor(
+        ktPrimaryConstructor: KtPrimaryConstructor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPrimaryConstructor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY' in the AST before visiting the child nodes.
+     *
+     * @param ktProperty the [KtProperty] of a node with element type 'PROPERTY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeProperty(
+        ktProperty: KtProperty,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktProperty.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPEALIAS' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeAlias the [KtTypeAlias] of a node with element type 'TYPEALIAS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeAlias(
+        ktTypeAlias: KtTypeAlias,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeAlias.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DESTRUCTURING_DECLARATION' in the AST before visiting the child nodes.
+     *
+     * @param ktDestructuringDeclaration the [KtDestructuringDeclaration] of a node with element type 'DESTRUCTURING_DECLARATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDestructuringDeclaration(
+        ktDestructuringDeclaration: KtDestructuringDeclaration,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDestructuringDeclaration.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DESTRUCTURING_DECLARATION_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktDestructuringDeclarationEntry the [KtDestructuringDeclarationEntry] of a node with element type 'DESTRUCTURING_DECLARATION_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDestructuringDeclarationEntry(
+        ktDestructuringDeclarationEntry: KtDestructuringDeclarationEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDestructuringDeclarationEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'kotlin.FILE' in the AST before visiting the child nodes.
+     *
+     * @param ktFile the [KtFile] of a node with element type 'kotlin.FILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeFile(
+        ktFile: KtFile,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktFile.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SCRIPT' in the AST before visiting the child nodes.
+     *
+     * @param ktScript the [KtScript] of a node with element type 'SCRIPT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeScript(
+        ktScript: KtScript,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktScript.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_ALIAS' in the AST before visiting the child nodes.
+     *
+     * @param ktImportAlias the [KtImportAlias] of a node with element type 'IMPORT_ALIAS'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeImportAlias(
+        ktImportAlias: KtImportAlias,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktImportAlias.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_DIRECTIVE' in the AST before visiting the child nodes.
+     *
+     * @param ktImportDirective the [KtImportDirective] of a node with element type 'IMPORT_DIRECTIVE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeImportDirective(
+        ktImportDirective: KtImportDirective,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktImportDirective.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IMPORT_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktImportList the [KtImportList] of a node with element type 'IMPORT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeImportList(
+        ktImportList: KtImportList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktImportList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_BODY' in the AST before visiting the child nodes.
+     *
+     * @param ktClassBody the [KtClassBody] of a node with element type 'CLASS_BODY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeClassBody(
+        ktClassBody: KtClassBody,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktClassBody.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'MODIFIER_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktModifierList the [KtModifierList] of a node with element type 'MODIFIER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeModifierList(
+        ktModifierList: KtModifierList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktModifierList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATION' in the AST before visiting the child nodes.
+     *
+     * @param ktAnnotation the [KtAnnotation] of a node with element type 'ANNOTATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeAnnotation(
+        ktAnnotation: KtAnnotation,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktAnnotation.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATION_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktAnnotationEntry the [KtAnnotationEntry] of a node with element type 'ANNOTATION_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeAnnotationEntry(
+        ktAnnotationEntry: KtAnnotationEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktAnnotationEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONSTRUCTOR_CALLEE' in the AST before visiting the child nodes.
+     *
+     * @param ktConstructorCalleeExpression the [KtConstructorCalleeExpression] of a node with element type 'CONSTRUCTOR_CALLEE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeConstructorCalleeExpression(
+        ktConstructorCalleeExpression: KtConstructorCalleeExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktConstructorCalleeExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PARAMETER_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeParameterList the [KtTypeParameterList] of a node with element type 'TYPE_PARAMETER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeParameterList(
+        ktTypeParameterList: KtTypeParameterList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeParameterList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PARAMETER' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeParameter the [KtTypeParameter] of a node with element type 'TYPE_PARAMETER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeParameter(
+        ktTypeParameter: KtTypeParameter,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeParameter.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ENUM_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktEnumEntry the [KtEnumEntry] of a node with element type 'ENUM_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeEnumEntry(
+        ktEnumEntry: KtEnumEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktEnumEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_PARAMETER_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktParameterList the [KtParameterList] of a node with element type 'VALUE_PARAMETER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeParameterList(
+        ktParameterList: KtParameterList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktParameterList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_PARAMETER' in the AST before visiting the child nodes.
+     *
+     * @param ktParameter the [KtParameter] of a node with element type 'VALUE_PARAMETER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeParameter(
+        ktParameter: KtParameter,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktParameter.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktSuperTypeList the [KtSuperTypeList] of a node with element type 'SUPER_TYPE_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSuperTypeList(
+        ktSuperTypeList: KtSuperTypeList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSuperTypeList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DELEGATED_SUPER_TYPE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktDelegatedSuperTypeEntry the [KtDelegatedSuperTypeEntry] of a node with element type 'DELEGATED_SUPER_TYPE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDelegatedSuperTypeEntry(
+        ktDelegatedSuperTypeEntry: KtDelegatedSuperTypeEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDelegatedSuperTypeEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_CALL_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktSuperTypeCallEntry the [KtSuperTypeCallEntry] of a node with element type 'SUPER_TYPE_CALL_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSuperTypeCallEntry(
+        ktSuperTypeCallEntry: KtSuperTypeCallEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSuperTypeCallEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_TYPE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktSuperTypeEntry the [KtSuperTypeEntry] of a node with element type 'SUPER_TYPE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSuperTypeEntry(
+        ktSuperTypeEntry: KtSuperTypeEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSuperTypeEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONTEXT_RECEIVER_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktContextReceiverList the [KtContextReceiverList] of a node with element type 'CONTEXT_RECEIVER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeContextReceiverList(
+        ktContextReceiverList: KtContextReceiverList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktContextReceiverList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONSTRUCTOR_DELEGATION_CALL' in the AST before visiting the child nodes.
+     *
+     * @param ktConstructorDelegationCall the [KtConstructorDelegationCall] of a node with element type 'CONSTRUCTOR_DELEGATION_CALL'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeConstructorDelegationCall(
+        ktConstructorDelegationCall: KtConstructorDelegationCall,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktConstructorDelegationCall.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY_DELEGATE' in the AST before visiting the child nodes.
+     *
+     * @param ktPropertyDelegate the [KtPropertyDelegate] of a node with element type 'PROPERTY_DELEGATE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePropertyDelegate(
+        ktPropertyDelegate: KtPropertyDelegate,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPropertyDelegate.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_REFERENCE' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeReference the [KtTypeReference] of a node with element type 'TYPE_REFERENCE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeReference(
+        ktTypeReference: KtTypeReference,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeReference.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_ARGUMENT_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktValueArgumentList the [KtValueArgumentList] of a node with element type 'VALUE_ARGUMENT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeValueArgumentList(
+        ktValueArgumentList: KtValueArgumentList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktValueArgumentList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'VALUE_ARGUMENT' in the AST before visiting the child nodes.
+     *
+     * @param ktValueArgument the [KtValueArgument] of a node with element type 'VALUE_ARGUMENT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeValueArgument(
+        ktValueArgument: KtValueArgument,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktValueArgument.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'REFERENCE_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktReferenceExpression the [KtReferenceExpression] of a node with element type 'REFERENCE_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeReferenceExpression(
+        ktReferenceExpression: KtReferenceExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktReferenceExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LABELED_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktLabeledExpression the [KtLabeledExpression] of a node with element type 'LABELED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeLabeledExpression(
+        ktLabeledExpression: KtLabeledExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktLabeledExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PREFIX_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktPrefixExpression the [KtPrefixExpression] of a node with element type 'PREFIX_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePrefixExpression(
+        ktPrefixExpression: KtPrefixExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPrefixExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'POSTFIX_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktPostfixExpression the [KtPostfixExpression] of a node with element type 'POSTFIX_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePostfixExpression(
+        ktPostfixExpression: KtPostfixExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPostfixExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BINARY_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktBinaryExpression the [KtBinaryExpression] of a node with element type 'BINARY_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeBinaryExpression(
+        ktBinaryExpression: KtBinaryExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktBinaryExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'THROW' in the AST before visiting the child nodes.
+     *
+     * @param ktThrowExpression the [KtThrowExpression] of a node with element type 'THROW'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeThrowExpression(
+        ktThrowExpression: KtThrowExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktThrowExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BREAK' in the AST before visiting the child nodes.
+     *
+     * @param ktBreakExpression the [KtBreakExpression] of a node with element type 'BREAK'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeBreakExpression(
+        ktBreakExpression: KtBreakExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktBreakExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CONTINUE' in the AST before visiting the child nodes.
+     *
+     * @param ktContinueExpression the [KtContinueExpression] of a node with element type 'CONTINUE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeContinueExpression(
+        ktContinueExpression: KtContinueExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktContinueExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IF' in the AST before visiting the child nodes.
+     *
+     * @param ktIfExpression the [KtIfExpression] of a node with element type 'IF'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeIfExpression(
+        ktIfExpression: KtIfExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktIfExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN' in the AST before visiting the child nodes.
+     *
+     * @param ktWhenExpression the [KtWhenExpression] of a node with element type 'WHEN'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhenExpression(
+        ktWhenExpression: KtWhenExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhenExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'COLLECTION_LITERAL_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktCollectionLiteralExpression the [KtCollectionLiteralExpression] of a node with element type 'COLLECTION_LITERAL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeCollectionLiteralExpression(
+        ktCollectionLiteralExpression: KtCollectionLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktCollectionLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TRY' in the AST before visiting the child nodes.
+     *
+     * @param ktTryExpression the [KtTryExpression] of a node with element type 'TRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTryExpression(
+        ktTryExpression: KtTryExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTryExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FOR' in the AST before visiting the child nodes.
+     *
+     * @param ktForExpression the [KtForExpression] of a node with element type 'FOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeForExpression(
+        ktForExpression: KtForExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktForExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHILE' in the AST before visiting the child nodes.
+     *
+     * @param ktWhileExpression the [KtWhileExpression] of a node with element type 'WHILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhileExpression(
+        ktWhileExpression: KtWhileExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhileExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DO_WHILE' in the AST before visiting the child nodes.
+     *
+     * @param ktDoWhileExpression the [KtDoWhileExpression] of a node with element type 'DO_WHILE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDoWhileExpression(
+        ktDoWhileExpression: KtDoWhileExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDoWhileExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LAMBDA_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktLambdaExpression the [KtLambdaExpression] of a node with element type 'LAMBDA_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeLambdaExpression(
+        ktLambdaExpression: KtLambdaExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktLambdaExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ANNOTATED_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktAnnotatedExpression the [KtAnnotatedExpression] of a node with element type 'ANNOTATED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeAnnotatedExpression(
+        ktAnnotatedExpression: KtAnnotatedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktAnnotatedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CALL_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktCallExpression the [KtCallExpression] of a node with element type 'CALL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeCallExpression(
+        ktCallExpression: KtCallExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktCallExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ARRAY_ACCESS_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktArrayAccessExpression the [KtArrayAccessExpression] of a node with element type 'ARRAY_ACCESS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeArrayAccessExpression(
+        ktArrayAccessExpression: KtArrayAccessExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktArrayAccessExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CALLABLE_REFERENCE_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktCallableReferenceExpression the [KtCallableReferenceExpression] of a node with element type 'CALLABLE_REFERENCE_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeCallableReferenceExpression(
+        ktCallableReferenceExpression: KtCallableReferenceExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktCallableReferenceExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_LITERAL_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktClassLiteralExpression the [KtClassLiteralExpression] of a node with element type 'CLASS_LITERAL_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeClassLiteralExpression(
+        ktClassLiteralExpression: KtClassLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktClassLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DOT_QUALIFIED_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktDotQualifiedExpression the [KtDotQualifiedExpression] of a node with element type 'DOT_QUALIFIED_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDotQualifiedExpression(
+        ktDotQualifiedExpression: KtDotQualifiedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDotQualifiedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SAFE_ACCESS_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktSafeQualifiedExpression the [KtSafeQualifiedExpression] of a node with element type 'SAFE_ACCESS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSafeQualifiedExpression(
+        ktSafeQualifiedExpression: KtSafeQualifiedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSafeQualifiedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'OBJECT_LITERAL' in the AST before visiting the child nodes.
+     *
+     * @param ktObjectLiteralExpression the [KtObjectLiteralExpression] of a node with element type 'OBJECT_LITERAL'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeObjectLiteralExpression(
+        ktObjectLiteralExpression: KtObjectLiteralExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktObjectLiteralExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BLOCK' in the AST before visiting the child nodes.
+     *
+     * @param ktBlockExpression the [KtBlockExpression] of a node with element type 'BLOCK'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeBlockExpression(
+        ktBlockExpression: KtBlockExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktBlockExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CATCH' in the AST before visiting the child nodes.
+     *
+     * @param ktCatchClause the [KtCatchClause] of a node with element type 'CATCH'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeCatchClause(
+        ktCatchClause: KtCatchClause,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktCatchClause.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FINALLY' in the AST before visiting the child nodes.
+     *
+     * @param ktFinallySection the [KtFinallySection] of a node with element type 'FINALLY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeFinallySection(
+        ktFinallySection: KtFinallySection,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktFinallySection.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_ARGUMENT_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeArgumentList the [KtTypeArgumentList] of a node with element type 'TYPE_ARGUMENT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeArgumentList(
+        ktTypeArgumentList: KtTypeArgumentList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeArgumentList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'THIS_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktThisExpression the [KtThisExpression] of a node with element type 'THIS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeThisExpression(
+        ktThisExpression: KtThisExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktThisExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SUPER_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktSuperExpression the [KtSuperExpression] of a node with element type 'SUPER_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSuperExpression(
+        ktSuperExpression: KtSuperExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSuperExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PARENTHESIZED' in the AST before visiting the child nodes.
+     *
+     * @param ktParenthesizedExpression the [KtParenthesizedExpression] of a node with element type 'PARENTHESIZED'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeParenthesizedExpression(
+        ktParenthesizedExpression: KtParenthesizedExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktParenthesizedExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'INITIALIZER_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktInitializerList the [KtInitializerList] of a node with element type 'INITIALIZER_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeInitializerList(
+        ktInitializerList: KtInitializerList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktInitializerList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SCRIPT_INITIALIZER' in the AST before visiting the child nodes.
+     *
+     * @param ktScriptInitializer the [KtScriptInitializer] of a node with element type 'SCRIPT_INITIALIZER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeScriptInitializer(
+        ktScriptInitializer: KtScriptInitializer,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktScriptInitializer.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'CLASS_INITIALIZER' in the AST before visiting the child nodes.
+     *
+     * @param ktClassInitializer the [KtClassInitializer] of a node with element type 'CLASS_INITIALIZER'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeClassInitializer(
+        ktClassInitializer: KtClassInitializer,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktClassInitializer.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PROPERTY_ACCESSOR' in the AST before visiting the child nodes.
+     *
+     * @param ktPropertyAccessor the [KtPropertyAccessor] of a node with element type 'PROPERTY_ACCESSOR'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePropertyAccessor(
+        ktPropertyAccessor: KtPropertyAccessor,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPropertyAccessor.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_CONSTRAINT_LIST' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeConstraintList the [KtTypeConstraintList] of a node with element type 'TYPE_CONSTRAINT_LIST'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeConstraintList(
+        ktTypeConstraintList: KtTypeConstraintList,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeConstraintList.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_CONSTRAINT' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeConstraint the [KtTypeConstraint] of a node with element type 'TYPE_CONSTRAINT'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeConstraint(
+        ktTypeConstraint: KtTypeConstraint,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeConstraint.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'USER_TYPE' in the AST before visiting the child nodes.
+     *
+     * @param ktUserType the [KtUserType] of a node with element type 'USER_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeUserType(
+        ktUserType: KtUserType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktUserType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'DYNAMIC_TYPE' in the AST before visiting the child nodes.
+     *
+     * @param ktDynamicType the [KtDynamicType] of a node with element type 'DYNAMIC_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeDynamicType(
+        ktDynamicType: KtDynamicType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktDynamicType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'FUNCTION_TYPE' in the AST before visiting the child nodes.
+     *
+     * @param ktFunctionType the [KtFunctionType] of a node with element type 'FUNCTION_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeFunctionType(
+        ktFunctionType: KtFunctionType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktFunctionType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'BINARY_WITH_TYPE' in the AST before visiting the child nodes.
+     *
+     * @param ktBinaryExpressionWithTypeRHS the [KtBinaryExpressionWithTypeRHS] of a node with element type 'BINARY_WITH_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeBinaryExpressionWithTypeRHS(
+        ktBinaryExpressionWithTypeRHS: KtBinaryExpressionWithTypeRHS,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktBinaryExpressionWithTypeRHS.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'STRING_TEMPLATE' in the AST before visiting the child nodes.
+     *
+     * @param ktStringTemplateExpression the [KtStringTemplateExpression] of a node with element type 'STRING_TEMPLATE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeStringTemplateExpression(
+        ktStringTemplateExpression: KtStringTemplateExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktStringTemplateExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'NULLABLE_TYPE' in the AST before visiting the child nodes.
+     *
+     * @param ktNullableType the [KtNullableType] of a node with element type 'NULLABLE_TYPE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeNullableType(
+        ktNullableType: KtNullableType,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktNullableType.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'TYPE_PROJECTION' in the AST before visiting the child nodes.
+     *
+     * @param ktTypeProjection the [KtTypeProjection] of a node with element type 'TYPE_PROJECTION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeTypeProjection(
+        ktTypeProjection: KtTypeProjection,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktTypeProjection.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktWhenEntry the [KtWhenEntry] of a node with element type 'WHEN_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhenEntry(
+        ktWhenEntry: KtWhenEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhenEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'IS_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktIsExpression the [KtIsExpression] of a node with element type 'IS_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeIsExpression(
+        ktIsExpression: KtIsExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktIsExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_IS_PATTERN' in the AST before visiting the child nodes.
+     *
+     * @param ktWhenConditionIsPattern the [KtWhenConditionIsPattern] of a node with element type 'WHEN_CONDITION_IS_PATTERN'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhenConditionIsPattern(
+        ktWhenConditionIsPattern: KtWhenConditionIsPattern,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhenConditionIsPattern.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_IN_RANGE' in the AST before visiting the child nodes.
+     *
+     * @param ktWhenConditionInRange the [KtWhenConditionInRange] of a node with element type 'WHEN_CONDITION_IN_RANGE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhenConditionInRange(
+        ktWhenConditionInRange: KtWhenConditionInRange,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhenConditionInRange.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'WHEN_CONDITION_WITH_EXPRESSION' in the AST before visiting the child nodes.
+     *
+     * @param ktWhenConditionWithExpression the [KtWhenConditionWithExpression] of a node with element type 'WHEN_CONDITION_WITH_EXPRESSION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeWhenConditionWithExpression(
+        ktWhenConditionWithExpression: KtWhenConditionWithExpression,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktWhenConditionWithExpression.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'OBJECT_DECLARATION' in the AST before visiting the child nodes.
+     *
+     * @param ktObjectDeclaration the [KtObjectDeclaration] of a node with element type 'OBJECT_DECLARATION'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeObjectDeclaration(
+        ktObjectDeclaration: KtObjectDeclaration,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktObjectDeclaration.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LONG_STRING_TEMPLATE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktBlockStringTemplateEntry the [KtBlockStringTemplateEntry] of a node with element type 'LONG_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeBlockStringTemplateEntry(
+        ktBlockStringTemplateEntry: KtBlockStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktBlockStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'SHORT_STRING_TEMPLATE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktSimpleNameStringTemplateEntry the [KtSimpleNameStringTemplateEntry] of a node with element type 'SHORT_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeSimpleNameStringTemplateEntry(
+        ktSimpleNameStringTemplateEntry: KtSimpleNameStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktSimpleNameStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'LITERAL_STRING_TEMPLATE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktLiteralStringTemplateEntry the [KtLiteralStringTemplateEntry] of a node with element type 'LITERAL_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeLiteralStringTemplateEntry(
+        ktLiteralStringTemplateEntry: KtLiteralStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktLiteralStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'ESCAPE_STRING_TEMPLATE_ENTRY' in the AST before visiting the child nodes.
+     *
+     * @param ktEscapeStringTemplateEntry the [KtEscapeStringTemplateEntry] of a node with element type 'ESCAPE_STRING_TEMPLATE_ENTRY'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeEscapeStringTemplateEntry(
+        ktEscapeStringTemplateEntry: KtEscapeStringTemplateEntry,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktEscapeStringTemplateEntry.node, autoCorrect, emit)
+
+    /**
+     * This method is called on a node of element type 'PACKAGE_DIRECTIVE' in the AST before visiting the child nodes.
+     *
+     * @param ktPackageDirective the [KtPackageDirective] of a node with element type 'PACKAGE_DIRECTIVE'
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforePackageDirective(
+        ktPackageDirective: KtPackageDirective,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ): Unit = beforeVisitChildNodes(ktPackageDirective.node, autoCorrect, emit)
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/NodeVisitor.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/NodeVisitor.kt
@@ -1,0 +1,706 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARRAY_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_WITH_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BREAK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALLABLE_REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CATCH
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_INITIALIZER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_CALLEE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_DELEGATION_CALL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTEXT_RECEIVER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTINUE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DELEGATED_SUPER_TYPE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DO_WHILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DYNAMIC_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ESCAPE_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FINALLY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_ALIAS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.INITIALIZER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABELED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LITERAL_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LONG_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.NULLABLE_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_DECLARATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PARENTHESIZED
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_ACCESSOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_DELEGATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SECONDARY_CONSTRUCTOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SHORT_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THIS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THROW
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPEALIAS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.USER_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_IN_RANGE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_IS_PATTERN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_WITH_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHILE
+import com.pinterest.ktlint.rule.engine.core.util.safeAs
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
+import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtContinueExpression
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
+import org.jetbrains.kotlin.psi.KtDoWhileExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtDynamicType
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtForExpression
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtImportAlias
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtInitializerList
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.KtScriptInitializer
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeConstraintList
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeParameterList
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtWhenConditionInRange
+import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
+import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.KtWhileExpression
+
+// IMPORTANT: This class is generated and therefore should not be changed manually.
+
+/**
+ * This visitor dispatches a request from the [KtlintRuleEngine] to visit a node to a more specified visitor function as declared in
+ * [BeforeNodeVisitor] or [RuleAfterNodeVisitor].
+ */
+public open class NodeVisitor :
+    BeforeNodeVisitor,
+    AfterNodeVisitor {
+    /**
+     * This method is called on a node in the AST before visiting the child nodes. If the node can be transformed to a known Kt-type (for
+     * example [KtIfExpression], the call is dispatched to the visit method [beforeIfExpression] for that specific type. Otherwise, the node
+     * is dispatched to the default handler [beforeVisitChildNodes].
+     *
+     * The called dispatch function can process other nodes in the AST. But do not that rule suppressions on other nodes are not guaranteed
+     * to be taken into account.
+     *
+     * @param node AST node
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun beforeNode(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        val dispatched =
+            when (node.elementType) {
+                CLASS ->
+                    node.dispatch<KtClass> { element -> beforeClass(element, autoCorrect, emit) }
+                SECONDARY_CONSTRUCTOR ->
+                    node.dispatch<KtSecondaryConstructor> { element -> beforeSecondaryConstructor(element, autoCorrect, emit) }
+                PRIMARY_CONSTRUCTOR ->
+                    node.dispatch<KtPrimaryConstructor> { element -> beforePrimaryConstructor(element, autoCorrect, emit) }
+                PROPERTY ->
+                    node.dispatch<KtProperty> { element -> beforeProperty(element, autoCorrect, emit) }
+                TYPEALIAS ->
+                    node.dispatch<KtTypeAlias> { element -> beforeTypeAlias(element, autoCorrect, emit) }
+                DESTRUCTURING_DECLARATION ->
+                    node.dispatch<KtDestructuringDeclaration> { element -> beforeDestructuringDeclaration(element, autoCorrect, emit) }
+                DESTRUCTURING_DECLARATION_ENTRY ->
+                    node.dispatch<KtDestructuringDeclarationEntry> { element ->
+                        beforeDestructuringDeclarationEntry(element, autoCorrect, emit)
+                    }
+                FILE ->
+                    node.dispatch<KtFile> { element -> beforeFile(element, autoCorrect, emit) }
+                SCRIPT ->
+                    node.dispatch<KtScript> { element -> beforeScript(element, autoCorrect, emit) }
+                IMPORT_ALIAS ->
+                    node.dispatch<KtImportAlias> { element -> beforeImportAlias(element, autoCorrect, emit) }
+                IMPORT_DIRECTIVE ->
+                    node.dispatch<KtImportDirective> { element -> beforeImportDirective(element, autoCorrect, emit) }
+                IMPORT_LIST ->
+                    node.dispatch<KtImportList> { element -> beforeImportList(element, autoCorrect, emit) }
+                CLASS_BODY ->
+                    node.dispatch<KtClassBody> { element -> beforeClassBody(element, autoCorrect, emit) }
+                MODIFIER_LIST ->
+                    node.dispatch<KtModifierList> { element -> beforeModifierList(element, autoCorrect, emit) }
+                ANNOTATION ->
+                    node.dispatch<KtAnnotation> { element -> beforeAnnotation(element, autoCorrect, emit) }
+                ANNOTATION_ENTRY ->
+                    node.dispatch<KtAnnotationEntry> { element -> beforeAnnotationEntry(element, autoCorrect, emit) }
+                CONSTRUCTOR_CALLEE ->
+                    node.dispatch<KtConstructorCalleeExpression> { element ->
+                        beforeConstructorCalleeExpression(element, autoCorrect, emit)
+                    }
+                TYPE_PARAMETER_LIST ->
+                    node.dispatch<KtTypeParameterList> { element -> beforeTypeParameterList(element, autoCorrect, emit) }
+                TYPE_PARAMETER ->
+                    node.dispatch<KtTypeParameter> { element -> beforeTypeParameter(element, autoCorrect, emit) }
+                ENUM_ENTRY ->
+                    node.dispatch<KtEnumEntry> { element -> beforeEnumEntry(element, autoCorrect, emit) }
+                VALUE_PARAMETER_LIST ->
+                    node.dispatch<KtParameterList> { element -> beforeParameterList(element, autoCorrect, emit) }
+                VALUE_PARAMETER ->
+                    node.dispatch<KtParameter> { element -> beforeParameter(element, autoCorrect, emit) }
+                SUPER_TYPE_LIST ->
+                    node.dispatch<KtSuperTypeList> { element -> beforeSuperTypeList(element, autoCorrect, emit) }
+                DELEGATED_SUPER_TYPE_ENTRY ->
+                    node.dispatch<KtDelegatedSuperTypeEntry> { element -> beforeDelegatedSuperTypeEntry(element, autoCorrect, emit) }
+                SUPER_TYPE_CALL_ENTRY ->
+                    node.dispatch<KtSuperTypeCallEntry> { element -> beforeSuperTypeCallEntry(element, autoCorrect, emit) }
+                SUPER_TYPE_ENTRY ->
+                    node.dispatch<KtSuperTypeEntry> { element -> beforeSuperTypeEntry(element, autoCorrect, emit) }
+                CONTEXT_RECEIVER_LIST ->
+                    node.dispatch<KtContextReceiverList> { element -> beforeContextReceiverList(element, autoCorrect, emit) }
+                CONSTRUCTOR_DELEGATION_CALL ->
+                    node.dispatch<KtConstructorDelegationCall> { element -> beforeConstructorDelegationCall(element, autoCorrect, emit) }
+                PROPERTY_DELEGATE ->
+                    node.dispatch<KtPropertyDelegate> { element -> beforePropertyDelegate(element, autoCorrect, emit) }
+                TYPE_REFERENCE ->
+                    node.dispatch<KtTypeReference> { element -> beforeTypeReference(element, autoCorrect, emit) }
+                VALUE_ARGUMENT_LIST ->
+                    node.dispatch<KtValueArgumentList> { element -> beforeValueArgumentList(element, autoCorrect, emit) }
+                VALUE_ARGUMENT ->
+                    node.dispatch<KtValueArgument> { element -> beforeValueArgument(element, autoCorrect, emit) }
+                REFERENCE_EXPRESSION ->
+                    node.dispatch<KtReferenceExpression> { element -> beforeReferenceExpression(element, autoCorrect, emit) }
+                LABELED_EXPRESSION ->
+                    node.dispatch<KtLabeledExpression> { element -> beforeLabeledExpression(element, autoCorrect, emit) }
+                PREFIX_EXPRESSION ->
+                    node.dispatch<KtPrefixExpression> { element -> beforePrefixExpression(element, autoCorrect, emit) }
+                POSTFIX_EXPRESSION ->
+                    node.dispatch<KtPostfixExpression> { element -> beforePostfixExpression(element, autoCorrect, emit) }
+                BINARY_EXPRESSION ->
+                    node.dispatch<KtBinaryExpression> { element -> beforeBinaryExpression(element, autoCorrect, emit) }
+                THROW ->
+                    node.dispatch<KtThrowExpression> { element -> beforeThrowExpression(element, autoCorrect, emit) }
+                BREAK ->
+                    node.dispatch<KtBreakExpression> { element -> beforeBreakExpression(element, autoCorrect, emit) }
+                CONTINUE ->
+                    node.dispatch<KtContinueExpression> { element -> beforeContinueExpression(element, autoCorrect, emit) }
+                IF ->
+                    node.dispatch<KtIfExpression> { element -> beforeIfExpression(element, autoCorrect, emit) }
+                WHEN ->
+                    node.dispatch<KtWhenExpression> { element -> beforeWhenExpression(element, autoCorrect, emit) }
+                COLLECTION_LITERAL_EXPRESSION ->
+                    node.dispatch<KtCollectionLiteralExpression> { element ->
+                        beforeCollectionLiteralExpression(element, autoCorrect, emit)
+                    }
+                TRY ->
+                    node.dispatch<KtTryExpression> { element -> beforeTryExpression(element, autoCorrect, emit) }
+                FOR ->
+                    node.dispatch<KtForExpression> { element -> beforeForExpression(element, autoCorrect, emit) }
+                WHILE ->
+                    node.dispatch<KtWhileExpression> { element -> beforeWhileExpression(element, autoCorrect, emit) }
+                DO_WHILE ->
+                    node.dispatch<KtDoWhileExpression> { element -> beforeDoWhileExpression(element, autoCorrect, emit) }
+                LAMBDA_EXPRESSION ->
+                    node.dispatch<KtLambdaExpression> { element -> beforeLambdaExpression(element, autoCorrect, emit) }
+                ANNOTATED_EXPRESSION ->
+                    node.dispatch<KtAnnotatedExpression> { element -> beforeAnnotatedExpression(element, autoCorrect, emit) }
+                CALL_EXPRESSION ->
+                    node.dispatch<KtCallExpression> { element -> beforeCallExpression(element, autoCorrect, emit) }
+                ARRAY_ACCESS_EXPRESSION ->
+                    node.dispatch<KtArrayAccessExpression> { element -> beforeArrayAccessExpression(element, autoCorrect, emit) }
+                CALLABLE_REFERENCE_EXPRESSION ->
+                    node.dispatch<KtCallableReferenceExpression> { element ->
+                        beforeCallableReferenceExpression(element, autoCorrect, emit)
+                    }
+                CLASS_LITERAL_EXPRESSION ->
+                    node.dispatch<KtClassLiteralExpression> { element -> beforeClassLiteralExpression(element, autoCorrect, emit) }
+                DOT_QUALIFIED_EXPRESSION ->
+                    node.dispatch<KtDotQualifiedExpression> { element -> beforeDotQualifiedExpression(element, autoCorrect, emit) }
+                SAFE_ACCESS_EXPRESSION ->
+                    node.dispatch<KtSafeQualifiedExpression> { element -> beforeSafeQualifiedExpression(element, autoCorrect, emit) }
+                OBJECT_LITERAL ->
+                    node.dispatch<KtObjectLiteralExpression> { element -> beforeObjectLiteralExpression(element, autoCorrect, emit) }
+                BLOCK ->
+                    node.dispatch<KtBlockExpression> { element -> beforeBlockExpression(element, autoCorrect, emit) }
+                CATCH ->
+                    node.dispatch<KtCatchClause> { element -> beforeCatchClause(element, autoCorrect, emit) }
+                FINALLY ->
+                    node.dispatch<KtFinallySection> { element -> beforeFinallySection(element, autoCorrect, emit) }
+                TYPE_ARGUMENT_LIST ->
+                    node.dispatch<KtTypeArgumentList> { element -> beforeTypeArgumentList(element, autoCorrect, emit) }
+                THIS_EXPRESSION ->
+                    node.dispatch<KtThisExpression> { element -> beforeThisExpression(element, autoCorrect, emit) }
+                SUPER_EXPRESSION ->
+                    node.dispatch<KtSuperExpression> { element -> beforeSuperExpression(element, autoCorrect, emit) }
+                PARENTHESIZED ->
+                    node.dispatch<KtParenthesizedExpression> { element -> beforeParenthesizedExpression(element, autoCorrect, emit) }
+                INITIALIZER_LIST ->
+                    node.dispatch<KtInitializerList> { element -> beforeInitializerList(element, autoCorrect, emit) }
+                SCRIPT_INITIALIZER ->
+                    node.dispatch<KtScriptInitializer> { element -> beforeScriptInitializer(element, autoCorrect, emit) }
+                CLASS_INITIALIZER ->
+                    node.dispatch<KtClassInitializer> { element -> beforeClassInitializer(element, autoCorrect, emit) }
+                PROPERTY_ACCESSOR ->
+                    node.dispatch<KtPropertyAccessor> { element -> beforePropertyAccessor(element, autoCorrect, emit) }
+                TYPE_CONSTRAINT_LIST ->
+                    node.dispatch<KtTypeConstraintList> { element -> beforeTypeConstraintList(element, autoCorrect, emit) }
+                TYPE_CONSTRAINT ->
+                    node.dispatch<KtTypeConstraint> { element -> beforeTypeConstraint(element, autoCorrect, emit) }
+                USER_TYPE ->
+                    node.dispatch<KtUserType> { element -> beforeUserType(element, autoCorrect, emit) }
+                DYNAMIC_TYPE ->
+                    node.dispatch<KtDynamicType> { element -> beforeDynamicType(element, autoCorrect, emit) }
+                FUNCTION_TYPE ->
+                    node.dispatch<KtFunctionType> { element -> beforeFunctionType(element, autoCorrect, emit) }
+                BINARY_WITH_TYPE ->
+                    node.dispatch<KtBinaryExpressionWithTypeRHS> { element ->
+                        beforeBinaryExpressionWithTypeRHS(element, autoCorrect, emit)
+                    }
+                STRING_TEMPLATE ->
+                    node.dispatch<KtStringTemplateExpression> { element -> beforeStringTemplateExpression(element, autoCorrect, emit) }
+                NULLABLE_TYPE ->
+                    node.dispatch<KtNullableType> { element -> beforeNullableType(element, autoCorrect, emit) }
+                TYPE_PROJECTION ->
+                    node.dispatch<KtTypeProjection> { element -> beforeTypeProjection(element, autoCorrect, emit) }
+                WHEN_ENTRY ->
+                    node.dispatch<KtWhenEntry> { element -> beforeWhenEntry(element, autoCorrect, emit) }
+                IS_EXPRESSION ->
+                    node.dispatch<KtIsExpression> { element -> beforeIsExpression(element, autoCorrect, emit) }
+                WHEN_CONDITION_IS_PATTERN ->
+                    node.dispatch<KtWhenConditionIsPattern> { element -> beforeWhenConditionIsPattern(element, autoCorrect, emit) }
+                WHEN_CONDITION_IN_RANGE ->
+                    node.dispatch<KtWhenConditionInRange> { element -> beforeWhenConditionInRange(element, autoCorrect, emit) }
+                WHEN_CONDITION_WITH_EXPRESSION ->
+                    node.dispatch<KtWhenConditionWithExpression> { element ->
+                        beforeWhenConditionWithExpression(element, autoCorrect, emit)
+                    }
+                OBJECT_DECLARATION ->
+                    node.dispatch<KtObjectDeclaration> { element -> beforeObjectDeclaration(element, autoCorrect, emit) }
+                LONG_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtBlockStringTemplateEntry> { element -> beforeBlockStringTemplateEntry(element, autoCorrect, emit) }
+                SHORT_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtSimpleNameStringTemplateEntry> { element ->
+                        beforeSimpleNameStringTemplateEntry(element, autoCorrect, emit)
+                    }
+                LITERAL_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtLiteralStringTemplateEntry> { element -> beforeLiteralStringTemplateEntry(element, autoCorrect, emit) }
+                ESCAPE_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtEscapeStringTemplateEntry> { element -> beforeEscapeStringTemplateEntry(element, autoCorrect, emit) }
+                PACKAGE_DIRECTIVE ->
+                    node.dispatch<KtPackageDirective> { element -> beforePackageDirective(element, autoCorrect, emit) }
+                else -> false
+            }
+        if (!dispatched) {
+            // In case no mapping exists for the element type, or if the PSI of the node could not safely be cast to the Kt-type, then fall back
+            // on the generic handler.
+            beforeVisitChildNodes(node, autoCorrect, emit)
+        }
+    }
+
+    /**
+     * This method is called on a node in the AST after visiting the child nodes. If the node can be transformed to a known Kt-type (for
+     * example [KtIfExpression], the call is dispatched to the visit method [afterIfExpression] for that specific type. Otherwise, the node
+     * is dispatched to the default handler [afterVisitChildNodes].
+     *
+     * The called dispatch function can process other nodes in the AST. But do not that rule suppressions on other nodes are not guaranteed
+     * to be taken into account.
+     *
+     * @param node AST node
+     * @param autoCorrect indicates whether rule should attempt autocorrection
+     * @param emit a way for rule to notify about a violation (lint error)
+     */
+    public fun afterNode(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        val dispatched =
+            when (node.elementType) {
+                CLASS ->
+                    node.dispatch<KtClass> { element -> afterClass(element, autoCorrect, emit) }
+
+                SECONDARY_CONSTRUCTOR ->
+                    node.dispatch<KtSecondaryConstructor> { element -> afterSecondaryConstructor(element, autoCorrect, emit) }
+
+                PRIMARY_CONSTRUCTOR ->
+                    node.dispatch<KtPrimaryConstructor> { element -> afterPrimaryConstructor(element, autoCorrect, emit) }
+
+                PROPERTY ->
+                    node.dispatch<KtProperty> { element -> afterProperty(element, autoCorrect, emit) }
+
+                TYPEALIAS ->
+                    node.dispatch<KtTypeAlias> { element -> afterTypeAlias(element, autoCorrect, emit) }
+
+                DESTRUCTURING_DECLARATION ->
+                    node.dispatch<KtDestructuringDeclaration> { element -> afterDestructuringDeclaration(element, autoCorrect, emit) }
+
+                DESTRUCTURING_DECLARATION_ENTRY ->
+                    node.dispatch<KtDestructuringDeclarationEntry> { element ->
+                        afterDestructuringDeclarationEntry(element, autoCorrect, emit)
+                    }
+
+                FILE ->
+                    node.dispatch<KtFile> { element -> afterFile(element, autoCorrect, emit) }
+
+                SCRIPT ->
+                    node.dispatch<KtScript> { element -> afterScript(element, autoCorrect, emit) }
+
+                IMPORT_ALIAS ->
+                    node.dispatch<KtImportAlias> { element -> afterImportAlias(element, autoCorrect, emit) }
+
+                IMPORT_DIRECTIVE ->
+                    node.dispatch<KtImportDirective> { element -> afterImportDirective(element, autoCorrect, emit) }
+
+                IMPORT_LIST ->
+                    node.dispatch<KtImportList> { element -> afterImportList(element, autoCorrect, emit) }
+
+                CLASS_BODY ->
+                    node.dispatch<KtClassBody> { element -> afterClassBody(element, autoCorrect, emit) }
+
+                MODIFIER_LIST ->
+                    node.dispatch<KtModifierList> { element -> afterModifierList(element, autoCorrect, emit) }
+
+                ANNOTATION ->
+                    node.dispatch<KtAnnotation> { element -> afterAnnotation(element, autoCorrect, emit) }
+
+                ANNOTATION_ENTRY ->
+                    node.dispatch<KtAnnotationEntry> { element -> afterAnnotationEntry(element, autoCorrect, emit) }
+
+                CONSTRUCTOR_CALLEE ->
+                    node.dispatch<KtConstructorCalleeExpression> { element -> afterConstructorCalleeExpression(element, autoCorrect, emit) }
+
+                TYPE_PARAMETER_LIST ->
+                    node.dispatch<KtTypeParameterList> { element -> afterTypeParameterList(element, autoCorrect, emit) }
+
+                TYPE_PARAMETER ->
+                    node.dispatch<KtTypeParameter> { element -> afterTypeParameter(element, autoCorrect, emit) }
+
+                ENUM_ENTRY ->
+                    node.dispatch<KtEnumEntry> { element -> afterEnumEntry(element, autoCorrect, emit) }
+
+                VALUE_PARAMETER_LIST ->
+                    node.dispatch<KtParameterList> { element -> afterParameterList(element, autoCorrect, emit) }
+
+                VALUE_PARAMETER ->
+                    node.dispatch<KtParameter> { element -> afterParameter(element, autoCorrect, emit) }
+
+                SUPER_TYPE_LIST ->
+                    node.dispatch<KtSuperTypeList> { element -> afterSuperTypeList(element, autoCorrect, emit) }
+
+                DELEGATED_SUPER_TYPE_ENTRY ->
+                    node.dispatch<KtDelegatedSuperTypeEntry> { element -> afterDelegatedSuperTypeEntry(element, autoCorrect, emit) }
+
+                SUPER_TYPE_CALL_ENTRY ->
+                    node.dispatch<KtSuperTypeCallEntry> { element -> afterSuperTypeCallEntry(element, autoCorrect, emit) }
+
+                SUPER_TYPE_ENTRY ->
+                    node.dispatch<KtSuperTypeEntry> { element -> afterSuperTypeEntry(element, autoCorrect, emit) }
+
+                CONTEXT_RECEIVER_LIST ->
+                    node.dispatch<KtContextReceiverList> { element -> afterContextReceiverList(element, autoCorrect, emit) }
+
+                CONSTRUCTOR_DELEGATION_CALL ->
+                    node.dispatch<KtConstructorDelegationCall> { element -> afterConstructorDelegationCall(element, autoCorrect, emit) }
+
+                PROPERTY_DELEGATE ->
+                    node.dispatch<KtPropertyDelegate> { element -> afterPropertyDelegate(element, autoCorrect, emit) }
+
+                TYPE_REFERENCE ->
+                    node.dispatch<KtTypeReference> { element -> afterTypeReference(element, autoCorrect, emit) }
+
+                VALUE_ARGUMENT_LIST ->
+                    node.dispatch<KtValueArgumentList> { element -> afterValueArgumentList(element, autoCorrect, emit) }
+
+                VALUE_ARGUMENT ->
+                    node.dispatch<KtValueArgument> { element -> afterValueArgument(element, autoCorrect, emit) }
+
+                REFERENCE_EXPRESSION ->
+                    node.dispatch<KtReferenceExpression> { element -> afterReferenceExpression(element, autoCorrect, emit) }
+
+                LABELED_EXPRESSION ->
+                    node.dispatch<KtLabeledExpression> { element -> afterLabeledExpression(element, autoCorrect, emit) }
+
+                PREFIX_EXPRESSION ->
+                    node.dispatch<KtPrefixExpression> { element -> afterPrefixExpression(element, autoCorrect, emit) }
+
+                POSTFIX_EXPRESSION ->
+                    node.dispatch<KtPostfixExpression> { element -> afterPostfixExpression(element, autoCorrect, emit) }
+
+                BINARY_EXPRESSION ->
+                    node.dispatch<KtBinaryExpression> { element -> afterBinaryExpression(element, autoCorrect, emit) }
+
+                THROW ->
+                    node.dispatch<KtThrowExpression> { element -> afterThrowExpression(element, autoCorrect, emit) }
+
+                BREAK ->
+                    node.dispatch<KtBreakExpression> { element -> afterBreakExpression(element, autoCorrect, emit) }
+
+                CONTINUE ->
+                    node.dispatch<KtContinueExpression> { element -> afterContinueExpression(element, autoCorrect, emit) }
+
+                IF ->
+                    node.dispatch<KtIfExpression> { element -> afterIfExpression(element, autoCorrect, emit) }
+
+                WHEN ->
+                    node.dispatch<KtWhenExpression> { element -> afterWhenExpression(element, autoCorrect, emit) }
+
+                COLLECTION_LITERAL_EXPRESSION ->
+                    node.dispatch<KtCollectionLiteralExpression> { element -> afterCollectionLiteralExpression(element, autoCorrect, emit) }
+
+                TRY ->
+                    node.dispatch<KtTryExpression> { element -> afterTryExpression(element, autoCorrect, emit) }
+
+                FOR ->
+                    node.dispatch<KtForExpression> { element -> afterForExpression(element, autoCorrect, emit) }
+
+                WHILE ->
+                    node.dispatch<KtWhileExpression> { element -> afterWhileExpression(element, autoCorrect, emit) }
+
+                DO_WHILE ->
+                    node.dispatch<KtDoWhileExpression> { element -> afterDoWhileExpression(element, autoCorrect, emit) }
+
+                LAMBDA_EXPRESSION ->
+                    node.dispatch<KtLambdaExpression> { element -> afterLambdaExpression(element, autoCorrect, emit) }
+
+                ANNOTATED_EXPRESSION ->
+                    node.dispatch<KtAnnotatedExpression> { element -> afterAnnotatedExpression(element, autoCorrect, emit) }
+
+                CALL_EXPRESSION ->
+                    node.dispatch<KtCallExpression> { element -> afterCallExpression(element, autoCorrect, emit) }
+
+                ARRAY_ACCESS_EXPRESSION ->
+                    node.dispatch<KtArrayAccessExpression> { element -> afterArrayAccessExpression(element, autoCorrect, emit) }
+
+                CALLABLE_REFERENCE_EXPRESSION ->
+                    node.dispatch<KtCallableReferenceExpression> { element -> afterCallableReferenceExpression(element, autoCorrect, emit) }
+
+                CLASS_LITERAL_EXPRESSION ->
+                    node.dispatch<KtClassLiteralExpression> { element -> afterClassLiteralExpression(element, autoCorrect, emit) }
+
+                DOT_QUALIFIED_EXPRESSION ->
+                    node.dispatch<KtDotQualifiedExpression> { element -> afterDotQualifiedExpression(element, autoCorrect, emit) }
+
+                SAFE_ACCESS_EXPRESSION ->
+                    node.dispatch<KtSafeQualifiedExpression> { element -> afterSafeQualifiedExpression(element, autoCorrect, emit) }
+
+                OBJECT_LITERAL ->
+                    node.dispatch<KtObjectLiteralExpression> { element -> afterObjectLiteralExpression(element, autoCorrect, emit) }
+
+                BLOCK ->
+                    node.dispatch<KtBlockExpression> { element -> afterBlockExpression(element, autoCorrect, emit) }
+
+                CATCH ->
+                    node.dispatch<KtCatchClause> { element -> afterCatchClause(element, autoCorrect, emit) }
+
+                FINALLY ->
+                    node.dispatch<KtFinallySection> { element -> afterFinallySection(element, autoCorrect, emit) }
+
+                TYPE_ARGUMENT_LIST ->
+                    node.dispatch<KtTypeArgumentList> { element -> afterTypeArgumentList(element, autoCorrect, emit) }
+
+                THIS_EXPRESSION ->
+                    node.dispatch<KtThisExpression> { element -> afterThisExpression(element, autoCorrect, emit) }
+
+                SUPER_EXPRESSION ->
+                    node.dispatch<KtSuperExpression> { element -> afterSuperExpression(element, autoCorrect, emit) }
+
+                PARENTHESIZED ->
+                    node.dispatch<KtParenthesizedExpression> { element -> afterParenthesizedExpression(element, autoCorrect, emit) }
+
+                INITIALIZER_LIST ->
+                    node.dispatch<KtInitializerList> { element -> afterInitializerList(element, autoCorrect, emit) }
+
+                SCRIPT_INITIALIZER ->
+                    node.dispatch<KtScriptInitializer> { element -> afterScriptInitializer(element, autoCorrect, emit) }
+
+                CLASS_INITIALIZER ->
+                    node.dispatch<KtClassInitializer> { element -> afterClassInitializer(element, autoCorrect, emit) }
+
+                PROPERTY_ACCESSOR ->
+                    node.dispatch<KtPropertyAccessor> { element -> afterPropertyAccessor(element, autoCorrect, emit) }
+
+                TYPE_CONSTRAINT_LIST ->
+                    node.dispatch<KtTypeConstraintList> { element -> afterTypeConstraintList(element, autoCorrect, emit) }
+
+                TYPE_CONSTRAINT ->
+                    node.dispatch<KtTypeConstraint> { element -> afterTypeConstraint(element, autoCorrect, emit) }
+
+                USER_TYPE ->
+                    node.dispatch<KtUserType> { element -> afterUserType(element, autoCorrect, emit) }
+
+                DYNAMIC_TYPE ->
+                    node.dispatch<KtDynamicType> { element -> afterDynamicType(element, autoCorrect, emit) }
+
+                FUNCTION_TYPE ->
+                    node.dispatch<KtFunctionType> { element -> afterFunctionType(element, autoCorrect, emit) }
+
+                BINARY_WITH_TYPE ->
+                    node.dispatch<KtBinaryExpressionWithTypeRHS> { element -> afterBinaryExpressionWithTypeRHS(element, autoCorrect, emit) }
+
+                STRING_TEMPLATE ->
+                    node.dispatch<KtStringTemplateExpression> { element -> afterStringTemplateExpression(element, autoCorrect, emit) }
+
+                NULLABLE_TYPE ->
+                    node.dispatch<KtNullableType> { element -> afterNullableType(element, autoCorrect, emit) }
+
+                TYPE_PROJECTION ->
+                    node.dispatch<KtTypeProjection> { element -> afterTypeProjection(element, autoCorrect, emit) }
+
+                WHEN_ENTRY ->
+                    node.dispatch<KtWhenEntry> { element -> afterWhenEntry(element, autoCorrect, emit) }
+
+                IS_EXPRESSION ->
+                    node.dispatch<KtIsExpression> { element -> afterIsExpression(element, autoCorrect, emit) }
+
+                WHEN_CONDITION_IS_PATTERN ->
+                    node.dispatch<KtWhenConditionIsPattern> { element -> afterWhenConditionIsPattern(element, autoCorrect, emit) }
+
+                WHEN_CONDITION_IN_RANGE ->
+                    node.dispatch<KtWhenConditionInRange> { element -> afterWhenConditionInRange(element, autoCorrect, emit) }
+
+                WHEN_CONDITION_WITH_EXPRESSION ->
+                    node.dispatch<KtWhenConditionWithExpression> { element -> afterWhenConditionWithExpression(element, autoCorrect, emit) }
+
+                OBJECT_DECLARATION ->
+                    node.dispatch<KtObjectDeclaration> { element -> afterObjectDeclaration(element, autoCorrect, emit) }
+
+                LONG_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtBlockStringTemplateEntry> { element -> afterBlockStringTemplateEntry(element, autoCorrect, emit) }
+
+                SHORT_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtSimpleNameStringTemplateEntry> { element ->
+                        afterSimpleNameStringTemplateEntry(element, autoCorrect, emit)
+                    }
+
+                LITERAL_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtLiteralStringTemplateEntry> { element -> afterLiteralStringTemplateEntry(element, autoCorrect, emit) }
+
+                ESCAPE_STRING_TEMPLATE_ENTRY ->
+                    node.dispatch<KtEscapeStringTemplateEntry> { element -> afterEscapeStringTemplateEntry(element, autoCorrect, emit) }
+
+                PACKAGE_DIRECTIVE ->
+                    node.dispatch<KtPackageDirective> { element -> afterPackageDirective(element, autoCorrect, emit) }
+                else -> false
+            }
+        if (!dispatched) {
+            // In case no mapping exists for the element type, or if the PSI of the node could not safely be cast to the Kt-type, then fall back
+            // on the generic handler.
+            afterVisitChildNodes(node, autoCorrect, emit)
+        }
+    }
+
+    private inline fun <reified T : KtElement> ASTNode.dispatch(ktElement: (T) -> Unit): Boolean =
+        psi
+            .safeAs<T>()
+            ?.let {
+                ktElement(it)
+                true
+            }
+            ?: false
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/AfterNodeVisitorGenerator.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/AfterNodeVisitorGenerator.kt
@@ -1,0 +1,96 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor.internal
+
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.decapitalizeSmart
+
+internal fun Map<IElementType, Class<out KtElement>>.generateAfterNodeVisitor(): String {
+    val sortedImports =
+        map { (_, clazz) -> "import ${clazz.canonicalName}" }
+            .sorted()
+            .joinToString(separator = "\n")
+
+    val elementTypeFunctions =
+        map { (elementType, clazz) -> generateAfterFunction(elementType, clazz) }
+            .joinToString(separator = "\n\n")
+    return """
+        |package com.pinterest.ktlint.rule.engine.core.api.visitor
+        |
+        |import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+        |$sortedImports
+        |
+        |public interface AfterNodeVisitor {
+        |$afterVisitChildNodesFunction
+        |
+        |$elementTypeFunctions
+        |}
+        """.trimMargin()
+        .plus("\n\n")
+}
+
+private val afterVisitChildNodesFunction =
+    """
+    |    /**
+    |     * This method is called on a node in AST after visiting the child nodes. This is repeated recursively for the child nodes resulting in
+    |     * a depth first traversal of the AST. Note: this method won't be called for a node for which the visit method of the type of that node
+    |     * has been overridden in the rule.
+    |     *
+    |     * ```
+    |     * class ExampleRule(...) {
+    |     *     override fun afterIfExpression(
+    |     *         ktIfExpression: KtIfExpression,
+    |     *         autoCorrect: Boolean,
+    |     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |     *     ) {
+    |     *         // Only called for nodes having element type 'IF'
+    |     *     }
+    |
+    |     *     override fun afterWhenExpression(...) {
+    |     *         // Only called for nodes having element type 'WHEN'
+    |     *     }
+    |     *
+    |     *     override fun afterVisitChildNodes(
+    |     *         node: ASTNode,
+    |     *         autoCorrect: Boolean,
+    |     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |     *     ) {
+    |     *         // Called for nodes of other types than 'IF' and 'WHEN' because the 'afterIfExpression' and 'afterWhenExpression' are
+    |     *         // overridden.
+    |     *     }
+    |     * }
+    |     * ```
+    |     *
+    |     * @param node AST node
+    |     * @param autoCorrect indicates whether rule should attempt autocorrection
+    |     * @param emit a way for rule to notify about a violation (lint error)
+    |     */
+    |    public fun afterVisitChildNodes(
+    |        node: ASTNode,
+    |        autoCorrect: Boolean,
+    |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |    ) {}
+    """.trimMargin()
+
+private fun generateAfterFunction(
+    elementType: IElementType,
+    ktClazz: Class<out KtElement>,
+): String {
+    val elementTypeName = elementType.debugName
+    val ktClassName = ktClazz.simpleName
+    val functionName = "after${ktClassName.substring(2)}"
+    val ktClassNameAsVariableName = ktClassName.decapitalizeSmart()
+    return """
+        |    /**
+        |     * This method is called on a node of element type '$elementTypeName' in the AST after visiting the child nodes.
+        |     *
+        |     * @param $ktClassNameAsVariableName the [$ktClassName] of a node with element type '$elementTypeName'
+        |     * @param autoCorrect indicates whether rule should attempt autocorrection
+        |     * @param emit a way for rule to notify about a violation (lint error)
+        |     */
+        |    public fun $functionName(
+        |        $ktClassNameAsVariableName: $ktClassName,
+        |        autoCorrect: Boolean,
+        |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        |    ): Unit = afterVisitChildNodes($ktClassNameAsVariableName.node, autoCorrect, emit)
+        """.trimMargin()
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/BeforeNodeVisitorGenerator.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/BeforeNodeVisitorGenerator.kt
@@ -1,0 +1,96 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor.internal
+
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.decapitalizeSmart
+
+internal fun Map<IElementType, Class<out KtElement>>.generateBeforeNodeVisitor(): String {
+    val sortedImports =
+        map { (_, clazz) -> "import ${clazz.canonicalName}" }
+            .sorted()
+            .joinToString(separator = "\n")
+
+    val elementTypeFunctions =
+        map { (elementType, clazz) -> generateBeforeFunction(elementType, clazz) }
+            .joinToString(separator = "\n\n")
+    return """
+        |package com.pinterest.ktlint.rule.engine.core.api.visitor
+        |
+        |import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+        |$sortedImports
+        |
+        |public interface BeforeNodeVisitor {
+        |$beforeVisitChildNodesFunction
+        |
+        |$elementTypeFunctions
+        |}
+        """.trimMargin()
+        .plus("\n\n")
+}
+
+private val beforeVisitChildNodesFunction =
+    """
+    |    /**
+    |     * This method is called on a node in AST before visiting the child nodes. This is repeated recursively for the child nodes resulting in
+    |     * a depth first traversal of the AST. Note: this method won't be called for a node for which the visit method of the type of that node
+    |     * has been overridden in the rule.
+    |     *
+    |     * ```
+    |     * class ExampleRule(...) {
+    |     *     override fun beforeIfExpression(
+    |     *         ktIfExpression: KtIfExpression,
+    |     *         autoCorrect: Boolean,
+    |     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |     *     ) {
+    |     *         // Only called for nodes having element type 'IF'
+    |     *     }
+    |
+    |     *     override fun beforeWhenExpression(...) {
+    |     *         // Only called for nodes having element type 'WHEN'
+    |     *     }
+    |     *
+    |     *     override fun beforeVisitChildNodes(
+    |     *         node: ASTNode,
+    |     *         autoCorrect: Boolean,
+    |     *         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |     *     ) {
+    |     *         // Called for nodes of other types than 'IF' and 'WHEN' because the 'beforeIfExpression' and 'beforeWhenExpression' are
+    |     *         // overridden.
+    |     *     }
+    |     * }
+    |     * ```
+    |     *
+    |     * @param node AST node
+    |     * @param autoCorrect indicates whether rule should attempt autocorrection
+    |     * @param emit a way for rule to notify about a violation (lint error)
+    |     */
+    |    public fun beforeVisitChildNodes(
+    |        node: ASTNode,
+    |        autoCorrect: Boolean,
+    |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    |    ) {}
+    """.trimMargin()
+
+private fun generateBeforeFunction(
+    elementType: IElementType,
+    ktClazz: Class<out KtElement>,
+): String {
+    val elementTypeName = elementType.debugName
+    val ktClassName = ktClazz.simpleName
+    val functionName = "before${ktClassName.substring(2)}"
+    val ktClassNameAsVariableName = ktClassName.decapitalizeSmart()
+    return """
+        |    /**
+        |     * This method is called on a node of element type '$elementTypeName' in the AST before visiting the child nodes.
+        |     *
+        |     * @param $ktClassNameAsVariableName the [$ktClassName] of a node with element type '$elementTypeName'
+        |     * @param autoCorrect indicates whether rule should attempt autocorrection
+        |     * @param emit a way for rule to notify about a violation (lint error)
+        |     */
+        |    public fun $functionName(
+        |        $ktClassNameAsVariableName: $ktClassName,
+        |        autoCorrect: Boolean,
+        |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        |    ): Unit = beforeVisitChildNodes($ktClassNameAsVariableName.node, autoCorrect, emit)
+        """.trimMargin()
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/NodeVisitorGenerator.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/NodeVisitorGenerator.kt
@@ -1,0 +1,147 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor.internal
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.psi.KtElement
+
+internal fun Map<IElementType, Class<out KtElement>>.generateNodeVisitor(): String {
+    val imports =
+        listOf(
+            "import com.pinterest.ktlint.rule.engine.core.api.ElementType",
+            "import com.pinterest.ktlint.rule.engine.core.util.safeAs",
+            "import org.jetbrains.kotlin.com.intellij.lang.ASTNode",
+            "import org.jetbrains.kotlin.psi.KtElement",
+        )
+    val elementTypeImports =
+        map { (elementType, _) ->
+            "import com.pinterest.ktlint.rule.engine.core.api.ElementType.${elementType.filename()}"
+        }
+    val ktElementImports = map { (_, clazz) -> "import ${clazz.canonicalName}" }
+    val sortedImports =
+        imports
+            .plus(elementTypeImports)
+            .plus(ktElementImports)
+            .sorted()
+            .joinToString(separator = "\n")
+
+    val dispatchersBefore =
+        map { (elementType, clazz) -> generateDispatchersBefore(elementType, clazz) }
+            .joinToString(separator = "\n")
+    val dispatchersAfter =
+        map { (elementType, clazz) -> generateDispatchersAfter(elementType, clazz) }
+            .joinToString(separator = "\n\n")
+    return """
+        |package com.pinterest.ktlint.rule.engine.core.api.visitor
+        |
+        |$sortedImports
+        |
+        |// IMPORTANT: This class is generated and therefore should not be changed manually.
+        |
+        |/**
+        | * This visitor dispatches a request from the [KtlintRuleEngine] to visit a node to a more specified visitor function as declared in
+        | * [BeforeNodeVisitor] or [RuleAfterNodeVisitor].
+        | */
+        |public open class NodeVisitor :
+        |    BeforeNodeVisitor,
+        |    AfterNodeVisitor {
+        |    /**
+        |     * This method is called on a node in the AST before visiting the child nodes. If the node can be transformed to a known Kt-type (for
+        |     * example [KtIfExpression], the call is dispatched to the visit method [beforeIfExpression] for that specific type. Otherwise, the node
+        |     * is dispatched to the default handler [beforeVisitChildNodes].
+        |     *
+        |     * The called dispatch function can process other nodes in the AST. But do not that rule suppressions on other nodes are not guaranteed
+        |     * to be taken into account.
+        |     *
+        |     * @param node AST node
+        |     * @param autoCorrect indicates whether rule should attempt autocorrection
+        |     * @param emit a way for rule to notify about a violation (lint error)
+        |     */
+        |    public fun beforeNode(
+        |        node: ASTNode,
+        |        autoCorrect: Boolean,
+        |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        |    ) {
+        |        val dispatched =
+        |            when (node.elementType) {
+        |$dispatchersBefore
+        |                else -> false
+        |            }
+        |        if (!dispatched) {
+        |            // In case no mapping exists for the element type, or if the PSI of the node could not safely be cast to the Kt-type, then fall back
+        |            // on the generic handler.
+        |            beforeVisitChildNodes(node, autoCorrect, emit)
+        |        }
+        |    }
+        |
+        |    /**
+        |     * This method is called on a node in the AST after visiting the child nodes. If the node can be transformed to a known Kt-type (for
+        |     * example [KtIfExpression], the call is dispatched to the visit method [afterIfExpression] for that specific type. Otherwise, the node
+        |     * is dispatched to the default handler [afterVisitChildNodes].
+        |     *
+        |     * The called dispatch function can process other nodes in the AST. But do not that rule suppressions on other nodes are not guaranteed
+        |     * to be taken into account.
+        |     *
+        |     * @param node AST node
+        |     * @param autoCorrect indicates whether rule should attempt autocorrection
+        |     * @param emit a way for rule to notify about a violation (lint error)
+        |     */
+        |    public fun afterNode(
+        |        node: ASTNode,
+        |        autoCorrect: Boolean,
+        |        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+        |    ) {
+        |        val dispatched =
+        |            when (node.elementType) {
+        |$dispatchersAfter
+        |                else -> false
+        |            }
+        |        if (!dispatched) {
+        |            // In case no mapping exists for the element type, or if the PSI of the node could not safely be cast to the Kt-type, then fall back
+        |            // on the generic handler.
+        |            afterVisitChildNodes(node, autoCorrect, emit)
+        |        }
+        |    }
+        |
+        |    private inline fun <reified T : KtElement> ASTNode.dispatch(ktElement: (T) -> Unit): Boolean =
+        |        psi
+        |            .safeAs<T>()
+        |            ?.let {
+        |                ktElement(it)
+        |                true
+        |            }
+        |            ?: false
+        |}
+        """.trimMargin()
+        .plus("\n\n")
+}
+
+private fun generateDispatchersBefore(
+    elementType: IElementType,
+    ktClazz: Class<out KtElement>,
+): String {
+    val ktClassName = ktClazz.simpleName
+    val functionName = "before${ktClassName.substring(2)}"
+    return """
+        |                ${elementType.filename()} ->
+        |                    node.dispatch<$ktClassName> { element -> $functionName(element, autoCorrect, emit) }
+        """.trimMargin()
+}
+
+private fun generateDispatchersAfter(
+    elementType: IElementType,
+    ktClazz: Class<out KtElement>,
+): String {
+    val ktClassName = ktClazz.simpleName
+    val functionName = "after${ktClassName.substring(2)}"
+    return """
+        |                ${elementType.filename()} ->
+        |                    node.dispatch<$ktClassName> { element -> $functionName(element, autoCorrect, emit) }
+        """.trimMargin()
+}
+
+private fun IElementType.filename() =
+    if (this == FILE) {
+        "FILE"
+    } else {
+        debugName
+    }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/VisitorGeneratorMain.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor/internal/VisitorGeneratorMain.kt
@@ -1,0 +1,329 @@
+package com.pinterest.ktlint.rule.engine.core.api.visitor.internal
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARRAY_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_WITH_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BREAK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALLABLE_REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CATCH
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_INITIALIZER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_CALLEE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_DELEGATION_CALL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTEXT_RECEIVER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTINUE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DELEGATED_SUPER_TYPE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DO_WHILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DYNAMIC_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ESCAPE_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FINALLY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_ALIAS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.INITIALIZER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABELED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LITERAL_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LONG_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.NULLABLE_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_DECLARATION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PARENTHESIZED
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_ACCESSOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY_DELEGATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SECONDARY_CONSTRUCTOR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SHORT_STRING_TEMPLATE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THIS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THROW
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPEALIAS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CONSTRAINT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.USER_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_IN_RANGE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_IS_PATTERN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_CONDITION_WITH_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHILE
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
+import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtContinueExpression
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
+import org.jetbrains.kotlin.psi.KtDoWhileExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtDynamicType
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtForExpression
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtImportAlias
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtInitializerList
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.KtScriptInitializer
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeEntry
+import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeConstraintList
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeParameterList
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtWhenConditionInRange
+import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
+import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.KtWhileExpression
+import java.io.File
+
+/**
+ * This script generates the classes [com.pinterest.ktlint.rule.engine.core.api.visitor.AfterNodeVisitor],
+ * [com.pinterest.ktlint.rule.engine.core.api.visitor.BeforeNodeVisitor] and
+ * [com.pinterest.ktlint.rule.engine.core.api.visitor.NodeVisitor].
+ *
+ * The configuration table of this script needs to be updated whenever new `Kt` classes are introduced with new Kotlin versions. As this
+ * does not happen regularly, it suffices to run this script manually.
+ */
+internal fun main() {
+    val targetDir = "ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/visitor"
+
+    elementTypeMap
+        .generateNodeVisitor()
+        .let { content ->
+            File("$targetDir/NodeVisitor.kt")
+                .also { println("Generate ${it.absolutePath}") }
+                .writeText(content)
+        }
+    elementTypeMap
+        .generateBeforeNodeVisitor()
+        .let { content ->
+            File("$targetDir/beforeNodeVisitor.kt")
+                .also { println("Generate ${it.absolutePath}") }
+                .writeText(content)
+        }
+    elementTypeMap
+        .generateAfterNodeVisitor()
+        .let { content ->
+            File("$targetDir/afterNodeVisitor.kt")
+                .also { println("Generate ${it.absolutePath}") }
+                .writeText(content)
+        }
+}
+
+/*
+ * Mapping is based on function available in https://github.com/JetBrains/kotlin/blob/master/compiler/psi/src/org/jetbrains/kotlin/psi/KtVisitorVoid.java
+ * Not all function available in ktVisitorVoid can be mapped to ElementTypes.
+ */
+private val elementTypeMap =
+    mapOf(
+        /*
+         * KtVisitorVoid contains methods below which could not be mapped to a single ElementType. As of that not overridable functions will
+         * be generated:
+         *  - visitAnonymousInitializer
+         *  - visitClassOrObject
+         *  - visitConstantExpression
+         *  - visitDeclaration
+         *  - visitDoubleColonExpression
+         *  - visitExpression
+         *  - visitExpressionWithLabel
+         *  - visitIntersectionType
+         *  - visitKtElement
+         *  - visitLoopExpression
+         *  - visitNamedDeclaration
+         *  - visitNamedFunction
+         *  - visitQualifiedExpression
+         *  - visitSelfType
+         *  - visitSimpleNameExpression
+         *  - visitStringTemplateEntry
+         *  - visitStringTemplateEntryWithExpression
+         *  - visitSuperTypeListEntry
+         *  - visitUnaryExpression
+         */
+        ANNOTATED_EXPRESSION to KtAnnotatedExpression::class.java,
+        ANNOTATION to KtAnnotation::class.java,
+        ANNOTATION_ENTRY to KtAnnotationEntry::class.java,
+        ARRAY_ACCESS_EXPRESSION to KtArrayAccessExpression::class.java,
+        BINARY_EXPRESSION to KtBinaryExpression::class.java,
+        BINARY_WITH_TYPE to KtBinaryExpressionWithTypeRHS::class.java,
+        BLOCK to KtBlockExpression::class.java,
+        BREAK to KtBreakExpression::class.java,
+        CALL_EXPRESSION to KtCallExpression::class.java,
+        CALLABLE_REFERENCE_EXPRESSION to KtCallableReferenceExpression::class.java,
+        CATCH to KtCatchClause::class.java,
+        CLASS to KtClass::class.java,
+        CLASS_BODY to KtClassBody::class.java,
+        CLASS_INITIALIZER to KtClassInitializer::class.java,
+        CLASS_LITERAL_EXPRESSION to KtClassLiteralExpression::class.java,
+        COLLECTION_LITERAL_EXPRESSION to KtCollectionLiteralExpression::class.java,
+        CONSTRUCTOR_CALLEE to KtConstructorCalleeExpression::class.java,
+        CONSTRUCTOR_DELEGATION_CALL to KtConstructorDelegationCall::class.java,
+        CONTEXT_RECEIVER_LIST to KtContextReceiverList::class.java,
+        CONTINUE to KtContinueExpression::class.java,
+        DELEGATED_SUPER_TYPE_ENTRY to KtDelegatedSuperTypeEntry::class.java,
+        DESTRUCTURING_DECLARATION to KtDestructuringDeclaration::class.java,
+        DESTRUCTURING_DECLARATION_ENTRY to KtDestructuringDeclarationEntry::class.java,
+        DO_WHILE to KtDoWhileExpression::class.java,
+        DOT_QUALIFIED_EXPRESSION to KtDotQualifiedExpression::class.java,
+        DYNAMIC_TYPE to KtDynamicType::class.java,
+        ENUM_ENTRY to KtEnumEntry::class.java,
+        ESCAPE_STRING_TEMPLATE_ENTRY to KtEscapeStringTemplateEntry::class.java,
+        FILE to KtFile::class.java,
+        FINALLY to KtFinallySection::class.java,
+        FOR to KtForExpression::class.java,
+        FUNCTION_TYPE to KtFunctionType::class.java,
+        IF to KtIfExpression::class.java,
+        IMPORT_ALIAS to KtImportAlias::class.java,
+        IMPORT_DIRECTIVE to KtImportDirective::class.java,
+        IMPORT_LIST to KtImportList::class.java,
+        INITIALIZER_LIST to KtInitializerList::class.java,
+        IS_EXPRESSION to KtIsExpression::class.java,
+        LABELED_EXPRESSION to KtLabeledExpression::class.java,
+        LAMBDA_EXPRESSION to KtLambdaExpression::class.java,
+        LITERAL_STRING_TEMPLATE_ENTRY to KtLiteralStringTemplateEntry::class.java,
+        LONG_STRING_TEMPLATE_ENTRY to KtBlockStringTemplateEntry::class.java,
+        MODIFIER_LIST to KtModifierList::class.java,
+        NULLABLE_TYPE to KtNullableType::class.java,
+        OBJECT_DECLARATION to KtObjectDeclaration::class.java,
+        OBJECT_LITERAL to KtObjectLiteralExpression::class.java,
+        PACKAGE_DIRECTIVE to KtPackageDirective::class.java,
+        PARENTHESIZED to KtParenthesizedExpression::class.java,
+        POSTFIX_EXPRESSION to KtPostfixExpression::class.java,
+        PREFIX_EXPRESSION to KtPrefixExpression::class.java,
+        PRIMARY_CONSTRUCTOR to KtPrimaryConstructor::class.java,
+        PROPERTY to KtProperty::class.java,
+        PROPERTY_ACCESSOR to KtPropertyAccessor::class.java,
+        PROPERTY_DELEGATE to KtPropertyDelegate::class.java,
+        REFERENCE_EXPRESSION to KtReferenceExpression::class.java,
+        SAFE_ACCESS_EXPRESSION to KtSafeQualifiedExpression::class.java,
+        SCRIPT to KtScript::class.java,
+        SCRIPT_INITIALIZER to KtScriptInitializer::class.java,
+        SECONDARY_CONSTRUCTOR to KtSecondaryConstructor::class.java,
+        SHORT_STRING_TEMPLATE_ENTRY to KtSimpleNameStringTemplateEntry::class.java,
+        STRING_TEMPLATE to KtStringTemplateExpression::class.java,
+        SUPER_EXPRESSION to KtSuperExpression::class.java,
+        SUPER_TYPE_CALL_ENTRY to KtSuperTypeCallEntry::class.java,
+        SUPER_TYPE_ENTRY to KtSuperTypeEntry::class.java,
+        SUPER_TYPE_LIST to KtSuperTypeList::class.java,
+        THIS_EXPRESSION to KtThisExpression::class.java,
+        THROW to KtThrowExpression::class.java,
+        TRY to KtTryExpression::class.java,
+        TYPE_ARGUMENT_LIST to KtTypeArgumentList::class.java,
+        TYPE_CONSTRAINT to KtTypeConstraint::class.java,
+        TYPE_CONSTRAINT_LIST to KtTypeConstraintList::class.java,
+        TYPE_PARAMETER to KtTypeParameter::class.java,
+        TYPE_PARAMETER_LIST to KtTypeParameterList::class.java,
+        TYPE_PROJECTION to KtTypeProjection::class.java,
+        TYPE_REFERENCE to KtTypeReference::class.java,
+        TYPEALIAS to KtTypeAlias::class.java,
+        USER_TYPE to KtUserType::class.java,
+        VALUE_ARGUMENT to KtValueArgument::class.java,
+        VALUE_ARGUMENT_LIST to KtValueArgumentList::class.java,
+        VALUE_PARAMETER to KtParameter::class.java,
+        VALUE_PARAMETER_LIST to KtParameterList::class.java,
+        WHEN to KtWhenExpression::class.java,
+        WHEN_CONDITION_IN_RANGE to KtWhenConditionInRange::class.java,
+        WHEN_CONDITION_IS_PATTERN to KtWhenConditionIsPattern::class.java,
+        WHEN_CONDITION_WITH_EXPRESSION to KtWhenConditionWithExpression::class.java,
+        WHEN_ENTRY to KtWhenEntry::class.java,
+        WHILE to KtWhileExpression::class.java,
+    )

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleKtTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/RuleKtTest.kt
@@ -1,26 +1,11 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
-import com.pinterest.ktlint.rule.engine.api.Code
-import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
-import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtScript
-import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.KtWhenExpression
-import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.reflect.KFunction1
 
 class RuleKtTest {
     @Test
@@ -57,48 +42,9 @@ class RuleKtTest {
         assertThat(rule.ruleId.ruleSetId.value).isEqualTo(ruleSetId)
     }
 
-    @Test
-    fun `Dispatch to IfExpression`() {
-        val rule = object : KtElementRule() {
-            override fun beforeIfExpression(
-                ktIfExpression: KtIfExpression,
-                autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
-            ) {
-                emit(ktIfExpression.startOffset, "Found if expression", false)
-            }
-        }
-
-        val code =
-            """
-            fun foo() {
-                if (true) {
-                    println("foo")
-                }
-            }
-            """.trimIndent()
-
-        assertThat(rule.lint(code)).containsExactly("Found if expression")
-    }
-
     private fun creatRule(ruleId: String) =
         object : Rule(
             ruleId = RuleId(ruleId),
             about = About(),
         ) {}
-
-    private open class KtElementRule : Rule(
-        ruleId = RuleId("test:kt-element"),
-        about = About()
-    )
-
-    private fun KtElementRule.lint(code: String): List<String> {
-        val details = mutableListOf<String>()
-        KtLintRuleEngine(
-            ruleProviders = setOf(RuleProvider { this }),
-        ).lint(Code.fromSnippet(code)) { lintError ->
-            details.add(lintError.detail)
-        }
-        return details.toList()
-    }
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -139,7 +139,7 @@ internal class RuleExecutionContext private constructor(
                 }
         }
         suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit ->
-            rule.afterVisitChildNodes(node, autoCorrect, emit)
+            rule.afterNode(node, autoCorrect, emit)
         }
     }
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -122,7 +122,7 @@ internal class RuleExecutionContext private constructor(
         suppressHandler: SuppressHandler,
     ) {
         suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit ->
-            rule.beforeVisitChildNodes(node, autoCorrect, emit)
+            rule.beforeNode(node, autoCorrect, emit)
         }
         if (rule.shouldContinueTraversalOfAST()) {
             node


### PR DESCRIPTION
## Description

This PR aimed to provide a convenience API for rule providers comparable to [Kotlin compiler's KtVisitorVoid](https://github.com/JetBrains/kotlin/blob/master/compiler/psi/src/org/jetbrains/kotlin/psi/KtVisitorVoid.java). The basic idea to implement this is described in [this comment](https://github.com/pinterest/ktlint/issues/1984#issuecomment-1651842809).

A generator script has been written to generate all boilerplate code based on a mapping between ktlint's ElementType and the methods in KtVisitorVoid. Although most methods of that visitor could be mapped to an ElementType, this was not possible for methods below:
- visitAnonymousInitializer
- visitClassOrObject
- visitConstantExpression
- visitDeclaration
- visitDoubleColonExpression
- visitExpression
- visitExpressionWithLabel
- visitIntersectionType
- visitKtElement
- visitLoopExpression
- visitNamedDeclaration
- visitNamedFunction
- visitQualifiedExpression
- visitSelfType
- visitSimpleNameExpression
- visitStringTemplateEntry
- visitStringTemplateEntryWithExpression
- visitSuperTypeListEntry
- visitUnaryExpression

Providing unit tests to validate the new  rule functions is a lot of work to get full coverage and has been skipped in this PR for now.

The NodeVisitor generator script has to be started manually. The generator code is about 600 lines of code which is manageable. In total the generated code for the Rule base class (`NodeVisitor`) and two accompanying interfaces (`BeforeNodeVisitor` and `AfterNodeVisitor`) is in total 3200 lines of code. Via the Rule base class and the interfaces, each Rule gets 88 overridable functions as alternative for `beforeVisitChildNodes` and 88 overridable functions as alternative for `afterVisitChildNodes`.
![Screenshot 2023-07-30 at 17 22 26](https://github.com/pinterest/ktlint/assets/5195292/810f48f0-41a2-4b08-8529-4c43a5451b7d). I doubt whether this makes it easier for developers of rules to understand.

Biggest problem at this moment is a *severe* performance penalty when using the generated NodeVisitor's. When running `ktlintFormat` on Ktlint's own code base on my local machine, the performance was up to 15 times slower than before:
* 3 consecutive runs on `master` branch:
    * 30 seconds -> https://scans.gradle.com/s/zaggzx72jiprw
    * 12 seconds -> https://gradle.com/s/rlkryshigxtji
    * 9 seconds -> https://gradle.com/s/gkor5svo6kc4i
* 3 consecutive runs on `1984-convenience-api` branch:
    * 2m33 seconds -> https://gradle.com/s/cj2ofnex4cjpu
    * 2m39 seconds -> https://gradle.com/s/2bfxvtxw3p76g
    * 2m45 seconds -> https://gradle.com/s/vu3qpcprsdntc

I consider the benefits for rule developers quite low when comparing it is the performance downgrade for users. As of that this PR should not be merged.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
