### PR TITLE
Add configuration setting for ignoring `argument-list-wrapping` above treshold of parameters

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -2231,9 +2231,9 @@ All arguments should be on the same line, or every argument should be on a separ
         )
     ```
 
-| Configuration setting per code style                                                |  ktlint_official  |  intellij_idea  |  android_studio  |
-|:------------------------------------------------------------------------------------|:-----------------:|:---------------:|:----------------:|
-| `ktlint_argument_list_wrapping_ignore_when_parameter_count_greater_or_equal_than`   |      `unset`      |        8        |        8         |
+| Configuration setting                                                             | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_argument_list_wrapping_ignore_when_parameter_count_greater_or_equal_than` |     `unset`     |       8       |       8        |
 
 Rule-id: `argument-list-wrapping` (`standard` rule set)
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -415,7 +415,7 @@ Enforce naming of function.
     When using Compose, you might want to suppress the `function-naming` rule by setting `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
 
 !!! note
-    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
+    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test-functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
 
 This rule can also be suppressed with the IntelliJ IDEA inspection suppression `FunctionName`.
 
@@ -1148,7 +1148,7 @@ Rule id: `no-trailing-spaces` (`standard` rule set)
 
 ## No `Unit` as return type 
 
-The `Unit` type is not allowed as return type of a function.
+The `Unit` type is not allowed as return-type of a function.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -2230,6 +2230,10 @@ All arguments should be on the same line, or every argument should be on a separ
             b, c,
         )
     ```
