### PR TITLE
Fix wrapping of multiline postfix expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Fix null pointer exception for if-else statement with empty THEN block `if-else-bracing` [#2135](https://github.com/pinterest/ktlint/issues/2135)
 * Do not wrap a single line enum class `statement-wrapping` [#2177](https://github.com/pinterest/ktlint/issues/2177)
 * Fix alignment of type constraints after `where` keyword in function signature `indent` [#2175](https://github.com/pinterest/ktlint/issues/2175)
+* Fix wrapping of multiline postfix expression `multiline-expression-wrapping` [#2183](https://github.com/pinterest/ktlint/issues/2183)
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -581,10 +581,11 @@ public class IndentationRule :
             node.prevSibling { it.isWhiteSpaceWithNewline() } == null &&
             node == node.treeParent.findChildByType(VALUE_PARAMETER)
         ) {
-            nextToAstNode = startIndentContext(
-                fromAstNode = fromAstNode,
-                toAstNode = nextToAstNode,
-            ).fromASTNode.prevLeaf { !it.isWhiteSpace() }!!
+            nextToAstNode =
+                startIndentContext(
+                    fromAstNode = fromAstNode,
+                    toAstNode = nextToAstNode,
+                ).fromASTNode.prevLeaf { !it.isWhiteSpace() }!!
         } else {
             startIndentContext(
                 fromAstNode = node,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
@@ -15,6 +15,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
@@ -180,6 +181,7 @@ public class MultilineExpressionWrappingRule :
                 IS_EXPRESSION,
                 OBJECT_LITERAL,
                 PREFIX_EXPRESSION,
+                POSTFIX_EXPRESSION,
                 REFERENCE_EXPRESSION,
                 SAFE_ACCESS_EXPRESSION,
                 TRY,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -210,23 +210,24 @@ public class WrappingRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val rElementType = MATCHING_RTOKEN_MAP[node.elementType]
+        val closingElementType = MATCHING_RTOKEN_MAP[node.elementType]
         var newlineInBetween = false
         var parameterListInBetween = false
         var numberOfArgs = 0
         var firstArg: ASTNode? = null
         // matching ), ] or }
-        val r = node.nextSibling {
-            val isValueArgument = it.elementType == VALUE_ARGUMENT
-            val hasLineBreak = if (isValueArgument) it.hasLineBreak(LAMBDA_EXPRESSION, FUN) else it.hasLineBreak()
-            newlineInBetween = newlineInBetween || hasLineBreak
-            parameterListInBetween = parameterListInBetween || it.elementType == VALUE_PARAMETER_LIST
-            if (isValueArgument) {
-                numberOfArgs++
-                firstArg = it
-            }
-            it.elementType == rElementType
-        }!!
+        val closingElement =
+            node.nextSibling {
+                val isValueArgument = it.elementType == VALUE_ARGUMENT
+                val hasLineBreak = if (isValueArgument) it.hasLineBreak(LAMBDA_EXPRESSION, FUN) else it.hasLineBreak()
+                newlineInBetween = newlineInBetween || hasLineBreak
+                parameterListInBetween = parameterListInBetween || it.elementType == VALUE_PARAMETER_LIST
+                if (isValueArgument) {
+                    numberOfArgs++
+                    firstArg = it
+                }
+                it.elementType == closingElementType
+            }!!
         if (
             !newlineInBetween ||
             // keep { p ->
@@ -279,8 +280,8 @@ public class WrappingRule :
         ) {
             requireNewlineAfterLeaf(node, autoCorrect, emit)
         }
-        if (!r.prevLeaf().isWhiteSpaceWithNewline()) {
-            requireNewlineBeforeLeaf(r, autoCorrect, emit, indentConfig.parentIndentOf(node))
+        if (!closingElement.prevLeaf().isWhiteSpaceWithNewline()) {
+            requireNewlineBeforeLeaf(closingElement, autoCorrect, emit, indentConfig.parentIndentOf(node))
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
@@ -793,4 +793,23 @@ class MultilineExpressionWrappingRuleTest {
             .addAdditionalRuleProvider { IndentationRule() }
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2183 - Given a multiline postfix expression then reformat`() {
+        val code =
+            """
+            val foobar = foo!!
+                .bar()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foobar =
+                foo!!
+                    .bar()
+            """.trimIndent()
+        multilineExpressionWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolation(1, 14, "A multiline expression should start on a new line")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Fix wrapping of multiline postfix expression

Closes #2183

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
