### PR TITLE
Resolve conflict between parameter-list-spacing and parameter-list-wrapping

### DIFF
--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -626,6 +626,7 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/PackageNameRuleKt
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
@@ -1,5 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
@@ -477,6 +479,33 @@ class ParameterListSpacingRuleTest {
             )
             """.trimIndent()
         parameterListSpacingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2488 - Given a parameter with type reference which does not fit on a single line`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+            class Foo(
+                val foooooooooooo:
+                    Foooooooooooo,
+                val fooooooooooooX:
+                    Foooooooooooo,
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+            class Foo(
+                val foooooooooooo: Foooooooooooo,
+                val fooooooooooooX:
+                    Foooooooooooo,
+            )
+            """.trimIndent()
+        parameterListSpacingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolation(3, 23, "Expected a single space")
+            .isFormattedAs(formattedCode)
     }
 
     private companion object {


### PR DESCRIPTION
## Description

Resolve conflict between parameter-list-spacing and parameter-list-wrapping

Closes #2488

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
