### PR TITLE
Fix searching from inside a hidden directory

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -136,9 +136,14 @@ internal fun FileSystem.fileSequence(
                         dirPath: Path,
                         dirAttr: BasicFileAttributes,
                     ): FileVisitResult =
-                        if (Files.isHidden(dirPath) && dirPath != commonRootDir) {
-                            LOGGER.trace { "- Dir: $dirPath: Ignore" }
-                            FileVisitResult.SKIP_SUBTREE
+                        if (Files.isHidden(dirPath)) {
+                            if (dirPath == commonRootDir) {
+                                LOGGER.trace { "- Dir: $dirPath: Traverse started from hidden directory" }
+                                FileVisitResult.CONTINUE
+                            } else {
+                                LOGGER.trace { "- Dir: $dirPath: Ignore traversal of hidden directory" }
+                                FileVisitResult.SKIP_SUBTREE
+                            }
                         } else {
                             LOGGER.trace { "- Dir: $dirPath: Traverse" }
                             FileVisitResult.CONTINUE

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -136,7 +136,7 @@ internal fun FileSystem.fileSequence(
                         dirPath: Path,
                         dirAttr: BasicFileAttributes,
                     ): FileVisitResult =
-                        if (Files.isHidden(dirPath)) {
+                        if (Files.isHidden(dirPath) && dirPath != commonRootDir) {
                             LOGGER.trace { "- Dir: $dirPath: Ignore" }
                             FileVisitResult.SKIP_SUBTREE
                         } else {

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -107,6 +107,20 @@ internal class FileUtilsTest {
     }
 
     @Test
+    fun `Given the current directory is hidden the patterns should work`() {
+        val foundFiles =
+            getFiles(
+                patterns = listOf("*.kt"),
+                rootDir = ktlintTestFileSystem.resolve("project1/.git"),
+            )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(
+                ktFileInHiddenDirectory,
+            )
+    }
+
+    @Test
     fun `Given some patterns including a negate pattern and no workdir then select all files except files in the negate pattern`() {
         val foundFiles =
             getFiles(

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -26,9 +26,9 @@ internal class FileUtilsTest {
     private val javaFileRootDirectory = "Root.java"
     private val ktFileRootDirectory = "Root.kt"
     private val ktsFileRootDirectory = "Root.kts"
-    private val javaFileInHiddenDirectory = "project1/.git/Ignored.java"
-    private val ktFileInHiddenDirectory = "project1/.git/Ignored.kt"
-    private val ktsFileInHiddenDirectory = "project1/.git/Ignored.kts"
+    private val javaFileInHiddenDirectory = "project1/.hidden/Ignored.java"
+    private val ktFileInHiddenDirectory = "project1/.hidden/Ignored.kt"
+    private val ktsFileInHiddenDirectory = "project1/.hidden/Ignored.kts"
     private val javaFileInProjectRootDirectory = "project1/ProjectRoot.java"
     private val ktFileInProjectRootDirectory = "project1/ProjectRoot.kt"
     private val ktsFileInProjectRootDirectory = "project1/ProjectRoot.kts"
@@ -107,17 +107,14 @@ internal class FileUtilsTest {
     }
 
     @Test
-    fun `Given the current directory is hidden the patterns should work`() {
+    fun `Given the root directory where scanning starts is hidden, then the patterns should work`() {
         val foundFiles =
             getFiles(
                 patterns = listOf("*.kt"),
-                rootDir = ktlintTestFileSystem.resolve("project1/.git"),
+                rootDir = ktlintTestFileSystem.resolve("project1/.hidden"),
             )
 
-        assertThat(foundFiles)
-            .containsExactlyInAnyOrder(
-                ktFileInHiddenDirectory,
-            )
+        assertThat(foundFiles).containsExactlyInAnyOrder(ktFileInHiddenDirectory)
     }
 
     @Test


### PR DESCRIPTION
## Description

When searching files like this:
```
mkdir .hidden_folder
cd .hidden_folder
touch File.kt
ktlint '*.kt'
```
ktlint reported that it found no files.
The fact that the current directory is hidden should have no effect.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
