### PR TITLE
Remove dependency org.codehaus.janino:janino

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,6 @@ poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.2"
 # TODO: Update "renovate.json" once logback-classic is updated to 1.4 (once java8 support for ktlint is dropped)
 logback = "ch.qos.logback:logback-classic:1.3.14"
 logcaptor = "io.github.hakky54:logcaptor:2.9.2"
-# Required for logback.xml conditional configuration
-janino = "org.codehaus.janino:janino:3.1.11"
 # Testing libraries
 junit5 = "org.junit.jupiter:junit-jupiter:5.10.2"
 assertj = "org.assertj:assertj-core:3.25.3"

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyFileRuleTest.kt
@@ -120,7 +120,6 @@ class NoEmptyFileRuleTest {
                 implementation(projects.ktlintCliRulesetCore)
                 api(libs.assertj)
                 api(libs.junit5)
-                api(libs.janino)
                 api(libs.jimfs)
             }
             """.trimIndent()

--- a/ktlint-test/build.gradle.kts
+++ b/ktlint-test/build.gradle.kts
@@ -8,6 +8,5 @@ dependencies {
     implementation(projects.ktlintCliRulesetCore)
     api(libs.assertj)
     api(libs.junit5)
-    api(libs.janino)
     api(libs.jimfs)
 }


### PR DESCRIPTION
## Description

Dependency `org.codehaus.janino:janino` is no longer needed to build the project.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
