### PR TITLE
Set offset of `max-line-length` violation to the last position at which a newline can be inserted to fix the violation

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -83,8 +83,10 @@ public class MaxLineLengthRule :
             ?.takeUnless { it.isPartOfRawMultiLineString() }
             ?.takeUnless { it.isLineOnlyContainingComment() }
             ?.let { lastNodeOnLine ->
+                // Calculate the offset at the last possible position at which the newline should be inserted on the line
+                val offset = node.leavesOnLine().first().startOffset + maxLineLength + 1
                 emit(
-                    lastNodeOnLine.startOffset + lastNodeOnLine.textLength - 1,
+                    offset,
                     "Exceeded max line length ($maxLineLength)",
                     false,
                 )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
@@ -27,7 +27,7 @@ class MaxLineLengthRuleTest {
             .setMaxLineLength()
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 47, "Exceeded max line length (46)"),
-                LintViolation(3, 61, "Exceeded max line length (46)"),
+                LintViolation(3, 47, "Exceeded max line length (46)"),
                 LintViolation(5, 47, "Exceeded max line length (46)"),
             )
     }
@@ -159,7 +159,7 @@ class MaxLineLengthRuleTest {
                 .withEditorConfigOverride(IGNORE_BACKTICKED_IDENTIFIER_PROPERTY to true)
                 .hasLintViolationsWithoutAutoCorrect(
                     // Note that no error was generated on line 2 with the long fun name but on another line
-                    LintViolation(3, 91, "Exceeded max line length (37)"),
+                    LintViolation(3, 38, "Exceeded max line length (37)"),
                     LintViolation(4, 38, "Exceeded max line length (37)"),
                 )
         }


### PR DESCRIPTION
## Description

Set offset of `max-line-length` violation to the last position at which a newline can be inserted to fix the violation

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
