### PR TITLE
Suppress `function-naming` based on annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* Add `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with` so that rule `function-naming` can be ignored based on annotations on that rule. See [function-naming](https://pinterest.github.io/ktlint/1.0.1/rules/standard/#function-naming).
+
 ### Removed
 
 ### Fixed

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -412,7 +412,10 @@ Enforce naming of function.
     ```
 
 !!! note
-    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Or function names can be specified between backticks and do not need to adhere to the normal naming convention.
+    When using Compose, you might want to suppress the `function-naming` rule by setting `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
+
+!!! note
+    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
 
 This rule can also be suppressed with the IntelliJ IDEA inspection suppression `FunctionName`.
 

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -506,6 +506,11 @@ public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeSt
 	public static fun values ()[Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleValue;
 }
 
+public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/CommaSeparatedListValueParser : org/ec4j/core/model/PropertyType$PropertyValueParser {
+	public fun <init> ()V
+	public fun parse (Ljava/lang/String;Ljava/lang/String;)Lorg/ec4j/core/model/PropertyType$PropertyValue;
+}
+
 public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CommaSeparatedListValueParser.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CommaSeparatedListValueParser.kt
@@ -1,0 +1,26 @@
+package com.pinterest.ktlint.rule.engine.core.api.editorconfig
+
+import org.ec4j.core.model.PropertyType
+import org.ec4j.core.model.PropertyType.PropertyValueParser
+
+/**
+ * A [PropertyValueParser] implementation that allows a comma separate list of strings.
+ */
+public class CommaSeparatedListValueParser : PropertyValueParser<Set<String>> {
+    override fun parse(
+        name: String?,
+        value: String?,
+    ): PropertyType.PropertyValue<Set<String>> =
+        if (value == "unset") {
+            PropertyType.PropertyValue.valid(value, emptySet())
+        } else {
+            PropertyType.PropertyValue.valid(
+                value,
+                value
+                    .orEmpty()
+                    .split(",")
+                    .map { it.trim() }
+                    .toSet(),
+            )
+        }
+}

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CommaSeparatedListValueParserTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/editorconfig/CommaSeparatedListValueParserTest.kt
@@ -1,0 +1,47 @@
+package com.pinterest.ktlint.rule.engine.core.api.editorconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.ec4j.core.model.PropertyType
+import org.junit.jupiter.api.Test
+
+class CommaSeparatedListValueParserTest {
+    private val propertyType =
+        PropertyType.LowerCasingPropertyType(
+            "some-property-type",
+            null,
+            CommaSeparatedListValueParser(),
+        )
+
+    @Test
+    fun `Given a comma separated list property with value unset`() {
+        val actual = propertyType.parse("unset")
+
+        assertThat(actual.isUnset).isTrue()
+    }
+
+    @Test
+    fun `Given a comma separated list property with a single value`() {
+        val actual = propertyType.parse(SOME_VALUE_1)
+
+        assertThat(actual.parsed).containsExactlyInAnyOrder(SOME_VALUE_1)
+    }
+
+    @Test
+    fun `Given a comma separated list property with a multiple values`() {
+        val actual = propertyType.parse("$SOME_VALUE_1,$SOME_VALUE_2")
+
+        assertThat(actual.parsed).containsExactlyInAnyOrder(SOME_VALUE_1, SOME_VALUE_2)
+    }
+
+    @Test
+    fun `Given a comma separated list property with a multiple values and redundant space before or after value`() {
+        val actual = propertyType.parse(" $SOME_VALUE_1 , $SOME_VALUE_2 ")
+
+        assertThat(actual.parsed).containsExactlyInAnyOrder(SOME_VALUE_1, SOME_VALUE_2)
+    }
+
+    private companion object {
+        const val SOME_VALUE_1 = "some-value-1"
+        const val SOME_VALUE_2 = "some-value-2"
+    }
+}

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -220,8 +220,14 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRu
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
+	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule$Companion;
 	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRule$Companion {
+	public final fun getIGNORE_WHEN_ANNOTATED_WITH_PROPERTY ()Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleKt {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionNamingRule.Companion.IGNORE_WHEN_ANNOTATED_WITH_PROPERTY
 import com.pinterest.ktlint.test.KtLintAssertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -195,5 +196,26 @@ class FunctionNamingRuleTest {
             }
             """.trimIndent()
         functionNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2259 - Given a fun which is to be ignored because it is annotated with a blacklisted annotation`() {
+        val code =
+            """
+            @Bar
+            @Foo
+            fun SomeFooBar()
+
+            @Composable
+            @Foo
+            fun SomeComposableFoo()
+
+            @Bar
+            @Composable
+            fun SomeComposableBar()
+            """.trimIndent()
+        functionNamingRuleAssertThat(code)
+            .withEditorConfigOverride(IGNORE_WHEN_ANNOTATED_WITH_PROPERTY to "Composable, Foo")
+            .hasNoLintViolations()
     }
 }


### PR DESCRIPTION
## Description

Add `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with`.

When using Compose, set property `ktlint_function_naming_ignore_when_annotated_with=Composable` to suppress the `function-naming` rule for functions annotated with `@Composable`. A dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) can be used for checking naming conventions for such Composable functions.

Closes #2259

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
