### PR TITLE
Fix false positive violation in `annotation` rule

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -724,7 +724,7 @@ class AnnotationRuleTest {
         }
 
         @Test
-        fun `Given a custom type with multiple annotations on it type parameter(s)`() {
+        fun `Given a custom type with multiple annotations on it type parameter(s)`() { // xxx
             val code =
                 """
                 val fooBar: FooBar<String, @Foo String, @Foo @Bar String, @Bar("bar") @Foo String> = FooBar()
@@ -983,6 +983,18 @@ class AnnotationRuleTest {
                 bar: Bar,
             ) : @Suppress("DEPRECATION")
                 FooBar()
+            """.trimIndent()
+        annotationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2399 - Given a type projection with an annotated type reference`() {
+        val code =
+            """
+            val foo: List<
+                @Bar("bar")
+                Any,
+            >? = null
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
## Description

Fix false positive violation in `annotation` rule

Closes #2399

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
