### PR TITLE
Move configuration setting documentation to rule

### DIFF
--- a/documentation/release-latest/docs/rules/configuration-ktlint.md
+++ b/documentation/release-latest/docs/rules/configuration-ktlint.md
@@ -13,7 +13,7 @@ By default, the `ktlint_official` code style is applied. Alternatively, the code
 ktlint_code_style = ktlint_official
 ```
 
-## Disabled rules
+## Disable rule(s)
 
 Rule sets and individual rules can be disabled / enabled with a separate property per rule (set).
 
@@ -39,221 +39,26 @@ ktlint_custom-rule-set_custom-rule = disabled # Disables the `custom-rule` rule 
 !!! note
     The *rule* properties are applied after applying the *rule set* properties and take precedence. So if a rule set is disabled but a specific rule of that rule set is enabled, then the rule will be executed.
 
+## Rule specific configuration settings
 
-## Final newline
+The configuration settings below are used to configure the behavior of a specific rule. As of that, those settings only take effect when the corresponding rule is enabled. See description of rule for more information about the setting.
 
-By default, a final newline is required at the end of the file.
-
-```ini
-[*.{kt,kts}]
-insert_final_newline = true
-```
-
-This setting only takes effect when rule `final-newline` is enabled.
-
-## Force multiline chained methods based on number of chain operators
-
-Setting `ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than` forces a chained method to be wrapped at each chain operator (`.` or `?.`) in case it contains the specified minimum number of chain operators even in case the entire chained method fits on a single line. Use value `unset` (default) to disable this setting.
-
-!!! note
-    By default, chained methods are wrapped when an expression contains 4 or more chain operators in an expression. Note that if a chained method contains nested expressions the chain operators of the inner expression are not taken into account.
-
-```ini
-[*.{kt,kts}]
-ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than=unset
-```
-
-This setting only takes effect when rule `chain-method-continution` is enabled.
-
-## Force multiline function signature based on number of parameters
-
-Setting `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` forces a multiline function signature in case the function contains the specified minimum number of parameters even in case the function signature would fit on a single line. Use value `unset` (default) to disable this setting.
-
-!!! note
-    By default, the `ktlint_official` code style wraps parameters of functions having at least 2 parameters. For other code styles, this setting is disabled by default. 
-
-```ini
-[*.{kt,kts}]
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
-```
-
-This setting only takes effect when rule `function-signature` is enabled.
-
-## Wrapping the expression body of a function
-
-Setting `ktlint_function_signature_body_expression_wrapping` determines if and when the expression body of a function is wrapped to a new line. This setting can be set to value `default`, `multiline` or `always`. 
-
-!!! note
-    In this context `default` means the default behavior of the IntelliJ IDEA formatter. If not set explicitly, this style is used by code styles `intellij_idea` and `android_studio`. Code style `ktlint_official` uses style `multiline` when this setting has no value.
-
-When set to `default`, the first line of a body expression is appended to the function signature as long as the max line length is not exceeded.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=default"
-// Given that the function signature has to be written as a single line function signature
-fun someFunction(a: Any, b: Any): String = "some-result"
-    .uppercase()
-
-// Given that the function signature has to be written as a multiline function signature
-fun someFunction(
-    a: Any,
-    b: Any
-): String = "some-result"
-    .uppercase()
-```
-
-When set to `multiline`, the body expression starts on a separate line in case it is a multiline expression. A single line body expression is wrapped only when it does not fit on the same line as the function signature.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=multiline"
-// Given a single line body expression and
-// a the function signature that has to be written as a single line function signature and
-// it does not exceed the max line length
-fun someFunction(a: Any, b: Any): String = "some-result".uppercase()
-
-// Given a single line body expression and
-// a the function signature that has to be written as a multiline function signature and
-// it does not exceed the max line length
-fun someFunction(
-    a: Any,
-    b: Any
-): String = "some-result".uppercase()
-
-// Given a single line body expression then always wrap it to a separate line
-fun someFunction(a: Any, b: Any): String =
-    "some-result"
-         .uppercase()
-fun someFunction(
-    a: Any,
-    b: Any
-): String =
-    "some-result"
-       .uppercase()
-```
-
-When set to `always` the body expression is always wrapped to a separate line.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=always"
-fun someFunction(a: Any, b: Any): String =
-    "some-result".uppercase()
-fun functionWithAVeryLongName(
-    a: Any,
-    b: Any
-): String =
-    "some-result"
-        .uppercase()
-```
-
-This setting only takes effect when rule `function-signature` is enabled.
-
-## Ignore identifiers enclosed in backticks
-
-By default, the identifiers enclosed in backticks are not ignored.
-
-According to [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) it is acceptable to write method names in natural language. When using natural language, the description tends to be longer. This property allows lines containing an identifier between backticks to be longer than the maximum line length. (Since 0.41.0)
-
-```kotlin
-@Test
-fun `Given a test with a very loooooooooooooooooooooong test description`() {
-    
-}
-```
-
-```ini
-[*.{kt,kts}]
-ktlint_ignore_back_ticked_identifier = false
-```
-
-This setting only takes effect when rule `max-line-length` is enabled.
-
-## Import layouts
-
-By default, the same imports are allowed as in IntelliJ IDEA. The import path can be a full path, e.g. "java.util.List.*" as well as wildcard path, e.g. "kotlin.**".
-
-The layout can be composed by the following symbols:
-
-*  `*` - wildcard. There must be at least one entry of a single wildcard to match all other imports. Matches anything after a specified symbol/import as well.
-* `|` - blank line. Supports only single blank lines between imports. No blank line is allowed in the beginning or end of the layout.
-* `^` - alias import, e.g. "^android.*" will match all android alias imports, "^" will match all other alias imports.
-
-Examples:
-```kotlin
-ij_kotlin_imports_layout=* # alphabetical with capital letters before lower case letters (e.g. Z before a), no blank lines
-ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^ # default IntelliJ IDEA style, same as alphabetical, but with "java", "javax", "kotlin" and alias imports in the end of the imports list
-ij_kotlin_imports_layout=android.**,|,^org.junit.**,kotlin.io.Closeable.*,|,*,^ # custom imports layout
-```
-
-Wildcard imports can be allowed for specific import paths (Comma-separated list, use "**" as wildcard for package and all subpackages). This setting overrides the no-wildcard-imports rule. This setting is best be used for allowing wildcard imports from libraries like Ktor where extension functions are used in a way that creates a lot of imports.
-
-```ini
-[*.{kt,kts}]
-ij_kotlin_packages_to_use_import_on_demand = java.util.*,kotlinx.android.synthetic.**
-```
-
-This setting only takes effect when rule `no-wildcard-imports` is enabled.
-
-## Indent size & style
-
-By default, indenting is done with 4 spaces per indent level. Code style `android_studio` uses a tab per indent level.
-
-```ini
-[*.{kt,kts}]
-indent_size = 4 # possible values: number (e.g. 2), "unset" (makes ktlint ignore indentation completely)  
-indent_style = space # or "tab"
-```
-
-Those settings are used by multiple rules of which rule `indent` is the most important.
-
-## Max line length
-
-By default, the maximum line length is not set. The `android` code style sets the max line length to 100 (per Android Kotlin Style Guide).
-
-```ini
-[*.{kt,kts}]
-max_line_length = off # Use "off" to ignore max line length or a positive number to set max line length
-```
-
-This setting is used by multiple rules of which rule `max-line-length` is the most important.
-
-## Trailing comma on call site
-
-KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma_on_call_site` to *enforce* the usage of the trailing comma at call site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
-
-    Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) leaves it to the developer's discretion to use trailing commas on the call site, it also states that usage of trailing commas has several benefits:
-    
-     * It makes version-control diffs cleaner – as all the focus is on the changed value.
-     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
-     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
-
-Example:
-```ini
-[*.{kt,kts}]
-ij_kotlin_allow_trailing_comma_on_call_site = false
-```
-
-This setting only takes effect when rule `trailing-comma-on-call-site` is enabled.
-
-## Trailing comma on declaration site
-
-KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to *enforce* the usage of the trailing comma at declaration site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
-
-    The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) encourages the usage of trailing commas on the declaration site, but leaves it to the developer's discretion to use trailing commas on the call site. But next to this, it also states that usage of trailing commas has several benefits:
-    
-     * It makes version-control diffs cleaner – as all the focus is on the changed value.
-     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
-     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
-
-Example:
-```ini
-[*.{kt,kts}]
-ij_kotlin_allow_trailing_comma = false # Only used for declaration site 
-```
-
-This setting only takes effect when rule `trailing-comma-on-declaration-site` is enabled.
+| Configuration setting                                                                     | Rule                                                                                        |
+|:------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------|
+| ij_kotlin_allow_trailing_comma                                                            | [trailing-comma-on-declaration-site](../rules/standard/#trailing-comma-on-declaration-site) |
+| ij_kotlin_allow_trailing_comma_on_call_site                                               | [trailing-comma-on-call-site](../rules/standard/#trailing-comma-on-call-site)               |
+| ij_kotlin_packages_to_use_import_on_demand                                                | [no-wildcard-imports](../rules/standard/#no-wildcard-imports)                               |
+| indent_size                                                                               | [indent](../rules/standard/#indentation)                                                    |                                                                                       |
+| indent_style                                                                              | [indent](../rules/standard/#indentation)                                                    |                                                                                       |
+                                                                                    |
+| insert_final_newline                                                                      | [final-newline](../rules/standard/#final-newline)                                           |                                                                                       |
+| ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than  | [chain-method-continuation](../rules/experimental/#chain-method-continuation)               |
+| ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than    | [class-signature](../rules/experimental/#class-signature)                                   |
+| ktlint_ignore_back_ticked_identifier                                                      | [max-line-length](../rules/standard/#max-line-length)                                       |
+| ktlint_function_naming_ignore_when_annotated_with                                        | [function-naming](../rules/standard/#function-naming)                                       |
+| ktlint_function_signature_body_expression_wrapping                                        | [function-signature](../rules/standard/#function-signature)                                 |
+| ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than | [function-signature](../rules/standard/#function-signature)                                 |
+| max_line_length                                                                           | [max-line-length](../rules/standard/#max-line-length) and several other rules               |
 
 ## Overriding Editorconfig properties for specific directories
 
@@ -266,4 +71,4 @@ ktlint_standard_import-ordering = disabled
 ktlint_standard_indent = disabled
 ```
 
