### PR TITLE
Ignore EOL comment that causes max_line_length to be exceeded, except in max-line-length rule

### DIFF
--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -3,6 +3,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun beforeCodeSibling (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun betweenCodeSiblings (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun dropTrailingEolComment (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
@@ -28,6 +29,8 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun leavesIncludingSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Lkotlin/sequences/Sequence;
 	public static synthetic fun leavesIncludingSelf$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
 	public static final fun leavesOnLine (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun lineLength (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)I
+	public static synthetic fun lineLength$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)I
 	public static final fun lineLengthWithoutNewlinePrefix (Lkotlin/sequences/Sequence;)I
 	public static final fun lineLengthWithoutNewlinePrefix (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun logStructure (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -665,66 +665,189 @@ class ASTNodeExtensionTest {
         )
     }
 
-    @Test
-    fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
-        val code =
-            """
-            class Foo1 {
-                val foo2 = "foo2"
+    @Suppress("DEPRECATION")
+    @Nested
+    inner class LineLengthWithoutNewlinePrefix {
+        @Test
+        fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2"
 
-                fun foo3() {
-                    val foo4 = "foo4"
+                    fun foo3() {
+                        val foo4 = "foo4"
+                    }
                 }
-            }
-            """.trimIndent()
+                """.trimIndent()
 
-        val actual =
-            transformCodeToAST(code)
-                .firstChildLeafOrSelf()
-                .leaves()
-                .filter { it.elementType == IDENTIFIER }
-                .map { identifier -> identifier.lineLengthWithoutNewlinePrefix() }
-                .toList()
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier -> identifier.lineLengthWithoutNewlinePrefix() }
+                    .toList()
 
-        assertThat(actual).contains(
-            "class Foo1 {".length,
-            "    val foo2 = \"foo2\"".length,
-            "    fun foo3() {".length,
-            "        val foo4 = \"foo4\"".length,
-        )
+            assertThat(actual).contains(
+                "class Foo1 {".length,
+                "    val foo2 = \"foo2\"".length,
+                "    fun foo3() {".length,
+                "        val foo4 = \"foo4\"".length,
+            )
+        }
+
+        @Test
+        fun `Given some lines containing identifiers and EOL comment then get line length exclusive the leading newline characters and exclusive EOL comment`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2" // some comment
+
+                    fun foo3() {
+                        val foo4 = "foo4" // some comment
+                    }
+                }
+                """.trimIndent()
+
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier -> identifier.lineLengthWithoutNewlinePrefix() }
+                    .toList()
+
+            assertThat(actual).contains(
+                "class Foo1 {".length,
+                "    val foo2 = \"foo2\" // some comment".length,
+                "    fun foo3() {".length,
+                "        val foo4 = \"foo4\" // some comment".length,
+            )
+        }
+
+        @Test
+        fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters until and including the identifier`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2"
+
+                    fun foo3() {
+                        val foo4 = "foo4"
+                    }
+                }
+                """.trimIndent()
+
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier ->
+                        identifier
+                            .leavesOnLine()
+                            .takeWhile { it.prevLeaf() != identifier }
+                            .lineLengthWithoutNewlinePrefix()
+                    }.toList()
+
+            assertThat(actual).contains(
+                "class Foo1".length,
+                "    val foo2".length,
+                "    fun foo3".length,
+                "        val foo4".length,
+            )
+        }
     }
 
-    @Test
-    fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters until and including the identifier`() {
-        val code =
-            """
-            class Foo1 {
-                val foo2 = "foo2"
+    @Nested
+    inner class LineLength {
+        @Test
+        fun `Given some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2"
 
-                fun foo3() {
-                    val foo4 = "foo4"
+                    fun foo3() {
+                        val foo4 = "foo4"
+                    }
                 }
-            }
-            """.trimIndent()
+                """.trimIndent()
 
-        val actual =
-            transformCodeToAST(code)
-                .firstChildLeafOrSelf()
-                .leaves()
-                .filter { it.elementType == IDENTIFIER }
-                .map { identifier ->
-                    identifier
-                        .leavesOnLine()
-                        .takeWhile { it.prevLeaf() != identifier }
-                        .lineLengthWithoutNewlinePrefix()
-                }.toList()
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier -> identifier.lineLength() }
+                    .toList()
 
-        assertThat(actual).contains(
-            "class Foo1".length,
-            "    val foo2".length,
-            "    fun foo3".length,
-            "        val foo4".length,
-        )
+            assertThat(actual).contains(
+                "class Foo1 {".length,
+                "    val foo2 = \"foo2\"".length,
+                "    fun foo3() {".length,
+                "        val foo4 = \"foo4\"".length,
+            )
+        }
+
+        @Test
+        fun `Given some lines containing identifiers and EOL comment then get line length exclusive the leading newline characters`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2" // some comment
+
+                    fun foo3() {
+                        val foo4 = "foo4" // some comment
+                    }
+                }
+                """.trimIndent()
+
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier -> identifier.lineLength() }
+                    .toList()
+
+            assertThat(actual).contains(
+                "class Foo1 {".length,
+                "    val foo2 = \"foo2\" // some comment".length,
+                "    fun foo3() {".length,
+                "        val foo4 = \"foo4\" // some comment".length,
+            )
+        }
+
+        @Test
+        fun `Given some lines containing identifiers and EOL comment then get line length exclusive the leading newline characters and exclusive EOL comment`() {
+            val code =
+                """
+                class Foo1 {
+                    val foo2 = "foo2" // some comment
+
+                    fun foo3() {
+                        val foo4 = "foo4" // some comment
+                    }
+                }
+                """.trimIndent()
+
+            val actual =
+                transformCodeToAST(code)
+                    .firstChildLeafOrSelf()
+                    .leaves()
+                    .filter { it.elementType == IDENTIFIER }
+                    .map { identifier -> identifier.lineLength(excludeEolComment = true) }
+                    .toList()
+
+            assertThat(actual).contains(
+                "class Foo1 {".length,
+                "    val foo2 = \"foo2\"".length,
+                "    fun foo3() {".length,
+                "        val foo4 = \"foo4\"".length,
+            )
+        }
     }
 
     @ParameterizedTest(name = "Text between FUN_KEYWORD and IDENTIFIER: {0}")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -28,7 +28,7 @@ import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
