### PR TITLE
Remove logic which was moved to new rule 'kdoc'.

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRule.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PROJECTION
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -66,10 +65,6 @@ public class TypeArgumentCommentRule : StandardRule("type-argument-comment") {
                             )
                         }
                     }
-                }
-
-                KDOC -> {
-                    emit(node.startOffset, "A KDoc is not allowed inside a 'type_argument_list'", false)
                 }
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRule.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -66,10 +65,6 @@ public class TypeParameterCommentRule : StandardRule("type-parameter-comment") {
                             )
                         }
                     }
-                }
-
-                KDOC -> {
-                    emit(node.startOffset, "A KDoc is not allowed inside a 'type_parameter_list'", false)
                 }
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRule.kt
@@ -1,8 +1,5 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -30,52 +27,44 @@ public class ValueArgumentCommentRule : StandardRule("value-argument-comment") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
         if (node.isPartOfComment() && node.treeParent.elementType in valueArgumentTokenSet) {
-            when (node.elementType) {
-                EOL_COMMENT, BLOCK_COMMENT -> {
-                    if (node.treeParent.elementType == VALUE_ARGUMENT) {
-                        // Disallow:
-                        //     val foo = foo(
-                        //         bar /* some comment */ = "bar"
-                        //     )
-                        // or
-                        //     val foo = foo(
-                        //         bar =
-                        //            // some comment
-                        //            "bar"
-                        //     )
-                        emit(
-                            node.startOffset,
-                            "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed " +
-                                "on a separate line above.",
-                            false,
-                        )
-                    } else if (node.treeParent.elementType == VALUE_ARGUMENT_LIST) {
-                        if (node.prevLeaf().isWhiteSpaceWithNewline()) {
-                            // Allow:
-                            //     val foo = foo(
-                            //         // some comment
-                            //         bar = "bar"
-                            //     )
-                        } else {
-                            // Disallow
-                            //     class Foo(
-                            //         val bar1: Bar, // some comment 1
-                            //         // some comment 2
-                            //         val bar2: Bar,
-                            //     )
-                            // It is not clear whether "some comment 2" belongs to bar1 as a continuation of "some comment 1" or that it belongs to
-                            // bar2. Note both comments are direct children of the value_argument_list.
-                            emit(
-                                node.startOffset,
-                                "A comment in a 'value_argument_list' is only allowed when placed on a separate line",
-                                false,
-                            )
-                        }
-                    }
-                }
-
-                KDOC -> {
-                    emit(node.startOffset, "A KDoc is not allowed inside a 'value_argument_list'", false)
+            if (node.treeParent.elementType == VALUE_ARGUMENT) {
+                // Disallow:
+                //     val foo = foo(
+                //         bar /* some comment */ = "bar"
+                //     )
+                // or
+                //     val foo = foo(
+                //         bar =
+                //            // some comment
+                //            "bar"
+                //     )
+                emit(
+                    node.startOffset,
+                    "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed " +
+                        "on a separate line above.",
+                    false,
+                )
+            } else if (node.treeParent.elementType == VALUE_ARGUMENT_LIST) {
+                if (node.prevLeaf().isWhiteSpaceWithNewline()) {
+                    // Allow:
+                    //     val foo = foo(
+                    //         // some comment
+                    //         bar = "bar"
+                    //     )
+                } else {
+                    // Disallow
+                    //     class Foo(
+                    //         val bar1: Bar, // some comment 1
+                    //         // some comment 2
+                    //         val bar2: Bar,
+                    //     )
+                    // It is not clear whether "some comment 2" belongs to bar1 as a continuation of "some comment 1" or that it belongs to
+                    // bar2. Note both comments are direct children of the value_argument_list.
+                    emit(
+                        node.startOffset,
+                        "A comment in a 'value_argument_list' is only allowed when placed on a separate line",
+                        false,
+                    )
                 }
             }
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -229,9 +229,9 @@ class FunctionSignatureRuleTest {
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
                 LintViolation(5, 17, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
-                LintViolation(6, 18, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(7, 19, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(8, 23, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(6, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(7, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(8, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
                 LintViolation(13, 13, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
     }
@@ -252,9 +252,9 @@ class FunctionSignatureRuleTest {
         functionSignatureWrappingRuleAssertThat(code)
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
-                LintViolation(1, 18, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(2, 19, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(3, 23, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(1, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(2, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(3, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
                 LintViolation(5, 13, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
         // When ValueParameterCommentRule is not loaded or disabled:

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
@@ -8,16 +8,6 @@ class TypeArgumentCommentRuleTest {
     private val typeArgumentCommentRuleAssertThat = assertThatRule { TypeArgumentCommentRule() }
 
     @Test
-    fun `Given a kdoc inside a type projection`() {
-        val code =
-            """
-            fun Foo<out /** some comment */ Any>.foo() {}
-            """.trimIndent()
-        typeArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 13, "A KDoc is not allowed inside a 'type_argument_list'")
-    }
-
-    @Test
     fun `Given a block comment inside a type projection`() {
         val code =
             """
@@ -38,18 +28,6 @@ class TypeArgumentCommentRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         typeArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 13, "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.")
-    }
-
-    @Test
-    fun `Given a kdoc as child of type argument list`() {
-        val code =
-            """
-            val fooBar: FooBar<
-                /** some comment */
-                Foo, Bar>
-            """.trimIndent()
-        typeArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed inside a 'type_argument_list'")
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
@@ -8,16 +8,6 @@ class TypeParameterCommentRuleTest {
     private val typeParameterCommentRuleAssertThat = assertThatRule { TypeParameterCommentRule() }
 
     @Test
-    fun `Given a kdoc inside a type parameter`() {
-        val code =
-            """
-            class Foo<in /** some comment */ Bar>
-            """.trimIndent()
-        typeParameterCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 14, "A KDoc is not allowed inside a 'type_parameter_list'")
-    }
-
-    @Test
     fun `Given a block comment inside a type parameter`() {
         val code =
             """
@@ -38,18 +28,6 @@ class TypeParameterCommentRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 14, "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.")
-    }
-
-    @Test
-    fun `Given a kdoc as child of type parameter list`() {
-        val code =
-            """
-            class Foo<
-                /** some comment */
-                Bar>
-            """.trimIndent()
-        typeParameterCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed inside a 'type_parameter_list'")
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
@@ -8,18 +8,6 @@ class ValueArgumentCommentRuleTest {
     private val valueArgumentCommentRuleAssertThat = KtLintAssertThat.assertThatRule { ValueArgumentCommentRule() }
 
     @Test
-    fun `Given a kdoc inside a value argument`() {
-        val code =
-            """
-            val foo = foo(
-                bar /** some comment */ = "bar"
-            )
-            """.trimIndent()
-        valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 9, "A KDoc is not allowed inside a 'value_argument_list'")
-    }
-
-    @Test
     fun `Given a block comment inside a value argument`() {
         val code =
             """
@@ -44,18 +32,6 @@ class ValueArgumentCommentRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         valueArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(2, 9, "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.")
-    }
-
-    @Test
-    fun `Given a kdoc as child of value argument list`() {
-        val code =
-            """
-            val foo = foo(
-                /** some comment */
-            )
-            """.trimIndent()
-        valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed inside a 'value_argument_list'")
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
@@ -8,19 +8,6 @@ class ValueParameterCommentRuleTest {
     private val valueParameterCommentRuleAssertThat = KtLintAssertThat.assertThatRule { ValueParameterCommentRule() }
 
     @Test
-    fun `Given a kdoc as child of value parameter list`() {
-        val code =
-            """
-            class Foo(
-                /** some comment */
-            )
-            """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-        valueParameterCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 5, "A KDoc is not allowed inside a 'value_parameter_list' when not followed by a property")
-    }
-
-    @Test
     fun `Given a kdoc as only child of value parameter list`() {
         val code =
             """
@@ -95,9 +82,9 @@ class ValueParameterCommentRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(3, 9, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(7, 14, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(10, 14, "A kdoc in a 'value_parameter' is only allowed when placed on a new line before this element"),
+                LintViolation(3, 9, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(7, 14, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(10, 14, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
             )
     }
 
@@ -118,9 +105,9 @@ class ValueParameterCommentRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 18, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(5, 18, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(8, 18, "A (block or EOL) comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(2, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(5, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(8, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
             )
     }
 


### PR DESCRIPTION
## Description

Remove logic which was moved to new rule 'kdoc' in #2548.

Relates #2547

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