-Note that the `import-ordering` rule is disabled for *all* packages including the `api` sub package. Next to this the `indent` rule is disabled for the `api` package and its sub packages.
+Note that in example above the `import-ordering` rule is disabled for *all* packages including the `api` sub package. Next to this the `indent` rule is disabled for the `api` package and its sub packages.

--- a/documentation/release-latest/docs/rules/experimental.md
+++ b/documentation/release-latest/docs/rules/experimental.md
@@ -125,6 +125,11 @@ This rule can be configured with `.editorconfig` property [`ktlint_chain_method_
             .bar()
     ```
 
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                  | ktlint_official | intellij_idea | android_studio |
+|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than`<br/><i>Force wrapping of chained methods in case an expression contains at least the specified number of chain operators. If a chained method contains nested expressions, the chain operators of the inner expression are not taken into account. Use value `unset` (default) to disable this setting.</i> |        4        |       4       |       4        |
+
+
 Rule id: `chain-method-continuation` (`standard` rule set)
 
 !!! Note
@@ -330,6 +335,10 @@ The other code styles allow an infinite amount of parameters on the same line (a
 
     class Foo6(a: Any, b: Any, c: Any) : FooBar(a, c)
     ```
+
+| Configuration setting                                                                                                                                                                                                                                                                                                                       | ktlint_official | intellij_idea | android_studio |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`<br/><i>Force wrapping of the parameters of the class signature in case it contains at least the specified number of parameters, even in case the entire class signature would fit on a single line. Use value `unset` to disable this setting.</i> |        1        |    `unset`    |    `unset`     |
 
 Rule id: `class-signature` (`standard` rule set)
 

--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -164,15 +164,15 @@ Rule id: `filename` (`standard` rule set)
 
 Ensures consistent usage of a newline at the end of each file. 
 
-This rule can be configured with `.editorconfig` property [`insert_final_newline`](../configuration-ktlint/#final-newline).
+| Configuration setting                                                             | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `insert_final_newline` |     `true`      |       `true`        |       `true`        |
 
 Rule id: `final-newline` (`standard` rule set)
 
 ## Function signature
 
-Rewrites the function signature to a single line when possible (e.g. when not exceeding the `max_line_length` property) or a multiline signature otherwise. In case of function with a body expression, the body expression is placed on the same line as the function signature when not exceeding the `max_line_length` property. 
-
-In `ktlint-official` code style, a function signature is always rewritten to a multiline signature in case the function has 2 or more parameters. This number of parameters can be set via `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`.
+Rewrites the function signature to a single line when possible (e.g. when not exceeding the `max_line_length` property) or a multiline signature otherwise. 
 
 !!! note
     Wrapping of parameters is also influenced by the `parameter-list-wrapping` rule.
@@ -242,6 +242,84 @@ In `ktlint-official` code style, a function signature is always rewritten to a m
     // at the X character on the right           X
     fun f(a: Any, b: Any): String = "some-result"
         .uppercase()
+    ```
+
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                   | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_function_signature_body_expression_wrapping`<br/><i>Determines how to wrap the body of function in case it is an expression. Use `default` to wrap the body expression only when the first line of the expression does not fit on the same line as the function signature. Use `multiline` to force wrapping of body expressions that consists of multiple lines. Use `always` to force wrapping of body expression always.</i> |   `multiline`   |   `default`   |   `default`    |
+| `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`<br/><i>Forces a multiline function signature in case the function contains the specified minimum number of parameters even in case the function signature would fit on a single line. Use value `unset` (default) to disable this setting.</i>                                                                                              |        2        |    `unset`    |    `unset`     |
+
+=== "[:material-heart:](#) default"
+
+    When `ktlint_function_signature_body_expression_wrapping` is set to `default`, the first line of a body expression is appended to the function signature as long as the max line length is not exceeded.
+
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=default"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a multiline body expression
+    fun someFunction(a: Any, b: Any): String = "some-result"
+        .uppercase()
+    
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String = "some-result"
+        .uppercase()
+    ```
+
+=== "[:material-heart:](#) multiline"
+
+    When `ktlint_function_signature_body_expression_wrapping` is set to `multiline`, the body expression starts on a separate line in case it is a multiline expression. A single line body expression is wrapped only when it does not fit on the same line as the function signature.
+    
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=multiline"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a single line body expression
+    // that fits on the same line as the function signature.
+    fun someFunction(a: Any, b: Any): String = "some-result".uppercase()
+    
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a single line body expression
+    // that fits on the same line as the function signature.
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String = "some-result".uppercase()
+    
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a multiline body expression
+    fun someFunction(a: Any, b: Any): String =
+        "some-result"
+             .uppercase()
+
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String =
+        "some-result"
+           .uppercase()
+    ```
+
+=== "[:material-heart:](#) always"
+
+    When `ktlint_function_signature_body_expression_wrapping` is  set to `always` the body expression is always wrapped to a separate line.
+    
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=always"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a single line body expression
+    fun someFunction(a: Any, b: Any): String =
+        "some-result".uppercase()
+
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun functionWithAVeryLongName(
+        a: Any,
+        b: Any
+    ): String =
+        "some-result"
+            .uppercase()
     ```
 
 Rule id: `function-signature` (`standard` rule set)
@@ -335,6 +413,11 @@ Indentation formatting - respects `.editorconfig` `indent_size` with no continua
 !!! note
     This rule handles indentation for many different language constructs which can not be summarized with a few examples. See the [unit tests](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt) for more details.
 
+| Configuration setting                                                                                                                     | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `indent_size`</br><i>The size of an indentation level when `indent_style` is set to `space`. Use value `unset` to ignore indentation.</i> |        4        |       4       |       4        |
+| `indent_style`</br><i>Style of indentation. Set this value to `space` or `tab`.</i>                                                       |     `space`     |    `space`    |    `space`     |
+
 Rule id: `indent` (`standard` rule set)
 
 ## Naming
@@ -411,11 +494,15 @@ Enforce naming of function.
     fun do_something() {}
     ```
 
-!!! note
-    When using Compose, you might want to suppress the `function-naming` rule by setting `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
+| Configuration setting                                                                                                                                                                                 | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_function_naming_ignore_when_annotated_with`</br><i>Ignore functions that are annotated with values in this setting. This value is a comma separated list of names without the '@' prefix.</i> |     `unset`     |    `unset`    |    `unset`     |
 
 !!! note
-    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
+    When using Compose, you might want to configure the `function-naming` rule with `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
+
+!!! note
+    Functions in files which import a class from package `io.kotest`, `junit.framework`, `kotlin.test`, `org.junit`, or `org.testng` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
 
 This rule can also be suppressed with the IntelliJ IDEA inspection suppression `FunctionName`.
 
@@ -819,7 +906,7 @@ Rule id: `ktlint-suppression` (`standard` rule set)
 
 ## Max line length
 
-Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to a comment that disables ktlint rules then that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
+Ensures that lines do not exceed the maximum length of a line. This rule does not apply in a number of situations. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -850,6 +937,12 @@ Ensures that lines do not exceed the given length of `.editorconfig` property `m
     val fooooooooooooo =
         "foooooooooooooooooooooooooooooooooooooooo"
     ```
+
+
+| Configuration setting                                                                                               | ktlint_official | intellij_idea | android_studio |
+|:--------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_ignore_back_ticked_identifier`<br/><i>Defines whether the backticked identifier (``) should be ignored.</i> |     `false`     |    `false`    |    `false`     |
+| `max_line_length`<br/><i>Maximum length of a (regular) line.</i>                                                    |       140       |     `off`     |     `100`      |
 
 Rule id: `max-line-length` (`standard` rule set)
 
@@ -1172,7 +1265,7 @@ Rule id: `no-unused-imports` (`standard` rule set)
 
 ## No wildcard imports
 
-No wildcard imports except imports listed in `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand`.
+No wildcard imports except whitelisted imports.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -1186,12 +1279,31 @@ No wildcard imports except imports listed in `.editorconfig` property `ij_kotlin
     import foobar.*
     ```
 
+| Configuration setting                                                                     | ktlint_official |               intellij_idea                |                 android_studio                  |
+|:------------------------------------------------------------------------------------------|:---------------:|:------------------------------------------:|:-----------------------------------------------:|
+| `ij_kotlin_packages_to_use_import_on_demand`<br/><i>Defines allowed wildcard imports.</i> |        -        | `java.util.*,`<br/>`kotlinx.android.synthetic.**` | `java.util.*,`<br/>`kotlinx.android.synthetic.**` |
+
 !!! warning
     In case property `ij_kotlin_packages_to_use_import_on_demand` is not explicitly set, it allows wildcards imports like `java.util.*` by default to keep in sync with IntelliJ IDEA behavior. To disallow *all* wildcard imports, add property below to your `.editorconfig`:
     ```editorconfig
     [*.{kt,kts}]
     ij_kotlin_packages_to_use_import_on_demand = unset
     ```
+
+Configuration setting `ij_kotlin_packages_to_use_import_on_demand` is a comma separated string of import paths. This can be a full path, e.g. "java.util.List.*", or a wildcard path, e.g. "kotlin.**". Use "**" as wildcard for package and all subpackages.
+
+The layout can be composed by the following symbols:
+
+*  `*` - wildcard. There must be at least one entry of a single wildcard to match all other imports. Matches anything after a specified symbol/import as well.
+* `|` - blank line. Supports only single blank lines between imports. No blank line is allowed in the beginning or end of the layout.
+* `^` - alias import, e.g. "^android.*" will match all android alias imports, "^" will match all other alias imports.
+
+Examples:
+```kotlin
+ij_kotlin_imports_layout=* # alphabetical with capital letters before lower case letters (e.g. Z before a), no blank lines
+ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^ # default IntelliJ IDEA style, same as alphabetical, but with "java", "javax", "kotlin" and alias imports in the end of the imports list
+ij_kotlin_imports_layout=android.**,|,^org.junit.**,kotlin.io.Closeable.*,|,*,^ # custom imports layout
+```
 
 Rule id: `no-wildcard-imports` (`standard` rule set)
 
@@ -1932,9 +2044,6 @@ Rule id: `string-template-indent` (`standard` rule set)
 
 Consistent removal (default) or adding of trailing commas on call site.
 
-!!! important
-    KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma_on_call_site` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at call site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
@@ -1956,26 +2065,24 @@ Consistent removal (default) or adding of trailing commas on call site.
         ),) // it's weird to insert "," between unwrapped (continued) parenthesis
     ```
 
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                               | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ij_kotlin_allow_trailing_comma_on_call_site`<br/><i>Defines whether a trailing comma (or no trailing comma) should be enforced on the calling site, e.g. argument-list, when-entries, lambda-arguments, indices, etc. When set, IntelliJ IDEA uses this property to <b>allow</b> usage of a trailing comma by discretion of the developer. KtLint however uses this setting to <b>enforce</b> consistent usage of the trailing comma when set.</i> |     `true`      |    `true`     |    `false`     |
 
