### PR TITLE
Fix conflict between rules due to annotated super type call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ If an `EditorConfigProperty` is defined in a `Rule` that is only provided via a 
 * Fix wrapping of multiline postfix expression `multiline-expression-wrapping` [#2183](https://github.com/pinterest/ktlint/issues/2183)
 * Remove registration of class "org.jetbrains.kotlin.com.intellij.treeCopyHandler" as extension point for the compiler as this is not supported in the embedded Kotlin compiler version 1.9. Also remove Ktlint CLI command line flag `disable-kotlin-extension-point`, and parameter `enableKotlinCompilerExtensionPoint` from `KtLintRuleEngine` to disable the kotlin extension point [#2061](https://github.com/pinterest/ktlint/issues/2061)
 * Do not wrap expression after a spread operator `multiline-expression-wrapping` [#2188](https://github.com/pinterest/ktlint/issues/2188)
+* Do not wrap expression after a spread operator `multiline-expression-wrapping` [#2188](https://github.com/pinterest/ktlint/issues/2188)
+* Prevent cyclic dependency between `modifier-list-spacing` rule and `indent` rule when the super type call entry is annotated
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ If an `EditorConfigProperty` is defined in a `Rule` that is only provided via a 
 * Remove registration of class "org.jetbrains.kotlin.com.intellij.treeCopyHandler" as extension point for the compiler as this is not supported in the embedded Kotlin compiler version 1.9. Also remove Ktlint CLI command line flag `disable-kotlin-extension-point`, and parameter `enableKotlinCompilerExtensionPoint` from `KtLintRuleEngine` to disable the kotlin extension point [#2061](https://github.com/pinterest/ktlint/issues/2061)
 * Do not wrap expression after a spread operator `multiline-expression-wrapping` [#2188](https://github.com/pinterest/ktlint/issues/2188)
 * Do not wrap expression after a spread operator `multiline-expression-wrapping` [#2188](https://github.com/pinterest/ktlint/issues/2188)
-* Prevent cyclic dependency between `modifier-list-spacing` rule and `indent` rule when the super type call entry is annotated
+* Prevent cyclic dependency between `modifier-list-spacing` rule and `indent` rule when the super type call entry is annotated ([#2227](https://github.com/pinterest/ktlint/pull/2227))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRule.kt
@@ -9,7 +9,6 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
-import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
@@ -59,28 +58,21 @@ public class ModifierListSpacingRule : StandardRule("modifier-list-spacing") {
                 if (node.isAnnotationElement() ||
                     (node.elementType == MODIFIER_LIST && node.lastChildNode.isAnnotationElement())
                 ) {
-                    val expectedWhiteSpace =
-                        if (whitespace.textContains('\n')) {
-                            node.indent()
-                        } else {
-                            " "
-                        }
-                    if (whitespace.text != expectedWhiteSpace) {
-                        emit(
-                            whitespace.startOffset,
-                            "Single whitespace or newline expected after annotation",
-                            true,
-                        )
+                    if (whitespace.text.contains("\n\n")) {
+                        emit(whitespace.startOffset, "Single newline expected after annotation", true)
                         if (autoCorrect) {
-                            (whitespace as LeafPsiElement).rawReplaceWithText(expectedWhiteSpace)
+                            (whitespace as LeafPsiElement).rawReplaceWithText(
+                                "\n".plus(whitespace.text.substringAfterLast("\n")),
+                            )
+                        }
+                    } else if (!whitespace.text.contains('\n') && whitespace.text != " ") {
+                        emit(whitespace.startOffset, "Single whitespace or newline expected after annotation", true)
+                        if (autoCorrect) {
+                            (whitespace as LeafPsiElement).rawReplaceWithText(" ")
                         }
                     }
                 } else {
-                    emit(
-                        whitespace.startOffset,
-                        "Single whitespace expected after modifier",
-                        true,
-                    )
+                    emit(whitespace.startOffset, "Single whitespace expected after modifier", true)
                     if (autoCorrect) {
                         (whitespace as LeafPsiElement).rawReplaceWithText(" ")
                     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRuleTest.kt
@@ -143,8 +143,8 @@ class ModifierListSpacingRuleTest {
             """.trimIndent()
         modifierListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 6, "Single whitespace or newline expected after annotation"),
-                LintViolation(3, 6, "Single whitespace or newline expected after annotation"),
+                LintViolation(1, 6, "Single newline expected after annotation"),
+                LintViolation(3, 6, "Single newline expected after annotation"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -170,6 +170,18 @@ class ModifierListSpacingRuleTest {
               */
             @Foo3
             class Bar {}
+            """.trimIndent()
+        modifierListSpacingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a class with an annotated super type call entry`() {
+        val code =
+            """
+            class Foo(
+                bar: Bar,
+            ) : @Unused
+                FooBar()
             """.trimIndent()
         modifierListSpacingRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
## Description

Fix conflict between indentation rule and modifier list spacing rule resulting in cyclic changing of indentation of super type call entry which is annotated:
```
class Foo(
    bar: Bar,
) : @Unused
    FooBar()
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
