### PR TITLE
Publish correct release notes

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -27,6 +27,16 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
           ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
 
+      - name: Validate changelog.md
+        id: validate_changelog
+        if: ${{ success() }}
+        run: |
+          FIRST_HEADING2=$(grep "^## " CHANGELOG.md | head -n 1)
+          if [[ "$FIRST_HEADING2" != "## [Unreleased]" ]]; then
+            echo "First heading at level 2 should be '## [Unreleased]'"
+            exit 1
+          fi
+
       - name: Extract release notes
         id: release_notes
         if: ${{ success() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ Note: These steps should be done directly in the pinterest/ktlint repository, no
 14. Announce release on Ktlint Slack channel 
 15. Update `gradle.properties` with the new `SNAPSHOT` version, and add the section below to the top of `CHANGELOG.md` and commit. (This can be done directly in the main repo or in your fork.)
 ```markdown
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -33,3 +33,4 @@ Note: These steps should be done directly in the pinterest/ktlint repository, no
 
 ### Changed
 ```
+Note: the heading "[Unreleased]" may not be changed as this will result in incorrect release notes being extracted from the 'changelog.md' file. 


### PR DESCRIPTION
## Description

Release notes for release 1.0.0 were not correct as the changelog heading "## [Unreleased]" was changed to "## Unreleased"

- Fix releasing notes
- Fix changelog.md for next release
- Add check in publish release workflow

Closes #2240

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
