### PR TITLE
Fix adding blank line between declaration and an annotated declaration which is preceded by comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -9,7 +9,8 @@ import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
-import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -46,7 +47,7 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
             ?.takeIf { it is KtDeclaration }
             ?.takeIf { prevDeclaration -> hasNoBlankLineBetweenDeclarations(node, prevDeclaration) }
             ?.let {
-                val prevLeaf = node.prevLeaf { it.isWhiteSpace() || it.isPartOfComment() }!!
+                val prevLeaf = node.prevCodeLeaf()?.nextLeaf { it.isWhiteSpace() }!!
                 emit(
                     prevLeaf.startOffset + 1,
                     "Declarations and declarations with annotations should have an empty space between.",

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
@@ -220,4 +220,90 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
             """.trimIndent()
         spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2416 - Given a declaration followed by an EOL comment and other annotated declaration`() {
+        val code =
+            """
+            fun foobar() {
+                val bar = "bar"
+                // Some comment
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foobar() {
+                val bar = "bar"
+
+                // Some comment
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Declarations and declarations with annotations should have an empty space between.")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2416 - Given a declaration followed by a block comment and other annotated declaration`() {
+        val code =
+            """
+            fun foobar() {
+                val bar = "bar"
+                /*
+                 * Some comment
+                 */
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foobar() {
+                val bar = "bar"
+
+                /*
+                 * Some comment
+                 */
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Declarations and declarations with annotations should have an empty space between.")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2416 - Given a declaration followed by a KDoc and other annotated declaration`() {
+        val code =
+            """
+            fun foobar() {
+                val bar = "bar"
+                /**
+                 * Some comment
+                 */
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foobar() {
+                val bar = "bar"
+
+                /**
+                 * Some comment
+                 */
+                @Suppress("unused")
+                val foo  = "foo"
+            }
+            """.trimIndent()
+        spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Declarations and declarations with annotations should have an empty space between.")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Fix adding blank line between declaration and an annotated declaration which is preceded by comment

Closes #2416

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
