### PR TITLE
Remove references to `0.49` when applicable

### DIFF
--- a/documentation/release-latest/docs/api/custom-integration.md
+++ b/documentation/release-latest/docs/api/custom-integration.md
@@ -1,8 +1,5 @@
 # Custom integration
 
-!!! warning
-    This page is based on Ktlint `0.49.x` which has to be released. Most concepts are also applicable for `0.48.x`.  
-
 ## Ktlint Rule Engine
 
 The `Ktlint Rule Engine` is the central entry point for custom integrations with the `Ktlint API`. See [basic API Consumer](https://github.com/pinterest/ktlint/blob/master/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt) for a basic example on how to invoke the `Ktlint Rule Engine`. This example also explains how the logging of the `Ktlint Rule Engine` can be configured to your needs.

--- a/documentation/release-latest/docs/faq.md
+++ b/documentation/release-latest/docs/faq.md
@@ -73,7 +73,7 @@ When using Ktlint CLI, you may pass a list of disabled rules via the `--disabled
 
 ## Why is `.editorconfig` property `disabled_rules` deprecated and how do I resolve this?
 
-The `.editorconfig` properties `disabled_rules` and `ktlint_disabled_rules` are deprecated as of KtLint version `0.48` and are removed in version `0.49`. Those properties contain a comma separated list of rules which are disabled. Using a comma separated list of values has some disadvantages.
+The `.editorconfig` properties `disabled_rules` and `ktlint_disabled_rules` have been removed in version `0.49`. Those properties contain a comma separated list of rules which are disabled. Using a comma separated list of values has some disadvantages.
 
 A big disadvantage is that it is not possible to override the property partially in an `.editorconfig` file in a subpackage. Another disadvantage is that it is not possible to express explicitly that a rule is enabled. Lastly, (qualified) rule ids can be 20 characters or longer, which makes a list with multiple entries hard to read.
 
@@ -146,7 +146,7 @@ kotlinFile.writeText(
 
 # Are formatter tags respected?
 
-As of version `0.49.x` the formatter tags of IntelliJ IDEA are respected. By default, those formatter tags are disabled. The formatter tags can be enabled with `.editorconfig` properties below:
+The formatter tags of IntelliJ IDEA are respected. By default, those formatter tags are disabled. The formatter tags can be enabled with `.editorconfig` properties below:
 ```editorconfig
 ij_formatter_tags_enabled = true # Defaults to 'false'
 ij_formatter_off_tag = some-custom-off-tag # Defaults to '@formatter:off'

--- a/documentation/release-latest/docs/rules/code-styles.md
+++ b/documentation/release-latest/docs/rules/code-styles.md
@@ -1,4 +1,4 @@
-In ktlint `0.49` the new code style `ktlint_official` is introduced. This code style is work in progress but will become the default code style in the `1.0` release. Please try out the new code style and provide your feedback via the [issue tracker](https://github.com/pinterest/ktlint/issues).
+The code style `ktlint_official` is first introduced in version `0.49`. This code style is work in progress but will become the default code style in the `1.0` release. Please try out the new code style and provide your feedback via the [issue tracker](https://github.com/pinterest/ktlint/issues).
 
 ```ini
 [*.{kt,kts}]
@@ -12,6 +12,6 @@ This `ktlint_official` code style combines the best elements from the [Kotlin Co
 
 The existing code styles have been renamed to make more clear what the basis of the code style is.
 
-* The `official` code style has been renamed to `intellij_idea`. Code formatted with this code style aims to be compatible with default formatter of IntelliJ IDEA. This code style is based on [Kotlin Coding conventions](https://kotlinlang.org/docs/coding-conventions.html). If `.editorconfig` property `ktlint_code_style` has been set to `official` then do not forget to change the value of that property to `intellij_idea`. When not set, this is still the default code style of ktlint `0.49`. Be aware that the default code style will be changed to `ktlint_official` in the `1.0` release.
+* The `official` code style has been renamed to `intellij_idea`. Code formatted with this code style aims to be compatible with default formatter of IntelliJ IDEA. This code style is based on [Kotlin Coding conventions](https://kotlinlang.org/docs/coding-conventions.html). If `.editorconfig` property `ktlint_code_style` has been set to `official` then do not forget to change the value of that property to `intellij_idea`. When not set, this is the default code style. Be aware that the default code style will be changed to `ktlint_official` in the `1.0` release.
 
 * Code style `android` has been renamed to `android_studio`. Code formatted with this code style aims to be compatible with default formatter of Android Studio. This code style is based on [Android's Kotlin styleguide](https://developer.android.com/kotlin/style-guide). If `.editorconfig` property `ktlint_code_style` has been set to `android` then do not forget to change the value of that property to `android_studio`.

--- a/documentation/release-latest/docs/rules/configuration-ktlint.md
+++ b/documentation/release-latest/docs/rules/configuration-ktlint.md
@@ -18,9 +18,6 @@ ktlint_code_style = ktlint_official
 
 ## Disabled rules
 
-!!! note
-    Support of properties `disabled_rules` and `ktlint_disabled_rules` has been removed in KtLint `0.49`.
-
 Rule sets and individual rules can be disabled / enabled with a separate property per rule (set).
 
 All rules in a rule set can be enabled or disabled with a rule set property. The name of the rule set property consists of the `ktlint_` prefix followed by the rule set id. Examples:

--- a/documentation/snapshot/docs/api/custom-integration.md
+++ b/documentation/snapshot/docs/api/custom-integration.md
@@ -1,8 +1,5 @@
 # Custom integration
 
-!!! warning
-    This page is based on Ktlint `0.49.x` which has to be released. Most concepts are also applicable for `0.48.x`.  
-
 ## Ktlint Rule Engine
 
 The `Ktlint Rule Engine` is the central entry point for custom integrations with the `Ktlint API`. See [basic API Consumer](https://github.com/pinterest/ktlint/blob/master/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt) for a basic example on how to invoke the `Ktlint Rule Engine`. This example also explains how the logging of the `Ktlint Rule Engine` can be configured to your needs.

--- a/documentation/snapshot/docs/rules/code-styles.md
+++ b/documentation/snapshot/docs/rules/code-styles.md
@@ -1,4 +1,4 @@
-In ktlint `0.49` the new code style `ktlint_official` is introduced. This code style is work in progress but will become the default code style in the `1.0` release. Please try out the new code style and provide your feedback via the [issue tracker](https://github.com/pinterest/ktlint/issues).
+The code style `ktlint_official` is first introduced in version `0.49`. This code style is work in progress but will become the default code style in the `1.0` release. Please try out the new code style and provide your feedback via the [issue tracker](https://github.com/pinterest/ktlint/issues).
 
 ```ini
 [*.{kt,kts}]
@@ -12,6 +12,6 @@ This `ktlint_official` code style combines the best elements from the [Kotlin Co
 
 The existing code styles have been renamed to make more clear what the basis of the code style is.
 
-* The `official` code style has been renamed to `intellij_idea`. Code formatted with this code style aims to be compatible with default formatter of IntelliJ IDEA. This code style is based on [Kotlin Coding conventions](https://kotlinlang.org/docs/coding-conventions.html). If `.editorconfig` property `ktlint_code_style` has been set to `official` then do not forget to change the value of that property to `intellij_idea`. When not set, this is still the default code style of ktlint `0.49`. Be aware that the default code style will be changed to `ktlint_official` in the `1.0` release.
+* The `official` code style has been renamed to `intellij_idea`. Code formatted with this code style aims to be compatible with default formatter of IntelliJ IDEA. This code style is based on [Kotlin Coding conventions](https://kotlinlang.org/docs/coding-conventions.html). If `.editorconfig` property `ktlint_code_style` has been set to `official` then do not forget to change the value of that property to `intellij_idea`. When not set, this is the default code style. Be aware that the default code style will be changed to `ktlint_official` in the `1.0` release.
 
 * Code style `android` has been renamed to `android_studio`. Code formatted with this code style aims to be compatible with default formatter of Android Studio. This code style is based on [Android's Kotlin styleguide](https://developer.android.com/kotlin/style-guide). If `.editorconfig` property `ktlint_code_style` has been set to `android` then do not forget to change the value of that property to `android_studio`.

--- a/documentation/snapshot/docs/rules/configuration-ktlint.md
+++ b/documentation/snapshot/docs/rules/configuration-ktlint.md
@@ -18,9 +18,6 @@ ktlint_code_style = ktlint_official
 
 ## Disabled rules
 
-!!! note
-    Support of properties `disabled_rules` and `ktlint_disabled_rules` has been removed in KtLint `0.49`.
-
 Rule sets and individual rules can be disabled / enabled with a separate property per rule (set).
 
 All rules in a rule set can be enabled or disabled with a rule set property. The name of the rule set property consists of the `ktlint_` prefix followed by the rule set id. Examples:


### PR DESCRIPTION
## Description

As documentation is now version specific, some reference to version `0.49` are no longer needed.

Closes #2154

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
