### PR TITLE
Remove deprecated cli parameters `--experimental`, `--code-style`, `--disabled-rules`

### DIFF
--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -138,17 +138,17 @@ By default, the `info` log level is used meaning that all log lines at level `in
 
 Some rules can be tweaked via the [`editorconfig file`](../../rules/configuration-ktlint/).
 
-A scaffold of the `.editorconfig file` can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
+A scaffold of the `.editorconfig` file can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-ktlint generateEditorConfig
+ktlint generateEditorConfig ktlint_official
 # or
-ktlint generateEditorConfig
+ktlint generateEditorConfig ktlint_official
 # or
-ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig  ktlint_official
 ```
 
-Normally this file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.
+Normally the `.editorconfig` file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.
 
 Use command below, to specify a default `editorconfig`. In case a property is not defined in any `.editorconfig` file on the path to the file, the value from the default file is used. The path may point to any valid file or directory. The path can be relative or absolute. Depending on your OS, the "~" at the beginning of a path is replaced by the user home directory.
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitPreCommitHookSubCommand.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitPreCommitHookSubCommand.kt
@@ -3,26 +3,16 @@ package com.pinterest.ktlint.cli.internal
 import picocli.CommandLine
 
 @CommandLine.Command(
-    description = [
-        "Install git hook to automatically check files for style violations on commit",
-    ],
+    description = ["Install git hook to automatically check files for style violations on commit"],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class,
 )
 internal class GitPreCommitHookSubCommand : Runnable {
-    @CommandLine.ParentCommand
-    private lateinit var ktlintCommand: KtlintCommandLine
-
     @CommandLine.Spec
     private lateinit var commandSpec: CommandLine.Model.CommandSpec
 
     override fun run() {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
-
-        if (ktlintCommand.codeStyle == null) {
-            System.err.println("Option --code-style must be set as to generate the git pre commit hook correctly")
-            exitKtLintProcess(1)
-        }
 
         GitHookInstaller.installGitHook("pre-commit") {
             """
@@ -30,7 +20,7 @@ internal class GitPreCommitHookSubCommand : Runnable {
 
             # <https://github.com/pinterest/ktlint> pre-commit hook
 
-            git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --code-style=${ktlintCommand.codeStyle} --relative --patterns-from-stdin=''
+            git diff --name-only -z --cached --relative -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''
             """.trimIndent().toByteArray()
         }
     }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitPrePushHookSubCommand.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GitPrePushHookSubCommand.kt
@@ -3,26 +3,16 @@ package com.pinterest.ktlint.cli.internal
 import picocli.CommandLine
 
 @CommandLine.Command(
-    description = [
-        "Install git hook to automatically check files for style violations before push",
-    ],
+    description = ["Install git hook to automatically check files for style violations before push"],
     mixinStandardHelpOptions = true,
     versionProvider = KtlintVersionProvider::class,
 )
 internal class GitPrePushHookSubCommand : Runnable {
-    @CommandLine.ParentCommand
-    private lateinit var ktlintCommand: KtlintCommandLine
-
     @CommandLine.Spec
     private lateinit var commandSpec: CommandLine.Model.CommandSpec
 
     override fun run() {
         commandSpec.commandLine().printCommandLineHelpOrVersionUsage()
-
-        if (ktlintCommand.codeStyle == null) {
-            System.err.println("Option --code-style must be set as to generate the git pre push hook correctly")
-            exitKtLintProcess(1)
-        }
 
         GitHookInstaller.installGitHook("pre-push") {
             """
@@ -30,7 +20,7 @@ internal class GitPrePushHookSubCommand : Runnable {
 
             # <https://github.com/pinterest/ktlint> pre-push hook
 
-            git diff --name-only -z HEAD "origin/${'$'}(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --code-style=${ktlintCommand.codeStyle} --relative --patterns-from-stdin=''
+            git diff --name-only -z HEAD "origin/${'$'}(git rev-parse --abbrev-ref HEAD)" -- '*.kt' '*.kts' | ktlint --relative --patterns-from-stdin=''
             """.trimIndent().toByteArray()
         }
     }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -243,169 +243,61 @@ class SimpleCLITest {
             }
     }
 
-    @Nested
-    inner class `Generate git pre commit hook` {
-        @Test
-        fun `Given that the code-style option is specified before the command`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("--code-style=ktlint_official", "installGitPreCommitHook"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            // The command will throw an error because the testProjectName directory does not contain a
-                            // '.git' directory. This is sufficient to know that the ktlint command was recognized.
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "git directory not found. Are you sure you are inside project directory?",
-                            )
-                        }.assertAll()
-                }
-        }
-
-        @Test
-        fun `Given that the code-style option is specified after the command`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("installGitPreCommitHook", "--code-style=ktlint_official"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            // The command will throw an error because the testProjectName directory does not contain a
-                            // '.git' directory. This is sufficient to know that the ktlint command was recognized.
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "git directory not found. Are you sure you are inside project directory?",
-                            )
-                        }.assertAll()
-                }
-        }
-
-        @Test
-        fun `Given that no code-style option is specified then the command should fail`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("installGitPreCommitHook"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "Option --code-style must be set as to generate the git pre commit hook correctly",
-                            )
-                        }.assertAll()
-                }
-        }
+    @Test
+    fun `Generate git pre commit hook`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                "too-many-empty-lines",
+                listOf("installGitPreCommitHook"),
+            ) {
+                SoftAssertions()
+                    .apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching(
+                            "git directory not found. Are you sure you are inside project directory?",
+                        )
+                    }.assertAll()
+            }
     }
 
