### PR TITLE
Re-enable releasing to SDKMan

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -70,7 +70,7 @@ jobs:
           download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
 
       - name: Release to sdkman
-        if: false
+        if: ${{ success() }}
         env:
           SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
           SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}


### PR DESCRIPTION
SDKMan credentials have been updating, so re-enabling for releases