### PR TITLE
Add brew formula path

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -66,6 +66,7 @@ jobs:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
         with:
           formula-name: ktlint
+          formula-path: Formula/k/ktlint.rb
           download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
 
       - name: Release to sdkman


### PR DESCRIPTION
## Description

Brew formula has been relocated (https://github.com/Homebrew/homebrew-core/pull/139592). The default formula path as resolved by GitHub action is no longer valid and needs to be overridden (https://github.com/mislav/bump-homebrew-formula-action/issues/58).

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [ ] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
