### PR TITLE
Ignore imports for `assign` in `no-unused-imports` rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -298,8 +298,8 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
                 "get", "set",
                 // invoke
                 "invoke",
-                // augmented assignments
-                "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
+                // (augmented) assignment
+                "assign", "plusAssign", "minusAssign", "timesAssign", "divAssign", "modAssign",
                 // (in)equality
                 "equals",
                 // comparison

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
@@ -856,4 +856,29 @@ class NoUnusedImportsRuleTest {
             """.trimIndent()
         noUnusedImportsRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2343 - Do not mark assign as unused import`() {
+        val code =
+            """
+            package com.github.erdi.ktlint.bug
+
+            import org.gradle.api.Plugin
+            import org.gradle.api.Project
+            import org.gradle.kotlin.dsl.assign
+            import javax.inject.Inject
+
+            class ExamplePlugin @Inject constructor() : Plugin<Project> {
+              override fun apply(project: Project) {
+                project.let {
+                  it.javaexec {
+                    mainClass = "com.github.erdi.ktlint.bug.ExampleMainClass"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        noUnusedImportsRuleAssertThat(code)
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Ignore imports for `assign` in `no-unused-imports` rule

Removing this import results in compilation error when shorthand "=" is used instead of function `assign(..)`.

Closes #2343

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
