### PR TITLE
Fix compiler warnings

### DIFF
--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
@@ -21,7 +21,7 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
  * This example uses 'slf4j-simple' as logging provider. But any logging provider that implements SLF4J API can be used depending on your
  * needs.
  */
-public fun main(args: Array<String>) {
+public fun main() {
     // The KtLint RuleEngine only needs to be instantiated once and can be reused in multiple invocations
     val ktLintRuleEngine =
         KtLintRuleEngine(

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitHookInstaller.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitHookInstaller.kt
@@ -9,6 +9,7 @@ import java.security.MessageDigest
 
 private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
+private const val DEFAULT_GIT_DIR = ".git"
 private const val DEFAULT_GIT_HOOKS_DIR = "hooks"
 
 internal object GitHookInstaller {
@@ -56,18 +57,16 @@ internal object GitHookInstaller {
     private fun getGitDir(): File {
         val gitDir =
             try {
-                val root =
-                    Runtime
-                        .getRuntime()
-                        .exec("git rev-parse --show-toplevel")
-                        .inputStream
-                        .bufferedReader()
-                        .readText()
-                        .trim()
-
-                File(root).resolve(".git")
+                with(ProcessBuilder("git", "rev-parse", "--show-toplevel").start()) {
+                    val rootDir =
+                        inputStream
+                            .bufferedReader()
+                            .readLine()
+                    waitFor()
+                    File(rootDir ?: DEFAULT_GIT_DIR).resolve(".git")
+                }
             } catch (_: IOException) {
-                File(".git")
+                File(DEFAULT_GIT_DIR)
             }
         if (!gitDir.isDirectory) {
             throw IOException(".git directory not found. Are you sure you are inside project directory?")
@@ -78,14 +77,17 @@ internal object GitHookInstaller {
 
     private fun getHooksDirName() =
         try {
-            Runtime
-                .getRuntime()
-                .exec("git config --get core.hooksPath")
-                .inputStream
-                .bufferedReader()
-                .readText()
-                .trim()
-                .ifEmpty { DEFAULT_GIT_HOOKS_DIR }
+            with(ProcessBuilder("git", "config", "--get", "core.hooksPath").start()) {
+                val hooksDir =
+                    inputStream
+                        .bufferedReader()
+                        .readLine()
+                waitFor()
+                hooksDir
+                    ?.trim()
+                    .orEmpty()
+                    .ifEmpty { DEFAULT_GIT_HOOKS_DIR }
+            }
         } catch (_: IOException) {
             DEFAULT_GIT_HOOKS_DIR
         }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -157,7 +157,7 @@ class CommandLineTestRunner(
 
                 addAll(arguments)
             }.joinToString(separator = " ")
-            .also { LOGGER.debug("Command to be executed: $it") }
+            .also { LOGGER.debug { "Command to be executed: $it" } }
 
     private fun String?.javaVersionAsInt(): Int? {
         if (this == null) {

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/SafeEnumValueParser.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/SafeEnumValueParser.kt
@@ -15,10 +15,10 @@ import java.util.Locale
  * @param <T> the type of the value <T>
  *
  */
-internal class SafeEnumValueParser<T : Enum<*>?>(
-    enumType: Class<out T?>,
+internal class SafeEnumValueParser<T : Enum<T>>(
+    enumType: Class<T>,
 ) : PropertyValueParser<T> {
-    private val enumType: Class<out Enum<*>?>
+    private val enumType: Class<T>
 
     init {
         this.enumType = enumType
@@ -29,7 +29,7 @@ internal class SafeEnumValueParser<T : Enum<*>?>(
         value: String?,
     ): PropertyType.PropertyValue<T> =
         if (value == null) {
-            PropertyType.PropertyValue.invalid(null, "Cannot make enum " + enumType.name + " out of null")
+            PropertyType.PropertyValue.invalid(null, "Cannot make enum ${enumType.name} out of null")
         } else {
             try {
                 PropertyType.PropertyValue.valid(

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -219,7 +219,7 @@ public class KtLintRuleEngine(
         } else {
             formattedCode
         }.also {
-            LOGGER.debug("Finished with formatting file '${code.fileNameOrStdin()}'")
+            LOGGER.debug { "Finished with formatting file '${code.fileNameOrStdin()}'" }
         }
     }
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -185,16 +185,11 @@ public class KtLintRuleEngine(
             visitorProvider
                 .visitor()
                 .invoke { rule ->
-                    ruleExecutionContext.executeRule(rule, false) { offset, message, canBeAutoCorrected ->
-                        if (canBeAutoCorrected) {
-                            ruleExecutionContext.rebuildSuppressionLocator()
-                            val formattedCode =
-                                ruleExecutionContext
-                                    .rootNode
-                                    .text
-                                    .replace("\n", ruleExecutionContext.determineLineSeparator(code.content))
-                            val (line, col) = ruleExecutionContext.positionInTextLocator(offset)
-                            hasErrorsWhichCanBeAutocorrected = true
+                    if (!hasErrorsWhichCanBeAutocorrected) {
+                        ruleExecutionContext.executeRule(rule, false) { _, _, canBeAutoCorrected ->
+                            if (canBeAutoCorrected) {
+                                hasErrorsWhichCanBeAutocorrected = true
+                            }
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -423,12 +423,13 @@ class FunctionLiteralRuleTest {
                     .bar()
                     .foobar()
             }
-            val foo = bar
-                .filter { it > 2 }!!
-                .takeIf {
-                    it.count() > 100
-                }.map { it * it }
-                ?.sum()!!
+            val foo =
+                bar
+                    .filter { it > 2 }!!
+                    .takeIf {
+                        it.count() > 100
+                    }.map { it * it }
+                    ?.sum()!!
             """.trimIndent()
         functionLiteralRuleAssertThat(code)
             .addAdditionalRuleProvider { MultilineExpressionWrappingRule() }


### PR DESCRIPTION
## Description

Fix compiler warnings except warning below which will be resolved when migrating to Kotlin 1.9:
```
KotlinPsiFileFactory.kt:137:41 'getRootArea(): ExtensionsArea!' is deprecated. Deprecated in Java
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