+!!! note
     Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) leaves it to the developer's discretion to use trailing commas on the call site, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped calls. (see [dependencies](./dependencies.md)).
+    KtLint values *consistent* formatting more than a per-situation decision, and therefore uses this setting to *enforce/disallow* usage of trailing comma's on the calling site.
 
 Rule id: `trailing-comma-on-call-site` (`standard` rule set)
 
 ## Trailing comma on declaration site
 
 Consistent removal (default) or adding of trailing commas on declaration site.
-
-!!! important
-    KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at declaration site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -1996,17 +2103,18 @@ Consistent removal (default) or adding of trailing commas on declaration site.
     ),) // it's weird to insert "," between unwrapped (continued) parenthesis
     ```
 
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                                      | ktlint_official | intellij_idea | android_studio |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ij_kotlin_allow_trailing_comma`<br/><i>Defines whether a trailing comma (or no trailing comma) should be enforced on the defining site, e.g. parameter-list, type-argument-list, lambda-value-parameters, enum-entries, etc. When set, IntelliJ IDEA uses this property to <b>allow</b> usage of a trailing comma by discretion of the developer. KtLint however uses this setting to <b>enforce</b> consistent usage of the trailing comma when set.</i> |     `true`      |    `true`     |    `false`     |
 
+!!! note
     The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) encourages the usage of trailing commas on the declaration site, but leaves it to the developer's discretion to use trailing commas on the call site. But next to this, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped declarations. (see [dependencies](./dependencies.md)).
