### PR TITLE
Fix operator spacing

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRuleTest.kt
@@ -47,7 +47,7 @@ class SpacingAroundOperatorsRuleTest {
             .hasLintViolations(
                 LintViolation(1, 13, "Missing spacing around \"${operator}\""),
                 LintViolation(2, 13, "Missing spacing before \"${operator}\""),
-                LintViolation(3, 15, "Missing spacing after \"${operator}\""),
+                LintViolation(3, 14 + operator.length, "Missing spacing after \"${operator}\""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -248,10 +248,10 @@ class SpacingAroundOperatorsRuleTest {
                 """.trimIndent()
             spacingAroundOperatorsRuleAssertThat(code)
                 .hasLintViolations(
-                    LintViolation(3, 8, "Missing spacing after \"+=\""),
-                    LintViolation(4, 8, "Missing spacing after \"-=\""),
-                    LintViolation(5, 8, "Missing spacing after \"/=\""),
-                    LintViolation(6, 8, "Missing spacing after \"*=\""),
+                    LintViolation(3, 9, "Missing spacing after \"+=\""),
+                    LintViolation(4, 9, "Missing spacing after \"-=\""),
+                    LintViolation(5, 9, "Missing spacing after \"/=\""),
+                    LintViolation(6, 9, "Missing spacing after \"*=\""),
                 ).isFormattedAs(formattedCode)
         }
     }
@@ -284,5 +284,34 @@ class SpacingAroundOperatorsRuleTest {
             val foo = Map<PropertyType<*>>
             """.trimIndent()
         spacingAroundOperatorsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a custom DSL`() {
+        val code =
+            """
+            fun foo() {
+                every { foo() }returns(bar)andThen(baz)
+                every { foo() }returns (bar)andThen (baz)
+                every { foo() } returns(bar) andThen(baz)
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                every { foo() } returns (bar) andThen (baz)
+                every { foo() } returns (bar) andThen (baz)
+                every { foo() } returns (bar) andThen (baz)
+            }
+            """.trimIndent()
+        spacingAroundOperatorsRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 20, "Missing spacing around \"returns\""),
+                LintViolation(2, 32, "Missing spacing around \"andThen\""),
+                LintViolation(3, 20, "Missing spacing before \"returns\""),
+                LintViolation(3, 33, "Missing spacing before \"andThen\""),
+                LintViolation(4, 28, "Missing spacing after \"returns\""),
+                LintViolation(4, 41, "Missing spacing after \"andThen\""),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

If an operation reference contains an identifier, then it is used in a DSL notation in which the identifier should be separated with a from a parenthesized expression to avoid confusion with a function call. E.g. format as `every { foo() } returns (bar) andThen (baz)`

Offsets for operators having length 2 or more, and not followed by single space were incorrect as length of the operator was not taken into account.

Closes #2459

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