-import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
+import com.pinterest.ktlint.rule.engine.core.api.lineLength
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.ec4j.core.model.PropertyType
@@ -128,7 +128,7 @@ public class ArgumentListWrappingRule :
             false
         }
 
-    private fun ASTNode.exceedsMaxLineLength() = lineLengthWithoutNewlinePrefix() > maxLineLength && !textContains('\n')
+    private fun ASTNode.exceedsMaxLineLength() = lineLength(excludeEolComment = true) > maxLineLength && !textContains('\n')
 
     private fun intendedIndent(child: ASTNode): String =
         when {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -21,6 +21,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
@@ -31,6 +32,7 @@ import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine
+import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.noNewLineInClosedRange
@@ -246,19 +248,18 @@ public class BinaryExpressionWrappingRule :
             }
     }
 
-    private fun ASTNode.isOnLineExceedingMaxLineLength() = leavesOnLine().lengthWithoutNewlinePrefix() > maxLineLength
+    private fun ASTNode.isOnLineExceedingMaxLineLength() =
+        maxLineLength <
+            leavesOnLine()
+                .dropTrailingEolComment()
+                .lineLengthWithoutNewlinePrefix()
 
     private fun ASTNode.causesMaxLineLengthToBeExceeded() =
         lastChildLeafOrSelf().let { lastChildLeaf ->
             leavesOnLine()
                 .takeWhile { it.prevLeaf() != lastChildLeaf }
-                .lengthWithoutNewlinePrefix()
+                .lineLengthWithoutNewlinePrefix()
         } > maxLineLength
-
-    private fun Sequence<ASTNode>.lengthWithoutNewlinePrefix() =
-        joinToString(separator = "") { it.text }
-            .dropWhile { it == '\n' }
-            .length
 }
 
 private fun IElementType.anyOf(vararg elementType: IElementType): Boolean = elementType.contains(this)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
@@ -79,11 +79,9 @@ public class FunctionExpressionBodyRule :
     Rule.Experimental {
     private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
-    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         codeStyle = editorConfig[CODE_STYLE_PROPERTY]
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
         indentConfig =
             IndentConfig(
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -30,6 +30,7 @@ import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithoutNewline
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.leavesIncludingSelf
 import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine
+import com.pinterest.ktlint.rule.engine.core.api.lineLength
 import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
@@ -196,7 +197,7 @@ public class FunctionLiteralRule :
             }.length
     }
 
