### PR TITLE
Allow making requests to engine with raw .editorconfig string, disabling .editorconfig IO.

### DIFF
--- a/ktlint-rule-engine/api/ktlint-rule-engine.api
+++ b/ktlint-rule-engine/api/ktlint-rule-engine.api
@@ -1,9 +1,10 @@
 public final class com/pinterest/ktlint/rule/engine/api/Code {
 	public static final field Companion Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;ZZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun fileNameOrStdin ()Ljava/lang/String;
 	public final fun filePathOrStdin ()Ljava/lang/String;
 	public final fun getContent ()Ljava/lang/String;
+	public final fun getEditorConfig ()Ljava/lang/String;
 	public final fun getFileName ()Ljava/lang/String;
 	public final fun getFilePath ()Ljava/nio/file/Path;
 	public final fun getScript ()Z
@@ -13,10 +14,10 @@ public final class com/pinterest/ktlint/rule/engine/api/Code {
 public final class com/pinterest/ktlint/rule/engine/api/Code$Companion {
 	public final fun fromFile (Ljava/io/File;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public final fun fromPath (Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
-	public final fun fromSnippet (Ljava/lang/String;Z)Lcom/pinterest/ktlint/rule/engine/api/Code;
-	public static synthetic fun fromSnippet$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
-	public final fun fromSnippetWithPath (Ljava/lang/String;Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
-	public static synthetic fun fromSnippetWithPath$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;Ljava/nio/file/Path;ILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public final fun fromSnippet (Ljava/lang/String;ZLjava/lang/String;)Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public static synthetic fun fromSnippet$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public final fun fromSnippetWithPath (Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;)Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public static synthetic fun fromSnippetWithPath$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;ILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public final fun fromStdin ()Lcom/pinterest/ktlint/rule/engine/api/Code;
 }
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
@@ -19,6 +19,7 @@ public class Code private constructor(
     public val filePath: Path?,
     public val script: Boolean,
     public val isStdIn: Boolean,
+    public val editorConfig: String? = null,
 ) {
     public fun fileNameOrStdin(): String =
         if (isStdIn) {
@@ -76,6 +77,7 @@ public class Code private constructor(
         public fun fromSnippet(
             content: String,
             script: Boolean = false,
+            editorConfig: String? = null,
         ): Code =
             Code(
                 content = content,
@@ -83,6 +85,7 @@ public class Code private constructor(
                 fileName = null,
                 script = script,
                 isStdIn = true,
+                editorConfig = editorConfig,
             )
 
         /**
@@ -101,6 +104,7 @@ public class Code private constructor(
              * is loaded at all.
              */
             virtualPath: Path? = null,
+            editorConfig: String? = null,
         ): Code =
             Code(
                 content = content,
@@ -108,6 +112,7 @@ public class Code private constructor(
                 fileName = null,
                 script = virtualPath?.pathString.orEmpty().endsWith(".kts", ignoreCase = true),
                 isStdIn = true,
+                editorConfig = editorConfig,
             )
 
         /**

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -21,6 +21,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.ec4j.core.EditorConfigLoader
 import org.ec4j.core.PropertyTypeRegistry
 import org.ec4j.core.Resource
+import org.ec4j.core.Resource.Resources.StringResourceTree
 import org.ec4j.core.ResourcePropertiesService
 import org.ec4j.core.model.Property
 import org.ec4j.core.model.PropertyType
@@ -55,11 +56,27 @@ internal class EditorConfigLoader(
      * Properties specified in [editorConfigOverride] take precedence above any other '.editorconfig' file on [filePath]
      * or default value.
      */
-    internal fun load(filePath: Path?): EditorConfig {
+    internal fun load(
+        filePath: Path?,
+        editorConfig: String? = null,
+    ): EditorConfig {
         val editorConfigPath = filePath ?: defaultFilePath()
+        val resource =
+            editorConfig?.let {
+                StringResourceTree
+                    .builder()
+                    .resource(
+                        editorConfigPath.toString(),
+                        null,
+                    ).resource(
+                        editorConfigPath.parent.resolve(".editorconfig").toString(),
+                        editorConfig,
+                    ).build()
+                    .getResource(editorConfigPath.toString())
+            } ?: editorConfigPath.resource()
         val editorConfigProperties: MutableMap<String, Property> =
             createResourcePropertiesService(editorConfigLoaderEc4j.editorConfigLoader, editorConfigDefaults)
-                .queryProperties(editorConfigPath.resource())
+                .queryProperties(resource)
                 .properties
         return editorConfigProperties
             .also { properties ->

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -179,7 +179,7 @@ internal class RuleExecutionContext private constructor(
             val editorConfig =
                 ktLintRuleEngine
                     .editorConfigLoader
-                    .load(code.filePath,code.editorConfig)
+                    .load(code.filePath, code.editorConfig)
                     .also {
                         // TODO: Remove warning below in KtLint 0.52 or later as some users skips multiple versions
                         it.warnIfPropertyIsObsolete("disabled_rules", "0.49")

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -179,7 +179,7 @@ internal class RuleExecutionContext private constructor(
             val editorConfig =
                 ktLintRuleEngine
                     .editorConfigLoader
-                    .load(code.filePath)
+                    .load(code.filePath,code.editorConfig)
                     .also {
                         // TODO: Remove warning below in KtLint 0.52 or later as some users skips multiple versions
                         it.warnIfPropertyIsObsolete("disabled_rules", "0.49")


### PR DESCRIPTION
## Description

Fixes https://github.com/pinterest/ktlint/issues/2532

Allows the API user to make requests to the engine with a raw .editorconfig string in like so:

```kotlin
Code.fromSnippet(
                content = "kotlinCode",
                editorConfig = "[*]\nktlint_simple-test_a = disabled",
)
// or
Code.fromSnippetWithPath(
                content = "kotlinCode",
                virtualPath = "/virtual/path.kt", // no .editorconfig IO, but used in `standard:filename`
                editorConfig = "[*]\nktlint_simple-test_a = disabled",
)
```

This should allow the API user to completely avoid the engine from doing any IO at all in relation to .editorconfig files, providing more flexibility possible(not measured) performance gains, and stability.

Added one simple test to verify that the .editorconfig string is correctly applied. However, more tests and refining the current test would be good.

Did not modify or add any documentation yet.

This is a rough draft. It might be controversial, so I kept it minimal just as an example. If it looks good as is, it just needs better tests and documentation. But I expect reviewers might have opinions on how this should be implemented in a way that enhances flexibility while minimizing confusion and complexity for API users.

Note that the `virtualPath` for `fromSnippetWithPath` is still useful and sometimes neccesary, as it gets used in rules that use the file path such as `standard:filename`.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
