### PR TITLE
Fix false positive newline expected before comment in enum

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRuleTest.kt
@@ -153,7 +153,7 @@ class EnumWrappingRuleTest {
                 """.trimIndent()
             enumWrappingRuleAssertThat(code)
                 .hasLintViolations(
-                    LintViolation(1, 16, "Expected a newline before comment"),
+                    LintViolation(1, 16, "Expected a (single) newline before comment"),
                     LintViolation(1, 32, "Enum entry should start on a separate line"),
                     LintViolation(1, 35, "Enum entry should start on a separate line"),
                     LintViolation(1, 37, "Expected newline before '}'"),
@@ -241,5 +241,31 @@ class EnumWrappingRuleTest {
             enum class Foo {}
             """.trimIndent()
         enumWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2510 - Given an enum class with comment before the first entry`() {
+        val code =
+            """
+            enum class FooBar {
+
+                // Some comment about FooBar
+
+                // Foo
+                Foo,
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            enum class FooBar {
+                // Some comment about FooBar
+
+                // Foo
+                Foo,
+            }
+            """.trimIndent()
+        enumWrappingRuleAssertThat(code)
+            .hasLintViolation(1, 19, "Expected a (single) newline before comment")
+            .isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Fix false positive newline expected before comment in enum

Closes #2510

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
