### PR TITLE
Remove invalid argumentation why EOL-comments are disallowed

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -2253,14 +2253,14 @@ Disallows comments to be placed at certain locations inside a value argument (li
     ```
 
 !!! note
-    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
     ```kotlin
-    fun foo(
-        bar1: Bar1, // some comment
-        bar2: Bar2, // some other comment
-    )
+    val foo1 =
+        foo(
+            bar1: Bar1, // some comment
+            bar2: Bar2, // some other comment
+        )
     ```
-    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-argument-comment` (`standard` rule set)
 
@@ -2302,14 +2302,13 @@ Disallows comments to be placed at certain locations inside a value argument (li
     ```
 
 !!! note
-    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
     ```kotlin
     class Foo(
         bar1: Bar1, // some comment
         bar2: Bar2, // some other comment
     )
     ```
-    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-parameter-comment` (`standard` rule set)
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -2255,14 +2255,14 @@ Disallows comments to be placed at certain locations inside a value argument (li
     ```
 
 !!! note
-    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
     ```kotlin
-    fun foo(
-        bar1: Bar1, // some comment
-        bar2: Bar2, // some other comment
+    val foo1 =
+    foo(
+    bar1: Bar1, // some comment
+    bar2: Bar2, // some other comment
     )
     ```
-    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-argument-comment` (`standard` rule set)
 
@@ -2304,14 +2304,13 @@ Disallows comments to be placed at certain locations inside a value argument (li
     ```
 
 !!! note
-    In a lot of projects it is an accepted practice to use EOL comments to document the parameter *before* the comma as is shown below:
+    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
     ```kotlin
     class Foo(
         bar1: Bar1, // some comment
         bar2: Bar2, // some other comment
     )
     ```
-    Although this code sample might look ok, it is semantically and programmatically unclear on which parameter `some comment` refers. From the developer perspective it might be clear that it belongs to parameter `bar1`. From the parsers perspective, it does belong to parameter `bar2`. This might lead to [unexpected behavior in Intellij IDEA](https://github.com/pinterest/ktlint/issues/2445#issuecomment-1863432022).
 
 Rule id: `value-parameter-comment` (`standard` rule set)
 


### PR DESCRIPTION
## Description

Remove invalid argumentation why EOL-comments are disallowed

Closes #2513

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
