### PR TITLE
Allow string template to exceed max line length when it is the only element on a line

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -819,7 +819,9 @@ Rule id: `ktlint-suppression` (`standard` rule set)
 
 ## Max line length
 
-Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to a comment that disables ktlint rules then that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
+Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations like multiline raw string literals, or single line string templates which are the sole element on a line.
+
+The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -831,10 +833,13 @@ Ensures that lines do not exceed the given length of `.editorconfig` property `m
     package com.toooooooooooooooooooooooooooo.long
     import com.tooooooooooooooooooooooooooooo.long
 
-    val foo =
+    val foo1 =
         """
         fooooooooooooooooooooooooooooooooooooooooo
         """
+
+    val foo2 =
+        "fooooooooooooooooooooooooooooooooooooooo"
 
     @Test
     fun `Test description which is toooooooooooo long`() {
@@ -846,9 +851,8 @@ Ensures that lines do not exceed the given length of `.editorconfig` property `m
     // Assume that the last allowed character is
     // at the X character on the right           X
     val fooooooooooooooo = "fooooooooooooooooooooo"
+    val foo = "foo" + "ooooooooooooooooooooooooooo"
     val foooooooooooooo = "foooooooooooooooooooo" // some comment
-    val fooooooooooooo =
-        "foooooooooooooooooooooooooooooooooooooooo"
     ```
 
 Rule id: `max-line-length` (`standard` rule set)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
@@ -20,15 +20,12 @@ class MaxLineLengthRuleTest {
             // $MAX_LINE_LENGTH_MARKER                   $EOL_CHAR
             val fooooooooooooooo = "fooooooooooooooooooooo"
             val foooooooooooooo = "foooooooooooooooooooo" // some comment
-            val fooooooooooooo =
-                "foooooooooooooooooooooooooooooooooooooooo"
             """.trimIndent()
         maxLineLengthRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 47, "Exceeded max line length (46)"),
                 LintViolation(3, 47, "Exceeded max line length (46)"),
-                LintViolation(5, 47, "Exceeded max line length (46)"),
             )
     }
 
@@ -71,6 +68,25 @@ class MaxLineLengthRuleTest {
             maxLineLengthRuleAssertThat(code)
                 .setMaxLineLength()
                 .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given a single line string which exceeds the max line length, and which has no other non-whitespace elements on the same line then do not return a lint error`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+                fun foo() {
+                    logger.info {
+                        "fooooooooooooooooooooooooooo"
+                    }
+                    logger.info {
+                        "foo" + "oooooooooooooooooooo"
+                    }
+                }
+                """.trimIndent()
+            maxLineLengthRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolationWithoutAutoCorrect(7, 38, "Exceeded max line length (37)")
         }
 
         @Test


### PR DESCRIPTION
## Description

Allow string template to exceed max line length when it is the only element on a line

Closes #2453

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
