### PR TITLE
Report violation when parameter list is preceded by a comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRule.kt
@@ -14,7 +14,7 @@ import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.noNewLineInClosedRange
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
-import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
@@ -97,7 +97,7 @@ public class KdocWrappingRule :
     ) {
         emit(startOffset, "A KDoc comment may not be followed by any other element on that same line", true)
         if (autoCorrect) {
-            this.upsertWhitespaceBeforeMe(kdocCommentNode.indent())
+            kdocCommentNode.upsertWhitespaceAfterMe(kdocCommentNode.indent())
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
@@ -111,4 +111,31 @@ class KdocWrappingRuleTest {
             .hasLintViolation(2, 29, "A KDoc comment may not be followed by any other element on that same line")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2535 - Given a class with a KDoc on the primary constructor instead of on the class name`() {
+        val code =
+            // Code sample below contains a code smell. The KDoc is at the wrong position.
+            """
+            class ClassA
+                /**
+                 * some comment
+                 */(paramA: String)
+            """.trimIndent()
+        val formattedCode =
+            // Code sample below contains a code smell. The KDoc is at the wrong position. The formatted code is not intended to show
+            // that this code is well formatted according to good coding practices. It merely is used to validate that the newline is
+            // inserted at the correct position in the AST so that no exception will be thrown in the ParameterListWrappingRule.
+            """
+            class ClassA
+                /**
+                 * some comment
+                 */
+                (paramA: String)
+            """.trimIndent()
+        kdocWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { ParameterListWrappingRule() }
+            .hasLintViolation(4, 8, "A KDoc comment may not be followed by any other element on that same line")
+            .isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -702,4 +702,32 @@ class ParameterListWrappingRuleTest {
                 LintViolation(3, 61, "Exceeded max line length (60)", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
     }
+
+    @Test
+    fun `Issue 2535 - Given a class with a KDoc on the primary constructor instead of on the class name`() {
+        val code =
+            // Code sample below contains a code smell. The KDoc is at the wrong position.
+            """
+            class ClassA
+                /**
+                 * some comment
+                 */(paramA: String)
+            """.trimIndent()
+        val formattedCode =
+            // Code sample below contains a code smell. The KDoc is at the wrong position. The formatted code is not intended to show
+            // that this code is well formatted according to good coding practices. It merely is used to validate that the newline is
+            // inserted at the correct position in the AST so that no exception will be thrown in the ParameterListWrappingRule.
+            """
+            class ClassA
+            /**
+             * some comment
+             */
+            (paramA: String)
+            """.trimIndent()
+        parameterListWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { KdocWrappingRule() }
+            .hasLintViolations(
+                LintViolation(4, 8, "Parameter list should not be preceded by a comment", false),
+            ).isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Report violation when parameter list is preceded by a comment

Comments are not allowed between a class/function name and the parameter list.

Closes #2535

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
