### PR TITLE
fix(deps): update dependency ch.qos.logback:logback-classic to v1.3.13

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ logging = "io.github.oshai:kotlin-logging-jvm:5.1.1"
 slf4j = "org.slf4j:slf4j-simple:2.0.9"
 poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.1"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
+# TODO: Update "renovate.json" once logback-classic is updated to 1.4 (once java8 support for ktlint is dropped)
 logback = "ch.qos.logback:logback-classic:1.3.13"
 logcaptor = "io.github.hakky54:logcaptor:2.9.1"
 # Required for logback.xml conditional configuration

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ logging = "io.github.oshai:kotlin-logging-jvm:5.1.1"
 slf4j = "org.slf4j:slf4j-simple:2.0.9"
 poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.1"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
-logback = "ch.qos.logback:logback-classic:1.3.5"
+logback = "ch.qos.logback:logback-classic:1.3.13"
 logcaptor = "io.github.hakky54:logcaptor:2.9.1"
 # Required for logback.xml conditional configuration
 janino = "org.codehaus.janino:janino:3.1.11"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["ch.qos.logback:logback-classic"],
+      "allowedVersions": "<1.4.0"
+    }
   ]
 }


### PR DESCRIPTION
## Description

Update logback to 1.3.13 and prevent renovate to upgrade to 1.4.x because java8 is to be supported.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
