### PR TITLE
Multiline function literal with single statement

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,13 +1,9 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-plugins {
-    `kotlin-dsl`
-}
+plugins { `kotlin-dsl` }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 kotlin {
     jvmToolchain(
@@ -24,9 +20,7 @@ kotlin {
 //  build-logic is an internal project and given we know how the "actual" project is built - it's fine to target current java here as well.
 //  @see https://github.com/pinterest/ktlint/pull/2120#discussion_r1260229055 for more details
 val buildLogicTargetJavaVersion = JavaVersion.VERSION_17
-tasks.withType<JavaCompile>().configureEach {
-    options.release.set(buildLogicTargetJavaVersion.majorVersion.toInt())
-}
+tasks.withType<JavaCompile>().configureEach { options.release.set(buildLogicTargetJavaVersion.majorVersion.toInt()) }
 tasks.withType<KotlinCompile>().configureEach {
     // Convert Java version (e.g. "1.8" or "11") to Kotlin JvmTarget ("8" resp. "11")
     compilerOptions.jvmTarget.set(JvmTarget.fromTarget(buildLogicTargetJavaVersion.toString()))

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,11 +1,6 @@
 dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) }
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
-}
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0" }

--- a/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -16,9 +16,7 @@ kotlin {
     jvmToolchain(jdkVersion = javaCompilationVersion.asInt())
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    options.release.set(javaTargetVersion.asInt())
-}
+tasks.withType<JavaCompile>().configureEach { options.release.set(javaTargetVersion.asInt()) }
 tasks.withType<KotlinCompile>().configureEach {
     // Convert Java version (e.g. "1.8" or "11") to Kotlin JvmTarget ("8" resp. "11")
     compilerOptions.jvmTarget.set(JvmTarget.fromTarget(JavaVersion.toVersion(javaTargetVersion).toString()))

--- a/build-logic/src/main/kotlin/ktlint-publication-library.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication-library.gradle.kts
@@ -4,6 +4,4 @@ plugins {
     id("ktlint-publication")
 }
 
-publishing.publications.named<MavenPublication>("maven") {
-    from(components["java"])
-}
+publishing.publications.named<MavenPublication>("maven") { from(components["java"]) }

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -95,7 +95,4 @@ signing {
 }
 
 // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
-fun Project.localGradleProperty(name: String): Provider<String> =
-    provider {
-        if (hasProperty(name)) property(name)?.toString() else null
-    }
+fun Project.localGradleProperty(name: String): Provider<String> = provider { if (hasProperty(name)) property(name)?.toString() else null }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,15 +22,11 @@ val internalNonPublishableProjects by extra(
     ),
 )
 
-apiValidation {
-    ignoredProjects += internalNonPublishableProjects
-}
+apiValidation { ignoredProjects += internalNonPublishableProjects }
 
 val ktlint: Configuration by configurations.creating
 
-dependencies {
-    ktlint(projects.ktlintCli)
-}
+dependencies { ktlint(projects.ktlintCli) }
 
 tasks.register<JavaExec>("ktlintCheck") {
     group = LifecycleBasePlugin.VERIFICATION_GROUP

--- a/ktlint-api-consumer/build.gradle.kts
+++ b/ktlint-api-consumer/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-kotlin-common")
-}
+plugins { id("ktlint-kotlin-common") }
 
 dependencies {
     // Any SLF4J compatible logging framework can be used. The "slf4j-simple" logging provider is configured in file

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
@@ -56,9 +56,7 @@ public fun main() {
         """.trimIndent()
     }
     ktLintRuleEngine
-        .lint(codeFile) {
-            LOGGER.info { "LintViolation reported by KtLint: $it" }
-        }
+        .lint(codeFile) { LOGGER.info { "LintViolation reported by KtLint: $it" } }
 
     LOGGER.info {
         """
@@ -70,9 +68,7 @@ public fun main() {
     }
     ktLintRuleEngine
         .format(codeFile)
-        .also {
-            LOGGER.info { "Code formatted by KtLint:\n$it" }
-        }
+        .also { LOGGER.info { "Code formatted by KtLint:\n$it" } }
 
     LOGGER.info {
         """

--- a/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/ApiTestRunner.kt
+++ b/ktlint-api-consumer/src/test/kotlin/com/pinterest/ktlint/api/consumer/ApiTestRunner.kt
@@ -18,12 +18,13 @@ class ApiTestRunner(
     private val tempDir: Path,
 ) {
     fun prepareTestProject(testProjectName: String): Path {
-        val testProjectPath = TEST_PROJECTS_PATHS.resolve(testProjectName)
-        assert(Files.exists(testProjectPath)) {
-            "Test project $testProjectName does not exist!"
-        }
-
-        return tempDir.resolve(testProjectName).also { testProjectPath.copyRecursively(it) }
+        val testProjectPath =
+            TEST_PROJECTS_PATHS
+                .resolve(testProjectName)
+                .also { require(Files.exists(it)) { "Test project $testProjectName does not exist!" } }
+        return tempDir
+            .resolve(testProjectName)
+            .also { testProjectPath.copyRecursively(it) }
     }
 
     private fun Path.copyRecursively(dest: Path) {

--- a/ktlint-bom/build.gradle.kts
+++ b/ktlint-bom/build.gradle.kts
@@ -3,9 +3,7 @@ plugins {
     id("ktlint-publication")
 }
 
-publishing.publications.named<MavenPublication>("maven") {
-    from(components["javaPlatform"])
-}
+publishing.publications.named<MavenPublication>("maven") { from(components["javaPlatform"]) }
 
 val internalNonPublishableProjects: Set<String> by rootProject.extra
 val excludeList = internalNonPublishableProjects + "ktlint-test-ruleset-provider-v2-deprecated"

--- a/ktlint-cli-reporter-baseline/build.gradle.kts
+++ b/ktlint-cli-reporter-baseline/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintLogger)

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/Baseline.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError.Status.BASELINE_IGNORED
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.util.cast
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.w3c.dom.Element
 import org.xml.sax.SAXException
@@ -140,9 +141,7 @@ private class BaselineLoader(
         with(getElementsByTagName("error")) {
             for (i in 0 until length) {
                 ktlintCliErrorsInFileElement.add(
-                    with(item(i) as Element) {
-                        parseBaselineErrorElement()
-                    },
+                    item(i).cast<Element>().parseBaselineErrorElement(),
                 )
             }
         }

--- a/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineReporter.kt
+++ b/ktlint-cli-reporter-baseline/src/main/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineReporter.kt
@@ -34,9 +34,7 @@ public class BaselineReporter(
             val relativeFile = Paths.get(file).relativeLocation()
             out.println("""    <file name="${relativeFile.escapeXMLAttrValue()}">""")
             for (err in errList) {
-                with(err) {
-                    out.println("""        <error line="$line" column="$col" source="$ruleId" />""")
-                }
+                with(err) { out.println("""        <error line="$line" column="$col" source="$ruleId" />""") }
             }
             out.println("""    </file>""")
         }

--- a/ktlint-cli-reporter-checkstyle/build.gradle.kts
+++ b/ktlint-cli-reporter-checkstyle/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-core/build.gradle.kts
+++ b/ktlint-cli-reporter-core/build.gradle.kts
@@ -1,3 +1,1 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }

--- a/ktlint-cli-reporter-format/build.gradle.kts
+++ b/ktlint-cli-reporter-format/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProvider.kt
+++ b/ktlint-cli-reporter-format/src/main/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterProvider.kt
@@ -23,7 +23,8 @@ public class FormatReporterProvider : ReporterProviderV2<FormatReporter> {
     private fun String.emptyOrTrue() = this == "" || this == "true"
 
     private fun getColor(color: String?): Color =
-        Color.values().firstOrNull {
-            it.name == color
-        } ?: throw IllegalArgumentException("Invalid color parameter.")
+        Color
+            .entries
+            .firstOrNull { it.name == color }
+            ?: throw IllegalArgumentException("Invalid color parameter.")
 }

--- a/ktlint-cli-reporter-html/build.gradle.kts
+++ b/ktlint-cli-reporter-html/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
+++ b/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
@@ -73,10 +73,7 @@ public class HtmlReporter(
 
                     acc.forEach { (file: String, ktlintCliErrors: MutableList<KtlintCliError>) ->
                         h3 { text(file) }
-                        ul {
-                            ktlintCliErrors.forEach { err ->
-                                with(err) { item("($line, $col): $detail  ($ruleId)") }
-                            }
+                        ul { ktlintCliErrors.forEach { err -> with(err) { item("($line, $col): $detail  ($ruleId)") } }
                         }
                     }
                 } else {

--- a/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
+++ b/ktlint-cli-reporter-html/src/main/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporter.kt
@@ -67,28 +67,20 @@ public class HtmlReporter(
                 if (!acc.isEmpty()) {
                     h1 { text("Overview") }
 
-                    paragraph {
-                        text("Issues found: $issueCount")
-                    }
+                    paragraph { text("Issues found: $issueCount") }
 
-                    paragraph {
-                        text("Issues corrected: $correctedCount")
-                    }
+                    paragraph { text("Issues corrected: $correctedCount") }
 
                     acc.forEach { (file: String, ktlintCliErrors: MutableList<KtlintCliError>) ->
                         h3 { text(file) }
                         ul {
                             ktlintCliErrors.forEach { err ->
-                                with(err) {
-                                    item("($line, $col): $detail  ($ruleId)")
-                                }
+                                with(err) { item("($line, $col): $detail  ($ruleId)") }
                             }
                         }
                     }
                 } else {
-                    paragraph {
-                        text("Congratulations, no issues found!")
-                    }
+                    paragraph { text("Congratulations, no issues found!") }
                 }
             }
         }

--- a/ktlint-cli-reporter-json/build.gradle.kts
+++ b/ktlint-cli-reporter-json/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-plain-summary/build.gradle.kts
+++ b/ktlint-cli-reporter-plain-summary/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-plain-summary/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plainsummary/PlainSummaryReporter.kt
+++ b/ktlint-cli-reporter-plain-summary/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plainsummary/PlainSummaryReporter.kt
@@ -21,15 +21,9 @@ public class PlainSummaryReporter(
         ktlintCliError: KtlintCliError,
     ) {
         if (ktlintCliError.status == KtlintCliError.Status.FORMAT_IS_AUTOCORRECTED) {
-            ruleViolationCountAutocorrected
-                .merge(ktlintCliError.ruleId, 1) { previousValue, _ ->
-                    previousValue + 1
-                }
+            ruleViolationCountAutocorrected.merge(ktlintCliError.ruleId, 1) { previousValue, _ -> previousValue + 1 }
         } else {
-            ruleViolationCountNoAutocorrection
-                .merge(ktlintCliError.causedBy(), 1) { previousValue, _ ->
-                    previousValue + 1
-                }
+            ruleViolationCountNoAutocorrection.merge(ktlintCliError.causedBy(), 1) { previousValue, _ -> previousValue + 1 }
         }
     }
 
@@ -62,12 +56,9 @@ public class PlainSummaryReporter(
     private companion object {
         val COUNT_DESC_AND_RULE_ID_ASC_COMPARATOR =
             kotlin
-                .Comparator<Pair<String, Long>> { left, right ->
-                    compareValuesBy(left, right) { it.second }
-                }.reversed()
-                .thenComparator { left, right ->
-                    compareValuesBy(left, right) { it.first }
-                }
+                .Comparator<Pair<String, Long>> { left, right -> compareValuesBy(left, right) { it.second } }
+                .reversed()
+                .thenComparator { left, right -> compareValuesBy(left, right) { it.first } }
 
         const val KOTLIN_PARSE_EXCEPTION_MESSAGE = "Not a valid Kotlin file"
         const val KTLINT_RULE_ENGINE_EXCEPTION_MESSAGE = "An internal error occurred in the Ktlint Rule Engine"

--- a/ktlint-cli-reporter-plain/build.gradle.kts
+++ b/ktlint-cli-reporter-plain/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporter.kt
+++ b/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporter.kt
@@ -41,10 +41,7 @@ public class PlainReporter(
                         "${ktlintCliError.detail} ${"(${ktlintCliError.ruleId})".colored()}",
                 )
             }
-            ruleViolationCount
-                .merge(ktlintCliError.causedBy(), 1) { previousValue, _ ->
-                    previousValue + 1
-                }
+            ruleViolationCount.merge(ktlintCliError.causedBy(), 1) { previousValue, _ -> previousValue + 1 }
         }
     }
 
@@ -104,12 +101,9 @@ public class PlainReporter(
     private companion object {
         val COUNT_DESC_AND_RULE_ID_ASC_COMPARATOR =
             kotlin
-                .Comparator<Pair<String, Long>> { left, right ->
-                    compareValuesBy(left, right) { it.second }
-                }.reversed()
-                .thenComparator { left, right ->
-                    compareValuesBy(left, right) { it.first }
-                }
+                .Comparator<Pair<String, Long>> { left, right -> compareValuesBy(left, right) { it.second } }
+                .reversed()
+                .thenComparator { left, right -> compareValuesBy(left, right) { it.first } }
 
         const val KOTLIN_PARSE_EXCEPTION_MESSAGE = "Not a valid Kotlin file"
         const val KTLINT_RULE_ENGINE_EXCEPTION_MESSAGE = "An internal error occurred in the Ktlint Rule Engine"

--- a/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterProvider.kt
+++ b/ktlint-cli-reporter-plain/src/main/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterProvider.kt
@@ -21,7 +21,8 @@ public class PlainReporterProvider : ReporterProviderV2<PlainReporter> {
     private fun String.emptyOrTrue() = this == "" || this == "true"
 
     private fun getColor(colorInput: String?): Color =
-        Color.values().firstOrNull {
-            it.name == colorInput
-        } ?: throw IllegalArgumentException("Invalid color parameter.")
+        Color
+            .entries
+            .firstOrNull { it.name == colorInput }
+            ?: throw IllegalArgumentException("Invalid color parameter.")
 }

--- a/ktlint-cli-reporter-sarif/build.gradle.kts
+++ b/ktlint-cli-reporter-sarif/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintCliReporterCore)

--- a/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
+++ b/ktlint-cli-reporter-sarif/src/main/kotlin/com/pinterest/ktlint/cli/reporter/sarif/SarifReporter.kt
@@ -105,9 +105,7 @@ public class SarifReporter(
                                         ),
                                 ),
                             originalURIBaseIDS =
-                                workingDirectory?.let {
-                                    mapOf(SRCROOT to ArtifactLocation(uri = "file://${it.path.sanitize()}"))
-                                },
+                                workingDirectory?.let { mapOf(SRCROOT to ArtifactLocation(uri = "file://${it.path.sanitize()}")) },
                             results = results,
                         ),
                     ),

--- a/ktlint-cli-ruleset-core/build.gradle.kts
+++ b/ktlint-cli-ruleset-core/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
-dependencies {
-    api(projects.ktlintRuleEngineCore)
-}
+dependencies { api(projects.ktlintRuleEngineCore) }

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -111,9 +111,10 @@ val shadowJarExecutable by tasks.registering(DefaultTask::class) {
         }
         if (isReleaseBuild) {
             logger.lifecycle("Creating the batch file for Windows OS: $windowsBatchFileOutputPath")
-            File(windowsBatchFileOutputPath).apply {
-                writeText(File(windowsBatchFileInputPath).readText())
-            }
+            File(windowsBatchFileOutputPath)
+                .writeText(
+                    File(windowsBatchFileInputPath).readText()
+                )
         }
         logger.lifecycle("Finished creating output files ktlint-cli")
     }

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -15,9 +15,7 @@ tasks.jar {
     }
 }
 
-tasks.shadowJar {
-    mergeServiceFiles()
-}
+tasks.shadowJar { mergeServiceFiles() }
 
 dependencies {
     implementation(projects.ktlintLogger)
@@ -113,7 +111,7 @@ val shadowJarExecutable by tasks.registering(DefaultTask::class) {
             logger.lifecycle("Creating the batch file for Windows OS: $windowsBatchFileOutputPath")
             File(windowsBatchFileOutputPath)
                 .writeText(
-                    File(windowsBatchFileInputPath).readText()
+                    File(windowsBatchFileInputPath).readText(),
                 )
         }
         logger.lifecycle("Finished creating output files ktlint-cli")

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -209,25 +209,19 @@ private fun FileSystem.toGlob(
             if (resolvedPath.isDirectory()) {
                 resolvedPath
                     .expandPathToDefaultPatterns()
-                    .also {
-                        LOGGER.trace { "Expanding resolved directory path '$resolvedPath' to patterns: [$it]" }
-                    }
+                    .also { LOGGER.trace { "Expanding resolved directory path '$resolvedPath' to patterns: [$it]" } }
             } else {
                 resolvedPath
                     .pathString
                     .expandDoubleStarPatterns()
-                    .also {
-                        LOGGER.trace { "Expanding resolved path '$resolvedPath` to patterns: [$it]" }
-                    }
+                    .also { LOGGER.trace { "Expanding resolved path '$resolvedPath` to patterns: [$it]" } }
             }
         } catch (e: InvalidPathException) {
             if (onWindowsOS) {
                 //  Windows throws an exception when passing a wildcard (*) to Path#resolve.
                 pathWithoutNegationPrefix
                     .expandDoubleStarPatterns()
-                    .also {
-                        LOGGER.trace { "On WindowsOS: expanding unresolved path '$pathWithoutNegationPrefix` to patterns: [$it]" }
-                    }
+                    .also { LOGGER.trace { "On WindowsOS: expanding unresolved path '$pathWithoutNegationPrefix` to patterns: [$it]" } }
             } else {
                 emptyList()
             }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -620,9 +620,7 @@ internal class KtlintCommandLine {
 
         return String(System.`in`.readBytes())
             .split(delimiter)
-            .let { patterns: List<String> ->
-                patterns.filterTo(LinkedHashSet(patterns.size), String::isNotEmpty)
-            }
+            .let { patterns -> patterns.filterTo(LinkedHashSet(patterns.size), String::isNotEmpty) }
     }
 
     /**

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintServiceLoader.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintServiceLoader.kt
@@ -24,9 +24,7 @@ internal fun <T> Class<T>.loadFromJarFiles(
             .also { providers ->
                 providers
                     .mapNotNull { it }
-                    .forEach {
-                        LOGGER.debug { "Discovered $simpleName with id '${providerId(it)}' in ktlint JAR" }
-                    }
+                    .forEach { LOGGER.debug { "Discovered $simpleName with id '${providerId(it)}' in ktlint JAR" } }
             }
     val providerIdsFromKtlintJars =
         providersFromKtlintJars

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -102,9 +102,7 @@ class CommandLineTestRunner(
 
     private fun prepareTestProject(testProjectName: String): Path {
         val testProjectPath = TEST_PROJECTS_PATHS.resolve(testProjectName)
-        assert(Files.exists(testProjectPath)) {
-            "Test project $testProjectName does not exist!"
-        }
+        require(Files.exists(testProjectPath)) { "Test project $testProjectName does not exist!" }
 
         return tempDir.resolve(testProjectName).also { testProjectPath.copyRecursively(it) }
     }
@@ -181,14 +179,14 @@ class CommandLineTestRunner(
     private fun ProcessBuilder.prependPathWithJavaBinHome() {
         val environment = environment()
         val pathKey =
-            when {
-                isWindows() -> {
-                    // On Windows, environment keys are case-insensitive, which is not handled by the JVM
-                    environment.keys.firstOrNull { key ->
-                        key.equals(PATH, ignoreCase = true)
-                    } ?: PATH
-                }
-                else -> PATH
+            if (isWindows()) {
+                // On Windows, environment keys are case-insensitive, which is not handled by the JVM
+                environment
+                    .keys
+                    .firstOrNull { key -> key.equals(PATH, ignoreCase = true) }
+                    ?: PATH
+            } else {
+                PATH
             }
         environment[pathKey] = "$JAVA_HOME_BIN_DIR${File.pathSeparator}${OsEnvironment()[PATH]}"
     }
@@ -293,30 +291,16 @@ private fun String.followedByIndentedList(
 ): String =
     lines
         .ifEmpty { listOf("<empty>") }
-        .joinToString(prefix = "$this\n", separator = "\n") {
-            "    ".repeat(indentLevel).plus(it)
-        }
+        .joinToString(prefix = "$this\n", separator = "\n") { "    ".repeat(indentLevel).plus(it) }
 
 @Suppress("unused")
-internal fun ListAssert<String>.containsLineMatching(string: String): ListAssert<String> =
-    this.anyMatch {
-        it.contains(string)
-    }
+internal fun ListAssert<String>.containsLineMatching(string: String): ListAssert<String> = this.anyMatch { it.contains(string) }
 
 @Suppress("unused")
-internal fun ListAssert<String>.containsLineMatching(regex: Regex): ListAssert<String> =
-    this.anyMatch {
-        it.matches(regex)
-    }
+internal fun ListAssert<String>.containsLineMatching(regex: Regex): ListAssert<String> = this.anyMatch { it.matches(regex) }
 
 @Suppress("unused")
-internal fun ListAssert<String>.doesNotContainLineMatching(string: String): ListAssert<String> =
-    this.noneMatch {
-        it.contains(string)
-    }
+internal fun ListAssert<String>.doesNotContainLineMatching(string: String): ListAssert<String> = this.noneMatch { it.contains(string) }
 
 @Suppress("unused")
-internal fun ListAssert<String>.doesNotContainLineMatching(regex: Regex): ListAssert<String> =
-    this.noneMatch {
-        it.matches(regex)
-    }
+internal fun ListAssert<String>.doesNotContainLineMatching(regex: Regex): ListAssert<String> = this.noneMatch { it.matches(regex) }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -446,9 +446,7 @@ class SimpleCLITest {
                 testProjectName = "too-many-empty-lines",
                 arguments = listOf("--stdin"),
                 stdin = ByteArrayInputStream("fun foo() = 42".toByteArray()),
-            ) {
-                assertThat(normalOutput).containsLineMatching(Regex(".*ktlint_standard_filename: disabled.*"))
-            }
+            ) { assertThat(normalOutput).containsLineMatching(Regex(".*ktlint_standard_filename: disabled.*")) }
     }
 
     @Test

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -216,9 +216,7 @@ internal class FileUtilsTest {
     ) {
         val homeDir = System.getProperty("user.home")
         val filePath = "$homeDir/project/src/main/kotlin/One.kt"
-        ktlintTestFileSystem.apply {
-            writeFile(filePath, SOME_CONTENT)
-        }
+        ktlintTestFileSystem.writeFile(filePath, SOME_CONTENT)
 
         val foundFiles =
             getFiles(
@@ -499,11 +497,7 @@ internal class FileUtilsTest {
             .map { it.normalize().toString() }
             .toList()
             .map { ktlintTestFileSystem.unixPathStringRelativeToRootDirectoryOfFileSystem(it) }
-            .also {
-                LOGGER.info {
-                    "Getting files with [patterns = $patterns] and [rootdir = $rootDir] returns [files = $it]"
-                }
-            }
+            .also { LOGGER.info { "Getting files with [patterns = $patterns] and [rootdir = $rootDir] returns [files = $it]" } }
 
     private fun KtlintTestFileSystem.rootDirectoryPath() = resolve()
 

--- a/ktlint-logger/build.gradle.kts
+++ b/ktlint-logger/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
-dependencies {
-    api(libs.logging)
-}
+dependencies { api(libs.logging) }

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -1,6 +1,8 @@
 public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt {
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
+	public static final fun findFirstLeafOnSameLineOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
+	public static final fun findLastLeafOnSameLineOrNull (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun hasNewLineInClosedRange (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
@@ -491,6 +493,8 @@ public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/Editor
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> ([Lorg/ec4j/core/model/Property;)V
 	public final fun addPropertiesWithDefaultValueIfMissing ([Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;)Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;
 	public final fun contains (Ljava/lang/String;)Z
@@ -499,8 +503,10 @@ public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/Editor
 	public final fun get (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;)Ljava/lang/Object;
 	public final fun getEditorConfigValueOrNull (Lorg/ec4j/core/model/PropertyType;Ljava/lang/String;)Ljava/lang/Object;
 	public fun hashCode ()I
+	public final fun isEnabledRule (Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;)Z
 	public final fun map (Lkotlin/jvm/functions/Function1;)Ljava/util/Collection;
 	public fun toString ()Ljava/lang/String;
+	public final fun withRuleProviders (Ljava/util/Set;)Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty {

--- a/ktlint-rule-engine-core/build.gradle.kts
+++ b/ktlint-rule-engine-core/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintLogger)

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -240,9 +240,7 @@ public fun ASTNode.upsertWhitespaceBeforeMe(text: String) {
         if (previous != null && previous.elementType == WHITE_SPACE) {
             previous.replaceWhitespaceWith(text)
         } else {
-            PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                (psi as LeafElement).rawInsertBeforeMe(psiWhiteSpace)
-            }
+            PsiWhiteSpaceImpl(text).also { psiWhiteSpace -> (psi as LeafElement).rawInsertBeforeMe(psiWhiteSpace) }
         }
     } else {
         when (val prevSibling = prevSibling()) {
@@ -257,9 +255,7 @@ public fun ASTNode.upsertWhitespaceBeforeMe(text: String) {
 
             else -> {
                 // Insert in between two composite nodes
-                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                    treeParent.addChild(psiWhiteSpace.node, this)
-                }
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace -> treeParent.addChild(psiWhiteSpace.node, this) }
             }
         }
     }
@@ -286,9 +282,7 @@ public fun ASTNode.upsertWhitespaceAfterMe(text: String) {
         if (next != null && next.elementType == WHITE_SPACE) {
             next.replaceWhitespaceWith(text)
         } else {
-            PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                (psi as LeafElement).rawInsertAfterMe(psiWhiteSpace)
-            }
+            PsiWhiteSpaceImpl(text).also { psiWhiteSpace -> (psi as LeafElement).rawInsertAfterMe(psiWhiteSpace) }
         }
     } else {
         when (val nextSibling = nextSibling()) {
@@ -303,9 +297,7 @@ public fun ASTNode.upsertWhitespaceAfterMe(text: String) {
 
             else -> {
                 // Insert in between two composite nodes
-                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                    treeParent.addChild(psiWhiteSpace.node, nextSibling)
-                }
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace -> treeParent.addChild(psiWhiteSpace.node, nextSibling) }
             }
         }
     }
@@ -347,9 +339,7 @@ public fun ASTNode.logStructure(): ASTNode =
         println("Processing ${text.replaceTabAndNewline()} : Type $elementType with parent ${treeParent?.elementType} ")
         children()
             .toList()
-            .map {
-                println("  ${it.text.replaceTabAndNewline()} : Type ${it.elementType}")
-            }
+            .map { println("  ${it.text.replaceTabAndNewline()} : Type ${it.elementType}") }
     }
 
 private fun String.replaceTabAndNewline(): String = replace("\t", "\\t").replace("\n", "\\n")

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -438,15 +438,23 @@ public fun ASTNode.leavesIncludingSelf(forward: Boolean = true): Sequence<ASTNod
  * with zero or more newline characters.
  */
 public fun ASTNode.leavesOnLine(): Sequence<ASTNode> {
-    val lastLeafOnLineOrNull = getLastLeafOnLineOrNull()
-    return getFirstLeafOnLineOrSelf()
+    val lastLeafOnLineOrNull = findLastLeafOnSameLineOrNull()
+    return findFirstLeafOnSameLineOrSelf()
         .leavesIncludingSelf()
         .takeWhile { lastLeafOnLineOrNull == null || it.prevLeaf() != lastLeafOnLineOrNull }
 }
 
-internal fun ASTNode.getFirstLeafOnLineOrSelf() = prevLeaf { it.textContains('\n') || it.prevLeaf() == null }!!
+/**
+ * The first leaf on the same line as [this] node. Note that if the first node is an ident node, it may start with one or more newline
+ * characters.
+ */
+public fun ASTNode.findFirstLeafOnSameLineOrSelf(): ASTNode = prevLeaf { it.textContains('\n') || it.prevLeaf() == null }!!
 
-internal fun ASTNode.getLastLeafOnLineOrNull() = nextLeaf { it.textContains('\n') }?.prevLeaf()
+/**
+ * The last leaf on the same line as [this] node. Returns 'null' in case [this] node is the last line in the file and is not followed by a
+ * final newline.
+ */
+public fun ASTNode.findLastLeafOnSameLineOrNull(): ASTNode? = nextLeaf { it.textContains('\n') }?.prevLeaf()
 
 /**
  * Get the total length of all leaves on the same line as the given node including the whitespace indentation but excluding all leading

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -722,6 +722,70 @@ class ASTNodeExtensionTest {
         )
     }
 
+    @Test
+    fun `Given some lines containing identifiers at different indentation levels then get the first leaf of each line containing an identifier`() {
+        val code =
+            """
+            class Foo1 {
+                val foo2 = "foo2"
+
+                fun foo3() {
+                    val foo4 = "foo4"
+                }
+            }
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .firstChildLeafOrSelf()
+                .leaves()
+                .filter { it.elementType == IDENTIFIER }
+                .map { identifier ->
+                    identifier
+                        .findFirstLeafOnSameLineOrSelf()
+                        .text
+                }.toList()
+
+        assertThat(actual).contains(
+            "class",
+            "\n    ",
+            "\n    ",
+            "\n        ",
+        )
+    }
+
+    @Test
+    fun `Given some lines containing identifiers at different indentation levels then get the last leaf of each line containing an identifier`() {
+        val code =
+            """
+            class Foo1 {
+                val foo2 = "foo2"
+
+                fun foo3() {
+                    val foo4 = "foo4"
+                }
+            }
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .firstChildLeafOrSelf()
+                .leaves()
+                .filter { it.elementType == IDENTIFIER }
+                .map { identifier ->
+                    identifier
+                        .findLastLeafOnSameLineOrNull()
+                        ?.text
+                }.toList()
+
+        assertThat(actual).contains(
+            "{",
+            "\"",
+            "{",
+            "\"",
+        )
+    }
+
     private inline fun String.transformAst(block: FileASTNode.() -> Unit): FileASTNode =
         transformCodeToAST(this)
             .apply(block)

--- a/ktlint-rule-engine/build.gradle.kts
+++ b/ktlint-rule-engine/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintLogger)

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
@@ -44,9 +44,7 @@ public class EditorConfigOverride {
                 "Can not create an EditorConfigOverride without properties. Use 'emptyEditorConfigOverride' instead."
             }
             return EditorConfigOverride()
-                .apply {
-                    properties.forEach { add(it.first, it.second) }
-                }
+                .apply { properties.forEach { add(it.first, it.second) } }
         }
 
         /**
@@ -57,12 +55,8 @@ public class EditorConfigOverride {
             require(properties.isNotEmpty()) { "Can not add EditorConfigOverride without properties." }
             return EditorConfigOverride()
                 .apply {
-                    this@plus._properties.forEach {
-                        add(it.key, it.value)
-                    }
-                    properties.forEach {
-                        add(it.first, it.second)
-                    }
+                    this@plus._properties.forEach { add(it.key, it.value) }
+                    properties.forEach { add(it.first, it.second) }
                 }
         }
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
@@ -45,9 +45,7 @@ public class EditorConfigOverride {
             }
             return EditorConfigOverride()
                 .apply {
-                    properties.forEach {
-                        add(it.first, it.second)
-                    }
+                    properties.forEach { add(it.first, it.second) }
                 }
         }
 
@@ -56,9 +54,7 @@ public class EditorConfigOverride {
          * the original [EditorConfigOverride] silently.
          */
         public fun EditorConfigOverride.plus(vararg properties: Pair<EditorConfigProperty<*>, *>): EditorConfigOverride {
-            require(properties.isNotEmpty()) {
-                "Can not add EditorConfigOverride without properties."
-            }
+            require(properties.isNotEmpty()) { "Can not add EditorConfigOverride without properties." }
             return EditorConfigOverride()
                 .apply {
                     this@plus._properties.forEach {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintRuleEngine.kt
@@ -63,9 +63,7 @@ public class KtLintRuleEngine(
     public val fileSystem: FileSystem = FileSystems.getDefault(),
 ) {
     init {
-        require(ruleProviders.any()) {
-            "A non-empty set of 'ruleProviders' need to be provided"
-        }
+        require(ruleProviders.any()) { "A non-empty set of 'ruleProviders' need to be provided" }
     }
 
     internal val editorConfigLoaderEc4j = EditorConfigLoaderEc4j(ruleProviders.propertyTypes())
@@ -210,9 +208,7 @@ public class KtLintRuleEngine(
             UTF8_BOM + formattedCode
         } else {
             formattedCode
-        }.also {
-            LOGGER.debug { "Finished with formatting file '${code.fileNameOrStdin()}'" }
-        }
+        }.also { LOGGER.debug { "Finished with formatting file '${code.fileNameOrStdin()}'" } }
     }
 
     private fun RuleExecutionContext.determineLineSeparator(fileContent: String): String {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigFinder.kt
@@ -29,15 +29,11 @@ internal class EditorConfigFinder(
         READ_WRITE_LOCK.read {
             val cacheValue =
                 IN_MEMORY_CACHE[path]
-                    ?.also {
-                        LOGGER.info { "Retrieving EditorConfig cache entry for path $path" }
-                    }
+                    ?.also { LOGGER.info { "Retrieving EditorConfig cache entry for path $path" } }
             return cacheValue
                 ?: READ_WRITE_LOCK.write {
                     cacheEditorConfigs(path)
-                        .also { cacheValue ->
-                            LOGGER.info { "Creating cache entry for path $path with value $cacheValue" }
-                        }
+                        .also { cacheValue -> LOGGER.info { "Creating cache entry for path $path with value $cacheValue" } }
                 }
         }
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -79,12 +79,9 @@ internal class EditorConfigLoader(
                 }
                 editorConfigOverride
                     .properties
-                    .forEach {
-                        properties[it.key.name] = it.key.toPropertyWithValue(it.value)
-                    }
-            }.also { properties ->
-                LOGGER.debug { properties.prettyPrint(filePath) }
-            }.let { properties ->
+                    .forEach { properties[it.key.name] = it.key.toPropertyWithValue(it.value) }
+            }.also { properties -> LOGGER.debug { properties.prettyPrint(filePath) } }
+            .let { properties ->
                 // Only add properties which are not related to rules but which are needed by the KtLint Rule Engine
                 EditorConfig(properties)
                     .addPropertiesWithDefaultValueIfMissing(
@@ -147,9 +144,8 @@ internal class EditorConfigLoader(
         .keepUnset(true)
         .cache(THREAD_SAFE_EDITOR_CONFIG_CACHE)
         .loader(editorConfigLoader)
-        .applyIf(editorConfigDefaults != EMPTY_EDITOR_CONFIG_DEFAULTS) {
-            defaultEditorConfigs(editorConfigDefaults.value)
-        }.build()
+        .applyIf(editorConfigDefaults != EMPTY_EDITOR_CONFIG_DEFAULTS) { defaultEditorConfigs(editorConfigDefaults.value) }
+        .build()
 
     companion object {
         /**
@@ -184,7 +180,6 @@ internal class EditorConfigLoaderEc4j(
         PropertyTypeRegistry
             .builder()
             .defaults()
-            .apply {
-                propertyTypes.forEach { type(it) }
-            }.build()
+            .apply { propertyTypes.forEach { type(it) } }
+            .build()
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
@@ -75,20 +75,27 @@ internal fun initPsiFileFactory(ktLintRuleEngine: KtLintRuleEngine): PsiFileFact
  * Note: this only works in CLI shadowed jar! 'extensions/compiler.xml' is absent in non-shadowed jar.
  */
 private fun extractCompilerExtension(): Path {
-    KtLintRuleEngine::class.java.getResourceAsStream("/META-INF/extensions/compiler.xml").use { input ->
-        val tempDir = Files.createTempDirectory("ktlint")
-        tempDir.toFile().deleteOnExit()
+    val extensionDirName = "META-INF/extensions"
+    val extensionFileName = "compiler.xml"
+    KtLintRuleEngine::class.java
+        .getResourceAsStream("/$extensionDirName/$extensionFileName")
+        .use { input ->
+            val tempDir = Files.createTempDirectory("ktlint")
+            tempDir.toFile().deleteOnExit()
 
-        val extensionsDir =
-            tempDir.resolve("META-INF/extensions").also {
-                Files.createDirectories(it)
-            }
-        extensionsDir.resolve("compiler.xml").toFile().outputStream().buffered().use {
-            input!!.copyTo(it)
+            val extensionsDir =
+                tempDir
+                    .resolve(extensionDirName)
+                    .also { Files.createDirectories(it) }
+            extensionsDir
+                .resolve(extensionFileName)
+                .toFile()
+                .outputStream()
+                .buffered()
+                .use { input!!.copyTo(it) }
+
+            return tempDir
         }
-
-        return tempDir
-    }
 }
 
 /**

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/PositionInTextLocator.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/PositionInTextLocator.kt
@@ -44,9 +44,7 @@ private class SegmentTree(
     private val segments: List<Segment> =
         sortedArray
             .dropLast(1)
-            .mapIndexed { index: Int, element: Int ->
-                Segment(element, sortedArray[index + 1] - 1)
-            }
+            .mapIndexed { index: Int, element: Int -> Segment(element, sortedArray[index + 1] - 1) }
 
     fun get(i: Int): Segment = segments[i]
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -199,7 +199,7 @@ internal class RuleExecutionContext private constructor(
                 code,
                 rootNode,
                 ruleProviders,
-                editorConfig,
+                editorConfig.withRuleProviders(ruleProviders.map { it.ruleId }.toSet()),
                 positionInTextLocator,
             )
         }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -121,9 +121,7 @@ internal class RuleExecutionContext private constructor(
         rule: Rule,
         suppressHandler: SuppressHandler,
     ) {
-        suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit ->
-            rule.beforeVisitChildNodes(node, autoCorrect, emit)
-        }
+        suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit -> rule.beforeVisitChildNodes(node, autoCorrect, emit) }
         if (rule.shouldContinueTraversalOfAST()) {
             node
                 .getChildren(null)
@@ -138,9 +136,7 @@ internal class RuleExecutionContext private constructor(
                     }
                 }
         }
-        suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit ->
-            rule.afterVisitChildNodes(node, autoCorrect, emit)
-        }
+        suppressHandler.handle(node, rule.ruleId) { autoCorrect, emit -> rule.afterVisitChildNodes(node, autoCorrect, emit) }
     }
 
     companion object {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorter.kt
@@ -36,10 +36,10 @@ internal class RuleProviderSorter {
             .also { previousValue ->
                 if (previousValue == null) {
                     // Logging was not printed for this combination of rule providers as no entry was found in the cache
-                    sortedRuleProviders
-                        .joinToString(prefix = "Rules will be executed in order below:") {
-                            "\n           - ${it.ruleId.value}"
-                        }.also { LOGGER.debug { it } }
+                    LOGGER.debug {
+                        sortedRuleProviders
+                            .joinToString(prefix = "Rules will be executed in order below:") { "\n           - ${it.ruleId.value}" }
+                    }
                 }
             }
     }
@@ -54,9 +54,7 @@ internal class RuleProviderSorter {
             .hashCode()
 
     private fun Set<RuleProvider>.sort(): List<RuleProvider> {
-        forEach { ruleProvider ->
-            ruleProvider.hasNoVisitorModifierReferringToSelf()
-        }
+        forEach { ruleProvider -> ruleProvider.hasNoVisitorModifierReferringToSelf() }
 
         val ruleIdsToBeSorted = map { it.ruleId }.toSet()
         val unprocessedRuleProviders =

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCache.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/ThreadSafeEditorConfigCache.kt
@@ -31,9 +31,8 @@ internal class ThreadSafeEditorConfigCache : Cache {
         readWriteLock.read {
             val cachedEditConfig =
                 inMemoryMap[resource]
-                    ?.also {
-                        LOGGER.trace { "Retrieving EditorConfig cache entry for path ${resource.path}" }
-                    }?.editConfig
+                    ?.also { LOGGER.trace { "Retrieving EditorConfig cache entry for path ${resource.path}" } }
+                    ?.editConfig
             return cachedEditConfig
                 ?: readWriteLock.write {
                     CacheValue(resource, editorConfigLoader)
@@ -56,9 +55,7 @@ internal class ThreadSafeEditorConfigCache : Cache {
                         cacheValue
                             .copy(editConfig = cacheValue.editorConfigLoader.load(resource))
                             .let { cacheValue -> inMemoryMap[resource] = cacheValue }
-                            .also {
-                                LOGGER.trace { "Reload EditorConfig cache entry for path ${resource.path}" }
-                            }
+                            .also { LOGGER.trace { "Reload EditorConfig cache entry for path ${resource.path}" } }
                     }
                 }
         }
@@ -70,9 +67,8 @@ internal class ThreadSafeEditorConfigCache : Cache {
     fun clear() =
         readWriteLock.write {
             inMemoryMap
-                .also {
-                    LOGGER.trace { "Removing ${it.size} entries from the EditorConfig cache" }
-                }.clear()
+                .also { LOGGER.trace { "Removing ${it.size} entries from the EditorConfig cache" } }
+                .clear()
         }
 
     /**

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/VisitorProvider.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/VisitorProvider.kt
@@ -41,8 +41,6 @@ internal class VisitorProvider(
             LOGGER.debug { "Skipping file as no enabled rules are found to be executed" }
             return { _ -> }
         }
-        return { visit ->
-            ruleProvidersSorted.forEach { visit(it.createNewRuleInstance()) }
-        }
+        return { visit -> ruleProvidersSorted.forEach { visit(it.createNewRuleInstance()) } }
     }
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/VisitorProvider.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/VisitorProvider.kt
@@ -42,9 +42,7 @@ internal class VisitorProvider(
             return { _ -> }
         }
         return { visit ->
-            ruleProvidersSorted.forEach {
-                visit(it.createNewRuleInstance())
-            }
+            ruleProvidersSorted.forEach { visit(it.createNewRuleInstance()) }
         }
     }
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilter.kt
@@ -179,9 +179,7 @@ internal class RunAfterRuleFilter : RuleFilter {
                     "Skipping rule(s) which are depending on a rule which is not loaded. Please check if you need to add additional " +
                         "rule sets before creating an issue.$separator",
                 separator = separator,
-            ) {
-                "Rule with id '${it.ruleId}' requires rule with id '${it.runAfterRuleId}' to be loaded"
-            }
+            ) { "Rule with id '${it.ruleId}' requires rule with id '${it.runAfterRuleId}' to be loaded" }
     }
 
     private fun createCyclicDependencyMessage(): String {
@@ -203,9 +201,7 @@ internal class RunAfterRuleFilter : RuleFilter {
         val separator = "\n  - "
         return blockedRuleProviders.joinToString(prefix = prefix + separator, separator = separator) {
             "Rule with id '${it.ruleId.value}' should run after rule(s) with id '${
-                it.runAfterRules.joinToString(separator = ", ") {
-                    it.ruleId.value
-                }
+                it.runAfterRules.joinToString(separator = ", ") { it.ruleId.value }
             }'"
         }
     }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
@@ -183,9 +183,7 @@ public class KtlintSuppressionRule(
             .takeIf { startsWith(KTLINT_SUPPRESSION_ID_PREFIX) }
             ?.substringAfter(KTLINT_SUPPRESSION_ID_PREFIX)
             ?.let { prefixWithRuleSetIdWhenMissing(it) }
-            ?.let { ruleId ->
-                allowedRuleIds.none { it.value == ruleId }
-            }
+            ?.let { ruleId -> allowedRuleIds.none { it.value == ruleId } }
             ?: false
 
     private fun KtLintDirective.visitKtlintDirective(

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -646,9 +646,7 @@ private class WithStateRule :
     private var hasNotBeenVisitedYet = true
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
-        check(hasNotBeenVisitedYet) {
-            "Rule has been visited before"
-        }
+        check(hasNotBeenVisitedYet) { "Rule has been visited before" }
         hasNotBeenVisitedYet = false
     }
 

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoaderTest.kt
@@ -96,9 +96,7 @@ class EditorConfigDefaultsLoaderTest {
     @Test
     fun `Given an existing directory containing an editor config file then load all settings from it`() {
         val somePathToDirectory = "some/path/to/directory"
-        ktlintTestFileSystem.apply {
-            writeEditorConfigFile(somePathToDirectory, SOME_EDITOR_CONFIG.toString())
-        }
+        ktlintTestFileSystem.writeEditorConfigFile(somePathToDirectory, SOME_EDITOR_CONFIG.toString())
 
         val actual =
             editorConfigDefaultsLoader.load(

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoaderTest.kt
@@ -59,15 +59,11 @@ internal class EditorConfigLoaderTest {
     fun `Given an editorconfig file in the project root and the file to be linted is in a subdirectory not containing an editorconfig file`(
         editorconfigContent: String,
     ) {
-        ktlintTestFileSystem.apply {
-            writeRootEditorConfigFile(editorconfigContent.trimIndent())
-        }
+        ktlintTestFileSystem.writeRootEditorConfigFile(editorconfigContent.trimIndent())
 
         createEditorConfigLoader()
             .load(ktlintTestFileSystem.resolve("some-subdirectory/test.kt"))
-            .run {
-                assertThat(convertToPropertyValues()).contains("indent_size = 2")
-            }
+            .run { assertThat(convertToPropertyValues()).contains("indent_size = 2") }
     }
 
     @Test

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleProviderSorterTest.kt
@@ -403,9 +403,8 @@ class RuleProviderSorterTest {
 
     private fun createRuleProviders(vararg rules: Rule): Set<RuleProvider> =
         rules
-            .map {
-                RuleProvider { it }
-            }.toSet()
+            .map { RuleProvider { it } }
+            .toSet()
 
     private companion object {
         const val RULE_A = "rule-a"

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/InternalRuleProvidersFilterTest.kt
@@ -17,9 +17,7 @@ class InternalRuleProvidersFilterTest {
             KtLintRuleEngine(
                 ruleProviders =
                     setOf(
-                        RuleProvider {
-                            object : R(ruleId = STANDARD_RULE_A) {}
-                        },
+                        RuleProvider { object : R(ruleId = STANDARD_RULE_A) {} },
                     ),
             )
         val actual =

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RunAfterRuleFilterTest.kt
@@ -389,9 +389,8 @@ class RunAfterRuleFilterTest {
 
     private fun createRuleProviders(vararg rules: Rule) =
         rules
-            .map {
-                RuleProvider { it }
-            }.toSet()
+            .map { RuleProvider { it } }
+            .toSet()
 
     private fun Set<RuleProvider>.toRuleId() = map { it.ruleId }
 }

--- a/ktlint-ruleset-standard/build.gradle.kts
+++ b/ktlint-ruleset-standard/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintLogger)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevSibling
+import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -147,13 +148,10 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
     }
 
     private fun removeExtraLineBreaks(node: ASTNode) {
-        val next =
-            node.nextSibling {
-                it.isWhiteSpaceWithNewline()
-            } as? LeafPsiElement
-        if (next != null) {
-            rawReplaceExtraLineBreaks(next)
-        }
+        node
+            .nextSibling { it.isWhiteSpaceWithNewline() }
+            .safeAs<LeafPsiElement>()
+            ?.let { rawReplaceExtraLineBreaks(it) }
     }
 
     private fun rawReplaceExtraLineBreaks(leaf: LeafPsiElement) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
@@ -39,9 +39,7 @@ public class ClassNamingRule : StandardRule("class-naming") {
             .takeIf { node.elementType == CLASS || node.elementType == OBJECT_DECLARATION }
             ?.findChildByType(IDENTIFIER)
             ?.takeUnless { it.isValidFunctionName() || it.isTestClass() }
-            ?.let {
-                emit(it.startOffset, "Class or object name should start with an uppercase letter and use camel case", false)
-            }
+            ?.let { emit(it.startOffset, "Class or object name should start with an uppercase letter and use camel case", false) }
     }
 
     private fun ASTNode.isValidFunctionName() = text.matches(VALID_CLASS_NAME_REGEXP)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -458,9 +458,7 @@ public class ClassSignatureRule :
                         superTypeCallEntry
                             .prevSibling()
                             ?.takeIf { it.elementType == WHITE_SPACE }
-                            ?.let { whitespaceBeforeSuperTypeCallEntry ->
-                                superTypeList.removeChild(whitespaceBeforeSuperTypeCallEntry)
-                            }
+                            ?.let { superTypeList.removeChild(it) }
 
                         superTypeList.addChild(superTypeCallEntry, superTypes.first())
                         superTypeList.addChild(commaBeforeSuperTypeCall, originalFirstSuperType)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
@@ -57,9 +57,7 @@ public class EnumWrappingRule :
             .takeIf { node.elementType == CLASS }
             ?.takeIf { (node.psi as KtClass).isEnum() }
             ?.findChildByType(CLASS_BODY)
-            ?.let { classBody ->
-                visitEnumClass(classBody, autoCorrect, emit)
-            }
+            ?.let { classBody -> visitEnumClass(classBody, autoCorrect, emit) }
     }
 
     private fun visitEnumClass(
@@ -127,9 +125,7 @@ public class EnumWrappingRule :
         node
             .children()
             .filter { it.elementType == ENUM_ENTRY }
-            .forEach { enumEntry ->
-                wrapEnumEntry(enumEntry, autoCorrect, emit)
-            }
+            .forEach { enumEntry -> wrapEnumEntry(enumEntry, autoCorrect, emit) }
     }
 
     private fun wrapEnumEntry(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule.kt
@@ -28,9 +28,8 @@ public class FunctionNamingRule :
             (node.psi as KtImportDirective)
                 .importPath
                 ?.pathStr
-                ?.takeIf {
-                    it.startsWith(ORG_JUNIT) || it.startsWith(ORG_TESTNG) || it.startsWith(KOTLIN_TEST)
-                }?.let {
+                ?.takeIf { it.startsWith(ORG_JUNIT) || it.startsWith(ORG_TESTNG) || it.startsWith(KOTLIN_TEST) }
+                ?.let {
                     // Assume that each file that imports a Junit Jupiter Api class is a test class
                     isTestClass = true
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRule.kt
@@ -67,10 +67,7 @@ public class IfElseBracingRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val thenNode =
-            requireNotNull(node.findChildByType(THEN)) {
-                "Can not find THEN branch in IF"
-            }
+        val thenNode = requireNotNull(node.findChildByType(THEN)) { "Can not find THEN branch in IF" }
         val elseNode = node.findChildByType(ELSE) ?: return
         val parentIfBracing =
             node
@@ -144,9 +141,7 @@ public class IfElseBracingRule :
         prevLeaves
             .firstOrNull()
             .takeIf { it.isWhiteSpace() }
-            ?.let {
-                (it as LeafPsiElement).rawReplaceWithText(" ")
-            }
+            ?.let { (it as LeafPsiElement).rawReplaceWithText(" ") }
         KtBlockExpression(null).apply {
             val previousChild = node.firstChildNode
             if (previousChild == null) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -852,9 +852,7 @@ public class IndentationRule :
             }
         node
             .findChildByType(CONDITION)
-            ?.let { fromAstNode ->
-                startIndentContext(fromAstNode)
-            }
+            ?.let { fromAstNode -> startIndentContext(fromAstNode) }
     }
 
     private fun visitLBracket(node: ASTNode) {
@@ -1485,9 +1483,8 @@ private class StringTemplateIndenter(
         val prefixLength = nonBlankLines.minOfOrNull { it.indentLength() } ?: 0
         val distinctIndentCharacters =
             nonBlankLines
-                .joinToString(separator = "") {
-                    it.splitIndentAt(prefixLength).first
-                }.toCharArray()
+                .joinToString(separator = "") { it.splitIndentAt(prefixLength).first }
+                .toCharArray()
                 .distinct()
                 .count()
         return distinctIndentCharacters > 1

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -99,9 +99,7 @@ public class MaxLineLengthRule :
         } else if (!rangeTree.isEmpty() && node.psi is LeafPsiElement) {
             rangeTree
                 .query(node.startOffset, node.startOffset + node.textLength)
-                .forEach { offset ->
-                    emit(offset, "Exceeded max line length ($maxLineLength)", false)
-                }
+                .forEach { offset -> emit(offset, "Exceeded max line length ($maxLineLength)", false) }
         }
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -81,9 +81,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
                         )
                     }
                 if (autoCorrect) {
-                    modifierArr.forEachIndexed { i, n ->
-                        node.replaceChild(n, sorted[i].clone() as ASTNode)
-                    }
+                    modifierArr.forEachIndexed { i, n -> node.replaceChild(n, sorted[i].clone() as ASTNode) }
                 }
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultiLineIfElseRule.kt
@@ -133,9 +133,7 @@ public class MultiLineIfElseRule :
         prevLeaves
             .firstOrNull()
             .takeIf { it.isWhiteSpace() }
-            ?.let {
-                (it as LeafPsiElement).rawReplaceWithText(" ")
-            }
+            ?.let { (it as LeafPsiElement).rawReplaceWithText(" ") }
         KtBlockExpression(null).apply {
             val previousChild = node.firstChildNode
             node.replaceChild(node.firstChildNode, this)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInListRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineInListRule.kt
@@ -34,9 +34,7 @@ public class NoBlankLineInListRule :
             .treeParent
             .elementType
             .takeIf { it in LIST_TYPES }
-            ?.let { treeParentElementType ->
-                visitWhiteSpace(node, emit, autoCorrect, treeParentElementType)
-            }
+            ?.let { treeParentElementType -> visitWhiteSpace(node, emit, autoCorrect, treeParentElementType) }
 
         // Note: depending on the implementation of the list type in the Kotlin language, the whitespace before the first and after the last
         // element in the list might be or not be part of the list.

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoLineBreakBeforeAssignmentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoLineBreakBeforeAssignmentRule.kt
@@ -54,9 +54,7 @@ public class NoLineBreakBeforeAssignmentRule : StandardRule("no-line-break-befor
                     assignmentNode
                         .nextSibling()
                         .takeIf { it.isWhiteSpace() }
-                        ?.let { whiteSpaceAfterEquals ->
-                            parent.removeChild(whiteSpaceAfterEquals)
-                        }
+                        ?.let { whiteSpaceAfterEquals -> parent.removeChild(whiteSpaceAfterEquals) }
                     parent.removeChild(assignmentNode)
                 }
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -177,9 +177,7 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
                         } else {
                             nextSibling
                                 .takeIf { it.isWhiteSpaceWithNewline() }
-                                ?.let { whitespace ->
-                                    whitespace.treeParent.removeChild(whitespace)
-                                }
+                                ?.let { whitespace -> whitespace.treeParent.removeChild(whitespace) }
                         }
                         importDirective.delete()
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -173,9 +173,7 @@ public class ParameterListSpacingRule :
             .findChildByType(COLON)
             ?.prevLeaf()
             ?.takeIf { it.elementType == WHITE_SPACE }
-            ?.let { whiteSpaceBeforeColon ->
-                removeUnexpectedWhiteSpace(whiteSpaceBeforeColon, emit, autoCorrect)
-            }
+            ?.let { whiteSpaceBeforeColon -> removeUnexpectedWhiteSpace(whiteSpaceBeforeColon, emit, autoCorrect) }
     }
 
     private fun fixWhiteSpaceAfterColonInParameter(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -68,9 +68,7 @@ public class PropertyNamingRule :
         identifier
             .text
             .takeUnless { it.matches(BACKING_PROPERTY_LOWER_CAMEL_CASE_REGEXP) }
-            ?.let {
-                emit(identifier.startOffset, "Backing property name should start with underscore followed by lower camel case", false)
-            }
+            ?.let { emit(identifier.startOffset, "Backing property name should start with underscore followed by lower camel case", false) }
     }
 
     private fun visitConstProperty(
@@ -102,9 +100,7 @@ public class PropertyNamingRule :
         identifier
             .text
             .takeUnless { it.matches(LOWER_CAMEL_CASE_REGEXP) }
-            ?.let {
-                emit(identifier.startOffset, "Property name should start with a lowercase letter and use camel case", false)
-            }
+            ?.let { emit(identifier.startOffset, "Property name should start with a lowercase letter and use camel case", false) }
     }
 
     private fun ASTNode.hasCustomGetter() = findChildByType(PROPERTY_ACCESSOR)?.findChildByType(GET_KEYWORD) != null
@@ -131,9 +127,7 @@ public class PropertyNamingRule :
         takeIf { hasModifier(PRIVATE_KEYWORD) }
             ?.findChildByType(IDENTIFIER)
             ?.takeIf { it.text.startsWith("_") }
-            ?.let { identifier ->
-                this.hasPublicProperty(identifier.text.removePrefix("_"))
-            }
+            ?.let { identifier -> hasPublicProperty(identifier.text.removePrefix("_")) }
             ?: false
 
     private fun ASTNode.hasPublicProperty(identifier: String) =

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
@@ -67,9 +67,7 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                             equalsSignElement
                                 .treeNext
                                 ?.let { treeNext ->
-                                    prevNonCodeElements.forEach {
-                                        node.treeParent.addChild(it, treeNext)
-                                    }
+                                    prevNonCodeElements.forEach { node.treeParent.addChild(it, treeNext) }
                                     if (treeNext.isWhiteSpace()) {
                                         equalsSignElement.treeParent.removeChild(treeNext)
                                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundColonRule.kt
@@ -97,17 +97,13 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
                                     } else {
                                         it
                                     }
-                                }.forEach {
-                                    blockElement.addChild(it, before)
-                                }
+                                }.forEach { blockElement.addChild(it, before) }
                         }
                     }
 
                     prevLeaf.prevLeaf()?.isPartOfComment() == true -> {
                         val nextLeaf = node.nextLeaf()
-                        prevNonCodeElements.forEach {
-                            node.treeParent.addChild(it, nextLeaf)
-                        }
+                        prevNonCodeElements.forEach { node.treeParent.addChild(it, nextLeaf) }
                         if (nextLeaf != null && nextLeaf.isWhiteSpace()) {
                             node.treeParent.removeChild(nextLeaf)
                         }
@@ -137,9 +133,7 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
             if (autoCorrect) {
                 node
                     .prevSibling()
-                    ?.let { prevSibling ->
-                        prevSibling.treeParent.removeChild(prevSibling)
-                    }
+                    ?.let { prevSibling -> prevSibling.treeParent.removeChild(prevSibling) }
             }
         }
         if (node.nextSibling().isWhiteSpaceWithoutNewline() && node.spacingAfter) {
@@ -147,9 +141,7 @@ public class SpacingAroundColonRule : StandardRule("colon-spacing") {
             if (autoCorrect) {
                 node
                     .nextSibling()
-                    ?.let { nextSibling ->
-                        nextSibling.treeParent.removeChild(nextSibling)
-                    }
+                    ?.let { nextSibling -> nextSibling.treeParent.removeChild(nextSibling) }
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
@@ -55,9 +55,7 @@ public class SpacingAroundCurlyRule : StandardRule("curly-spacing") {
                 spacingAfter = nextLeaf is PsiWhiteSpace || nextLeaf?.elementType == RBRACE
                 if (prevLeaf is PsiWhiteSpace &&
                     !prevLeaf.textContains('\n') &&
-                    prevLeaf.prevLeaf()?.let {
-                        it.elementType == LPAR || it.elementType == AT
-                    } == true
+                    prevLeaf.prevLeaf()?.let { it.elementType == LPAR || it.elementType == AT } == true
                 ) {
                     emit(node.startOffset, "Unexpected space before \"${node.text}\"", true)
                     if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -128,9 +128,8 @@ public class StringTemplateIndentRule :
                 ?: 0
         val distinctIndentCharacters =
             nonBlankLines
-                .joinToString(separator = "") {
-                    it.splitIndentAt(prefixLength).first
-                }.toCharArray()
+                .joinToString(separator = "") { it.splitIndentAt(prefixLength).first }
+                .toCharArray()
                 .distinct()
                 .count()
         return distinctIndentCharacters > 1

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
@@ -175,9 +175,7 @@ public class TrailingCommaOnCallSiteRule :
                         inspectNode
                             .prevCodeSibling()
                             ?.nextSibling()
-                            ?.let { before ->
-                                before.treeParent.addChild(LeafPsiElement(COMMA, ","), before)
-                            }
+                            ?.let { before -> before.treeParent.addChild(LeafPsiElement(COMMA, ","), before) }
                     }
                 }
             TrailingCommaState.REDUNDANT -> {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -330,9 +330,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                                 inspectNode
                                     .prevCodeLeaf()
                                     ?.nextLeaf()
-                                    ?.let { before ->
-                                        before.treeParent.addChild(PsiWhiteSpaceImpl(indent), before)
-                                    }
+                                    ?.let { before -> before.treeParent.addChild(PsiWhiteSpaceImpl(indent), before) }
                             }
                         }
 
@@ -350,9 +348,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                             inspectNode
                                 .prevCodeLeaf()
                                 ?.nextLeaf()
-                                ?.let { before ->
-                                    before.treeParent.addChild(LeafPsiElement(COMMA, ","), before)
-                                }
+                                ?.let { before -> before.treeParent.addChild(LeafPsiElement(COMMA, ","), before) }
                         }
                     }
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -158,9 +158,7 @@ public class TypeParameterListSpacingRule :
         node
             .lastChildNode
             .nextLeaf(includeEmpty = true)
-            ?.let { nextSibling ->
-                singleSpaceExpected(nextSibling, autoCorrect, emit)
-            }
+            ?.let { nextSibling -> singleSpaceExpected(nextSibling, autoCorrect, emit) }
     }
 
     private fun visitInsideTypeParameterList(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -664,9 +664,7 @@ public class WrappingRule :
         if (this.elementType != LPAR) {
             return treeParent.findChildByType(LPAR)!!.isPartOfForLoopConditionWithMultilineExpression()
         }
-        require(elementType == LPAR) {
-            "Node should be the LPAR of the FOR loop"
-        }
+        require(elementType == LPAR) { "Node should be the LPAR of the FOR loop" }
 
         var node: ASTNode? = this
         while (node != null && node.elementType != RPAR) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class FunctionLiteralRuleTest {
@@ -18,187 +19,290 @@ class FunctionLiteralRuleTest {
         functionLiteralRuleAssertThat(code).hasNoLintViolations()
     }
 
-    @Test
-    fun `Given a multiline lambda without parameters`() {
-        val code =
-            """
-            val foobar =
-                {
-                    foo + bar
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    @Nested
+    inner class `Given a multiline lambda without parameters` {
+        @Test
+        fun `Given max line length is not set then rewrite to single line is not enforced`() {
+            val code =
+                """
+                val foobar =
+                    {
+                        foo + bar
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .unsetMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given max line length is set and expression fits on single line then rewrite to single line`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+                val foobar =
+                    {
+                        fooooooooooooooo + bar
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+                val foobar =
+                    { fooooooooooooooo + bar }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(3, 6, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(4, 31, "Unexpected newline as function literal fits on single line"),
+                ).isFormattedAs(formattedCode)
+        }
     }
 
-    @Test
-    fun `Given a lambda with a single parameter fitting on the first line`() {
-        val code =
-            """
-            val foobar =
-                { foo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    @Nested
+    inner class `Given a multiline lambda with a single parameter` {
+        @Test
+        fun `Given max line length is not set then rewrite to single line is not enforced`() {
+            val code =
+                """
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .unsetMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given max line length is set and expression fits on single line then rewrite to single line`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    { foo: Foo -> foo.repeat(2) }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(3, 18, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(4, 22, "Unexpected newline as function literal fits on single line"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given max line length is set and expression does not fit on single line then do not rewrite to single line`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2).repeat(3)
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
     }
 
-    @Test
-    fun `Given a lambda with a single parameter not on same line as opening brace`() {
-        val code =
-            """
-            val foobar =
-                {
-                    foo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        val formattedCode =
-            """
-            val foobar =
-                { foo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .hasLintViolation(3, 9, "No newline expected before parameter")
-            .isFormattedAs(formattedCode)
+    @Nested
+    inner class `Given a multiline lambda with a single parameter not on same line as opening brace` {
+        @Test
+        fun `Given max line length is not set then place parameters on same line as opening brace but do not rewrite to single line`() {
+            val code =
+                """
+                val foobar =
+                    {
+                        foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .unsetMaxLineLength()
+                .hasLintViolation(3, 9, "Unexpected newline before parameter")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given max line length is set and expression fits on single line then rewrite to single line`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    {
+                        foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    { foo: Foo -> foo.repeat(2) }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(3, 6, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(4, 20, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(5, 22, "Unexpected newline as function literal fits on single line"),
+                ).isFormattedAs(formattedCode)
+        }
     }
 
-    @Test
-    fun `Given a lambda with a single parameter and arrow on separate line`() {
-        val code =
-            """
-            val foobar =
-                { foo: Foo
-                    ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        val formattedCode =
-            """
-            val foobar =
-                { foo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .hasLintViolation(2, 15, "No newline expected after parameter")
-            .isFormattedAs(formattedCode)
+    @Nested
+    inner class `Given a multiline lambda with a single parameter and arrow on separate line` {
+        @Test
+        fun `Given max line length is not set then move arrow to same line as parameter`() {
+            val code =
+                """
+                val foobar =
+                    { foo: Foo
+                        ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .unsetMaxLineLength()
+                .hasLintViolation(2, 15, "Unexpected newline after parameter")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given max line length is set and expression fits on single line then rewrite as single line expression`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    { foo: Foo
+                        ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+                val foobar =
+                    { foo: Foo -> foo.repeat(2) }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(3, 15, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(4, 11, "Unexpected newline as function literal fits on single line"),
+                    LintViolation(5, 22, "Unexpected newline as function literal fits on single line"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given max line length is set and expression does not fit on single line then move arrow to same line as parameter list`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+                val foobar =
+                    { foo: Foo
+                        ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
+                val foobar =
+                    { foo: Foo ->
+                        foo.repeat(2)
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolation(3, 15, "Unexpected newline after parameter")
+                .isFormattedAs(formattedCode)
+        }
     }
 
-    @Test
-    fun `Given a lambda with a single parameter not fitting on the first line`() {
-        val code =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                { fooooooooooooooo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .setMaxLineLength()
-            .hasNoLintViolations()
-    }
+    @Nested
+    inner class `Given a multiline lambda with multiple parameters on same line` {
+        @Test
+        fun `Given max line length is not set then do not rewrite as single line`() {
+            val code =
+                """
+                val foobar =
+                    { foo: Foo, bar: Bar ->
+                        foo + bar
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .unsetMaxLineLength()
+                .hasNoLintViolations()
+        }
 
-    @Test
-    fun `Given a call expression followed by a lambda with a single parameter not fitting on the same line as the opening brace`() {
-        val code =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                barrrrrrrrrr { foooooooooooo: Foo ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        val formattedCode =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                barrrrrrrrrr {
-                    foooooooooooo: Foo
-                    ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .setMaxLineLength()
-            .hasLintViolations(
-                LintViolation(3, 20, "Newline expected before parameter"),
-                LintViolation(3, 39, "Newline expected before arrow"),
-            ).isFormattedAs(formattedCode)
-    }
+        @Test
+        fun `Given max line length is set and parameter list fits on single line then do not rewrite`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+                val foobar =
+                    { fooooo: Foo, bar: Bar ->
+                        foo + bar
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
 
-    @Test
-    fun `Given a lambda with multiple parameters fitting on the first line`() {
-        val code =
-            """
-            val foobar =
-                { foo: Foo, bar: Bar ->
-                    foo + bar
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `Given a lambda with multiple parameters but not fitting on the first line`() {
-        val code =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                { fooooo: Foo, bar: Bar ->
-                    foo + bar
-                }
-            """.trimIndent()
-        val formattedCode =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                {
-                    fooooo: Foo,
-                    bar: Bar
-                    ->
-                    foo + bar
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .setMaxLineLength()
-            .hasLintViolations(
-                LintViolation(3, 7, "Newline expected before parameter"),
-                LintViolation(3, 20, "Newline expected before parameter"),
-                LintViolation(3, 29, "Newline expected before arrow"),
-            ).isFormattedAs(formattedCode)
-    }
-
-    @Test
-    fun `Given a lambda with multiple parameters of which some are not fitting on line`() {
-        val code =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                { fooooooooooo: Foo, bar: Bar ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        val formattedCode =
-            """
-            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
-            val foobar =
-                {
-                    fooooooooooo: Foo,
-                    bar: Bar
-                    ->
-                    foo.repeat(2)
-                }
-            """.trimIndent()
-        functionLiteralRuleAssertThat(code)
-            .setMaxLineLength()
-            .hasLintViolations(
-                LintViolation(3, 7, "Newline expected before parameter"),
-                LintViolation(3, 26, "Newline expected before parameter"),
-                LintViolation(3, 35, "Newline expected before arrow"),
-            ).isFormattedAs(formattedCode)
+        @Test
+        fun `Given max line length is set and parameter list does not fit on single line then rewrite as multiline expression`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+                val foobar =
+                    { fooooo: Foo, bar: Bar ->
+                        foo + bar
+                    }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+                val foobar =
+                    {
+                        fooooo: Foo,
+                        bar: Bar
+                        ->
+                        foo + bar
+                    }
+                """.trimIndent()
+            functionLiteralRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(3, 7, "Newline expected before parameter"),
+                    LintViolation(3, 20, "Newline expected before parameter"),
+                    LintViolation(3, 29, "Newline expected before arrow"),
+                ).isFormattedAs(formattedCode)
+        }
     }
 
     @Test
@@ -261,6 +365,34 @@ class FunctionLiteralRuleTest {
     }
 
     @Test
+    fun `Given a call expression followed by a lambda with a single parameter not fitting on the same line as the opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                barrrrrrrrrr { foooooooooooo: Foo ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                barrrrrrrrrr {
+                    foooooooooooo: Foo
+                    ->
+                    foo.repeat(2)
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(3, 20, "Newline expected before parameter"),
+                LintViolation(3, 39, "Newline expected before arrow"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given a single line parameter list starting on the next line below the opening brace`() {
         val code =
             """
@@ -281,7 +413,7 @@ class FunctionLiteralRuleTest {
             """.trimIndent()
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
-            .hasLintViolation(4, 7, "No newline expected before parameter")
+            .hasLintViolation(4, 7, "Unexpected newline before parameter")
             .isFormattedAs(formattedCode)
     }
 
@@ -308,8 +440,8 @@ class FunctionLiteralRuleTest {
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(4, 7, "No newline expected before parameter"),
-                LintViolation(4, 35, "No newline expected after parameter"),
+                LintViolation(4, 7, "Unexpected newline before parameter"),
+                LintViolation(4, 35, "Unexpected newline after parameter"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -339,7 +471,6 @@ class FunctionLiteralRuleTest {
             """.trimIndent()
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
-            .isFormattedAs(formattedCode)
             .hasLintViolations(
                 LintViolation(4, 19, "Newline expected before parameter"),
                 LintViolation(4, 29, "Newline expected before parameter"),
@@ -382,7 +513,7 @@ class FunctionLiteralRuleTest {
     }
 
     @Test
-    fun `Given a multiline code block starting on same line a arrow`() {
+    fun `Given a multiline code block starting on same line a arrow but it can not fit entirely on that line`() {
         val code =
             """
             // $MAX_LINE_LENGTH_MARKER               $EOL_CHAR
@@ -402,6 +533,32 @@ class FunctionLiteralRuleTest {
             .addAdditionalRuleProvider { MultilineExpressionWrappingRule() }
             .setMaxLineLength()
             .hasLintViolation(2, 36, "Newline expected after arrow")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function literal with a single, but multiline, parameter`() {
+        val code =
+            """
+            val foo = {
+                    bar:
+                        @Baz("baz")
+                        Bar
+                -> bar()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = {
+                    bar:
+                        @Baz("baz")
+                        Bar
+                ->
+                bar()
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolation(5, 6, "Newline expected after arrow")
             .isFormattedAs(formattedCode)
     }
 
@@ -448,5 +605,68 @@ class FunctionLiteralRuleTest {
                 LintViolation(3, 67, "Newline expected after opening brace"),
                 LintViolation(3, 77, "Newline expected before closing brace"),
             ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline line function literal with single statement on same line as lbrace not separated with whitespace`() {
+        val code =
+            """
+            val foo = {doSomething()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = { doSomething() }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(1, 11, "Expected single space after opening curly brace"),
+                LintViolation(1, 25, "Unexpected newline as function literal fits on single line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a multiline line function literal with single statement on same line as rbrace not separated with whitespace`() {
+        val code =
+            """
+            val foo = {
+                doSomething()}
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = { doSomething() }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(1, 12, "Unexpected newline as function literal fits on single line"),
+                LintViolation(2, 18, "Expected single space before closing curly brace"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `xx`() {
+        val code =
+            """
+            fun foo() {
+                node
+                    .findChildByType(CONDITION)
+                    ?.let { fromAstNode ->
+                        startIndentContext(fromAstNode)
+                    }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                node
+                    .findChildByType(CONDITION)
+                    ?.let { fromAstNode -> startIndentContext(fromAstNode) }
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+//            .addAdditionalRuleProvider { WrappingRule() }
+            .addAdditionalRuleProvider { StatementWrappingRule() }
+            .addAdditionalRuleProvider { IndentationRule() }
+            .isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StatementWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StatementWrappingRuleTest.kt
@@ -1,13 +1,12 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class StatementWrappingRuleTest {
-    private val statementWrappingRuleAssertThat =
-        KtLintAssertThat.assertThatRule { StatementWrappingRule() }
+    private val statementWrappingRuleAssertThat = assertThatRule { StatementWrappingRule() }
 
     @Test
     fun `Given a function body with first statement at the same line as lbrace`() {
@@ -188,6 +187,24 @@ class StatementWrappingRuleTest {
             """.trimIndent()
         statementWrappingRuleAssertThat(code)
             .hasLintViolation(2, 18, "Expected new line before '}'")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given the function literal rule enabled and a multiline line function literal with last statement on same line as rbrace`() {
+        val code =
+            """
+            val foo = {
+                doSomething()}
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = { doSomething() }
+            """.trimIndent()
+        statementWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { WrappingRule() }
+            .addAdditionalRuleProvider { FunctionLiteralRule() }
+            .hasNoLintViolationsExceptInAdditionalRules()
             .isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -2623,6 +2623,82 @@ internal class WrappingRuleTest {
         wrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
+    @Nested
+    inner class `a multiline line function literal with single statement on same line as lbrace not separated with whitespace` {
+        @Test
+        fun `Given that the function literal rule is disabled`() {
+            val code =
+                """
+                val foo = {doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = {
+                    doSomething()
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .hasLintViolation(1, 12, "Missing newline after \"{\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given that the function literal rule is enabled`() {
+            val code =
+                """
+                val foo = {doSomething()
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = { doSomething() }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { FunctionLiteralRule() }
+                .hasNoLintViolationsExceptInAdditionalRules()
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `a multiline line function literal with single statement on same line as rbrace not separated with whitespace` {
+        @Test
+        fun `Given that the function literal rule is disabled`() {
+            val code =
+                """
+                val foo = {
+                    doSomething()}
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = {
+                    doSomething()
+                }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .hasLintViolation(2, 17, "Missing newline before \"}\"")
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Given that the function literal rule is enabled`() {
+            val code =
+                """
+                val foo = {
+                    doSomething()}
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo = { doSomething() }
+                """.trimIndent()
+            wrappingRuleAssertThat(code)
+                .addAdditionalRuleProvider { FunctionLiteralRule() }
+                .hasNoLintViolationsExceptInAdditionalRules()
+                .isFormattedAs(formattedCode)
+        }
+    }
+
     @Test
     fun `Given a nested function literal`() {
         val code =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportLayoutParserTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportLayoutParserTest.kt
@@ -11,16 +11,14 @@ import org.junit.jupiter.params.provider.ValueSource
 class ImportLayoutParserTest {
     @Test
     fun `blank lines in the beginning and end of import list are not allowed`() {
-        assertThatThrownBy {
-            parseImportsLayout("|,*,|")
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { parseImportsLayout("|,*,|") }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
     fun `pattern without single wildcard is not allowed`() {
-        assertThatThrownBy {
-            parseImportsLayout("java.util.List.*")
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { parseImportsLayout("java.util.List.*") }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @ParameterizedTest(name = "Imports layout: {0}")

--- a/ktlint-ruleset-template/build.gradle.kts
+++ b/ktlint-ruleset-template/build.gradle.kts
@@ -44,9 +44,7 @@ val ktlintCheck by tasks.registering(JavaExec::class) {
     args("--log-level=debug", "src/**/*.kt")
 }
 
-tasks.check {
-    dependsOn(ktlintCheck)
-}
+tasks.check { dependsOn(ktlintCheck) }
 
 publishing {
     publications {

--- a/ktlint-test-ruleset-provider-v2-deprecated/build.gradle.kts
+++ b/ktlint-test-ruleset-provider-v2-deprecated/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-    id("ktlint-kotlin-common")
-}
+plugins { id("ktlint-kotlin-common") }
 
-dependencies {
-    implementation(projects.ktlintCore)
-}
+dependencies { implementation(projects.ktlintCore) }

--- a/ktlint-test/api/ktlint-test.api
+++ b/ktlint-test/api/ktlint-test.api
@@ -19,6 +19,7 @@ public final class com/pinterest/ktlint/test/KtLintAssertThat {
 	public final fun hasNoLintViolationsForRuleId (Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;)Lcom/pinterest/ktlint/test/KtLintAssertThatAssertable;
 	public final fun isFormattedAs (Ljava/lang/String;)Lcom/pinterest/ktlint/test/KtLintAssertThatAssertable;
 	public final fun setMaxLineLength ()Lcom/pinterest/ktlint/test/KtLintAssertThat;
+	public final fun unsetMaxLineLength ()Lcom/pinterest/ktlint/test/KtLintAssertThat;
 	public final fun withEditorConfigOverride ([Lkotlin/Pair;)Lcom/pinterest/ktlint/test/KtLintAssertThat;
 }
 

--- a/ktlint-test/build.gradle.kts
+++ b/ktlint-test/build.gradle.kts
@@ -1,6 +1,4 @@
-plugins {
-    id("ktlint-publication-library")
-}
+plugins { id("ktlint-publication-library") }
 
 dependencies {
     implementation(projects.ktlintLogger)

--- a/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
+++ b/ktlint-test/src/main/kotlin/com/pinterest/ktlint/test/KtLintAssertThat.kt
@@ -528,9 +528,7 @@ public class KtLintAssertThatAssertable(
      * Asserts that the code is formatted as given.
      */
     public fun isFormattedAs(formattedCode: String): KtLintAssertThatAssertable {
-        check(formattedCode != code.content) {
-            "Use '.hasNoLintViolations()' instead of '.isFormattedAs(<original code>)'"
-        }
+        check(formattedCode != code.content) { "Use '.hasNoLintViolations()' instead of '.isFormattedAs(<original code>)'" }
 
         // Also format the code to be absolutely sure that codes does not get changed
         val (actualFormattedCode, _) = format()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,9 +9,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-    }
+    repositories { mavenCentral() }
 }
 
 plugins {


### PR DESCRIPTION
## Description

The idea of this change was to rewrite multiline function literals which only contains one single line statement:
```
val foo =
    listOf(1, 2, 3)
        .filter {
            it > 2
        }.count()
```
to a single line function literal given that it fits on a single line:
```
val foo =
    listOf(1, 2, 3)
        .filter { it > 2 }
        .count()
```

When applying this changes on the Ktlint code base itself, the results were mixed. There was a number of cases where rewriting the code, resulted in nicer code. Unfortunately, there were also a number of cases in which the formatted code was less readable or too different from common usage.

Before:
```
tasks.withType<JavaCompile>().configureEach {
    options.release.set(buildLogicTargetJavaVersion.majorVersion.toInt())
}
```
After:
```
tasks.withType<JavaCompile>().configureEach { options.release.set(buildLogicTargetJavaVersion.majorVersion.toInt()) }
```

Before:
```
dependencyResolutionManagement {
    versionCatalogs {
        create("libs") {
            from(files("../gradle/libs.versions.toml"))
        }
    }
}
```
After:
```
dependencyResolutionManagement {
    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) }  }
}
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
