### PR TITLE
Allow property, function and class name to be same as keyword wrapped with backticks

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -346,6 +346,8 @@ Enforce naming of class and objects.
     class Foo
 
     class Foo1
+
+    class `class` // Any keyword is allowed when wrapped between backticks
     ```
 === "[:material-heart:](#) Ktlint JUnit Test"
 
@@ -384,6 +386,8 @@ Enforce naming of function.
     fun foo() {}
 
     fun fooBar() {}
+
+    fun `fun` {} // Any keyword is allowed when wrapped between backticks
     ```
 === "[:material-heart:](#) Ktlint Test"
 
@@ -469,6 +473,8 @@ Enforce naming of property.
             val FOO1 = Foo() // In case developer want to communicate that Foo is deeply immutable
         }
     }
+
+    var `package` = "foo" // Any keyword is allowed when wrapped between backticks
     ```
 === "[:material-heart-off-outline:](#) Disallowed"
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
@@ -139,4 +139,25 @@ class ClassNamingRuleTest {
             """.trimIndent()
         classNamingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @ParameterizedTest(name = "Keyword: {0}")
+    @Suppress("ktlint:standard:argument-list-wrapping")
+    @ValueSource(
+        strings = [
+            "abstract", "actual", "annotation", "as", "break", "by", "catch", "class", "companion", "const", "constructor", "context",
+            "continue", "contract", "crossinline", "data", "delegate", "do", "dynamic", "else", "enum", "expect", "external", "false",
+            "field", "file", "final", "finally", "for", "fun", "get", "header", "if", "impl", "import", "in", "infix", "init", "inline",
+            "inner", "interface", "internal", "is", "lateinit", "noinline", "null", "object", "open", "operator", "out", "override",
+            "package", "param", "private", "property", "protected", "public", "receiver", "reified", "return", "sealed", "set", "setparam",
+            "super", "suspend", "tailrec", "this", "throw", "true", "try", "typealias", "typeof", "val", "value", "var", "vararg", "when",
+            "where", "while",
+        ],
+    )
+    fun `Issue 2352 - Given a keyword then allow it to be wrapped between backticks`(keyword: String) {
+        val code =
+            """
+            class `$keyword`
+            """.trimIndent()
+        classNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -271,4 +271,25 @@ class FunctionNamingRuleTest {
             """.trimIndent()
         functionNamingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @ParameterizedTest(name = "Keyword: {0}")
+    @Suppress("ktlint:standard:argument-list-wrapping")
+    @ValueSource(
+        strings = [
+            "abstract", "actual", "annotation", "as", "break", "by", "catch", "class", "companion", "const", "constructor", "context",
+            "continue", "contract", "crossinline", "data", "delegate", "do", "dynamic", "else", "enum", "expect", "external", "false",
+            "field", "file", "final", "finally", "for", "fun", "get", "header", "if", "impl", "import", "in", "infix", "init", "inline",
+            "inner", "interface", "internal", "is", "lateinit", "noinline", "null", "object", "open", "operator", "out", "override",
+            "package", "param", "private", "property", "protected", "public", "receiver", "reified", "return", "sealed", "set", "setparam",
+            "super", "suspend", "tailrec", "this", "throw", "true", "try", "typealias", "typeof", "val", "value", "var", "vararg", "when",
+            "where", "while",
+        ],
+    )
+    fun `Issue 2352 - Given a keyword then allow it to be wrapped between backticks`(keyword: String) {
+        val code =
+            """
+            fun `$keyword`() = "foo"
+            """.trimIndent()
+        functionNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -329,6 +329,31 @@ class PropertyNamingRuleTest {
         }
     }
 
+    @ParameterizedTest(name = "Keyword: {0}")
+    @Suppress("ktlint:standard:argument-list-wrapping")
+    @ValueSource(
+        strings = [
+            "abstract", "actual", "annotation", "as", "break", "by", "catch", "class", "companion", "const", "constructor", "context",
+            "continue", "contract", "crossinline", "data", "delegate", "do", "dynamic", "else", "enum", "expect", "external", "false",
+            "field", "file", "final", "finally", "for", "fun", "get", "header", "if", "impl", "import", "in", "infix", "init", "inline",
+            "inner", "interface", "internal", "is", "lateinit", "noinline", "null", "object", "open", "operator", "out", "override",
+            "package", "param", "private", "property", "protected", "public", "receiver", "reified", "return", "sealed", "set", "setparam",
+            "super", "suspend", "tailrec", "this", "throw", "true", "try", "typealias", "typeof", "val", "value", "var", "vararg", "when",
+            "where", "while",
+        ],
+    )
+    fun `Issue 2352 - Given a keyword then allow it to be wrapped between backticks`(keyword: String) {
+        val code =
+            """
+            var `$keyword` = "some-value"
+            fun foo() {
+                var `$keyword` = "some-value"
+                val `$keyword` = "some-value"
+            }
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
     @KtlintDocumentationTest
     fun `Ktlint allowed examples`() {
         val code =


### PR DESCRIPTION
## Description

Allow property, function and class name to be same as keyword wrapped with backticks

Closes #2352

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
