### PR TITLE
Support annotation array when ignoring function-naming rule

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -218,4 +218,22 @@ class FunctionNamingRuleTest {
             .withEditorConfigOverride(IGNORE_WHEN_ANNOTATED_WITH_PROPERTY to "Composable, Foo")
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2259 - Given a fun which is to be ignored because it is annotated with a blacklisted annotation using annotation array`() {
+        val code =
+            """
+            @[Bar Foo]
+            fun SomeFooBar()
+
+            @[Composable Foo]
+            fun SomeComposableFoo()
+
+            @[Bar Composable]
+            fun SomeComposableBar()
+            """.trimIndent()
+        functionNamingRuleAssertThat(code)
+            .withEditorConfigOverride(IGNORE_WHEN_ANNOTATED_WITH_PROPERTY to "Composable, Foo")
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Follow-up on #2259. Allow to ignore `function-name` rule when annotation is part of array:

```
@[Composable Foo]
fun SomeComposableFoo()
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
