### PR TITLE
Remove install overview page

### DIFF
--- a/documentation/release-latest/docs/install/overview.md
+++ b/documentation/release-latest/docs/install/overview.md
@@ -1,6 +1,0 @@
-See [command line interface](cli.md) or [integrations](integrations.md) for details on installing the latest release of `ktlint`.
-
-## Online demo
-
-See [`ktlint` online](https://saveourtool.com/#/demo/diktat) if you want to try-out 'ktlint'. This online version compares rule sets provided by `ktlint` and `diktat` (a layer on top of `ktlint`). To contribute to or get more info about `ktlint` online, please visit the [GitHub repository](https://github.com/saveourtool/diktat-demo).
-

--- a/documentation/release-latest/mkdocs.yml
+++ b/documentation/release-latest/mkdocs.yml
@@ -40,7 +40,6 @@ theme:
 nav:
   - Home: index.md
   - Installation:
-    - Overview: install/overview.md
     - Command line: install/cli.md
     - Integrations: install/integrations.md
 #    - API: install/api.md  TODO: properly document

--- a/documentation/snapshot/docs/install/overview.md
+++ b/documentation/snapshot/docs/install/overview.md
@@ -1,6 +1,0 @@
-See [command line interface](cli.md) or [integrations](integrations.md) for details on installing the latest release of `ktlint`.
-
-## Online demo
-
-See [`ktlint` online](https://saveourtool.com/#/demo/diktat) if you want to try-out 'ktlint'. This online version compares rule sets provided by `ktlint` and `diktat` (a layer on top of `ktlint`). To contribute to or get more info about `ktlint` online, please visit the [GitHub repository](https://github.com/saveourtool/diktat-demo).
-

--- a/documentation/snapshot/mkdocs.yml
+++ b/documentation/snapshot/mkdocs.yml
@@ -40,7 +40,6 @@ theme:
 nav:
   - Home: index.md
   - Installation:
-    - Overview: install/overview.md
     - Command line: install/cli.md
     - Integrations: install/integrations.md
 #    - API: install/api.md  TODO: properly document


### PR DESCRIPTION
## Description

The online version to compare ktlint and diktat is no longer available. The project (https://github.com/saveourtool/diktat-demo) has been archived since June 8th, 2023.

Closes #2169

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
