### PR TITLE
Suppress property-naming rule via `@Suppress("ConstPropertyName")`

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -499,7 +499,7 @@ Enforce naming of property.
     }
     ```
 
-This rule can also be suppressed with the IntelliJ IDEA inspection suppression `PropertyName`.
+This rule can also be suppressed with the IntelliJ IDEA inspection suppression `PropertyName` or `ConstPropertyName`.
 
 Rule id: `property-naming` (`standard` rule set)
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
@@ -42,6 +42,7 @@ internal object SuppressionLocatorBuilder {
             "FunctionName" to "standard:function-naming",
             "PackageName" to "standard:package-name",
             "PropertyName" to "standard:property-naming",
+            "ConstPropertyName" to "standard:property-naming",
             "UnusedImport" to "standard:no-unused-imports",
         )
     private val SUPPRESS_ANNOTATIONS = setOf("Suppress", "SuppressWarnings")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -416,4 +416,30 @@ class PropertyNamingRuleTest {
                 LintViolation(12, 9, "Backing property name not allowed when 'private' modifier is missing", canBeAutoCorrected = false),
             )
     }
+
+    @Test
+    fun `Given a property name suppressed via 'PropertyName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            class Foo {
+                @Suppress("PropertyName")
+                var FOO = "foo"
+            }
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2441 - Given a property name suppressed via 'ConstPropertyName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            interface Bar {
+                companion object {
+                    @Suppress("ConstPropertyName")
+                    const val bar: String = ""
+                }
+            }
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Suppress property-naming rule via `@Suppress("ConstPropertyName")`

Suppression via `@Suppress("PropertyName")` was already supported before.

Closes #2441 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
