### PR TITLE
Keep arrow when both parameter list and block of function literal are empty

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -374,7 +374,7 @@ public class FunctionLiteralRule :
         require(arrow.elementType == ARROW)
         arrow
             .prevSibling { it.elementType == VALUE_PARAMETER_LIST }
-            ?.takeIf { it.findChildByType(VALUE_PARAMETER) == null }
+            ?.takeIf { it.findChildByType(VALUE_PARAMETER) == null && arrow.isFollowedByNonEmptyBlock() }
             ?.let {
                 emit(arrow.startOffset, "Arrow is redundant when parameter list is empty", true)
                 if (autoCorrect) {
@@ -385,6 +385,11 @@ public class FunctionLiteralRule :
                     arrow.treeParent.removeChild(arrow)
                 }
             }
+    }
+
+    private fun ASTNode.isFollowedByNonEmptyBlock(): Boolean {
+        require(elementType == ARROW)
+        return nextSibling { it.elementType == BLOCK }?.firstChildNode != null
     }
 
     private fun visitBlock(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -465,4 +465,13 @@ class FunctionLiteralRuleTest {
             .hasLintViolation(1, 42, "Arrow is redundant when parameter list is empty")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2465 - Given a function literal without parameters and with an empty block then do not remove the arrow`() {
+        val code =
+            """
+            fun foo(block: () -> Unit): Unit = foo { -> }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Keep arrow when both parameter list and block of function literal are empty

Removal of the arrow in this case would lead to a compilation error as the function literal is changed to a normal block when removing the arrow.

Closes #2465

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
