### PR TITLE
Generate changelog for unreleased PR's

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -33,29 +33,34 @@ jobs:
             {
               "categories": [
                 {
+                  "title": "### 🚀 API Changes",
+                  "labels": ["api changelog"]
+                },
+                {
                   "title": "### 🚀 Features",
-                  "labels": ["feature"],
+                  "labels": ["feature changelog"],
                   "empty_content": "None"
                 },
                 {
                   "title": "### 🐛 Fixes",
-                  "labels": ["fix"],
+                  "labels": ["fix changelog"],
                   "empty_content": "None"
                 },
                 {
                   "title": "### 📦 Dependencies",
-                  "labels": ["dependency"]
+                  "labels": ["dependency changelog"]
                 },
                 {
                   "title": "### 💬 Other",
-                  "labels": []
+                  "labels": [],
+                  "exclude_labels": ["documentation", "exclude from changelog"]
                 }
               ],
               "sort": {
                 "order": "ASC",
                 "on_property": "mergedAt"
               },
-              "template": "${{CHANGELOG}}",
+              "template": "## Unreleased\n\n${{CHANGELOG}}",
               "pr_template": "* ${{TITLE}}\n  PR [#${{NUMBER}}](${{URL}}), by @${{AUTHOR}}",
               "empty_template": "- no changes",
               "label_extractor": [
@@ -63,7 +68,7 @@ jobs:
                   "pattern": "renovate\\[bot\\]",
                   "on_property": "author",
                   "method": "replace",
-                  "target": "dependency"
+                  "target": "dependency changelog"
                 }
               ],
               "max_pull_requests": 1000,

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -16,51 +16,60 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
+      - name: Get version
+        id: get_version
+        if: ${{ success() }}
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
       - name: "Build Changelog"
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v3
         with:
-          fromTag: "0.49.0"
-          toTag: "0.50.0"
+          fromTag: "${{ env.version }}"
+          # This Github action is run before building a new release. All PR's created after last release and between current HEAD are to be
+          # included
+          toTag: "HEAD"
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
               "categories": [
                 {
-                  "title": "## 🚀 Features",
-                  "labels": ["feature"]
+                  "title": "### 🚀 Features",
+                  "labels": ["feature"],
+                  "empty_content": "None"
                 },
                 {
-                  "title": "## 🐛 Fixes",
-                  "labels": ["fix"]
+                  "title": "### 🐛 Fixes",
+                  "labels": ["fix"],
+                  "empty_content": "None"
                 },
                 {
-                  "title": "## 🧪 Tests",
-                  "labels": ["test"]
+                  "title": "### 📦 Dependencies",
+                  "labels": ["dependency"]
                 },
                 {
-                  "title": "## 💬 Uncategorized",
+                  "title": "### 💬 Other",
                   "labels": []
-                },
-                {
-                  "title": "## 📦 Dependencies",
-                  "labels": ["dependencies"]
                 }
-              ]
+              ],
+              "sort": {
+                "order": "ASC",
+                "on_property": "mergedAt"
+              },
+              "template": "${{CHANGELOG}}",
+              "pr_template": "* ${{TITLE}}\n  PR [#${{NUMBER}}](${{URL}}), by @${{AUTHOR}}",
+              "empty_template": "- no changes",
+              "label_extractor": [
+                {
+                  "pattern": "renovate\\[bot\\]",
+                  "on_property": "author",
+                  "method": "replace",
+                  "target": "dependency"
+                }
+              ],
+              "max_pull_requests": 1000,
+              "max_back_track_time_days": 1000
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: |
-          echo "==== test 1 ===="
-          echo -e "${{ steps.build_changelog.outputs.changelog }}"
-          echo "==== test 2 ===="
-          echo -e ${{ steps.build_changelog.outputs.changelog }}
-          echo "==== test 3 ===="
-          echo ${{ steps.build_changelog.outputs.changelog }}
-          echo "==== test 4 ===="
-          echo ${{ steps.build_changelog.outputs.failed }}
-          echo "==== test 5 ===="
-          echo ${{ steps.build_changelog.outputs.pull_requests }}
-          echo "==== test 6 ===="
-          echo ${{ steps.build_changelog.outputs.pull_requests }}
+      - run: echo -e "${{ steps.build_changelog.outputs.changelog }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@ Class "org.jetbrains.kotlin.com.intellij.treeCopyHandler" is no longer registere
 * Build the project with Java 20, run test on Java 8, 11, 17 and 20 ([#1888](https://github.com/pinterest/ktlint/issues/1888))
 * Update dependency `io.github.oshai:kotlin-logging-jvm` to `v5.1.0` ([#2174](https://github.com/pinterest/ktlint/pull/2174))
 * Update kotlin monorepo to v1.9.10 [#2197](https://github.com/pinterest/ktlint/issues/2197)
-* Update integrations doc with TCA [#2191](https://github.com/pinterest/ktlint/pull/2191)
 
 ## [0.50.0] - 2023-06-29
 


### PR DESCRIPTION
## Description

Generate changelog based for unreleased PR's, e.g. PR's between current version (latest release) and HEAD commit.

For now, the changelog should not be added automatically to the release. First, we need to experiment with the process of labeling PR's correctly.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
