### PR TITLE
Ignore imports for `rangeUntil` in `no-unused-imports` rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -291,7 +291,7 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
                 // inc/dec
                 "inc", "dec",
                 // arithmetic
-                "plus", "minus", "times", "div", "rem", "mod", "rangeTo",
+                "plus", "minus", "times", "div", "rem", "mod", "rangeTo", "rangeUntil",
                 // in
                 "contains",
                 // indexed access

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
@@ -841,4 +841,19 @@ class NoUnusedImportsRuleTest {
             """.trimIndent()
         noUnusedImportsRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2373 - Do not mark rangeUntil as unused import`() {
+        val code =
+            """
+            package com.example
+
+            // Assume that "com.example.Baz" defines a rangeUntil operator as follows:
+            //     operator fun Baz.rangeUntil(baz: Baz) = ...
+            import com.example.Baz.rangeUntil
+
+            val baz = Baz(1.0)..<Baz(2.0)
+            """.trimIndent()
+        noUnusedImportsRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/internal/Baz.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/internal/Baz.kt
@@ -1,0 +1,9 @@
+package com.pinterest.ktlint.ruleset.standard.rules.internal
+
+class Baz(
+    d: Double,
+)
+
+operator fun Baz.rangeUntil(baz: Baz): Any {
+    TODO("Not yet implemented")
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/internal/Baz.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/internal/Baz.kt
@@ -1,9 +1,0 @@
-package com.pinterest.ktlint.ruleset.standard.rules.internal
-
-class Baz(
-    d: Double,
-)
-
-operator fun Baz.rangeUntil(baz: Baz): Any {
-    TODO("Not yet implemented")
-}


### PR DESCRIPTION
## Description

Ignore imports for `rangeUntil` in `no-unused-imports` rule

Removing this import results in compilation error when shorthand `..<` is used instead of function `rangeUntil(..)`.

Closes #2373

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