+   KtLint values *consistent* formatting more than a per-situation decision, and therefore uses this setting to *enforce/disallow* usage of trailing comma's in declarations.
 
 Rule id: `trailing-comma-on-declaration-site` (`standard` rule set)
 
@@ -2041,14 +2149,15 @@ Disallows comments to be placed at certain locations inside a type argument (lis
         >
     ```
 
-Note: Although code sample below might look ok, it is semantically and programmatically unclear to which element `some comment 1` refers. As of that comments are only allowed when starting on a separate line. 
-```kotlin
-fun Foo<
-    out Bar1, // some comment 1
-    // some comment 2
-    out Bar2, // some comment
+!!! note
+    In some projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    ```kotlin
+    fun Foo<
+        out Bar1, // some comment
+        out Bar2, // some other comment
     >.foo() {}
-```
+    ```
+    Although this code sample might look ok, it is semantically and programmatically unclear to which type `some comment` refers. From the developer perspective it might be clear that it belongs to type `Bar1`. From the parsers perspective, it does belong to type `Bar2`.
 
 Rule id: `type-argument-comment` (`standard` rule set)
 
@@ -2082,14 +2191,15 @@ Disallows comments to be placed at certain locations inside a type parameter (li
         >
     ```
 
-Note: Although code sample below might look ok, it is semantically and programmatically unclear to which element `some comment 1` refers. As of that comments are only allowed when starting on a separate line.
-```kotlin
-class Foo<
-    out Bar1, // some comment 1
-    // some comment 2
-    out Bar2, // some comment
+!!! note
+    In some projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    ```kotlin
+    class Foo<
+        out Bar1, // some comment
+        out Bar2, // some other comment
     >
-```
+    ```
+   Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to type `Bar1`. From the parsers perspective, it does belong to type `Bar2`.
 
 Rule id: `type-parameter-comment` (`standard` rule set)
 
@@ -2142,14 +2252,15 @@ Disallows comments to be placed at certain locations inside a value argument (li
         )
     ```
 
-Note: Although code sample below might look ok, it is semantically and programmatically unclear to which element `some comment 1` refers. As of that comments are only allowed when starting on a separate line.
-```kotlin
-class Foo<
-    out Bar1, // some comment 1
-    // some comment 2
-    out Bar2, // some comment
-    >
-```
+!!! note
+    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    ```kotlin
+    fun foo(
+        bar1: Bar1, // some comment
+        bar2: Bar2, // some other comment
+    )
+    ```
+    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-argument-comment` (`standard` rule set)
 
@@ -2190,14 +2301,15 @@ Disallows comments to be placed at certain locations inside a value argument (li
     )
     ```
 
-Note: Although code sample below might look ok, it is semantically and programmatically unclear to which element `some comment 1` refers. As of that comments are only allowed when starting on a separate line.
-```kotlin
-class Foo(
-    bar: Bar1, // some comment 1
-    // some comment 2
-    bar2: Bar2, // some comment
-)
-```
+!!! note
+    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    ```kotlin
+    class Foo(
+        bar1: Bar1, // some comment
+        bar2: Bar2, // some other comment
+    )
+    ```
+    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-parameter-comment` (`standard` rule set)
 

--- a/documentation/snapshot/docs/rules/configuration-ktlint.md
+++ b/documentation/snapshot/docs/rules/configuration-ktlint.md
@@ -13,7 +13,7 @@ By default, the `ktlint_official` code style is applied. Alternatively, the code
 ktlint_code_style = ktlint_official
 ```
 
-## Disabled rules
+## Disable rule(s)
 
 Rule sets and individual rules can be disabled / enabled with a separate property per rule (set).
 
@@ -39,221 +39,26 @@ ktlint_custom-rule-set_custom-rule = disabled # Disables the `custom-rule` rule 
 !!! note
     The *rule* properties are applied after applying the *rule set* properties and take precedence. So if a rule set is disabled but a specific rule of that rule set is enabled, then the rule will be executed.
 
+## Rule specific configuration settings
 
-## Final newline
+The configuration settings below are used to configure the behavior of a specific rule. As of that, those settings only take effect when the corresponding rule is enabled. See description of rule for more information about the setting.
 
-By default, a final newline is required at the end of the file.
-
-```ini
-[*.{kt,kts}]
-insert_final_newline = true
-```
-
-This setting only takes effect when rule `final-newline` is enabled.
-
-## Force multiline chained methods based on number of chain operators
-
-Setting `ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than` forces a chained method to be wrapped at each chain operator (`.` or `?.`) in case it contains the specified minimum number of chain operators even in case the entire chained method fits on a single line. Use value `unset` (default) to disable this setting.
-
-!!! note
-    By default, chained methods are wrapped when an expression contains 4 or more chain operators in an expression. Note that if a chained method contains nested expressions the chain operators of the inner expression are not taken into account.
-
-```ini
-[*.{kt,kts}]
-ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than=unset
-```
-
-This setting only takes effect when rule `chain-method-continution` is enabled.
-
-## Force multiline function signature based on number of parameters
-
-Setting `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than` forces a multiline function signature in case the function contains the specified minimum number of parameters even in case the function signature would fit on a single line. Use value `unset` (default) to disable this setting.
-
-!!! note
-    By default, the `ktlint_official` code style wraps parameters of functions having at least 2 parameters. For other code styles, this setting is disabled by default. 
-
-```ini
-[*.{kt,kts}]
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
-```
-
-This setting only takes effect when rule `function-signature` is enabled.
-
-## Wrapping the expression body of a function
-
-Setting `ktlint_function_signature_body_expression_wrapping` determines if and when the expression body of a function is wrapped to a new line. This setting can be set to value `default`, `multiline` or `always`.
-
-!!! note
-    In this context `default` means the default behavior of the IntelliJ IDEA formatter. If not set explicitly, this style is used by code styles `intellij_idea` and `android_studio`. Code style `ktlint_official` uses style `multiline` when this setting has no value.
-
-When set to `default`, the first line of a body expression is appended to the function signature as long as the max line length is not exceeded.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=default"
-// Given that the function signature has to be written as a single line function signature
-fun someFunction(a: Any, b: Any): String = "some-result"
-    .uppercase()
-
-// Given that the function signature has to be written as a multiline function signature
-fun someFunction(
-    a: Any,
-    b: Any
-): String = "some-result"
-    .uppercase()
-```
-
-When set to `multiline`, the body expression starts on a separate line in case it is a multiline expression. A single line body expression is wrapped only when it does not fit on the same line as the function signature.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=multiline"
-// Given a single line body expression and
-// a the function signature that has to be written as a single line function signature and
-// it does not exceed the max line length
-fun someFunction(a: Any, b: Any): String = "some-result".uppercase()
-
-// Given a single line body expression and
-// a the function signature that has to be written as a multiline function signature and
-// it does not exceed the max line length
-fun someFunction(
-    a: Any,
-    b: Any
-): String = "some-result".uppercase()
-
-// Given a single line body expression then always wrap it to a separate line
-fun someFunction(a: Any, b: Any): String =
-    "some-result"
-         .uppercase()
-fun someFunction(
-    a: Any,
-    b: Any
-): String =
-    "some-result"
-       .uppercase()
-```
-
-When set to `always` the body expression is always wrapped to a separate line.
-
-```kotlin title="ktlint_function_signature_body_expression_wrapping=always"
-fun someFunction(a: Any, b: Any): String =
-    "some-result".uppercase()
-fun functionWithAVeryLongName(
-    a: Any,
-    b: Any
-): String =
-    "some-result"
-        .uppercase()
-```
-
-This setting only takes effect when rule `function-signature` is enabled.
-
-## Ignore identifiers enclosed in backticks
-
-By default, the identifiers enclosed in backticks are not ignored.
-
-According to [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#names-for-test-methods) it is acceptable to write method names in natural language. When using natural language, the description tends to be longer. This property allows lines containing an identifier between backticks to be longer than the maximum line length. (Since 0.41.0)
-
-```kotlin
-@Test
-fun `Given a test with a very loooooooooooooooooooooong test description`() {
-    
-}
-```
-
-```ini
-[*.{kt,kts}]
-ktlint_ignore_back_ticked_identifier = false
-```
-
-This setting only takes effect when rule `max-line-length` is enabled.
-
-## Import layouts
-
-By default, the same imports are allowed as in IntelliJ IDEA. The import path can be a full path, e.g. "java.util.List.*" as well as wildcard path, e.g. "kotlin.**".
-
-The layout can be composed by the following symbols:
-
-*  `*` - wildcard. There must be at least one entry of a single wildcard to match all other imports. Matches anything after a specified symbol/import as well.
-* `|` - blank line. Supports only single blank lines between imports. No blank line is allowed in the beginning or end of the layout.
-* `^` - alias import, e.g. "^android.*" will match all android alias imports, "^" will match all other alias imports.
-
-Examples:
-```kotlin
-ij_kotlin_imports_layout=* # alphabetical with capital letters before lower case letters (e.g. Z before a), no blank lines
-ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^ # default IntelliJ IDEA style, same as alphabetical, but with "java", "javax", "kotlin" and alias imports in the end of the imports list
-ij_kotlin_imports_layout=android.**,|,^org.junit.**,kotlin.io.Closeable.*,|,*,^ # custom imports layout
-```
-
-Wildcard imports can be allowed for specific import paths (Comma-separated list, use "**" as wildcard for package and all subpackages). This setting overrides the no-wildcard-imports rule. This setting is best be used for allowing wildcard imports from libraries like Ktor where extension functions are used in a way that creates a lot of imports.
-
-```ini
-[*.{kt,kts}]
-ij_kotlin_packages_to_use_import_on_demand = java.util.*,kotlinx.android.synthetic.**
-```
-
-This setting only takes effect when rule `no-wildcard-imports` is enabled.
-
-## Indent size & style
-
-By default, indenting is done with 4 spaces per indent level. Code style `android_studio` uses a tab per indent level.
-
-```ini
-[*.{kt,kts}]
-indent_size = 4 # possible values: number (e.g. 2), "unset" (makes ktlint ignore indentation completely)  
-indent_style = space # or "tab"
-```
-
-Those settings are used by multiple rules of which rule `indent` is the most important.
-
-## Max line length
-
-By default, the maximum line length is not set. The `android` code style sets the max line length to 100 (per Android Kotlin Style Guide).
-
-```ini
-[*.{kt,kts}]
-max_line_length = off # Use "off" to ignore max line length or a positive number to set max line length
-```
-
-This setting is used by multiple rules of which rule `max-line-length` is the most important.
-
-## Trailing comma on call site
-
-KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma_on_call_site` to *enforce* the usage of the trailing comma at call site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
-
-    Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) leaves it to the developer's discretion to use trailing commas on the call site, it also states that usage of trailing commas has several benefits:
-    
-     * It makes version-control diffs cleaner – as all the focus is on the changed value.
-     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
-     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
-
-Example:
-```ini
-[*.{kt,kts}]
-ij_kotlin_allow_trailing_comma_on_call_site = false
-```
-
-This setting only takes effect when rule `trailing-comma-on-call-site` is enabled.
-
-## Trailing comma on declaration site
-
-KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to *enforce* the usage of the trailing comma at declaration site when enabled. IntelliJ IDEA uses this property to *allow* the use of trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
-
-    The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) encourages the usage of trailing commas on the declaration site, but leaves it to the developer's discretion to use trailing commas on the call site. But next to this, it also states that usage of trailing commas has several benefits:
-    
-     * It makes version-control diffs cleaner – as all the focus is on the changed value.
-     * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
-     * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
-
-Example:
-```ini
-[*.{kt,kts}]
-ij_kotlin_allow_trailing_comma = false # Only used for declaration site 
-```
-
-This setting only takes effect when rule `trailing-comma-on-declaration-site` is enabled.
+| Configuration setting                                                                     | Rule                                                                                        |
+|:------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------|
+| ij_kotlin_allow_trailing_comma                                                            | [trailing-comma-on-declaration-site](../rules/standard/#trailing-comma-on-declaration-site) |
+| ij_kotlin_allow_trailing_comma_on_call_site                                               | [trailing-comma-on-call-site](../rules/standard/#trailing-comma-on-call-site)               |
+| ij_kotlin_packages_to_use_import_on_demand                                                | [no-wildcard-imports](../rules/standard/#no-wildcard-imports)                               |
+| indent_size                                                                               | [indent](../rules/standard/#indentation)                                                    |                                                                                       |
+| indent_style                                                                              | [indent](../rules/standard/#indentation)                                                    |                                                                                       |
+                                                                                    |
+| insert_final_newline                                                                      | [final-newline](../rules/standard/#final-newline)                                           |                                                                                       |
+| ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than  | [chain-method-continuation](../rules/experimental/#chain-method-continuation)               |
+| ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than    | [class-signature](../rules/experimental/#class-signature)                                   |
+| ktlint_ignore_back_ticked_identifier                                                      | [max-line-length](../rules/standard/#max-line-length)                                       |
+| ktlint_function_naming_ignore_when_annotated_with                                        | [function-naming](../rules/standard/#function-naming)                                       |
+| ktlint_function_signature_body_expression_wrapping                                        | [function-signature](../rules/standard/#function-signature)                                 |
+| ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than | [function-signature](../rules/standard/#function-signature)                                 |
+| max_line_length                                                                           | [max-line-length](../rules/standard/#max-line-length) and several other rules               |
 
 ## Overriding Editorconfig properties for specific directories
 
@@ -266,4 +71,4 @@ ktlint_standard_import-ordering = disabled
 ktlint_standard_indent = disabled
 ```
 
-Note that the `import-ordering` rule is disabled for *all* packages including the `api` sub package. Next to this the `indent` rule is disabled for the `api` package and its sub packages.
+Note that in example above the `import-ordering` rule is disabled for *all* packages including the `api` sub package. Next to this the `indent` rule is disabled for the `api` package and its sub packages.

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -125,6 +125,11 @@ This rule can be configured with `.editorconfig` property [`ktlint_chain_method_
             .bar()
     ```
 
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                  | ktlint_official | intellij_idea | android_studio |
+|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than`<br/><i>Force wrapping of chained methods in case an expression contains at least the specified number of chain operators. If a chained method contains nested expressions, the chain operators of the inner expression are not taken into account. Use value `unset` (default) to disable this setting.</i> |        4        |       4       |       4        |
+
+
 Rule id: `chain-method-continuation` (`standard` rule set)
 
 !!! Note
@@ -330,6 +335,10 @@ The other code styles allow an infinite amount of parameters on the same line (a
 
     class Foo6(a: Any, b: Any, c: Any) : FooBar(a, c)
     ```
+
+| Configuration setting                                                                                                                                                                                                                                                                                                                       | ktlint_official | intellij_idea | android_studio |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`<br/><i>Force wrapping of the parameters of the class signature in case it contains at least the specified number of parameters, even in case the entire class signature would fit on a single line. Use value `unset` to disable this setting.</i> |        1        |    `unset`    |    `unset`     |
 
 Rule id: `class-signature` (`standard` rule set)
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -164,15 +164,15 @@ Rule id: `filename` (`standard` rule set)
 
 Ensures consistent usage of a newline at the end of each file. 
 
-This rule can be configured with `.editorconfig` property [`insert_final_newline`](../configuration-ktlint/#final-newline).
+| Configuration setting                                                             | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `insert_final_newline` |     `true`      |       `true`        |       `true`        |
 
 Rule id: `final-newline` (`standard` rule set)
 
 ## Function signature
 
-Rewrites the function signature to a single line when possible (e.g. when not exceeding the `max_line_length` property) or a multiline signature otherwise. In case of function with a body expression, the body expression is placed on the same line as the function signature when not exceeding the `max_line_length` property. 
-
-In `ktlint-official` code style, a function signature is always rewritten to a multiline signature in case the function has 2 or more parameters. This number of parameters can be set via `.editorconfig` property `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`.
+Rewrites the function signature to a single line when possible (e.g. when not exceeding the `max_line_length` property) or a multiline signature otherwise. 
 
 !!! note
     Wrapping of parameters is also influenced by the `parameter-list-wrapping` rule.
@@ -242,6 +242,84 @@ In `ktlint-official` code style, a function signature is always rewritten to a m
     // at the X character on the right           X
     fun f(a: Any, b: Any): String = "some-result"
         .uppercase()
+    ```
+
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                   | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_function_signature_body_expression_wrapping`<br/><i>Determines how to wrap the body of function in case it is an expression. Use `default` to wrap the body expression only when the first line of the expression does not fit on the same line as the function signature. Use `multiline` to force wrapping of body expressions that consists of multiple lines. Use `always` to force wrapping of body expression always.</i> |   `multiline`   |   `default`   |   `default`    |
+| `ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`<br/><i>Forces a multiline function signature in case the function contains the specified minimum number of parameters even in case the function signature would fit on a single line. Use value `unset` (default) to disable this setting.</i>                                                                                              |        2        |    `unset`    |    `unset`     |
+
+=== "[:material-heart:](#) default"
+
+    When `ktlint_function_signature_body_expression_wrapping` is set to `default`, the first line of a body expression is appended to the function signature as long as the max line length is not exceeded.
+
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=default"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a multiline body expression
+    fun someFunction(a: Any, b: Any): String = "some-result"
+        .uppercase()
+    
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String = "some-result"
+        .uppercase()
+    ```
+
+=== "[:material-heart:](#) multiline"
+
+    When `ktlint_function_signature_body_expression_wrapping` is set to `multiline`, the body expression starts on a separate line in case it is a multiline expression. A single line body expression is wrapped only when it does not fit on the same line as the function signature.
+    
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=multiline"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a single line body expression
+    // that fits on the same line as the function signature.
+    fun someFunction(a: Any, b: Any): String = "some-result".uppercase()
+    
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a single line body expression
+    // that fits on the same line as the function signature.
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String = "some-result".uppercase()
+    
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a multiline body expression
+    fun someFunction(a: Any, b: Any): String =
+        "some-result"
+             .uppercase()
+
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun someFunction(
+        a: Any,
+        b: Any
+    ): String =
+        "some-result"
+           .uppercase()
+    ```
+
+=== "[:material-heart:](#) always"
+
+    When `ktlint_function_signature_body_expression_wrapping` is  set to `always` the body expression is always wrapped to a separate line.
+    
+    ```kotlin title="ktlint_function_signature_body_expression_wrapping=always"
+    // Given that the function signature has to be written as a single line
+    // function signature and that the function has a single line body expression
+    fun someFunction(a: Any, b: Any): String =
+        "some-result".uppercase()
+
+    // Given that the function signature has to be written as a multiline
+    // function signature and that the function has a multiline body expression
+    fun functionWithAVeryLongName(
+        a: Any,
+        b: Any
+    ): String =
+        "some-result"
+            .uppercase()
     ```
 
 Rule id: `function-signature` (`standard` rule set)
@@ -335,6 +413,11 @@ Indentation formatting - respects `.editorconfig` `indent_size` with no continua
 !!! note
     This rule handles indentation for many different language constructs which can not be summarized with a few examples. See the [unit tests](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt) for more details.
 
+| Configuration setting                                                                                                                     | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `indent_size`</br><i>The size of an indentation level when `indent_style` is set to `space`. Use value `unset` to ignore indentation.</i> |        4        |       4       |       4        |
+| `indent_style`</br><i>Style of indentation. Set this value to `space` or `tab`.</i>                                                       |     `space`     |    `space`    |    `space`     |
+
 Rule id: `indent` (`standard` rule set)
 
 ## Naming
@@ -411,11 +494,15 @@ Enforce naming of function.
     fun do_something() {}
     ```
 
-!!! note
-    When using Compose, you might want to suppress the `function-naming` rule by setting `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
+| Configuration setting                                                                                                                                                                                 | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_function_naming_ignore_when_annotated_with`</br><i>Ignore functions that are annotated with values in this setting. This value is a comma separated list of names without the '@' prefix.</i> |     `unset`     |    `unset`    |    `unset`     |
 
 !!! note
-    Functions in files which import a class from package `org.junit`, `org.testng` or `kotlin.test` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
+    When using Compose, you might want to configure the `function-naming` rule with `.editorconfig` property `ktlint_function_naming_ignore_when_annotated_with=Composable`. Furthermore, you can use a dedicated ktlint ruleset like [Compose Rules](https://mrmans0n.github.io/compose-rules/ktlint/) for checking naming conventions for Composable functions. 
+
+!!! note
+    Functions in files which import a class from package `io.kotest`, `junit.framework`, `kotlin.test`, `org.junit`, or `org.testng` are considered to be test functions. Functions in such classes are allowed to have underscores in the name. Also, function names enclosed between backticks do not need to adhere to the normal naming convention.
 
 This rule can also be suppressed with the IntelliJ IDEA inspection suppression `FunctionName`.
 
@@ -819,7 +906,7 @@ Rule id: `ktlint-suppression` (`standard` rule set)
 
 ## Max line length
 
-Ensures that lines do not exceed the given length of `.editorconfig` property `max_line_length` (see [EditorConfig](../configuration-ktlint/) section for more). This rule does not apply in a number of situations. For example, in the case a line exceeds the maximum line length due to a comment that disables ktlint rules then that comment is being ignored when validating the length of the line. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
+Ensures that lines do not exceed the maximum length of a line. This rule does not apply in a number of situations. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -850,6 +937,12 @@ Ensures that lines do not exceed the given length of `.editorconfig` property `m
     val fooooooooooooo =
         "foooooooooooooooooooooooooooooooooooooooo"
     ```
+
+
+| Configuration setting                                                                                               | ktlint_official | intellij_idea | android_studio |
+|:--------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_ignore_back_ticked_identifier`<br/><i>Defines whether the backticked identifier (``) should be ignored.</i> |     `false`     |    `false`    |    `false`     |
+| `max_line_length`<br/><i>Maximum length of a (regular) line.</i>                                                    |       140       |     `off`     |     `100`      |
 
 Rule id: `max-line-length` (`standard` rule set)
 
@@ -1172,7 +1265,7 @@ Rule id: `no-unused-imports` (`standard` rule set)
 
 ## No wildcard imports
 
-No wildcard imports except imports listed in `.editorconfig` property `ij_kotlin_packages_to_use_import_on_demand`.
+No wildcard imports except whitelisted imports.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -1186,12 +1279,31 @@ No wildcard imports except imports listed in `.editorconfig` property `ij_kotlin
     import foobar.*
     ```
 
+| Configuration setting                                                                     | ktlint_official |               intellij_idea                |                 android_studio                  |
+|:------------------------------------------------------------------------------------------|:---------------:|:------------------------------------------:|:-----------------------------------------------:|
+| `ij_kotlin_packages_to_use_import_on_demand`<br/><i>Defines allowed wildcard imports.</i> |        -        | `java.util.*,`<br/>`kotlinx.android.synthetic.**` | `java.util.*,`<br/>`kotlinx.android.synthetic.**` |
+
 !!! warning
     In case property `ij_kotlin_packages_to_use_import_on_demand` is not explicitly set, it allows wildcards imports like `java.util.*` by default to keep in sync with IntelliJ IDEA behavior. To disallow *all* wildcard imports, add property below to your `.editorconfig`:
     ```editorconfig
     [*.{kt,kts}]
     ij_kotlin_packages_to_use_import_on_demand = unset
     ```
+
+Configuration setting `ij_kotlin_packages_to_use_import_on_demand` is a comma separated string of import paths. This can be a full path, e.g. "java.util.List.*", or a wildcard path, e.g. "kotlin.**". Use "**" as wildcard for package and all subpackages.
+
+The layout can be composed by the following symbols:
+
+*  `*` - wildcard. There must be at least one entry of a single wildcard to match all other imports. Matches anything after a specified symbol/import as well.
+* `|` - blank line. Supports only single blank lines between imports. No blank line is allowed in the beginning or end of the layout.
+* `^` - alias import, e.g. "^android.*" will match all android alias imports, "^" will match all other alias imports.
+
+Examples:
+```kotlin
+ij_kotlin_imports_layout=* # alphabetical with capital letters before lower case letters (e.g. Z before a), no blank lines
+ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^ # default IntelliJ IDEA style, same as alphabetical, but with "java", "javax", "kotlin" and alias imports in the end of the imports list
+ij_kotlin_imports_layout=android.**,|,^org.junit.**,kotlin.io.Closeable.*,|,*,^ # custom imports layout
+```
 
 Rule id: `no-wildcard-imports` (`standard` rule set)
 
@@ -1932,9 +2044,6 @@ Rule id: `string-template-indent` (`standard` rule set)
 
 Consistent removal (default) or adding of trailing commas on call site.
 
-!!! important
-    KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma_on_call_site` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at call site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
-
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
@@ -1956,26 +2065,24 @@ Consistent removal (default) or adding of trailing commas on call site.
         ),) // it's weird to insert "," between unwrapped (continued) parenthesis
     ```
 
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on call site has been changed to `true` except when codestyle `android` is used.
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                               | ktlint_official | intellij_idea | android_studio |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ij_kotlin_allow_trailing_comma_on_call_site`<br/><i>Defines whether a trailing comma (or no trailing comma) should be enforced on the calling site, e.g. argument-list, when-entries, lambda-arguments, indices, etc. When set, IntelliJ IDEA uses this property to <b>allow</b> usage of a trailing comma by discretion of the developer. KtLint however uses this setting to <b>enforce</b> consistent usage of the trailing comma when set.</i> |     `true`      |    `true`     |    `false`     |
 
+!!! note
     Although the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) leaves it to the developer's discretion to use trailing commas on the call site, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on call site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped calls. (see [dependencies](./dependencies.md)).
+    KtLint values *consistent* formatting more than a per-situation decision, and therefore uses this setting to *enforce/disallow* usage of trailing comma's on the calling site.
 
 Rule id: `trailing-comma-on-call-site` (`standard` rule set)
 
 ## Trailing comma on declaration site
 
 Consistent removal (default) or adding of trailing commas on declaration site.
-
-!!! important
-    KtLint uses the IntelliJ IDEA `.editorconfig` property `ij_kotlin_allow_trailing_comma` to configure the rule. When this property is enabled, KtLint *enforces* the usage of the trailing comma at declaration site while IntelliJ IDEA default formatter only *allows* to use the trailing comma but leaves it to the developer's discretion to actually use it (or not). KtLint values *consistent* formatting more than a per-situation decision.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -1996,17 +2103,18 @@ Consistent removal (default) or adding of trailing commas on declaration site.
     ),) // it's weird to insert "," between unwrapped (continued) parenthesis
     ```
 
-!!! note
-    In KtLint 0.48.x the default value for using the trailing comma on declaration site has been changed to `true` except when codestyle `android` is used.
+| Configuration setting                                                                                                                                                                                                                                                                                                                                                                                                                                      | ktlint_official | intellij_idea | android_studio |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ij_kotlin_allow_trailing_comma`<br/><i>Defines whether a trailing comma (or no trailing comma) should be enforced on the defining site, e.g. parameter-list, type-argument-list, lambda-value-parameters, enum-entries, etc. When set, IntelliJ IDEA uses this property to <b>allow</b> usage of a trailing comma by discretion of the developer. KtLint however uses this setting to <b>enforce</b> consistent usage of the trailing comma when set.</i> |     `true`      |    `true`     |    `false`     |
 
+!!! note
     The [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) encourages the usage of trailing commas on the declaration site, but leaves it to the developer's discretion to use trailing commas on the call site. But next to this, it also states that usage of trailing commas has several benefits:
     
      * It makes version-control diffs cleaner – as all the focus is on the changed value.
      * It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
      * It simplifies code generation, for example, for object initializers. The last element can also have a comma.
 
-!!! note
-    Trailing comma on declaration site is automatically disabled if the [Wrapping](#wrapping) rule (or, before version `0.45.0`, the [Indentation](#indentation) rule) is disabled or not loaded. Because it cannot provide proper formatting with unwrapped declarations. (see [dependencies](./dependencies.md)).
+   KtLint values *consistent* formatting more than a per-situation decision, and therefore uses this setting to *enforce/disallow* usage of trailing comma's in declarations.
 
 Rule id: `trailing-comma-on-declaration-site` (`standard` rule set)
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -488,7 +488,7 @@ public class ChainMethodContinuationRule :
                 type =
                     PropertyType.LowerCasingPropertyType(
                         "ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than",
-                        "Force wrapping of chained methods in case and expression contains at least the specified number of chain " +
+                        "Force wrapping of chained methods in case an expression contains at least the specified number of chain " +
                             "operators. By default this parameter is set to 4.",
                         PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
                         setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -689,9 +689,9 @@ public class ClassSignatureRule :
                 type =
                     PropertyType.LowerCasingPropertyType(
                         "ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than",
-                        "Force wrapping the parameters of the class signature in case it contains at least the specified " +
-                            "number of parameters even in case the entire Class signature would fit on a single line. " +
-                            "By default this parameter is not enabled.",
+                        "Force wrapping of the parameters of the class signature in case it contains at least the specified " +
+                            "number of parameters, even in case the entire class signature would fit on a single line. " +
+                            "Use value 'unset' to disable this setting.",
                         PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
                         setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
                     ),


### PR DESCRIPTION
## Description

Move configuration setting documentation to rule

For settings which are tied to a specific rule, it is more clear to have the setting documented at the same place as the rule. Other generic settings are kept at the configuration page.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
