### PR TITLE
Fix incorrect generateEditorConfig example in documentation

### DIFF
--- a/documentation/release-latest/docs/install/cli.md
+++ b/documentation/release-latest/docs/install/cli.md
@@ -141,10 +141,8 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig file` can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-# By default use ktlint_official
-ktlint generateEditorConfig
-# or
-ktlint generateEditorConfig intellij_idea
+# Specify the code style(ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
+ktlint generateEditorConfig ktlint_official
 # or
 ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
 ```

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -141,10 +141,8 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig` file can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-# By default use ktlint_official
-ktlint generateEditorConfig
-# or
-ktlint generateEditorConfig intellij_idea
+# Specify the code style(ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
+ktlint generateEditorConfig ktlint_official
 # or
 ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
 ```


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->
I found incorrect example in the documentation for the `ktlint generateEditorConfig` command.
The `code-style` parameter defaults to `ktlint_official`, but **there is no default value for the `code-style` parameter**.

```
$ ktlint --version
1.1.0

$ ktlint generateEditorConfig
Exception in thread "main" picocli.CommandLine$MissingParameterException: Missing required parameter: 'code-style'
```

https://github.com/pinterest/ktlint/blob/ebfe2d022ecf082c180e761c8f07f82caebd1561/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/GenerateEditorConfigSubCommand.kt#L21-L28

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [x] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [x] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
