### PR TITLE
Support logging and exception throwing when loading baseline

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ slf4j = "org.slf4j:slf4j-simple:2.0.9"
 poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.0"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
 logback = "ch.qos.logback:logback-classic:1.3.5"
+logcaptor = "io.github.hakky54:logcaptor:2.9.0"
 # Required for logback.xml conditional configuration
 janino = "org.codehaus.janino:janino:3.1.10"
 # Testing libraries

--- a/ktlint-cli-reporter-baseline/api/ktlint-cli-reporter-baseline.api
+++ b/ktlint-cli-reporter-baseline/api/ktlint-cli-reporter-baseline.api
@@ -16,10 +16,24 @@ public final class com/pinterest/ktlint/cli/reporter/baseline/Baseline$Status : 
 	public static fun values ()[Lcom/pinterest/ktlint/cli/reporter/baseline/Baseline$Status;
 }
 
+public final class com/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling : java/lang/Enum {
+	public static final field EXCEPTION Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;
+	public static final field LOG Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;
+	public static fun values ()[Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;
+}
+
 public final class com/pinterest/ktlint/cli/reporter/baseline/BaselineKt {
 	public static final fun containsLintError (Ljava/util/List;Lcom/pinterest/ktlint/cli/reporter/core/api/KtlintCliError;)Z
 	public static final fun doesNotContain (Ljava/util/List;Lcom/pinterest/ktlint/cli/reporter/core/api/KtlintCliError;)Z
 	public static final fun loadBaseline (Ljava/lang/String;)Lcom/pinterest/ktlint/cli/reporter/baseline/Baseline;
+	public static final fun loadBaseline (Ljava/lang/String;Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;)Lcom/pinterest/ktlint/cli/reporter/baseline/Baseline;
+	public static synthetic fun loadBaseline$default (Ljava/lang/String;Lcom/pinterest/ktlint/cli/reporter/baseline/BaselineErrorHandling;ILjava/lang/Object;)Lcom/pinterest/ktlint/cli/reporter/baseline/Baseline;
+}
+
+public final class com/pinterest/ktlint/cli/reporter/baseline/BaselineLoaderException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
 public final class com/pinterest/ktlint/cli/reporter/baseline/BaselineReporter : com/pinterest/ktlint/cli/reporter/core/api/ReporterV2 {

--- a/ktlint-cli-reporter-baseline/build.gradle.kts
+++ b/ktlint-cli-reporter-baseline/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
     implementation(projects.ktlintCliReporterCore)
 
     testImplementation(projects.ktlintTest)
+    testImplementation(libs.logback)
+    testImplementation(libs.logcaptor)
 }

--- a/ktlint-cli-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineTest.kt
+++ b/ktlint-cli-reporter-baseline/src/test/kotlin/com/pinterest/ktlint/cli/reporter/baseline/BaselineTest.kt
@@ -1,0 +1,130 @@
+package com.pinterest.ktlint.cli.reporter.baseline
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
+import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError.Status.BASELINE_IGNORED
+import com.pinterest.ktlint.logger.api.initKtLintKLogger
+import com.pinterest.ktlint.logger.api.setDefaultLoggerModifier
+import io.github.oshai.kotlinlogging.DelegatingKLogger
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import nl.altindag.log.LogCaptor
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.xml.sax.SAXParseException
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.Path
+import kotlin.io.path.copyTo
+import kotlin.io.path.pathString
+
+@Suppress("unused")
+private val LOGGER =
+    KotlinLogging
+        .logger {}
+        .setDefaultLoggerModifier { logger -> logger.level = Level.DEBUG }
+        .initKtLintKLogger()
+
+private var KLogger.level: Level?
+    get() = underlyingLogger()?.level
+    set(value) {
+        underlyingLogger()?.level = value
+    }
+
+private fun KLogger.underlyingLogger(): Logger? =
+    @Suppress("UNCHECKED_CAST")
+    (this as? DelegatingKLogger<Logger>)
+        ?.underlyingLogger
+
+class BaselineTest {
+    @Test
+    fun `Given a valid baseline file then read without error`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        val path = "baseline-valid.xml".copyResourceToFileIn(tempDir)
+
+        val actual = loadBaseline(path)
+
+        assertThat(actual)
+            .usingRecursiveComparison()
+            .isEqualTo(
+                Baseline(
+                    path = path,
+                    status = Baseline.Status.VALID,
+                    lintErrorsPerFile =
+                        mapOf(
+                            "src/main/kotlin/foo.kt" to
+                                listOf(
+                                    KtlintCliError(1, 1, "standard:max-line-length", "", BASELINE_IGNORED),
+                                    KtlintCliError(2, 1, "standard:max-line-length", "", BASELINE_IGNORED),
+                                    KtlintCliError(4, 9, "standard:property-naming1", "", BASELINE_IGNORED),
+                                ),
+                        ),
+                ),
+            )
+    }
+
+    @Nested
+    inner class `Baseline has invalid xml structure` {
+        @Test
+        fun `Given that the baseline is loaded with classic loader then the log contains an error message`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val path = "baseline-invalid.xml".copyResourceToFileIn(tempDir)
+
+            val logCaptor = LogCaptor.forClass(Baseline::class.java)
+
+            loadBaseline(path)
+
+            assertThat(logCaptor.errorLogs).contains("Unable to parse baseline file: $path")
+        }
+
+        @Test
+        fun `Given that the baseline is loaded with new loader then an exception is thrown on error`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val path = "baseline-invalid.xml".copyResourceToFileIn(tempDir)
+
+            assertThatExceptionOfType(BaselineLoaderException::class.java)
+                .isThrownBy { loadBaseline(path, BaselineErrorHandling.EXCEPTION) }
+                .withMessage("Unable to parse baseline file: $path")
+                .withCauseInstanceOf(SAXParseException::class.java)
+                .havingCause()
+                .withMessage("The element type \"file\" must be terminated by the matching end-tag \"</file>\".")
+        }
+
+        @Test
+        fun `Given that the baseline is loaded with new loader then the log message is printed and no exception is thrown`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            val path = "baseline-invalid.xml".copyResourceToFileIn(tempDir)
+
+            val logCaptor = LogCaptor.forClass(Baseline::class.java)
+
+            loadBaseline(path)
+
+            assertThat(logCaptor.errorLogs).contains("Unable to parse baseline file: $path")
+        }
+    }
+
+    /**
+     * The resource needs to be copied in each test, because the file will be deleted in case it contains an error.
+     */
+    private fun String.copyResourceToFileIn(tempDir: Path) =
+        Paths
+            .get("$TEST_RESOURCE_PATH/$this")
+            .copyTo(tempDir, overwrite = true)
+            .pathString
+
+    private companion object {
+        val TEST_RESOURCE_PATH: Path = Path("src", "test", "resources")
+    }
+}

