### PR TITLE
Define EditorConfigOverride for dynamically loaded ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 Class "org.jetbrains.kotlin.com.intellij.treeCopyHandler" is no longer registered as extension point for the compiler as this is not supported in Kotlin 1.9. Please test your custom rules. In case of unexpected exceptions during formatting of code, see [#2044](https://github.com/pinterest/ktlint/pull/2044) for possible remediation.
 
+#### EditorConfigOverride - Ktlint API Consumer example
+
+The `EditorConfigOverride` parameter of the `KtlintRuleEngine` can be defined using the factory method `EditorConfigOverride.from(vararg properties: Pair<EditorConfigProperty<*>, *>)`. This requires the `EditorConfigProperty`'s to be available at compile time. Some common `EditorConfigProperty`'s are defined in `ktlint-rule-engine-core` which is loaded as transitive dependency of `ktlint-rule-engine` and as of that are available at compile.
+
+If an `EditorConfigProperty` is defined in a `Rule` that is only provided via a runtime dependency, it gets a bit more complicated. The `ktlint-api-consumer` example has now been updated to show how the `EditorConfigProperty` can be retrieved from the `Rule`.
+
 ### Added
 
 * Add experimental rule `class-signature`. This rule rewrites the class header to a consistent format. In code style `ktlint_official`, super types are always wrapped to a separate line. In other code styles, super types are only wrapped in classes having multiple super types. Especially for code style `ktlint_official` the class headers are rewritten in a more consistent format. See [examples in documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/#class-signature). `class-signature` [#875](https://github.com/pinterest/ktlint/issues/1349), [#1349](https://github.com/pinterest/ktlint/issues/875)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ If an `EditorConfigProperty` is defined in a `Rule` that is only provided via a 
 * Add experimental rule `function-expression-body`. This rule rewrites function bodies only contain a `return` or `throw` expression to an expression body. [#2150](https://github.com/pinterest/ktlint/issues/2150)
 * Add new experimental rule `statement-wrapping` which ensures function, class, or other blocks statement body doesn't start or end at starting or ending braces of the block ([#1938](https://github.com/pinterest/ktlint/issues/1938)). This rule was added in `0.50` release, but was never executed outside the unit tests. The rule is now added to the `StandardRuleSetProvider` ([#2170](https://github.com/pinterest/ktlint/issues/2170))
 * Add experimental rule `chain-method-continuation` to the `ktlint_official` code style, but it can be enabled explicitly for the other code styles as well. This rule requires the operators (`.` or `?.`) for chaining method calls, to be aligned with each other. This rule is enabled by ([#1953](https://github.com/pinterest/ktlint/issues/1953))
+* Add EditorConfigPropertyRegistry to assist API Consumers that load rulesets at runtime to define the EditorConfigOverride ([#2190](https://github.com/pinterest/ktlint/issues/2190))
 
 ### Removed
 

--- a/ktlint-api-consumer/build.gradle.kts
+++ b/ktlint-api-consumer/build.gradle.kts
@@ -9,9 +9,20 @@ dependencies {
 
     implementation(projects.ktlintLogger)
     implementation(projects.ktlintRuleEngine)
-    // This example API Consumer also depends on ktlint-ruleset-standard as it mixes custom rules and rules from ktlint-ruleset-standard
-    // into a new rule set.
-    implementation(projects.ktlintRulesetStandard)
+
+    // If the API consumer depends on a fixed set of ruleset, it might be best to provide those dependencies at compile time. In this way
+    // statically typing can be used when defining the EditorConfigOverride for the KtlintRuleEngine. However, in this example, the
+    // dependencies are provided at runtime.
+    // implementation(projects.ktlintRulesetStandard)
+
+    // For advanced use cases, the API consumer might prefer to provide the ruleset dependencies at runtime and load them dynamically using
+    // the RuleSetProvider of ktlint-cli-ruleset-core.
+    implementation(projects.ktlintCliRulesetCore)
+    runtimeOnly(projects.ktlintRulesetStandard)
+
+    // The standard ruleset is also provided as test dependency to demonstrate that rules that are provided at compile time can also be unit
+    // tested.
+    testImplementation(projects.ktlintRulesetStandard)
 
     testImplementation(projects.ktlintTest)
 }

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
@@ -146,7 +146,7 @@ private fun Set<RuleProvider>.findEditorConfigProperty(propertyName: String): Ed
                 .joinToString(
                     prefix = "Property with name '$propertyName' is not found in any of given rules. Available properties:\n\t",
                     separator = "\n\t",
-                    postfix = "Next to properties above, the properties to enable or disable rules are allowed as well."
+                    postfix = "Next to properties above, the properties to enable or disable rules are allowed as well.",
                 ) { "- $it" },
         )
 }

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/KtlintApiConsumer.kt
@@ -51,8 +51,10 @@ public fun main() {
                 // FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to always
             ).plus(
                 // For properties that are defined in rules for which the dependency is provided at runtime only, the property name can be
-                // provided as String and the value as Any type.
+                // provided as String and the value as Any type. In case the property value is invalid, the KtlintRuleEngine logs a warning.
                 ruleProviders.findEditorConfigProperty("ktlint_function_signature_body_expression_wrapping") to "alwaysx",
+                // In case an unknown property would be provided, an exception is thrown by the helper method
+                // ruleProviders.findEditorConfigProperty("unknown_property") to "some-value",
             )
 
     // The KtLint RuleEngine only needs to be instantiated once and can be reused in multiple invocations

--- a/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/CustomRuleSetProvider.kt
+++ b/ktlint-api-consumer/src/main/kotlin/com/example/ktlint/api/consumer/rules/CustomRuleSetProvider.kt
@@ -1,7 +1,6 @@
 package com.example.ktlint.api.consumer.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
-import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 
 internal val CUSTOM_RULE_SET_ID = "custom-rule-set-id"
 
@@ -9,6 +8,6 @@ internal val KTLINT_API_CONSUMER_RULE_PROVIDERS =
     setOf(
         // Can provide custom rules
         RuleProvider { NoVarRule() },
-        // but also reuse rules from KtLint rulesets
-        RuleProvider { IndentationRule() },
+        // If rulesets are include at compile time, they can be added to the custom rule provider.
+        // RuleProvider { IndentationRule() },
     )

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -440,6 +440,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/RuleId {
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/RuleId$Companion {
+	public final fun isValid (Ljava/lang/String;)Z
 	public final fun prefixWithStandardRuleSetIdWhenMissing (Ljava/lang/String;)Ljava/lang/String;
 }
 
@@ -471,6 +472,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/RuleSetId {
 
 public final class com/pinterest/ktlint/rule/engine/core/api/RuleSetId$Companion {
 	public final fun getSTANDARD ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleSetId;
+	public final fun isValid (Ljava/lang/String;)Z
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigPropertyKt {

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -27,6 +27,8 @@ public class RuleId(
             } else {
                 "${RuleSetId.STANDARD.value}$DELIMITER$id"
             }
+
+        public fun isValid(value: String): Boolean = IdNamingPolicy.isValidRuleId(value)
     }
 }
 
@@ -45,6 +47,8 @@ public class RuleSetId(
          * maintenance of the rule (set).
          */
         public val STANDARD: RuleSetId = RuleSetId("standard")
+
+        public fun isValid(value: String): Boolean = IdNamingPolicy.isValidRuleSetId(value)
     }
 }
 

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/internal/IdNamingPolicy.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/internal/IdNamingPolicy.kt
@@ -14,7 +14,9 @@ internal object IdNamingPolicy {
      * Will throw [IllegalArgumentException] on invalid [ruleId] name.
      */
     internal fun enforceRuleIdNaming(ruleId: String) =
-        require(ruleId.matches(RULE_ID_REGEX)) { "Rule with id '$ruleId' must match regexp '${RULE_ID_REGEX.pattern}'" }
+        require(isValidRuleId(ruleId)) { "Rule with id '$ruleId' must match regexp '${RULE_ID_REGEX.pattern}'" }
+
+    internal fun isValidRuleId(ruleId: String) = ruleId.matches(RULE_ID_REGEX)
 
     /**
      * Checks provided [ruleSetId] is valid.
@@ -22,5 +24,7 @@ internal object IdNamingPolicy {
      * Will throw [IllegalArgumentException] on invalid [ruleSetId] name.
      */
     internal fun enforceRuleSetIdNaming(ruleSetId: String) =
-        require(ruleSetId.matches(RULE_SET_ID_REGEX)) { "Rule set id '$ruleSetId' must match '${RULE_SET_ID_REGEX.pattern}'" }
+        require(isValidRuleSetId(ruleSetId)) { "Rule set id '$ruleSetId' must match '${RULE_SET_ID_REGEX.pattern}'" }
+
+    internal fun isValidRuleSetId(ruleSetId: String) = ruleSetId.matches(RULE_SET_ID_REGEX)
 }

--- a/ktlint-rule-engine/api/ktlint-rule-engine.api
+++ b/ktlint-rule-engine/api/ktlint-rule-engine.api
@@ -44,6 +44,15 @@ public final class com/pinterest/ktlint/rule/engine/api/EditorConfigOverride$Com
 	public final fun plus (Lcom/pinterest/ktlint/rule/engine/api/EditorConfigOverride;[Lkotlin/Pair;)Lcom/pinterest/ktlint/rule/engine/api/EditorConfigOverride;
 }
 
+public final class com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyNotFoundException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyRegistry {
+	public fun <init> (Ljava/util/Set;)V
+	public final fun find (Ljava/lang/String;)Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;
+}
+
 public final class com/pinterest/ktlint/rule/engine/api/KtLintParseException : java/lang/RuntimeException {
 	public fun <init> (IILjava/lang/String;)V
 	public final fun getCol ()I

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
@@ -4,15 +4,14 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProper
 import org.ec4j.core.model.PropertyType.PropertyValue
 
 /**
- * The [EditorConfigOverride] allows to add or replace properties which are loaded from the ".editorconfig" file. It
- * serves two purposes.
+ * The [EditorConfigOverride] allows to add or replace properties which are loaded from the ".editorconfig" file. It serves two purposes.
  *
- * Firstly, the [EditorConfigOverride] can be used by API consumers to run a rule with values which are not actually
- * save to the ".editorconfig" file. When doing so, this should be clearly communicated to their consumers who will
- * expect the settings in that file to be respected.
+ * Firstly, the [EditorConfigOverride] can be used by API consumers to run a rule with values which are not actually saved to the
+ * ".editorconfig" file. When doing so, this should be clearly communicated to their consumers who will expect the settings in that file to
+ * be respected.
  *
- * Secondly, the [EditorConfigOverride] is used in unit tests, to test a rule with distinct values of a property without
- * having to access an ".editorconfig" file from physical storage. This also improves readability of the tests.
+ * Secondly, the [EditorConfigOverride] is used in unit tests, to test a rule with distinct values of a property without having to access an
+ * ".editorconfig" file from physical storage. This also improves readability of the tests.
  */
 public class EditorConfigOverride {
     private val _properties = mutableMapOf<EditorConfigProperty<*>, PropertyValue<*>>()

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigOverride.kt
@@ -36,7 +36,8 @@ public class EditorConfigOverride {
 
     public companion object {
         /**
-         * Creates the [EditorConfigOverride] based on one or more property-value mappings.
+         * Creates the [EditorConfigOverride] based on one or more property-value mappings. In case rule sets are only loaded at runtime,
+         * you can use [EditorConfigPropertyRegistry] to retrieve the [EditorConfigProperty] for which a value is to be overridden.
          */
         public fun from(vararg properties: Pair<EditorConfigProperty<*>, *>): EditorConfigOverride {
             require(properties.isNotEmpty()) {

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyRegistry.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyRegistry.kt
@@ -1,0 +1,86 @@
+package com.pinterest.ktlint.rule.engine.api
+
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.END_OF_LINE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INSERT_FINAL_NEWLINE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleExecutionEditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleSetExecutionEditorConfigProperty
+
+/**
+ * Build a registry of [EditorConfigProperty]'s that can be used to instantiate the [EditorConfigOverride] of the [KtLintRuleEngine]. When
+ * possible, it is strongly advised to instantiate the [EditorConfigOverride] with compile versions of the [EditorConfigProperty] as that
+ * ensures that value is of the correct type.
+ *
+ * In case that [Rule]s and their [EditorConfigProperty]'s are loaded at runtime, the [EditorConfigPropertyRegistry] has to be instantiated
+ * with the same set of [RuleProvider]s that will be passed to the [KtLintRuleEngine]. Using the [EditorConfigPropertyRegistry], the
+ * [EditorConfigProperty]'s can than be retrieved with the name as is stored in the `.editorconfig` file. Note: only properties defined in
+ * the `ktlint-rule-engine-core` module, and properties defined in [Rule]s provided by the [RuleProvider]s can be found via the
+ * [EditorConfigPropertyRegistry].
+ */
+public class EditorConfigPropertyRegistry(
+    ruleProviders: Set<RuleProvider>,
+) {
+    private val properties =
+        ruleProviders
+            .map { it.createNewRuleInstance() }
+            .flatMap { it.usesEditorConfigProperties }
+            .plus(KTLINT_RULE_ENGINE_CORE_PROPERTIES)
+            .distinct()
+
+    /**
+     * Finds the first [EditorConfigProperty] with name [propertyName]. Only properties defined in the `ktlint-rule-engine-core` module,
+     * and properties defined in [Rule]s provided by the [RuleProvider]s to the [EditorConfigPropertyRegistry] will be found. An
+     * [EditorConfigPropertyNotFoundException] is thrown when no property with name [propertyName] is found
+     */
+    public fun find(propertyName: String): EditorConfigProperty<*> =
+        properties.findProperty(propertyName)
+            ?: propertyName.toRuleExecutionPropertyOrNull()
+            ?: throw EditorConfigPropertyNotFoundException(
+                properties
+                    .map { it.type.name }
+                    .sorted()
+                    .joinToString(
+                        prefix = "Property with name '$propertyName' is not found in any of given rules. Available properties:\n\t",
+                        separator = "\n\t",
+                        postfix = "\nNext to properties above, the properties to enable or disable ktlint rules are allowed as well.",
+                    ) { "- $it" },
+            )
+
+    private fun String.toRuleExecutionPropertyOrNull() =
+        takeIf { it.startsWith("ktlint_") }
+            ?.removePrefix("ktlint_")
+            ?.replace("_", ":")
+            ?.let {
+                when {
+                    RuleId.isValid(it) -> RuleId(it).createRuleExecutionEditorConfigProperty()
+                    RuleSetId.isValid(it) -> RuleSetId(it).createRuleSetExecutionEditorConfigProperty()
+                    else -> null
+                }
+            }
+
+    private fun List<EditorConfigProperty<*>>.findProperty(propertyName: String): EditorConfigProperty<*>? =
+        find { it.type.name == propertyName }
+
+    private companion object {
+        val KTLINT_RULE_ENGINE_CORE_PROPERTIES =
+            listOf(
+                CODE_STYLE_PROPERTY,
+                END_OF_LINE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                INDENT_SIZE_PROPERTY,
+                INSERT_FINAL_NEWLINE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            )
+    }
+}
+
+public class EditorConfigPropertyNotFoundException(
+    message: String,
+) : RuntimeException(message)

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyRegistryTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/EditorConfigPropertyRegistryTest.kt
@@ -1,0 +1,92 @@
+package com.pinterest.ktlint.rule.engine.api
+
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleExecutionEditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleSetExecutionEditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ktLintRuleExecutionPropertyName
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ktLintRuleSetExecutionPropertyName
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.ec4j.core.model.PropertyType
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EditorConfigPropertyRegistryTest {
+    @Nested
+    inner class `Given an editor config property without rule providers` {
+        val editorConfigPropertyRegistry = EditorConfigPropertyRegistry(emptySet())
+
+        @Test
+        fun `Given a property name defined in the ktlint rule engine core module then return that property`() {
+            val actual = editorConfigPropertyRegistry.find(INDENT_SIZE_PROPERTY.name)
+
+            assertThat(actual).isEqualTo(INDENT_SIZE_PROPERTY)
+        }
+
+        @Test
+        fun `Given a property name starting with 'ktlint_', and for which the suffix is a valid rule id then return the rule execution property for that rule id`() {
+            val actual = editorConfigPropertyRegistry.find(SOME_RULE_ID.ktLintRuleExecutionPropertyName())
+
+            assertThat(actual).isEqualTo(SOME_RULE_ID.createRuleExecutionEditorConfigProperty())
+        }
+
+        @Test
+        fun `Given a property name starting with 'ktlint_', and for which the suffix is not valid rule id, but the suffix is a valid rule set id then return the rule execution property for that rule set id`() {
+            val actual = editorConfigPropertyRegistry.find(SOME_RULE_SET_ID.ktLintRuleSetExecutionPropertyName())
+
+            assertThat(actual).isEqualTo(SOME_RULE_SET_ID.createRuleSetExecutionEditorConfigProperty())
+        }
+
+        @Test
+        fun `Given a property name that can not be found by name in the editor config property registry then throw an exception`() {
+            assertThatExceptionOfType(EditorConfigPropertyNotFoundException::class.java)
+                .isThrownBy { editorConfigPropertyRegistry.find("some-unknown-property-name") }
+        }
+    }
+
+    @Test
+    fun `Given a property name defined in a rule provided to the editor config property registry then return that property`() {
+        val editorConfigPropertyRegistry =
+            EditorConfigPropertyRegistry(
+                setOf(
+                    RuleProvider { SomeTestRule() },
+                ),
+            )
+
+        val actual = editorConfigPropertyRegistry.find(SomeTestRule.SOME_PROPERTY_NAME)
+
+        assertThat(actual).isEqualTo(SomeTestRule.SOME_PROPERTY)
+    }
+
+    private companion object {
+        val SOME_RULE_ID = RuleId("some-ruleset:some-rule-name")
+        val SOME_RULE_SET_ID = RuleSetId("some-ruleset")
+    }
+}
+
+private class SomeTestRule :
+    Rule(
+        ruleId = RuleId("test:some-test-rule"),
+        about = About(),
+        usesEditorConfigProperties = setOf(SOME_PROPERTY),
+    ) {
+    companion object {
+        const val SOME_PROPERTY_NAME = "some_property_name"
+        val SOME_PROPERTY: EditorConfigProperty<Int> =
+            EditorConfigProperty(
+                type =
+                    PropertyType.LowerCasingPropertyType(
+                        SOME_PROPERTY_NAME,
+                        "some description",
+                        PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+                        setOf("1", "2", "3"),
+                    ),
+                defaultValue = 1,
+            )
+    }
+}


### PR DESCRIPTION
## Description

Extend API Consumer example to showcase how EditorConfigOverride can be defined with dynamically loaded rulesets

Closes #2190

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
