### PR TITLE
2286 mulitline expression wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Do not force blank line before function in right hand side of assignment `blank-line-before-declaration` [#2260](https://github.com/pinterest/ktlint/issue/2260)
 * Ignore override of function in rule `function-naming` [#2271](https://github.com/pinterest/ktlint/issue/2271)
 * Do not replace function body having a return statement only in case the return statement contains an intermediate exit point 'function-expression-body' [#2269](https://github.com/pinterest/ktlint/issue/2269)
+* Prevent wrapping of nested multiline binary expression before operation reference as it results in a compilation error `multiline-expression-wrapping` [#2286](https://github.com/pinterest/ktlint/issue/2286)
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
@@ -38,13 +38,11 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
-import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
-import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
@@ -124,13 +122,14 @@ public class MultilineExpressionWrappingRule :
                                     // When binary expressions are wrapped, each binary expression for itself is checked whether it is a
                                     // multiline expression. So there is no need to check whether wrapping after the operation reference is
                                     // needed
-                                        Unit
+                                    Unit
                                 }
 
                                 leafOnSameLineAfterMultilineExpression.elementType == COMMA &&
-                                    (leafOnSameLineAfterMultilineExpression.treeParent.elementType == VALUE_ARGUMENT_LIST ||
-                                     leafOnSameLineAfterMultilineExpression.treeParent.elementType == VALUE_PARAMETER_LIST
-                                        ) -> {
+                                    (
+                                        leafOnSameLineAfterMultilineExpression.treeParent.elementType == VALUE_ARGUMENT_LIST ||
+                                            leafOnSameLineAfterMultilineExpression.treeParent.elementType == VALUE_PARAMETER_LIST
+                                    ) -> {
                                     // Keep comma on same line as multiline expression:
                                     //   foo(
                                     //      fooBar

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -12,7 +13,7 @@ class MultilineExpressionWrappingRuleTest {
     private val multilineExpressionWrappingRuleAssertThat = KtLintAssertThat.assertThatRule { MultilineExpressionWrappingRule() }
 
     @Nested
-    inner class `Given a function call using a named parameter` {
+    inner class `Given a function call using a named argument` {
         @Test
         fun `Given value argument for a named parameter in a function with a multiline dot qualified expression on the same line as the assignment`() {
             val code =
@@ -160,7 +161,7 @@ class MultilineExpressionWrappingRuleTest {
     }
 
     @Nested
-    inner class `Given a function call using an unnamed parameter` {
+    inner class `Given a function call using an unnamed argument` {
         @Test
         fun `Given value argument in a function with a multiline binary expression on the same line as the assignment`() {
             val code =
@@ -295,6 +296,31 @@ class MultilineExpressionWrappingRuleTest {
                     LintViolation(1, 15, "A multiline expression should start on a new line"),
                 ).isFormattedAs(formattedCode)
         }
+    }
+
+    @Test
+    fun `Given a declaration with parameter having a default value which is a multiline expression then keep trailing comma after the parameter`() {
+        val code =
+            """
+            fun foo(
+                val string: String = barFoo
+                    .count { it == "bar" },
+                val int: Int
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(
+                val string: String =
+                    barFoo
+                        .count { it == "bar" },
+                val int: Int
+            )
+            """.trimIndent()
+        multilineExpressionWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolation(2, 26, "A multiline expression should start on a new line")
+            .isFormattedAs(formattedCode)
     }
 
     @Test
@@ -829,5 +855,66 @@ class MultilineExpressionWrappingRuleTest {
             .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolation(1, 11, "A multiline expression should start on a new line")
             .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2286 - `() {
+        val code =
+            """
+            val foo = foo() + bar1 {
+                "bar1"
+            } +
+            bar2 {
+                "bar2"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo() +
+                    bar1 {
+                        "bar1"
+                    } +
+                    bar2 {
+                        "bar2"
+                    }
+            """.trimIndent()
+        multilineExpressionWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(1, 19, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Disabled
+    @Test
+    fun `Issue 2286 - xx `() {
+        val code =
+            """
+            val foo = foo() + bar1 {
+                "bar1"
+            } + "bar3" +
+            bar2 {
+                "bar2"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                foo() +
+                    bar1 {
+                        "bar1"
+                    } +
+                    bar2 {
+                        "bar2"
+                    }
+            """.trimIndent()
+        multilineExpressionWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolations(
+                LintViolation(1, 11, "A multiline expression should start on a new line"),
+                LintViolation(1, 19, "A multiline expression should start on a new line"),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Prevent wrapping of nested multiline binary expression before operation reference as it results in a compilation error

Closes #2286

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [ X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