+
+| Configuration setting per code style                                                |  ktlint_official  |  intellij_idea  |  android_studio  |
+|:------------------------------------------------------------------------------------|:-----------------:|:---------------:|:----------------:|
+| `ktlint_argument_list_wrapping_ignore_when_parameter_count_greater_or_equal_than`   |      `unset`      |        8        |        8         |
 
 Rule-id: `argument-list-wrapping` (`standard` rule set)
 

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -29,9 +29,14 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacing
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
+	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule$Companion;
 	public fun <init> ()V
 	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule$Companion {
+	public final fun getIGNORE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY ()Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleKt {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -41,25 +41,32 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
     // subset of ElementType.MODIFIER_KEYWORDS_ARRAY (+ annotations entries)
     private val order =
         arrayOf(
+            ABSTRACT_KEYWORD,
+            ACTUAL_KEYWORD,
             ANNOTATION_ENTRY,
-            PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
-            EXPECT_KEYWORD, ACTUAL_KEYWORD,
-            FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
+            ANNOTATION_KEYWORD,
+            COMPANION_KEYWORD,
+            CONST_KEYWORD,
+            DATA_KEYWORD,
+            ENUM_KEYWORD,
+            EXPECT_KEYWORD,
             EXTERNAL_KEYWORD,
-            OVERRIDE_KEYWORD,
+            FINAL_KEYWORD,
+            INFIX_KEYWORD,
+            INLINE_KEYWORD,
+            INNER_KEYWORD,
+            INTERNAL_KEYWORD,
             LATEINIT_KEYWORD,
+            OPEN_KEYWORD,
+            OPERATOR_KEYWORD,
+            OVERRIDE_KEYWORD,
+            PRIVATE_KEYWORD,
+            PROTECTED_KEYWORD,
+            PUBLIC_KEYWORD,
+            SEALED_KEYWORD,
+            SUSPEND_KEYWORD,
             TAILREC_KEYWORD,
             VARARG_KEYWORD,
-            SUSPEND_KEYWORD,
-            INNER_KEYWORD,
-            ENUM_KEYWORD, ANNOTATION_KEYWORD,
-            COMPANION_KEYWORD,
-            INLINE_KEYWORD,
-            INFIX_KEYWORD,
-            OPERATOR_KEYWORD,
-            DATA_KEYWORD,
-            // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
-            // HEADER_KEYWORD, IMPL_KEYWORD
         )
     private val tokenSet = TokenSet.create(*order)
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -38,38 +38,6 @@ import java.util.Arrays
 
 @SinceKtlint("0.7", STABLE)
 public class ModifierOrderRule : StandardRule("modifier-order") {
-    // subset of ElementType.MODIFIER_KEYWORDS_ARRAY (+ annotations entries)
-    private val order =
-        arrayOf(
-            ABSTRACT_KEYWORD,
-            ACTUAL_KEYWORD,
-            ANNOTATION_ENTRY,
-            ANNOTATION_KEYWORD,
-            COMPANION_KEYWORD,
-            CONST_KEYWORD,
-            DATA_KEYWORD,
-            ENUM_KEYWORD,
-            EXPECT_KEYWORD,
-            EXTERNAL_KEYWORD,
-            FINAL_KEYWORD,
-            INFIX_KEYWORD,
-            INLINE_KEYWORD,
-            INNER_KEYWORD,
-            INTERNAL_KEYWORD,
-            LATEINIT_KEYWORD,
-            OPEN_KEYWORD,
-            OPERATOR_KEYWORD,
-            OVERRIDE_KEYWORD,
-            PRIVATE_KEYWORD,
-            PROTECTED_KEYWORD,
-            PUBLIC_KEYWORD,
-            SEALED_KEYWORD,
-            SUSPEND_KEYWORD,
-            TAILREC_KEYWORD,
-            VARARG_KEYWORD,
-        )
-    private val tokenSet = TokenSet.create(*order)
-
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -77,7 +45,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
     ) {
         if (node.psi is KtDeclarationModifierList) {
             val modifierArr = node.getChildren(tokenSet)
-            val sorted = modifierArr.copyOf().apply { sortWith(compareBy { order.indexOf(it.elementType) }) }
+            val sorted = modifierArr.copyOf().apply { sortWith(compareBy { ORDERED_MODIFIERS.indexOf(it.elementType) }) }
             if (!Arrays.equals(modifierArr, sorted)) {
                 // Since annotations can be fairly lengthy and/or span multiple lines we are
                 // squashing them into a single placeholder text to guarantee a single line output
@@ -106,6 +74,42 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
         } else {
             nonAnnotationModifiers.map { it.text }
         }
+    }
+
+    private companion object {
+        // subset of ElementType.MODIFIER_KEYWORDS_ARRAY (+ annotations entries)
+        private val ORDERED_MODIFIERS =
+            arrayOf(
+                ANNOTATION_ENTRY,
+                PUBLIC_KEYWORD,
+                PROTECTED_KEYWORD,
+                PRIVATE_KEYWORD,
+                INTERNAL_KEYWORD,
+                EXPECT_KEYWORD,
+                ACTUAL_KEYWORD,
+                FINAL_KEYWORD,
+                OPEN_KEYWORD,
+                ABSTRACT_KEYWORD,
+                SEALED_KEYWORD,
+                CONST_KEYWORD,
+                EXTERNAL_KEYWORD,
+                OVERRIDE_KEYWORD,
+                LATEINIT_KEYWORD,
+                TAILREC_KEYWORD,
+                VARARG_KEYWORD,
+                SUSPEND_KEYWORD,
+                INNER_KEYWORD,
+                ENUM_KEYWORD,
+                ANNOTATION_KEYWORD,
+                COMPANION_KEYWORD,
+                INLINE_KEYWORD,
+                INFIX_KEYWORD,
+                OPERATOR_KEYWORD,
+                DATA_KEYWORD,
+                // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
+                // HEADER_KEYWORD, IMPL_KEYWORD
+            )
+        private val tokenSet = TokenSet.create(*ORDERED_MODIFIERS)
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -285,6 +285,7 @@ public class NoUnusedImportsRule : StandardRule("no-unused-imports") {
     private companion object {
         val COMPONENT_N_REGEX = Regex("^component\\d+$")
 
+        @Suppress("ktlint:standard:argument-list-wrapping")
         val OPERATOR_SET =
             setOf(
                 // unary

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundKeywordRule.kt
@@ -35,8 +35,15 @@ public class SpacingAroundKeywordRule : StandardRule("keyword-spacing") {
     private val noLFBeforeSet = create(ELSE_KEYWORD, CATCH_KEYWORD, FINALLY_KEYWORD)
     private val tokenSet =
         create(
-            FOR_KEYWORD, IF_KEYWORD, ELSE_KEYWORD, WHILE_KEYWORD, DO_KEYWORD,
-            TRY_KEYWORD, CATCH_KEYWORD, FINALLY_KEYWORD, WHEN_KEYWORD,
+            CATCH_KEYWORD,
+            DO_KEYWORD,
+            ELSE_KEYWORD,
+            FINALLY_KEYWORD,
+            FOR_KEYWORD,
+            IF_KEYWORD,
+            TRY_KEYWORD,
+            WHEN_KEYWORD,
+            WHILE_KEYWORD,
         )
 
     private val keywordsWithoutSpaces = create(GET_KEYWORD, SET_KEYWORD)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
@@ -44,8 +44,29 @@ import org.jetbrains.kotlin.psi.KtPrefixExpression
 public class SpacingAroundOperatorsRule : StandardRule("op-spacing") {
     private val tokenSet =
         TokenSet.create(
-            MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
-            EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW,
+            ANDAND,
+            ARROW,
+            DIV,
+            DIVEQ,
+            ELVIS,
+            EQ,
+            EQEQ,
+            EQEQEQ,
+            EXCLEQ,
+            EXCLEQEQEQ,
+            GT,
+            GTEQ,
+            LT,
+            LTEQ,
+            MINUS,
+            MINUSEQ,
+            MUL,
+            MULTEQ,
+            OROR,
+            PERC,
+            PERCEQ,
+            PLUS,
+            PLUSEQ,
         )
 
     override fun beforeVisitChildNodes(


### PR DESCRIPTION
## Description

Add configuration setting for ignoring `argument-list-wrapping` above treshold of parameters

Breaking change: For code style `ktlint_official` the default value for this setting has default `unset` which is different from previous default value `8`. Not wrapping parameters should be a conscious decision of the developer. This can either be done on a case by case basis by suppressing the rule, or by configuring the parameter.

Closes #2461

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
