### PR TITLE
Replace all function bodies with body expressions in a single run

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
@@ -23,7 +23,8 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
-import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.leavesInClosedRange
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
@@ -111,7 +112,7 @@ public class FunctionExpressionBodyRule :
         require(block.elementType == BLOCK)
         block
             .takeIf { it.containingOnly(RETURN) }
-            ?.takeUnless { it.containsMultipleReturns() }
+            ?.takeUnless { it.countReturnKeywords() > 1 }
             ?.findChildByType(RETURN)
             ?.findChildByType(RETURN_KEYWORD)
             ?.nextSibling { !it.isWhiteSpace() }
@@ -164,8 +165,9 @@ public class FunctionExpressionBodyRule :
                 .singleOrNull()
                 ?.elementType
 
-    private fun ASTNode.containsMultipleReturns() =
-        firstChildLeafOrSelf().leavesIncludingSelf().count { it.elementType == RETURN_KEYWORD } > 1
+    private fun ASTNode.countReturnKeywords() =
+        leavesInClosedRange(this.firstChildLeafOrSelf(), this.lastChildLeafOrSelf())
+            .count { it.elementType == RETURN_KEYWORD }
 
     private fun ASTNode.createUnitTypeReference() =
         PsiFileFactory

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -167,5 +168,28 @@ class FunctionExpressionBodyRuleTest {
             }
             """.trimIndent()
         functionExpressionBodyRule(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2394 - Given multiple function bodies with a single return statement`() {
+        val code =
+            """
+            fun foo1(): String {
+                return "foo1"
+            }
+            fun foo2(): String {
+                return "foo2"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo1(): String = "foo1"
+            fun foo2(): String = "foo2"
+            """.trimIndent()
+        functionExpressionBodyRule(code)
+            .hasLintViolations(
+                LintViolation(1, 20, "Function body should be replaced with body expression"),
+                LintViolation(4, 20, "Function body should be replaced with body expression"),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

If a file contains multiple function bodies that have to be replaced with a body expression, then all should be replaced with a single run of ktlint.

Closes #2394

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
