### PR TITLE
Improve insert of suppression

### DIFF
--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
@@ -300,7 +300,6 @@ class KtlintRuleEngineSuppressionKtTest {
         assertThat(actual).isEqualTo(formattedCode)
     }
 
-//
     @Nested
     inner class `Consecutive line suppression can not be placed at line` {
         @Test

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtlintRuleEngineSuppressionKtTest.kt
@@ -300,6 +300,7 @@ class KtlintRuleEngineSuppressionKtTest {
         assertThat(actual).isEqualTo(formattedCode)
     }
 
+//
     @Nested
     inner class `Consecutive line suppression can not be placed at line` {
         @Test


### PR DESCRIPTION
## Description

Improve insert of suppression:
* Prevent KtlintSuppressionOutOfBoundsException Suppression if offset equals the end the line.
* Insert suppression at parent in case the target location of the suppression is a whitespace.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
