### PR TITLE
Allow spread operator starting on new line (fixes regression of #2300)

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRule.kt
@@ -106,12 +106,18 @@ public class ChainWrappingRule :
                 return
             }
             val prevLeaf = node.prevLeaf()
-            if (node.elementType != MUL && prevLeaf?.isPartOfSpread() == true) {
-                // fn(*typedArray<...>()) case
+            if (node.isPartOfSpread()) {
+                // Allow:
+                //    fn(
+                //        *typedArray<...>()
+                //    )
                 return
             }
             if (prefixTokens.contains(elementType) && node.isInPrefixPosition()) {
-                // unary +/-
+                // Allow:
+                //    fn(
+                //        -42
+                //    )
                 return
             }
 
@@ -160,14 +166,16 @@ public class ChainWrappingRule :
     }
 
     private fun ASTNode.isPartOfSpread() =
-        prevCodeLeaf()?.let { leaf ->
-            val type = leaf.elementType
-            type == LPAR ||
-                type == COMMA ||
-                type == LBRACE ||
-                type == ELSE_KEYWORD ||
-                KtTokens.OPERATIONS.contains(type)
-        } == true
+        elementType == MUL &&
+            prevCodeLeaf()
+                ?.let { leaf ->
+                    val type = leaf.elementType
+                    type == LPAR ||
+                        type == COMMA ||
+                        type == LBRACE ||
+                        type == ELSE_KEYWORD ||
+                        KtTokens.OPERATIONS.contains(type)
+                } == true
 
     private fun ASTNode.isInPrefixPosition() = treeParent?.treeParent?.elementType == PREFIX_EXPRESSION
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainWrappingRuleTest.kt
@@ -329,4 +329,15 @@ class ChainWrappingRuleTest {
                 .isFormattedAs(formattedCode)
         }
     }
+
+    @Test
+    fun `Given a spread operator starting on a new line`() {
+        val code =
+            """
+            val foo = foo(
+                *bar,
+            )
+            """.trimIndent()
+        chainWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Allow spread operator starting on new line (fixes regression of #2300)

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