--- a/ktlint-cli-reporter-baseline/src/test/resources/baseline-invalid.xml
+++ b/ktlint-cli-reporter-baseline/src/test/resources/baseline-invalid.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="src/main/kotlin/Foo2.kt">
+        <error line="1" column="1" source="standard:max-line-length" />
+        <error line="2" column="1" source="standard:max-line-length" />
+        <error line="4" column="9" source="standard:property-naming" />
+</baseline>

--- a/ktlint-cli-reporter-baseline/src/test/resources/baseline-valid.xml
+++ b/ktlint-cli-reporter-baseline/src/test/resources/baseline-valid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="src/main/kotlin/Foo2.kt">
+    <file name="src/main/kotlin/Foo.kt">
         <error line="1" column="1" source="standard:max-line-length" />
         <error line="2" column="1" source="standard:max-line-length" />
         <error line="4" column="9" source="standard:property-naming" />

--- a/ktlint-cli-reporter-baseline/src/test/resources/baseline-valid.xml
+++ b/ktlint-cli-reporter-baseline/src/test/resources/baseline-valid.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="src/main/kotlin/Foo2.kt">
+        <error line="1" column="1" source="standard:max-line-length" />
+        <error line="2" column="1" source="standard:max-line-length" />
+        <error line="4" column="9" source="standard:property-naming" />
+    </file>
+</baseline>

--- a/ktlint-cli-reporter-baseline/src/test/resources/simplelogger.properties
+++ b/ktlint-cli-reporter-baseline/src/test/resources/simplelogger.properties
@@ -1,0 +1,40 @@
+# SLF4J's SimpleLogger configuration file
+
+# This file contains the configuration for the logging framework which is added as dependency of the module (see build.gradle.kts). When you
+# use another framework than "slf4j-simple", the configuration below will not work. Check out the documentation of the chosen framework how
+# it should be configured. Most likely, it has comparable capabilities.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+#org.slf4j.simpleLogger.defaultLogLevel=warn
+
+# Logging detail level which can either be set for a specific class or all classes in a specific package. If your project already contains
+# a logger, you might want to set the logging for ktlint classes only.
+#
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used. Specifying another loglevel (for example the value "off") results in
+# suppressing all logging for the class or package. Although this can be abused to suppress all logging from KtLint, you are advised no to
+# do this. It is better to set the loglevel to "debug" to reduce all logging except the error messages that you don't want to miss.
+org.slf4j.simpleLogger.log.com.pinterest.ktlint=debug
+# Additional logging detail levels can be set. Although rule above suppresses all log messages at levels warn, info, debug and trace, the
+# line below adds an exception for a specific class which might be relevant for you.
+org.slf4j.simpleLogger.log.com.pinterest.ktlint.rule.engine.internal.EditorConfigDefaultsLoader=warn
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.cli.internal
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import com.pinterest.ktlint.cli.reporter.baseline.Baseline
+import com.pinterest.ktlint.cli.reporter.baseline.BaselineErrorHandling
 import com.pinterest.ktlint.cli.reporter.baseline.doesNotContain
 import com.pinterest.ktlint.cli.reporter.baseline.loadBaseline
 import com.pinterest.ktlint.cli.reporter.core.api.KtlintCliError
@@ -300,7 +301,7 @@ internal class KtlintCommandLine {
             if (stdin || baselinePath.isBlank()) {
                 Baseline(status = Baseline.Status.DISABLED)
             } else {
-                loadBaseline(baselinePath)
+                loadBaseline(baselinePath, BaselineErrorHandling.LOG)
             }
         val aggregatedReporter =
             ReporterAggregator(


### PR DESCRIPTION
## Description

Support logging and exception throwing when loading baseline

The caller should be able to determine how errors while loading the baseline are to be handled. The ktlint CLI expects errors to be printed to the log. The ktlint-intellij-plugin requires exceptions to be thrown as the log is invisible for the plugin.

Closes #2344

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
