### PR TITLE
Fix offset for violation when final newline is missing

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRule.kt
@@ -36,7 +36,7 @@ public class FinalNewlineRule :
             val lastNode = lastChildNodeOf(node)
             if (insertFinalNewline) {
                 if (lastNode !is PsiWhiteSpace || !lastNode.textContains('\n')) {
-                    emit(0, "File must end with a newline (\\n)", true)
+                    emit(node.textLength - 1, "File must end with a newline (\\n)", true)
                     if (autoCorrect) {
                         node.addChild(PsiWhiteSpaceImpl("\n"), null)
                     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FinalNewlineRuleTest.kt
@@ -32,7 +32,7 @@ class FinalNewlineRuleTest {
                 """.trimIndent()
             finalNewlineRuleAssertThat(code)
                 .withEditorConfigOverride(FINAL_NEW_LINE_REQUIRED)
-                .hasLintViolation(1, 1, "File must end with a newline (\\n)")
+                .hasLintViolation(2, 1, "File must end with a newline (\\n)")
                 .isFormattedAs(formattedCode)
         }
 


### PR DESCRIPTION
## Description

Fix offset for violation (to last character in file) when final newline is missing

Closes #2391

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
