### PR TITLE
Improve generateEditorConfig example in docs

### DIFF
--- a/documentation/release-latest/docs/install/cli.md
+++ b/documentation/release-latest/docs/install/cli.md
@@ -141,9 +141,12 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig file` can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
+# By default use ktlint_official
 ktlint generateEditorConfig
 # or
-ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig
+ktlint generateEditorConfig intellij_idea
+# or
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
 ```
 
 Normally this file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.

--- a/documentation/release-latest/docs/install/cli.md
+++ b/documentation/release-latest/docs/install/cli.md
@@ -143,8 +143,6 @@ A scaffold of the `.editorconfig file` can be generated with command below. Note
 ```shell title="Generate .editorconfig"
 ktlint generateEditorConfig
 # or
-ktlint generateEditorConfig
-# or
 ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig
 ```
 

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -141,9 +141,12 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig` file can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-ktlint generateEditorConfig ktlint_official
+# By default use ktlint_official
+ktlint generateEditorConfig
 # or
-ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig  ktlint_official
+ktlint generateEditorConfig intellij_idea
+# or
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
 ```
 
 Normally the `.editorconfig` file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -143,8 +143,6 @@ A scaffold of the `.editorconfig` file can be generated with command below. Note
 ```shell title="Generate .editorconfig"
 ktlint generateEditorConfig ktlint_official
 # or
-ktlint generateEditorConfig ktlint_official
-# or
 ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig  ktlint_official
 ```
 


### PR DESCRIPTION
## Description

I deleted a duplicate command in the documentation. (`ktlint generateEditorConfig`) I don't believe it was intentional.

I figured the fix was simple enough that adding an extended description to the commit message is not necessary. I can change this, though.

I added the fix to both the snapshot and release documentations. It's not necessarily pressing enough to need being updated in the release version, but I figured it couldn't do too much harm.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [x] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [x] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
