### PR TITLE
Fix insert of suppression on binary expression

### DIFF
--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
@@ -3,7 +3,9 @@ package com.pinterest.ktlint.rule.engine.api
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.ruleset.standard.rules.CONDITION_WRAPPING_RULE_ID
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -183,6 +185,94 @@ class KtlintRuleEngineSuppressionKtTest {
                 )
 
         assertThat(actual).isEqualTo(formattedCode)
+    }
+
+    @Nested
+    inner class `Issue 2462 - Given binary expression on which a suppression is added` {
+        @Test
+        fun `Given a value argument with a multiline condition to which a suppression is to be added`() {
+            val code =
+                """
+                fun foo() {
+                    require(
+                        true && false ||
+                            true,
+                    )
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo() {
+                    @Suppress("ktlint:standard:condition-wrapping")
+                    require(
+                        true && false ||
+                            true,
+                    )
+                }
+                """.trimIndent()
+            val actual =
+                ktLintRuleEngine
+                    .insertSuppression(
+                        Code.fromSnippet(code, false),
+                        KtlintSuppressionAtOffset(3, 17, CONDITION_WRAPPING_RULE_ID),
+                    )
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given a property assignment with a multiline condition to which a suppression is to be added`() {
+            val code =
+                """
+                val bar =
+                    true && false ||
+                        true
+                """.trimIndent()
+            val formattedCode =
+                """
+                @Suppress("ktlint:standard:condition-wrapping")
+                val bar =
+                    true && false ||
+                        true
+                """.trimIndent()
+            val actual =
+                ktLintRuleEngine
+                    .insertSuppression(
+                        Code.fromSnippet(code, false),
+                        KtlintSuppressionAtOffset(2, 17, CONDITION_WRAPPING_RULE_ID),
+                    )
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Given an if statement with a multiline condition to which a suppression is to be added`() {
+            val code =
+                """
+                fun foo() {
+                    if (true && false ||
+                        true
+                    ) {}
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                fun foo() {
+                    @Suppress("ktlint:standard:condition-wrapping")
+                    if (true && false ||
+                        true
+                    ) {}
+                }
+                """.trimIndent()
+            val actual =
+                ktLintRuleEngine
+                    .insertSuppression(
+                        Code.fromSnippet(code, false),
+                        KtlintSuppressionAtOffset(2, 17, CONDITION_WRAPPING_RULE_ID),
+                    )
+
+            assertThat(actual).isEqualTo(formattedCode)
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Description

Do not place an annotation on a value argument, value parameter, type parameter, or type projection in case it is a binary expression

Make creation of the annotation more safe by not using a fake top element in the code which is used to generate the AST.

The 'Suppress' annotation has a parameter, which by default is not allowed to be placed inline (it should start on a new line). Just putting it above the binary expression results in it being applied to the first subexpression only instead of on the entire binary expression.

Closes #2462

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
