### PR TITLE
Fix code style parameter in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Fix ktlint cli parameter `--code-style` [#2238](https://github.com/pinterest/ktlint/pull/2238)
+
 ### Changed
 
 ## 1.0.0 - 2023-09-05

--- a/documentation/snapshot/docs/faq.md
+++ b/documentation/snapshot/docs/faq.md
@@ -86,11 +86,6 @@ As of Ktlint 0.50, an error can only be suppressed using @Suppress or @SuppressW
     import foo.*
     ```
 
-## How do I globally disable a rule without `.editorconfig`?
-
-When using Ktlint CLI, you may pass a list of disabled rules via the `--disabled_rules` command line flag. The value is a comma separated list of rule id's that have to be disabled. The rule id must be fully qualified (e.g. must be prefixed with the rule set id). 
-
-
 ## Why is `.editorconfig` property `disabled_rules` deprecated and how do I resolve this?
 
 The `.editorconfig` properties `disabled_rules` and `ktlint_disabled_rules` are deprecated as of KtLint version `0.48` and are removed in version `0.49`. Those properties contain a comma separated list of rules which are disabled. Using a comma separated list of values has some disadvantages.

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -59,20 +59,14 @@ On Arch Linux install package [ktlint <sup>AUR</sup>](https://aur.archlinux.org/
 
 ### Rule set(s)
 
-When no arguments are specified, the style of all Kotlin files (ending with '.kt' or '.kts') inside the current dir (recursively) are validated with the (non-experimental) rules from the [standard ruleset](../../rules/standard/). Hidden folders will be skipped.
+When no arguments are specified, the style of all Kotlin files (ending with '.kt' or '.kts') inside the current dir (recursively) are validated with the rules from the [standard ruleset](../../rules/standard/). Hidden folders will be skipped.
 
 ```shell title="Default validation with standard ruleset"
 ktlint
 ```
 
-To validate with the [standard ruleset](../../rules/standard/) including the experimental rules run command below: 
-
-```shell title="Validation with standard ruleset including the experimental rules"
-ktlint --experimental
-```
-
 !!! note
-    Instead of using this command line flag, it is advised to set `.editorconfig` property `ktlint_experimental = enabled` if you want the project always to be checked with the experimental rules.
+    The experimental rules in the standard rule set will only be run when `.editorconfig` property `ktlint_experimental = enabled` is set.
 
 To validate with a [custom ruleset](../../api/custom-rule-set/) run command below:  
 
@@ -83,7 +77,7 @@ ktlint -R /path/to/custom-ruleset.jar
 ```
 
 !!! note
-    If the custom rule set contains rules that are marked as experimental, those rule will only be run when `.editorconfig` property `ktlint_experimental = enabled` is set (or command line parameter `--experimental` is specified).
+    If the custom rule set contains rules that are marked as experimental, those rule will only be run when `.editorconfig` property `ktlint_experimental = enabled` is set.
 
 ### Format (autocorrect)
 
@@ -149,9 +143,9 @@ A scaffold of the `.editorconfig file` can be generated with command below. Note
 ```shell title="Generate .editorconfig"
 ktlint generateEditorConfig
 # or
-ktlint --experimental generateEditorConfig
+ktlint generateEditorConfig
 # or
-ktlint --experimental --ruleset=/path/to/custom-ruleset.jar generateEditorConfig
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig
 ```
 
 Normally this file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.
@@ -201,8 +195,6 @@ ktlint installGitPrePushHook
 `-a` or `--android`: Turn on Android Kotlin Style Guide compatibility. This flag is most likely to be removed in a future version. Use [`.editorconfig ktlint_code_style`](../../rules/configuration-ktlint/#code-style). 
 
 `--color` and `--color-name=<colorName>`: Make output colorful and optionally set the color name to use.
-
-`--disabled_rules=<disabledRules>`: A comma-separated list of rules to globally disable. To disable the standard ktlint rule-set use `--disabled_rules=standard`.  This flag is most likely to be removed in a future version. Use [`.editorconfig disabled_rules`](../../rules/configuration-ktlint/#disabled-rules).
 
 `-h` or `--help`: Prints help information.
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -105,11 +105,13 @@ internal class KtlintCommandLine {
         scope = CommandLine.ScopeType.INHERIT,
         names = ["--code-style"],
         description = [
-            "Defines the code style (ktlint_official, intellij_idea or android_studio) to be used for formatting the code. It is " +
-                "advised to define '.editorconfig' property 'ktlint_code_style'.",
+            "Defines the code style (ktlint_official, intellij_idea or android_studio) to be used for formatting the code. This option " +
+                "is deprecated, and will be removed in Ktlint 1.1. The code style has to be defined as '.editorconfig' property " +
+                "'ktlint_code_style'.",
         ],
         converter = [CodeStyleValueConverter::class],
     )
+    @Deprecated("Marked for removal in Ktlint 1.1")
     var codeStyle: CodeStyleValue? = null
 
     @Option(
@@ -127,10 +129,12 @@ internal class KtlintCommandLine {
     @Option(
         names = ["--disabled_rules"],
         description = [
-            "Comma-separated list of rules to globally disable." +
-                " To disable standard ktlint rule-set use --disabled_rules=standard",
+            "Comma-separated list of rules to globally disable. This option is deprecated, and will be removed in Ktlint 1.1. The " +
+                "disabled rules have to be defined as '.editorconfig' properties. See " +
+                "https://pinterest.github.io/ktlint/1.0.0/faq/#how-do-i-enable-or-disable-a-rule",
         ],
     )
+    @Deprecated("Marked for removal in Ktlint 1.1")
     var disabledRules: String = ""
 
     @Option(
@@ -202,8 +206,13 @@ internal class KtlintCommandLine {
 
     @Option(
         names = ["--experimental"],
-        description = ["Enable experimental rules"],
+        description = [
+            "Enable experimental rules. This option is deprecated, and will be removed in Ktlint 1.1. The experimental flag has to be " +
+                "set as '.editorconfig' property 'ktlint_experimental'. See " +
+                "https://pinterest.github.io/ktlint/1.0.0/faq/#how-do-i-enable-or-disable-a-rule-set",
+        ],
     )
+    @Deprecated("Marked for removal in Ktlint 1.1")
     var experimental: Boolean = false
 
     @Option(
@@ -246,14 +255,25 @@ internal class KtlintCommandLine {
             EditorConfigOverride
                 .EMPTY_EDITOR_CONFIG_OVERRIDE
                 .applyIf(experimental) {
-                    logger.debug { "Add editor config override to allow the experimental rule set" }
+                    logger.warn {
+                        "Parameter `--experimental is deprecated, and will be removed in Ktlint 1.1. The experimental flag has to be " +
+                            "set as '.editorconfig' property 'ktlint_experimental = enabled'. See " +
+                            "https://pinterest.github.io/ktlint/1.0.0/faq/#how-do-i-enable-or-disable-a-rule-set"
+                    }
                     plus(EXPERIMENTAL_RULES_EXECUTION_PROPERTY to RuleExecution.enabled)
                 }.applyIf(disabledRules.isNotBlank()) {
-                    logger.debug { "Add editor config override to disable rules: '$disabledRules'" }
+                    logger.warn {
+                        "Parameter `--disabled-rules is deprecated, and will be removed in Ktlint 1.1. The disabled rules have to be " +
+                            "defined as '.editorconfig' properties. See " +
+                            "https://pinterest.github.io/ktlint/1.0.0/faq/#how-do-i-enable-or-disable-a-rule"
+                    }
                     plus(*disabledRulesEditorConfigOverrides())
-                }.applyIf(codeStyle == CodeStyleValue.android_studio) {
-                    logger.debug { "Add editor config override to set code style to 'android_studio'" }
-                    plus(CODE_STYLE_PROPERTY to CodeStyleValue.android_studio)
+                }.applyIf(codeStyle != null) {
+                    logger.warn {
+                        "Parameter `--code-style=${codeStyle?.name} is deprecated. The code style should be defined as '.editorconfig' " +
+                            "property 'ktlint_code_style'."
+                    }
+                    plus(CODE_STYLE_PROPERTY to codeStyle)
                 }.applyIf(stdin) {
                     logger.debug {
                         "Add editor config override to disable 'filename' rule which can not be used in combination with reading from " +

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -387,12 +387,12 @@ class SimpleCLITest {
             CommandLineTestRunner(tempDir)
                 .run(
                     "too-many-empty-lines",
-                    listOf("--code-style=ktlint_official", "generateEditorConfig"),
+                    listOf("--code-style=intellij_idea", "generateEditorConfig"),
                 ) {
                     SoftAssertions()
                         .apply {
                             assertNormalExitCode()
-                            assertThat(normalOutput).containsLineMatching("ktlint_code_style = ktlint_official")
+                            assertThat(normalOutput).containsLineMatching("ktlint_code_style = intellij_idea")
                         }.assertAll()
                 }
         }
@@ -526,7 +526,9 @@ class SimpleCLITest {
                 arguments = listOf("--code-style=android_studio"),
             ) {
                 assertThat(normalOutput).containsLineMatching(
-                    Regex(".*Add editor config override to set code style to 'android_studio'.*"),
+                    Regex(
+                        ".*WARN.*Parameter `--code-style=android_studio is deprecated. The code style should be defined as " +
+                            "'.editorconfig' property 'ktlint_code_style'.*"),
                 )
             }
     }


### PR DESCRIPTION
## Description

Pass parameter `--code-style` correctly to KtlintRuleEngine if value other than `android_studio`.

Also, deprecate parameters '--code-style', '--disabled-rules' and '--experimental' as those should be specified in the '.editorconfig' properties

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
