### PR TITLE
Loosen dependency between chain-method-continuation and argument-list-wrapping

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -26,7 +26,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule
-import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
@@ -71,7 +71,7 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 public class ChainMethodContinuationRule :
     StandardRule(
         id = "chain-method-continuation",
-        visitorModifiers = setOf(RunAfterRule(ARGUMENT_LIST_WRAPPING_RULE_ID, ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED)),
+        visitorModifiers = setOf(RunAfterRule(ARGUMENT_LIST_WRAPPING_RULE_ID, REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED)),
         usesEditorConfigProperties =
             setOf(
                 CODE_STYLE_PROPERTY,
@@ -248,8 +248,6 @@ public class ChainMethodContinuationRule :
     }
 
     private fun ASTNode.isPrecededByComment() = treeParent.children().any { it.isPartOfComment() }
-
-    private fun ASTNode.isSucceededByComment() = nextSibling()?.isPartOfComment() ?: false
 
     private fun insertWhiteSpaceBeforeChainOperator(
         chainOperator: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -146,7 +146,6 @@ public class ChainMethodContinuationRule :
                     chainOperator.shouldBeOnSameLineAsClosingElementOfPreviousExpressionInMethodChain() -> {
                         removeWhiteSpaceBeforeChainOperator(chainOperator, emit, autoCorrect)
                     }
-
                     wrapBeforeEachChainOperator || exceedsMaxLineLength || chainOperator.isPrecededByComment() -> {
                         insertWhiteSpaceBeforeChainOperator(chainOperator, emit, autoCorrect)
                     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -146,6 +146,7 @@ public class ChainMethodContinuationRule :
                     chainOperator.shouldBeOnSameLineAsClosingElementOfPreviousExpressionInMethodChain() -> {
                         removeWhiteSpaceBeforeChainOperator(chainOperator, emit, autoCorrect)
                     }
+
                     wrapBeforeEachChainOperator || exceedsMaxLineLength || chainOperator.isPrecededByComment() -> {
                         insertWhiteSpaceBeforeChainOperator(chainOperator, emit, autoCorrect)
                     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -547,6 +547,27 @@ class ChainMethodContinuationRuleTest {
     @Nested
     inner class `Given a chained expression as function argument` {
         @Test
+        fun `Issue 2452 - Given that the argument-list-wrapping rule is not loaded or not enabled`() {
+            val code =
+                """
+                val foo1 = requireNotNull(bar.filter { it == 'b' }.filter { it == 'a' }
+                        .filter { it == 'r' })
+                val foo2 = requireNotNull(bar.filter { it == 'b' }.filter { it == 'a' }.filter { it == 'r' })
+                """.trimIndent()
+            val formattedCode =
+                """
+                val foo1 = requireNotNull(bar
+                    .filter { it == 'b' }
+                    .filter { it == 'a' }
+                    .filter { it == 'r' })
+                val foo2 = requireNotNull(bar.filter { it == 'b' }.filter { it == 'a' }.filter { it == 'r' })
+                """.trimIndent()
+            chainMethodContinuationRuleAssertThat(code)
+                .addAdditionalRuleProvider { IndentationRule() }
+                .isFormattedAs(formattedCode)
+        }
+
+        @Test
         fun `Wrapping the argument has precedence above wrapping on the chain operator`() {
             val code =
                 """
@@ -566,6 +587,7 @@ class ChainMethodContinuationRuleTest {
                 """.trimIndent()
             chainMethodContinuationRuleAssertThat(code)
                 .setMaxLineLength()
+                .addAdditionalRuleProvider { ArgumentListWrappingRule() }
                 .hasNoLintViolationsExceptInAdditionalRules()
                 .isFormattedAs(formattedCode)
         }


### PR DESCRIPTION
## Description

Loosen dependency between chain-method-continuation and argument-list-wrapping-wrapping

Allow the chain-method-continuation rule to be run when argument-list-wrapping is disabled or not loaded. Whenever both rules are loaded, the argument-list-wrapping takes precedence and runs before the chain-method-continuation.

Closes #2452

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
