### PR TITLE
Disallow comments in try-catch-finally at unexpected locations

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRule.kt
@@ -24,6 +24,7 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 
 /**
  * Checks spacing and wrapping of try-catch-finally.
@@ -55,6 +56,10 @@ public class TryCatchFinallySpacingRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
+        if (node.isPartOfComment() && node.treeParent.elementType in TRY_CATCH_FINALLY_TOKEN_SET) {
+            emit(node.startOffset, "No comment expected at this location", false)
+            return
+        }
         when (node.elementType) {
             BLOCK -> {
                 visitBlock(node, emit, autoCorrect)
@@ -70,7 +75,7 @@ public class TryCatchFinallySpacingRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
         autoCorrect: Boolean,
     ) {
-        if (node.treeParent.elementType !in TRY_CATCH_FINALLY_ELEMENT_TYPES) {
+        if (node.treeParent.elementType !in TRY_CATCH_FINALLY_TOKEN_SET) {
             return
         }
 
@@ -116,7 +121,7 @@ public class TryCatchFinallySpacingRule :
     private fun ASTNode.elementTypeName() = elementType.toString().lowercase()
 
     private companion object {
-        val TRY_CATCH_FINALLY_ELEMENT_TYPES = listOf(TRY, CATCH, FINALLY)
+        val TRY_CATCH_FINALLY_TOKEN_SET = TokenSet.create(TRY, CATCH, FINALLY)
     }
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TryCatchFinallySpacingRuleTest.kt
@@ -210,4 +210,29 @@ class TryCatchFinallySpacingRuleTest {
                 ).isFormattedAs(formattedCode)
         }
     }
+
+    @Test
+    fun `Issue 2427 - Given a try-catch with a comment at an unexpected location`() {
+        val code =
+            """
+            fun foo() {
+                try {
+                    trySomething()
+                } // Unexpected comment
+                catch (e: IOException) {
+                    catchSomething()
+                } // Unexpected comment
+                finally {
+                    finallySomething()
+                }
+            }
+            """.trimIndent()
+        tryCatchRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(4, 7, "No comment expected at this location", false),
+                LintViolation(5, 5, "A single space is required before 'catch'"),
+                LintViolation(7, 7, "No comment expected at this location", false),
+                LintViolation(8, 5, "A single space is required before 'finally'"),
+            )
+    }
 }


### PR DESCRIPTION
## Description

Disallow comments in try-catch-finally at unexpected locations. Merging a catch/finally block with closing curly brace at previous line, will no longer result in compilation error if that curly brace was followed by an EOL comment.

Closes #2427

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
