### PR TITLE
Super type list starting with an annotation having a parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ If an `EditorConfigProperty` is defined in a `Rule` that is only provided via a 
 * Prevent cyclic dependency between `modifier-list-spacing` rule and `indent` rule when the super type call entry is annotated ([#2227](https://github.com/pinterest/ktlint/pull/2227))
 * Do not remove parenthesis after explicit constructor keyword when it has no parameters ([#2226](https://github.com/pinterest/ktlint/pull/2226))
 * Fix indentation of super type list of class in case it is preceded by a comment ([#2228](https://github.com/pinterest/ktlint/pull/2228))
+* Allow a super type list starting with an annotation having a parameter to be on the same line as the closing parenthesis of the enclosing class ([#2230](https://github.com/pinterest/ktlint/pull/2230))
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -3,10 +3,13 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.GT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
@@ -32,6 +35,8 @@ import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
@@ -153,10 +158,19 @@ public class AnnotationRule :
                 .filter {
                     it.isAnnotationEntryWithValueArgumentList() ||
                         !it.isPrecededByOtherAnnotationEntryWithoutParametersOnTheSameLine()
-                }.forEach { annotationEntry ->
+                }.forEachIndexed { index, annotationEntry ->
                     annotationEntry
                         .prevLeaf()
-                        ?.let { prevLeaf ->
+                        .takeUnless {
+                            // Allow in ktlint_official code style:
+                            //     class Foo(
+                            //         bar: Bar,
+                            //     ) : @Suppress("DEPRECATION")
+                            //         FooBar()
+                            index == 0 &&
+                                codeStyle == CodeStyleValue.ktlint_official &&
+                                it.annotationOnSameLineAsClosingParenthesisOfClassParameterList()
+                        }?.let { prevLeaf ->
                             // Let the indentation rule determine the exact indentation and only report and fix when the line needs to be
                             // wrapped
                             if (!prevLeaf.textContains('\n')) {
@@ -368,6 +382,22 @@ public class AnnotationRule :
             .none { it.isWhiteSpaceWithNewline() }
 
     private fun ASTNode.isFollowedByOtherAnnotationEntry() = siblings(forward = true).any { it.elementType == ANNOTATION_ENTRY }
+
+    private fun ASTNode?.annotationOnSameLineAsClosingParenthesisOfClassParameterList() =
+        // Allow:
+        //     class Foo(
+        //         bar: Bar,
+        //     ) : @Suppress("DEPRECATION")
+        //         FooBar()
+        this
+            ?.takeIf { it.treeParent?.elementType == CLASS }
+            ?.prevCodeSibling()
+            ?.takeIf { it.elementType == COLON }
+            ?.prevCodeLeaf()
+            ?.takeIf { it.elementType == RPAR }
+            ?.prevLeaf()
+            ?.isWhiteSpaceWithNewline()
+            ?: false
 
     private fun ASTNode.isOnSameLineAsNextAnnotationEntry() =
         siblings(forward = true)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -974,4 +974,16 @@ class AnnotationRuleTest {
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Given a class with a super type list starting with an annotation having parameter`() {
+        val code =
+            """
+            class Foo(
+                bar: Bar,
+            ) : @Suppress("DEPRECATION")
+                FooBar()
+            """.trimIndent()
+        annotationRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

A super type list starting with an annotation having a parameters can be on the same line as the closing parenthesis of the enclosing class:
```
class Foo(
    bar: Bar,
) : @Suppress("DEPRECATION")
    FooBar()
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
