### PR TITLE
Break dependency between string-template-indent and multiline-expression-wrapping

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -518,7 +518,7 @@ internal class KtlintCommandLine {
         } catch (e: Exception) {
             if (code.isStdIn && e is KtLintParseException) {
                 if (code.script) {
-                    // When reading from stdin, code is only parsed as Kotlint script, if it could not be parsed as pure Kotlin. Now parsing
+                    // When reading from stdin, code is only parsed as Kotlin script, if it could not be parsed as pure Kotlin. Now parsing
                     // of the code has failed for both, the file has to be ignored.
                     logger.error {
                         """

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLOSING_QUOTE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LITERAL_STRING_TEMPLATE_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPEN_QUOTE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REGULAR_STRING_PART
@@ -105,7 +106,9 @@ public class StringTemplateIndentRule :
                         }
                     stringTemplate
                         .getFirstLeafAfterTrimIndent()
-                        ?.takeUnless { it.isWhiteSpaceWithNewline() || it.elementType == COMMA }
+                        ?.takeUnless { it.isWhiteSpaceWithNewline() }
+                        ?.takeUnless { it.elementType == COMMA }
+                        ?.takeUnless { it.treeParent.elementType == DOT_QUALIFIED_EXPRESSION }
                         ?.let { nextLeaf ->
                             emit(nextLeaf.startOffset, "Expected newline after multiline string template", true)
                             if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
@@ -425,4 +425,24 @@ class StringTemplateIndentRuleTest {
                 LintViolation(8, 17, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a multiline raw string literal and trimIndent is followed by another dot qualified expression`() {
+        val code =
+            """
+            val foo = $MULTILINE_STRING_QUOTE
+                someText
+                $MULTILINE_STRING_QUOTE.trimIndent().lowercase()
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo =
+                $MULTILINE_STRING_QUOTE
+                someText
+                $MULTILINE_STRING_QUOTE.trimIndent().lowercase()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .hasLintViolation(1, 11, "Expected newline before multiline string template")
+            .isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.test.TAB
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@Suppress("RemoveCurlyBracesFromTemplate")
 class StringTemplateIndentRuleTest {
     private val stringTemplateIndentRuleAssertThat =
         assertThatRuleBuilder { StringTemplateIndentRule() }
@@ -37,6 +38,7 @@ class StringTemplateIndentRuleTest {
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
                 LintViolation(3, 12, "Unexpected indent of raw string literal"),
+                LintViolation(3, 12, "Unexpected indent of raw string literal"),
                 LintViolation(4, 12, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
     }
@@ -59,6 +61,7 @@ class StringTemplateIndentRuleTest {
         stringTemplateIndentRuleAssertThat(code)
             .withEditorConfigOverride(INDENT_STYLE_PROPERTY to IndentConfig.IndentStyle.TAB)
             .hasLintViolations(
+                LintViolation(1, 22, "Expected newline before multiline string template"),
                 LintViolation(2, 5, "Unexpected indent of raw string literal"),
                 LintViolation(3, 5, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
@@ -66,7 +69,6 @@ class StringTemplateIndentRuleTest {
 
     @Nested
     inner class `A multiline raw string literal containing both tabs and spaces in the indentation margin can not be autocorrected` {
-        @Suppress("RemoveCurlyBracesFromTemplate")
         @Test
         fun `Mixed indentation characters on inner lines`() {
             val code =
@@ -76,14 +78,13 @@ class StringTemplateIndentRuleTest {
                 ${TAB} line2
                     $MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
-                1,
-                11,
-                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
-            )
+            stringTemplateIndentRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Expected newline before multiline string template"),
+                    LintViolation(1, 11, "Indentation of multiline raw string literal should not contain both tab(s) and space(s)", false),
+                )
         }
 
-        @Suppress("RemoveCurlyBracesFromTemplate", "RemoveCurlyBracesFromTemplate")
         @Test
         fun `Mixed indentation characters including line with opening quotes`() {
             val code =
@@ -92,14 +93,13 @@ class StringTemplateIndentRuleTest {
                     ${TAB} line2
                     $MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
-                1,
-                11,
-                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
-            )
+            stringTemplateIndentRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Expected newline before multiline string template"),
+                    LintViolation(1, 11, "Indentation of multiline raw string literal should not contain both tab(s) and space(s)", false),
+                )
         }
 
-        @Suppress("RemoveCurlyBracesFromTemplate")
         @Test
         fun `Mixed indentation characters including line with closing quotes`() {
             val code =
@@ -108,11 +108,11 @@ class StringTemplateIndentRuleTest {
                     ${TAB}line1
                     ${TAB} line2$MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            stringTemplateIndentRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
-                1,
-                11,
-                "Indentation of multiline raw string literal should not contain both tab(s) and space(s)",
-            )
+            stringTemplateIndentRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(1, 11, "Expected newline before multiline string template"),
+                    LintViolation(1, 11, "Indentation of multiline raw string literal should not contain both tab(s) and space(s)", false),
+                )
         }
     }
 
@@ -156,6 +156,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(1, 15, "Expected newline before multiline string template"),
                 LintViolation(2, 15, "Unexpected indent of raw string literal"),
                 LintViolation(3, 15, "Unexpected indent of raw string literal"),
                 LintViolation(3, 20, "Missing newline before the closing quotes of the raw string literal"),
@@ -179,6 +180,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(1, 15, "Expected newline before multiline string template"),
                 LintViolation(2, 15, "Unexpected indent of raw string literal"),
                 LintViolation(3, 15, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
@@ -206,8 +208,10 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(2, 13, "Expected newline before multiline string template"),
                 LintViolation(3, 13, "Unexpected indent of raw string literal"),
                 LintViolation(4, 13, "Unexpected indent of raw string literal"),
+                LintViolation(4, 29, "Expected newline after multiline string template"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -238,6 +242,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(2, 13, "Expected newline before multiline string template"),
                 LintViolation(3, 1, "Unexpected indent of raw string literal"),
                 LintViolation(5, 1, "Unexpected indent of raw string literal"),
                 LintViolation(6, 1, "Unexpected indent of raw string literal"),
@@ -263,13 +268,13 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(1, 11, "Expected newline before multiline string template"),
                 LintViolation(2, 1, "Unexpected 'tab' character(s) in margin of multiline string"),
                 LintViolation(3, 1, "Unexpected 'tab' character(s) in margin of multiline string"),
                 LintViolation(4, 1, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
     }
 
-    @Suppress("RemoveCurlyBracesFromTemplate")
     @Test
     fun `Format multiline string without tabs in the indentation margin`() {
         val code =
@@ -291,6 +296,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(1, 11, "Expected newline before multiline string template"),
                 LintViolation(2, 7, "Unexpected indent of raw string literal"),
                 LintViolation(3, 7, "Unexpected indent of raw string literal"),
                 LintViolation(4, 7, "Unexpected indent of raw string literal"),
@@ -319,6 +325,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(2, 15, "Expected newline before multiline string template"),
                 LintViolation(3, 15, "Unexpected indent of raw string literal"),
                 LintViolation(4, 15, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
@@ -328,10 +335,11 @@ class StringTemplateIndentRuleTest {
     fun `lint property delegate is indented properly 4`() {
         val code =
             """
-            fun lazyString() = lazy { $MULTILINE_STRING_QUOTE
-                                      someText
-                                      $MULTILINE_STRING_QUOTE.trimIndent()
-                                    }
+            fun lazyString() =
+                lazy { $MULTILINE_STRING_QUOTE
+                       someText
+                       $MULTILINE_STRING_QUOTE.trimIndent()
+                }
             """.trimIndent()
         val formattedCode =
             """
@@ -344,8 +352,9 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(2, 27, "Unexpected indent of raw string literal"),
-                LintViolation(3, 27, "Unexpected indent of raw string literal"),
+                LintViolation(2, 12, "Expected newline before multiline string template"),
+                LintViolation(3, 12, "Unexpected indent of raw string literal"),
+                LintViolation(4, 12, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -372,6 +381,7 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
+                LintViolation(2, 26, "Expected newline before multiline string template"),
                 LintViolation(3, 26, "Unexpected indent of raw string literal"),
                 LintViolation(4, 26, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
@@ -381,14 +391,15 @@ class StringTemplateIndentRuleTest {
     fun `lint parameter with multiline string raw string literal after arrow`() {
         val code =
             """
-            val result = when {
-                someBooleanFunction() -> $MULTILINE_STRING_QUOTE
-                                         someText
-                                         $MULTILINE_STRING_QUOTE.trimIndent()
-                else -> $MULTILINE_STRING_QUOTE
-                        someOtherText
-                        $MULTILINE_STRING_QUOTE.trimIndent()
-            }
+            val result =
+                when {
+                    someBooleanFunction() -> $MULTILINE_STRING_QUOTE
+                                             someText
+                                             $MULTILINE_STRING_QUOTE.trimIndent()
+                    else -> $MULTILINE_STRING_QUOTE
+                            someOtherText
+                            $MULTILINE_STRING_QUOTE.trimIndent()
+                }
             """.trimIndent()
         val formattedCode =
             """
@@ -406,10 +417,12 @@ class StringTemplateIndentRuleTest {
             """.trimIndent()
         stringTemplateIndentRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(3, 30, "Unexpected indent of raw string literal"),
-                LintViolation(4, 30, "Unexpected indent of raw string literal"),
-                LintViolation(6, 13, "Unexpected indent of raw string literal"),
-                LintViolation(7, 13, "Unexpected indent of raw string literal"),
+                LintViolation(3, 34, "Expected newline before multiline string template"),
+                LintViolation(4, 34, "Unexpected indent of raw string literal"),
+                LintViolation(5, 34, "Unexpected indent of raw string literal"),
+                LintViolation(6, 17, "Expected newline before multiline string template"),
+                LintViolation(7, 17, "Unexpected indent of raw string literal"),
+                LintViolation(8, 17, "Unexpected indent of raw string literal"),
             ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Break dependency between string-template-indent and multiline-expression-wrapping

If need be, the string-template-indent rule wraps the opening quotes of a multiline raw string literal to a new line. The `string-template-indent` can now be enabled regardless whether `multiline-expression-wrapping` is enabled.

Closes #2504

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