-    private fun ASTNode.exceedsMaxLineLength() = lineLengthWithoutNewlinePrefix() > maxLineLength
+    private fun ASTNode.exceedsMaxLineLength() = lineLength(excludeEolComment = true) > maxLineLength
 
     private fun ASTNode.wrapFirstParameterToNewline() =
         if (isFunctionLiteralLambdaWithNonEmptyValueParameterList()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -17,7 +17,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
-import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
+import com.pinterest.ktlint.rule.engine.core.api.lineLength
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
@@ -300,13 +300,13 @@ public class ParameterListSpacingRule :
             ?.let { typeReference ->
                 val length =
                     // length of previous line
-                    lineLengthWithoutNewlinePrefix() +
+                    lineLength(excludeEolComment = true) +
                         // single space before type reference
                         1 -
                         // length of current indent before typeReference
                         this.text.substringAfterLast("\n").length +
                         // length of line containing typeReference
-                        typeReference.lineLengthWithoutNewlinePrefix()
+                        typeReference.lineLength(excludeEolComment = true)
                 length > maxLineLength
             }
             ?: false

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -15,6 +15,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.column
+import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
@@ -134,10 +135,10 @@ public class ParameterListWrappingRule :
         when {
             hasNoParameters() -> false
             codeStyle != ktlint_official && isPartOfFunctionLiteralInNonKtlintOfficialCodeStyle() -> false
+            codeStyle == ktlint_official && containsAnnotatedParameter() -> true
             codeStyle == ktlint_official && isPartOfFunctionLiteralStartingOnSameLineAsClosingParenthesisOfPrecedingReferenceExpression() ->
                 false
             textContains('\n') -> true
-            codeStyle == ktlint_official && containsAnnotatedParameter() -> true
             isOnLineExceedingMaxLineLength() -> true
             else -> false
         }
@@ -291,6 +292,7 @@ public class ParameterListWrappingRule :
             prevLeaf { it.textContains('\n') }
                 ?.leavesIncludingSelf()
                 ?.takeWhile { it.prevLeaf() != stopLeaf }
+                ?.dropTrailingEolComment()
                 ?.joinToString(separator = "") { it.text }
                 ?.substringAfter('\n')
                 ?.substringBefore('\n')

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -1013,4 +1013,21 @@ class ArgumentListWrappingRuleTest {
             """.trimIndent()
         argumentListWrappingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2450 - Given a statement followed by an EOL comment that causes the max line length to be exceeded then only report a violation via max-line-length rule`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            val foo = Bar.builder().baz(0).build() // long comment at the end of the line regarding baz
+            """.trimIndent()
+        argumentListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .addAdditionalRuleProvider { ValueParameterCommentRule() }
+            .addAdditionalRuleProvider { ValueArgumentCommentRule() }
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(2, 45, "Exceeded max line length (44)", false),
+            )
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
@@ -457,4 +457,25 @@ class BinaryExpressionWrappingRuleTest {
             .setMaxLineLength()
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2450 - Given a binary expression followed by an EOL comment that causes the max line length to be exceeded, then only report a violation via max-line-length rule`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                  $EOL_CHAR
+            val bar = leftHandSideExpression && rightHandSideExpression // Some comment
+            val foo =
+                foobar(
+                    "foooooooooooooooooooooooooooooooooooooooooooooo" + // Some comment
+                    "bar"
+                )
+            """.trimIndent()
+        binaryExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(2, 62, "Exceeded max line length (61)", false),
+                LintViolation(5, 62, "Exceeded max line length (61)", false),
+            ).hasNoLintViolationsExceptInAdditionalRules()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -970,4 +970,24 @@ class ChainMethodContinuationRuleTest {
             """.trimIndent()
         chainMethodContinuationRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2450 - Given a chained method and a chain is followed by EOL comment that causes max line length to be exceeded then only report violation via max-line-length rule`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                $EOL_CHAR
+            val foo1 = "foo".filter { it.isUpperCase() }.lowercase() // Some comment
+            val foo2 =
+                "foo"
+                    .filter { it.isUpperCase() } // Some longgggggggg comment
+                    .lowercase()
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(2, 60, "Exceeded max line length (59)", false),
+                LintViolation(5, 60, "Exceeded max line length (59)", false),
+            ).hasNoLintViolationsExceptInAdditionalRules()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -340,11 +340,30 @@ class FunctionLiteralRuleTest {
             """.trimIndent()
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
-            .isFormattedAs(formattedCode)
             .hasLintViolations(
                 LintViolation(4, 19, "Newline expected before parameter"),
                 LintViolation(4, 29, "Newline expected before parameter"),
             ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2450 - Given a parameter list followed by EOL comment which causes the max line length to be exceed then only report the violation via the max-line-length rule`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
+            val foobar =
+                { foo: Foo // Some comment
+                    ->
+                    foo // Some other comment
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(3, 30, "Exceeded max line length (29)", false),
+                LintViolation(5, 30, "Exceeded max line length (29)", false),
+            ).hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -685,4 +685,21 @@ class ParameterListWrappingRuleTest {
                 .hasNoLintViolations()
         }
     }
+
+    @Test
+    fun `Issue 2450 - Given a variable declaration for a function type followed by an EOL comment that causes the max line length to be exceeded, then only report a violation via max-line-length rule`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+            val fooooo: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit) = {} // some comment
+            var foo: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null // some comment
+            """.trimIndent()
+        parameterListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(2, 61, "Exceeded max line length (60)", false),
+                LintViolation(3, 61, "Exceeded max line length (60)", false),
+            ).hasNoLintViolationsExceptInAdditionalRules()
+    }
 }


### PR DESCRIPTION
## Description

Ignore EOL comment that causes max_line_length to be exceeded, except in max-line-length rule

Rules should not start wrapping code in case the max_line_length is exceeded because of the EOL comment. The developer should determine whether the EOL comment should be shortened, or be placed on a separate line instead of wrapping via autocorrect.

Closes #2450

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
