### PR TITLE
Ignore EOL comments in `value-argument-comment` and `value-parameter-comment`

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -2244,16 +2244,6 @@ Disallows comments to be placed at certain locations inside a value argument.
         )
     ```
 
-!!! note
-    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
-    ```kotlin
-    val foo1 =
-    foo(
-    bar1: Bar1, // some comment
-    bar2: Bar2, // some other comment
-    )
-    ```
-
 Rule id: `value-argument-comment` (`standard` rule set)
 
 ## Value parameter comment
@@ -2264,10 +2254,14 @@ Disallows comments to be placed at certain locations inside a value argument.
 
     ```kotlin
     class Foo1(
-        /* some comment */
+        /** some kdoc */
         bar = "bar"
     )
     class Foo2(
+        /* some comment */
+        bar = "bar"
+    )
+    class Foo3(
         // some comment
         bar = "bar"
     )
@@ -2277,21 +2271,15 @@ Disallows comments to be placed at certain locations inside a value argument.
 
     ```kotlin
     class Foo1(
-       bar = /* some comment */ "bar"
+       bar = /** some kdoc */ "bar"
     )
     class Foo2(
+       bar = /* some comment */ "bar"
+    )
+    class Foo3(
         bar =
            // some comment
            "bar"
-    )
-    ```
-
-!!! note
-    In Ktlint 1.1.x EOL comments like below are disallowed. This will be reverted in Ktlint 1.2.
-    ```kotlin
-    class Foo(
-        bar1: Bar1, // some comment
-        bar2: Bar2, // some other comment
     )
     ```
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRule.kt
@@ -1,16 +1,12 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
-import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
-import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 
 /**
  * The AST allows comments to be placed anywhere. This however can lead to code which is unnecessarily hard to read. Or, it makes
@@ -26,52 +22,24 @@ public class ValueArgumentCommentRule : StandardRule("value-argument-comment") {
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        if (node.isPartOfComment() && node.treeParent.elementType in valueArgumentTokenSet) {
-            if (node.treeParent.elementType == VALUE_ARGUMENT) {
-                // Disallow:
-                //     val foo = foo(
-                //         bar /* some comment */ = "bar"
-                //     )
-                // or
-                //     val foo = foo(
-                //         bar =
-                //            // some comment
-                //            "bar"
-                //     )
-                emit(
-                    node.startOffset,
-                    "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed " +
-                        "on a separate line above.",
-                    false,
-                )
-            } else if (node.treeParent.elementType == VALUE_ARGUMENT_LIST) {
-                if (node.prevLeaf().isWhiteSpaceWithNewline()) {
-                    // Allow:
-                    //     val foo = foo(
-                    //         // some comment
-                    //         bar = "bar"
-                    //     )
-                } else {
-                    // Disallow
-                    //     class Foo(
-                    //         val bar1: Bar, // some comment 1
-                    //         // some comment 2
-                    //         val bar2: Bar,
-                    //     )
-                    // It is not clear whether "some comment 2" belongs to bar1 as a continuation of "some comment 1" or that it belongs to
-                    // bar2. Note both comments are direct children of the value_argument_list.
-                    emit(
-                        node.startOffset,
-                        "A comment in a 'value_argument_list' is only allowed when placed on a separate line",
-                        false,
-                    )
-                }
-            }
+        if (node.isPartOfComment() && node.treeParent.elementType == VALUE_ARGUMENT) {
+            // Disallow:
+            //     val foo = foo(
+            //         bar /* some comment */ = "bar"
+            //     )
+            // or
+            //     val foo = foo(
+            //         bar =
+            //            // some comment
+            //            "bar"
+            //     )
+            emit(
+                node.startOffset,
+                "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed " +
+                    "on a separate line above.",
+                false,
+            )
         }
-    }
-
-    private companion object {
-        val valueArgumentTokenSet = TokenSet.create(VALUE_ARGUMENT, VALUE_ARGUMENT_LIST)
     }
 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -945,26 +945,6 @@ class ArgumentListWrappingRuleTest {
     }
 
     @Test
