### PR TITLE
docs: Fix artifact url of Maven Central Badge

### DIFF
--- a/documentation/release-latest/docs/index.md
+++ b/documentation/release-latest/docs/index.md
@@ -8,7 +8,7 @@
 <p align="center">
 <a href="https://kotlinlang.slack.com/messages/CKS3XG0LS"><img src="https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack" alt="Join the chat at https://kotlinlang.slack.com"/></a>
 <a href="https://github.com/pinterest/ktlint/actions?query=workflow%3A%22Publish+snapshot+build%22"><img src="https://github.com/pinterest/ktlint/workflows/Publish%20snapshot%20build/badge.svg" alt="Build status snapshot"></a>
-<a href="https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.pinterest%22%20AND%20a%3A%22ktlint%22"><img src="https://img.shields.io/maven-central/v/com.pinterest/ktlint.svg" alt="Maven Central"></a>
+<a href="https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
 <a href="https://pinterest.github.io/ktlint/"><img src="https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081.svg" alt="ktlint"></a>
 </p>
 <p align="center">

--- a/documentation/snapshot/docs/index.md
+++ b/documentation/snapshot/docs/index.md
@@ -8,7 +8,7 @@
 <p align="center">
 <a href="https://kotlinlang.slack.com/messages/CKS3XG0LS"><img src="https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack" alt="Join the chat at https://kotlinlang.slack.com"/></a>
 <a href="https://github.com/pinterest/ktlint/actions?query=workflow%3A%22Publish+snapshot+build%22"><img src="https://github.com/pinterest/ktlint/workflows/Publish%20snapshot%20build/badge.svg" alt="Build status snapshot"></a>
-<a href="https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.pinterest%22%20AND%20a%3A%22ktlint%22"><img src="https://img.shields.io/maven-central/v/com.pinterest/ktlint.svg" alt="Maven Central"></a>
+<a href="https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
 <a href="https://pinterest.github.io/ktlint/"><img src="https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081.svg" alt="ktlint"></a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Description

Fix artifact url of Maven Central Badge in the [ktlint website](https://pinterest.github.io/ktlint/1.0.1/), it is showing the version of previous artifact:

![old version ktlint](https://github.com/pinterest/ktlint/assets/283778/97b1a853-1c4f-47ae-8846-91d1b57104ce)

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
