### PR TITLE
Prevent unwanted joining of KDoc with preceding type-parameter-list

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
@@ -1,5 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.android_studio
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
@@ -201,12 +203,12 @@ class TypeParameterListSpacingRuleTest {
             """.trimIndent()
         typeParameterListSpacingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 16, "Expected a single space or newline (with indent)"),
-                LintViolation(2, 16, "Expected a single space or newline (with indent)"),
-                LintViolation(3, 16, "Expected a single space or newline (with indent)"),
-                LintViolation(4, 16, "Expected a single space or newline (with indent)"),
-                LintViolation(5, 16, "Expected a single space or newline (with indent)"),
-                LintViolation(6, 16, "Expected a single space or newline (with indent)"),
+                LintViolation(1, 16, "Expected a single space"),
+                LintViolation(2, 16, "Expected a single space"),
+                LintViolation(3, 16, "Expected a single space"),
+                LintViolation(4, 16, "Expected a single space"),
+                LintViolation(5, 16, "Expected a single space"),
+                LintViolation(6, 16, "Expected a single space"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -319,7 +321,32 @@ class TypeParameterListSpacingRuleTest {
     }
 
     @Test
+    fun `Issue 2360 - Given a class with a KDoc on an explicit constructor starting on a separate line then do not report a violation`() {
+        val code =
+            """
+            class Foo<T>
+            /**
+             * some-comment
+             */
+            constructor(param: T)
+            """.trimIndent()
+        typeParameterListSpacingRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+            .hasNoLintViolations()
+    }
+
+    @Test
     fun `Given a class with an annotated constructor on same line as parameter type list then do not report a violation`() {
+        val code =
+            """
+            class Foo<out T> @Bar constructor(val value: T?) : FooBar<T>()
+            """.trimIndent()
+        typeParameterListSpacingRuleAssertThat(code)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2360`() {
         val code =
             """
             class Foo<out T> @Bar constructor(val value: T?) : FooBar<T>()


### PR DESCRIPTION
## Description

Prevent unwanted joining of KDoc with preceding type-parameter-list

Closes #2360

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