-    fun `Issue 2445 - Given a value argument followed by EOL comment after comma`() {
-        val code =
-            """
-            val foo = foo(
-                bar1 = "bar1", // some comment 1
-                bar2 = "bar2", // some comment 2
-            )
-            """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-        argumentListWrappingRuleAssertThat(code)
-            .addAdditionalRuleProvider { ValueArgumentCommentRule() }
-            .hasLintViolationsForAdditionalRule(
-                LintViolation(2, 20, "A comment in a 'value_argument_list' is only allowed when placed on a separate line", false),
-                LintViolation(3, 20, "A comment in a 'value_argument_list' is only allowed when placed on a separate line", false),
-            )
-        // When ValueArgumentCommentRule is not loaded or enabled
-        argumentListWrappingRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
     fun `Issue 2462 - Given a call expression with value argument list inside a binary expression, then first wrap the binary expression`() {
         val code =
             """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -211,28 +211,21 @@ class FunctionSignatureRuleTest {
             private /* some comment */ fun f1(a: Any, b: Any): String = "some-result"
             private fun /* some comment */ f2(a: Any, b: Any): String = "some-result"
             private fun f3 /* some comment */ (a: Any, b: Any): String = "some-result"
-            private fun f4( /* some comment */ a: Any, b: Any): String = "some-result"
             private fun f5(a /* some comment */: Any, b: Any): String = "some-result"
             private fun f6(a: /* some comment */ Any, b: Any): String = "some-result"
             private fun f7(a: Any /* some comment */, b: Any): String = "some-result"
             private fun f8(a: Any, b: Any) /* some comment */: String = "some-result"
             private fun f9(a: Any, b: Any): /* some comment */ String = "some-result"
             private fun f10(a: Any, b: Any): String /* some comment */ = "some-result"
-            private fun f11(
-                a: Any, // some-comment
-                b: Any
-            ): String = "f10"
             """.trimIndent()
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
-                LintViolation(5, 17, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
-                LintViolation(6, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(7, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(8, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(13, 13, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
+                LintViolation(5, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(6, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(7, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
     }
 
@@ -243,10 +236,6 @@ class FunctionSignatureRuleTest {
             private fun f5(a /* some comment */: Any, b: Any): String = "some-result"
             private fun f6(a: /* some comment */ Any, b: Any): String = "some-result"
             private fun f7(a: Any /* some comment */, b: Any): String = "some-result"
-            private fun f11(
-                a: Any, // some-comment
-                b: Any
-            ): String = "f10"
             """.trimIndent()
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
@@ -255,7 +244,6 @@ class FunctionSignatureRuleTest {
                 LintViolation(1, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
                 LintViolation(2, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
                 LintViolation(3, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(5, 13, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
         // When ValueParameterCommentRule is not loaded or disabled:
         functionSignatureWrappingRuleAssertThat(code).hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat
-import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class ValueArgumentCommentRuleTest {
@@ -62,44 +61,6 @@ class ValueArgumentCommentRuleTest {
             )
             """.trimIndent()
         valueArgumentCommentRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `Given a comment as last node of value argument ast node`() {
-        val code =
-            """
-            val foo1 = foo(
-                "bar" // some comment
-            )
-            val foo2 = foo(
-                "bar" /* some comment */
-            )
-            """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-        valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 11, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
-                LintViolation(5, 11, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
-            )
-    }
-
-    @Test
-    fun `Given a comment after a comma on the same line as an value argument ast node`() {
-        val code =
-            """
-            val foo1 = foo(
-                "bar", // some comment
-            )
-            val foo2 = foo(
-                "bar", /* some comment */
-            )
-            """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-        valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 12, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
-                LintViolation(5, 12, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
-            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
@@ -112,24 +112,6 @@ class ValueParameterCommentRuleTest {
     }
 
     @Test
-    fun `Given a comment after a comma on the same line as an value parameter ast node`() {
-        val code =
-            """
-            class Foo1(
-                val bar: Bar, // some comment
-            )
-            class Foo2(
-                val bar: Bar, /* some comment */
-            )
-            """.trimIndent()
-        valueParameterCommentRuleAssertThat(code)
-            .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 19, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line"),
-                LintViolation(5, 19, "A comment in a 'value_parameter_list' is only allowed when placed on a separate line"),
-            )
-    }
-
-    @Test
     fun `Given a comment as last node of value parameter list`() {
         val code =
             """


### PR DESCRIPTION
## Description

Ignore EOL comments in `value-argument-comment` and `value-parameter-comment`

EOL comments which are just before or after a value argument or value parameter do not belong to the VALUE_ARGUMENT or VALUE_PARAMETER AST node but to the out LIST element. So this rule only reports comments that are actually inside the VALUE_ARGUMENT or VALUE_PARAMETER node.

Closes #2519

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
