### PR TITLE
Add cross-references in documentation for parameter wrapping

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -195,6 +195,9 @@ Rewrites the function signature to a single line when possible (e.g. when not ex
 
 In `ktlint-official` code style, a function signature is always rewritten to a multiline signature in case the function has 2 or more parameters. This number of parameters can be set via `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`.
 
+!!! note
+    Wrapping of parameters is also influenced by the `parameter-list-wrapping` rule.
+
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
@@ -2276,7 +2279,10 @@ Rule id: `multiline-expression-wrapping` (`standard` rule set)
 
 ### Parameter list wrapping
 
-When class/function signature doesn't fit on a single line, each parameter must be on a separate line
+When class/function signature doesn't fit on a single line, each parameter must be on a separate line.
+
+!!! Note
+    Wrapping of parameters is also influenced by the `function-signature` rule.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -174,6 +174,9 @@ Rewrites the function signature to a single line when possible (e.g. when not ex
 
 In `ktlint-official` code style, a function signature is always rewritten to a multiline signature in case the function has 2 or more parameters. This number of parameters can be set via `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`.
 
+!!! note
+    Wrapping of parameters is also influenced by the `parameter-list-wrapping` rule.
+
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
@@ -2434,7 +2437,10 @@ Rule id: `multiline-expression-wrapping` (`standard` rule set)
 
 ### Parameter list wrapping
 
-When class/function signature doesn't fit on a single line, each parameter must be on a separate line
+When class/function signature doesn't fit on a single line, each parameter must be on a separate line.
+
+!!! Note
+    Wrapping of parameters is also influenced by the `function-signature` rule.
 
 === "[:material-heart:](#) Ktlint"
 


### PR DESCRIPTION
## Description

Add cross-references between `parameter-list-wrapping` and `function-signature` rules as both deal with wrapping parameters.

Closes #2424

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [x] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [x] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
