### PR TITLE
Fix alignment of type constraints after `where` keyword in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Store relative path of file in baseline file [#2146](https://github.com/pinterest/ktlint/issues/2146)
 * Fix null pointer exception for if-else statement with empty THEN block `if-else-bracing` [#2135](https://github.com/pinterest/ktlint/issues/2135)
 * Do not wrap a single line enum class `statement-wrapping` [#2177](https://github.com/pinterest/ktlint/issues/2177)
+* Fix alignment of type constraints after `where` keyword in function signature `indent` [#2175](https://github.com/pinterest/ktlint/issues/2175)
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -2641,6 +2641,71 @@ internal class IndentationRuleTest {
             .isFormattedAs(formattedCode)
     }
 
+    @Nested
+    inner class `Issue 2175 - Given a function using the WHERE keyword` {
+        @Test
+        fun `Issue 2175 - Given a function without return type but with WHERE`() {
+            val code =
+                """
+                fun <TFeature, TValidated> applyToAllCloseFeaturesWithUiFlow(
+                    thisFeature: TFeature,
+                    allFeaturesOfThisKind: List<TFeature>,
+                    optionsToApply: TValidated,
+                // .. more parameters
+                ) where TFeature : Clusterable,
+                    TFeature : SupportsExternalObjectCoordinates<out Options<out Options.Validated>, out Options.Validated, *>,
+                    TValidated : Options.Validated {
+                    // do something
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun <TFeature, TValidated> applyToAllCloseFeaturesWithUiFlow(
+                    thisFeature: TFeature,
+                    allFeaturesOfThisKind: List<TFeature>,
+                    optionsToApply: TValidated,
+                // .. more parameters
+                ) where TFeature : Clusterable,
+                        TFeature : SupportsExternalObjectCoordinates<out Options<out Options.Validated>, out Options.Validated, *>,
+                        TValidated : Options.Validated {
+                    // do something
+                }
+                """.trimIndent()
+            indentationRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(7, 1, "Unexpected indentation (4) (should be 8)"),
+                    LintViolation(8, 1, "Unexpected indentation (4) (should be 8)"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Issue 2175 - Given a function with return type and WHERE on separate lines`() {
+            val code =
+                """
+                fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                    where T : CharSequence,
+                          T : Comparable<T> {
+                    return list.filter { it > threshold }.map { it.toString() }
+                }
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2175 - Given a function with return type and WHERE on same line`() {
+            val code =
+                """
+                fun <T> copyWhenGreater(
+                    list: List<T>, threshold: T
+                ): List<String> where T : CharSequence,
+                                      T : Comparable<T> {
+                    return list.filter { it > threshold }.map { it.toString() }
+                }
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+    }
+
     @Test // "https://github.com/pinterest/ktlint/issues/433"
     fun `Given a parameter list in which parameters are prefixed with a comment block`() {
         val code =


### PR DESCRIPTION
## Description

Fix alignment of type constraints after `where` keyword in function signature

Closes #2175

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
