### PR TITLE
Remove redundant arrow in function literal without parameters / fix documentation

### DIFF
--- a/documentation/release-latest/docs/rules/experimental.md
+++ b/documentation/release-latest/docs/rules/experimental.md
@@ -456,9 +456,6 @@ If the function literal contains multiple parameter and at least one parameter o
 
 Rule id: `function-literal` (`standard` rule set)
 
-!!! Note
-    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
-
 ## Function type modifier spacing
 
 Enforce a single whitespace between the modifier list and the function type.

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -456,9 +456,6 @@ If the function literal contains multiple parameter and at least one parameter o
 
 Rule id: `function-literal` (`standard` rule set)
 
-!!! Note
-    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
-
 ## Function type modifier spacing
 
 Enforce a single whitespace between the modifier list and the function type.

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -449,4 +449,19 @@ class FunctionLiteralRuleTest {
                 LintViolation(3, 77, "Newline expected before closing brace"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2331 - Given a function literal with redundant arrow`() {
+        val code =
+            """
+            fun foo(block: () -> Unit): Unit = foo { -> block() }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo(block: () -> Unit): Unit = foo { block() }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolation(1, 42, "Arrow is redundant when parameter list is empty")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Remove redundant arrow in function literal without parameters

Kotlin allows a function literal to be defined with an empty parameter list and a redundant arrow symbol to divide the parameter list from the body.

Closes #2331

Fix documentation as `function-literal` rule is experimental and not bound to `ktlint_official` code style.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] `CHANGELOG.md` is updated
- [X] PR description added

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
- [ ] In case of adding a new rule, it needs to be added to [experimental rules documentation](https://pinterest.github.io/ktlint/latest/rules/experimental/)