-    @Nested
-    inner class `Generate git pre push hook` {
-        @Test
-        fun `Given that the code-style option is specified before the command`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("--code-style=ktlint_official", "installGitPrePushHook"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            // The command will throw an error because the testProjectName directory does not contain a
-                            // '.git' directory. This is sufficient to know that the ktlint command was recognized.
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "git directory not found. Are you sure you are inside project directory?",
-                            )
-                        }.assertAll()
-                }
-        }
-
-        @Test
-        fun `Given that the code-style option is specified after the command`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("installGitPrePushHook", "--code-style=ktlint_official"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            // The command will throw an error because the testProjectName directory does not contain a
-                            // '.git' directory. This is sufficient to know that the ktlint command was recognized.
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "git directory not found. Are you sure you are inside project directory?",
-                            )
-                        }.assertAll()
-                }
-        }
-
-        @Test
-        fun `Given that no code-style option is specified then the command should fail`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("installGitPrePushHook"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            assertErrorExitCode()
-                            assertThat(errorOutput).containsLineMatching(
-                                "Option --code-style must be set as to generate the git pre push hook correctly",
-                            )
-                        }.assertAll()
-                }
-        }
+    @Test
+    fun `Generate git pre push hook`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                "too-many-empty-lines",
+                listOf("installGitPrePushHook"),
+            ) {
+                SoftAssertions()
+                    .apply {
+                        // The command will throw an error because the testProjectName directory does not contain a
+                        // '.git' directory. This is sufficient to know that the ktlint command was recognized.
+                        assertErrorExitCode()
+                        assertThat(errorOutput).containsLineMatching(
+                            "git directory not found. Are you sure you are inside project directory?",
+                        )
+                    }.assertAll()
+            }
     }
 
     @Nested
     inner class `Generate 'editorconfig' file` {
         @Test
-        fun `Given that the code-style option is specified before the command`(
+        fun `Given that the code-style is specified`(
             @TempDir
             tempDir: Path,
         ) {
             CommandLineTestRunner(tempDir)
                 .run(
                     "too-many-empty-lines",
-                    listOf("--code-style=intellij_idea", "generateEditorConfig"),
-                ) {
-                    SoftAssertions()
-                        .apply {
-                            assertNormalExitCode()
-                            assertThat(normalOutput).containsLineMatching("ktlint_code_style = intellij_idea")
-                        }.assertAll()
-                }
-        }
-
-        @Test
-        fun `Given that the code-style option is specified after the command`(
-            @TempDir
-            tempDir: Path,
-        ) {
-            CommandLineTestRunner(tempDir)
-                .run(
-                    "too-many-empty-lines",
-                    listOf("generateEditorConfig", "--code-style=ktlint_official"),
+                    listOf("generateEditorConfig", "ktlint_official"),
                 ) {
                     SoftAssertions()
                         .apply {
@@ -416,7 +308,7 @@ class SimpleCLITest {
         }
 
         @Test
-        fun `Given that no code-style option is specified then the command should fail`(
+        fun `Given that the code-style is not specified then the command should fail`(
             @TempDir
             tempDir: Path,
         ) {
@@ -429,7 +321,7 @@ class SimpleCLITest {
                         .apply {
                             assertErrorExitCode()
                             assertThat(errorOutput).containsLineMatching(
-                                "Option --code-style must be set as to generate the '.editorconfig' correctly",
+                                "Missing required parameter: 'code-style'",
                             )
                         }.assertAll()
                 }
@@ -538,7 +430,7 @@ class SimpleCLITest {
     }
 
     @Test
-    fun `Enable android code style via parameter --code-style=android_studio`(
+    fun `Given that the deprecated parameter --code-style is specified, then return an error`(
         @TempDir
         tempDir: Path,
     ) {
@@ -549,8 +441,8 @@ class SimpleCLITest {
             ) {
                 assertThat(normalOutput).containsLineMatching(
                     Regex(
-                        ".*WARN.*Parameter `--code-style=android_studio is deprecated. The code style should be defined as " +
-                            "'.editorconfig' property 'ktlint_code_style'.*",
+                        ".*ERROR.*Parameter '--code-style=android_studio' is ignored. The code style should be defined as " +
+                            "'.editorconfig' property 'ktlint_code_style='.*",
                     ),
                 )
             }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -165,27 +165,6 @@ class SimpleCLITest {
     }
 
     @Test
-    fun `Given some code which only contains errors for rules which are disabled via CLI argument --disabled_rules then return from lint with the normal exit code and without error output`(
-        @TempDir
-        tempDir: Path,
-    ) {
-        CommandLineTestRunner(tempDir)
-            .run(
-                "too-many-empty-lines",
-                listOf("--disabled_rules=no-consecutive-blank-lines,no-empty-first-line-in-method-block"),
-            ) {
-                SoftAssertions()
-                    .apply {
-                        assertNormalExitCode()
-                        assertThat(normalOutput).doesNotContain(
-                            "no-consecutive-blank-lines",
-                            "no-empty-first-line-in-method-block",
-                        )
-                    }.assertAll()
-            }
-    }
-
-    @Test
     fun `Given some code with an error and a pattern which is read in from stdin which does not select the file then return the no files matched warning`(
         @TempDir
         tempDir: Path,


### PR DESCRIPTION
## Description

Remove deprecated cli parameters `--experimental`, `--code-style`, `--disabled-rules`

The `.editorconfig` is used for managing the configuration of ktlint regardless which API Consumer (for example Ktlint CLI, the KtLint intellij plugin, or third party integrators like Detekt, Spotless) is used. By using the `.editorconfig`, developers on the same project can use different tools to invoke ktlint, but the configuration is stored in 1 central place.

Ktlint CLI parameters `--experimental`, `--code-style` and `--disabled-rules` shadow `.editorconfig` properties, and should no longer be used. The parameters have been deprecated in a previous ktlint version (1.0), and so far only 1 request (#2397) to not remove them has been received.

The code style can be managed via `.editorconfig` property `ktlint_code_style`. See https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/

The disabled rules can be managed via `.editorconfig` properties. See:
* https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/#disabled-rules
* https://pinterest.github.io/ktlint/latest/faq/#how-do-i-enable-or-disable-a-rule-set
* https://pinterest.github.io/ktlint/latest/faq/#how-do-i-enable-or-disable-a-rule

Experimental rules can be managed via `.editorconfig` property `ktlint_experimental`. Also, it is possible via the `.editorconfig` to enable specific experimental rules. See:
* https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/#disabled-rules
* https://pinterest.github.io/ktlint/latest/faq/#how-do-i-enable-or-disable-a-rule-set
* https://pinterest.github.io/ktlint/latest/faq/#how-do-i-enable-or-disable-a-rule

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
