### PR TITLE
Fix chain method continuation containining higer order function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Force blank line before object declaration if preceded by another declaration `blank-line-before-declaration` [#2284](https://github.com/pinterest/ktlint/issues/2284)
 * Fix malformed AST when `&&` or `||` is at start of line `chain-wrapping` [#2297](https://github.com/pinterest/ktlint/issues/2297)
 * Do not report false positives `type-argument-list-spacing` and `type-parameter-list-spacing` [#2299](https://github.com/pinterest/ktlint/issues/2299)
+* Fix chain method continuation for dot qualifying expression containing a call expression returning a (higher order) function `chain-method-continuation` [#2304](https://github.com/pinterest/ktlint/issues/2304)
 
 ### Changed
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -397,7 +397,7 @@ public class ChainMethodContinuationRule :
                             }
                     }
 
-                    ARRAY_ACCESS_EXPRESSION, PREFIX_EXPRESSION, POSTFIX_EXPRESSION -> {
+                    CALL_EXPRESSION, ARRAY_ACCESS_EXPRESSION, PREFIX_EXPRESSION, POSTFIX_EXPRESSION -> {
                         children()
                             .mapNotNull { it.toChainedExpression() }
                             .singleOrNull()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -892,4 +892,25 @@ class ChainMethodContinuationRuleTest {
             .setMaxLineLength()
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2304 - Given a dot qualified expression in which the call expression returns a function which is called with value argument`() {
+        val code =
+            """
+            fun foo(baz: Baz) = bar.get()(baz)
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2304 - Given a dot qualified expression in which the call expression returns a function which is called with value argument ans has a trailing lambda`() {
+        val code =
+            """
+            fun foo(baz: Baz) =
+                bar.get()(baz) {
+                    // do something
+                }
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix chain method continuation for dot qualifying expression containing a call expression returning a (higher order) function `chain-method-continuation`

Closes #2304

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
