### PR TITLE
Ignore modifier of backing property in `android_studio` code style

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -8,6 +8,36 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](../configuration-ktlint/#disabled-rules).
 
+### Backing property naming
+
+Allows property names to start with `_` in case the property is a backing property. `ktlint_official` and `android_studio` code styles require the correlated property/function to be defined as `public`.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    class Bar {
+        // Backing property
+        private val _elementList = mutableListOf<Element>()
+        val elementList: List<Element>
+            get() = _elementList
+    }
+    ```
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    class Bar {
+        // Incomplete backing property as public property 'elementList1' is missing
+        private val _elementList1 = mutableListOf<Element>()
+
+        // Invalid backing property as '_elementList2' is not a private property
+        val _elementList2 = mutableListOf<Element>()
+        val elementList2: List<Element>
+            get() = _elementList2
+    }
+    ```
+
+Rule id: `backing-property-naming` (`standard` rule set)
+
 ## Binary expression wrapping
 
 Wraps binary expression at the operator reference whenever the binary expression does not fit on the line. In case the binary expression is nested, the expression is evaluated from outside to inside. If the left and right hand sides of the binary expression, after wrapping, fit on a single line then the inner binary expressions will not be wrapped. If one or both inner binary expression still do not fit on a single after wrapping of the outer binary expression, then each of those inner binary expressions will be wrapped.

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -43,6 +43,16 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrapp
 	public static final fun getARGUMENT_LIST_WRAPPING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleKt {
+	public static final fun getBACKING_PROPERTY_NAMING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/Rule$Experimental {
 	public fun <init> ()V
 	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 import com.pinterest.ktlint.ruleset.standard.rules.AnnotationRule
 import com.pinterest.ktlint.ruleset.standard.rules.AnnotationSpacingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ArgumentListWrappingRule
+import com.pinterest.ktlint.ruleset.standard.rules.BackingPropertyNamingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BinaryExpressionWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeDeclarationRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlockCommentInitialStarAlignmentRule
@@ -104,6 +105,7 @@ public class StandardRuleSetProvider : RuleSetProviderV3(RuleSetId.STANDARD) {
             RuleProvider { AnnotationRule() },
             RuleProvider { AnnotationSpacingRule() },
             RuleProvider { ArgumentListWrappingRule() },
+            RuleProvider { BackingPropertyNamingRule() },
             RuleProvider { BinaryExpressionWrappingRule() },
             RuleProvider { BlankLineBeforeDeclarationRule() },
             RuleProvider { BlockCommentInitialStarAlignmentRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
@@ -1,0 +1,133 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.INTERNAL_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIVATE_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROTECTED_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.android_studio
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.hasModifier
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import com.pinterest.ktlint.ruleset.standard.rules.internal.regExIgnoringDiacriticsAndStrokesOnLetters
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * https://kotlinlang.org/docs/coding-conventions.html#property-names
+ * https://developer.android.com/kotlin/style-guide#backing_properties
+ */
+@SinceKtlint("1.2.0", EXPERIMENTAL)
+public class BackingPropertyNamingRule :
+    StandardRule(
+        id = "backing-property-naming",
+        usesEditorConfigProperties = setOf(CODE_STYLE_PROPERTY),
+    ) {
+    private var codeStyle = CODE_STYLE_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        codeStyle = editorConfig[CODE_STYLE_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        node
+            .takeIf { node.elementType == PROPERTY }
+            ?.let { property -> visitProperty(property, emit) }
+    }
+
+    private fun visitProperty(
+        property: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        property
+            .findChildByType(IDENTIFIER)
+            ?.takeIf { it.text.startsWith("_") }
+            ?.let { identifier ->
+                visitBackingProperty(identifier, emit)
+            }
+    }
+
+    private fun visitBackingProperty(
+        identifier: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        identifier
+            .text
+            .takeUnless { it.matches(BACKING_PROPERTY_LOWER_CAMEL_CASE_REGEXP) }
+            ?.let {
+                emit(identifier.startOffset, "Backing property should start with underscore followed by lower camel case", false)
+            }
+
+        if (!identifier.treeParent.hasModifier(PRIVATE_KEYWORD)) {
+            emit(identifier.startOffset, "Backing property not allowed when 'private' modifier is missing", false)
+        }
+
+        // A backing property can only exist when a correlated public property or function exists
+        val correlatedPropertyOrFunction = identifier.findCorrelatedPropertyOrFunction()
+        if (correlatedPropertyOrFunction == null) {
+            emit(identifier.startOffset, "Backing property is only allowed when a matching property or function exists", false)
+        } else {
+            if (codeStyle == android_studio || correlatedPropertyOrFunction.isPublic()) {
+                return
+            } else {
+                emit(identifier.startOffset, "Backing property is only allowed when the matching property or function is public", false)
+            }
+        }
+    }
+
+    private fun ASTNode.findCorrelatedPropertyOrFunction() = findCorrelatedProperty() ?: findCorrelatedFunction()
+
+    private fun ASTNode.findCorrelatedProperty() =
+        treeParent
+            ?.treeParent
+            ?.children()
+            ?.filter { it.elementType == PROPERTY }
+            ?.mapNotNull { it.findChildByType(IDENTIFIER) }
+            ?.firstOrNull { it.text == text.removePrefix("_") }
+            ?.treeParent
+
+    private fun ASTNode.findCorrelatedFunction(): ASTNode? {
+        val correlatedFunctionName = "get${capitalizeFirstChar()}"
+        return treeParent
+            ?.treeParent
+            ?.children()
+            ?.filter { it.elementType == FUN }
+            ?.filter { it.hasNonEmptyParameterList() }
+            ?.mapNotNull { it.findChildByType(IDENTIFIER) }
+            ?.firstOrNull { it.text == correlatedFunctionName }
+            ?.treeParent
+    }
+
+    private fun ASTNode.hasNonEmptyParameterList() =
+        findChildByType(VALUE_PARAMETER_LIST)
+            ?.children()
+            ?.none { it.elementType == VALUE_PARAMETER }
+            ?: false
+
+    private fun ASTNode.capitalizeFirstChar() =
+        text
+            .removePrefix("_")
+            .replaceFirstChar { it.uppercase() }
+
+    private fun ASTNode.isPublic() =
+        !hasModifier(PRIVATE_KEYWORD) &&
+            !hasModifier(PROTECTED_KEYWORD) &&
+            !hasModifier(INTERNAL_KEYWORD)
+
+    private companion object {
+        val BACKING_PROPERTY_LOWER_CAMEL_CASE_REGEXP = "_[a-z][a-zA-Z0-9]*".regExIgnoringDiacriticsAndStrokesOnLetters()
+    }
+}
+
+public val BACKING_PROPERTY_NAMING_RULE_ID: RuleId = BackingPropertyNamingRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyRuleTest.kt
@@ -1,0 +1,347 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.android_studio
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtlintDocumentationTest
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class BackingPropertyRuleTest {
+    private val backingPropertyNamingRuleAssertThat = assertThatRule { BackingPropertyNamingRule() }
+
+    @Nested
+    inner class `Given a backing property correlating with a property` {
+        @ParameterizedTest(name = "Correlated property name: {0}")
+        @ValueSource(
+            strings = [
+                "foo",
+                "føø",
+            ],
+        )
+        fun `Given a valid property name then do not emit`(propertyName: String) {
+            val code =
+                """
+                class Foo {
+                    private var _$propertyName = "some-value"
+
+                    val $propertyName: String
+                        get() = _$propertyName
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the correlated property is implicitly public then do not emit`() {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    val elementList: List<Element>
+                        get() = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the correlated property is explicitly public then do not emit`() {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    public val elementList: List<Element>
+                        get() = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given ktlint_official code style, and the correlated property is non-public then emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier val elementList: List<Element>
+                        get() = _elementList
+                }
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given intellij_idea code style, and the correlated property is non-public then emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier val elementList: List<Element>
+                        get() = _elementList
+                }
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given android_studio code style, and the correlated property is non-public then do not emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier val elementList: List<Element>
+                        get() = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                .hasNoLintViolations()
+        }
+    }
+
+    @Nested
+    inner class `Given a backing property correlating with a function` {
+        @ParameterizedTest(name = "Correlated property name: {0}")
+        @CsvSource(
+            value = [
+                "foo,getFoo",
+                "føø,getFøø",
+            ],
+        )
+        fun `Given a valid backing property then do not emit`(
+            propertyName: String,
+            functionName: String,
+        ) {
+            val code =
+                """
+                class Foo {
+                    private var _$propertyName = "some-value"
+
+                    fun $functionName(): String = _$propertyName
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the correlated function is implicitly public then do not emit`() {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    fun getElementList(): List<Element> = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the correlated function is explicitly public then do not emit`() {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    public fun getElementList(): List<Element> = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given ktlint_official code style, and the correlated function is non-public then emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier fun getElementList(): List<Element> = _elementList
+                }
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given intellij_idea code style, and the correlated function is non-public then emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier fun getElementList(): List<Element> = _elementList
+                }
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+        }
+
+        @ParameterizedTest(name = "Modifier: {0}")
+        @ValueSource(
+            strings = [
+                "private",
+                "protected",
+                "internal",
+            ],
+        )
+        fun `Given android_studio code style, and the correlated function is non-public then do not emit`(modifier: String) {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    $modifier fun getElementList(): List<Element> = _elementList
+                }
+                """.trimIndent()
+            backingPropertyNamingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Given that the correlated function has at least 1 parameter then emit`() {
+            val code =
+                """
+                class Foo {
+                    private val _elementList = mutableListOf<Element>()
+
+                    fun getElementList(bar: String): List<Element> = _elementList + bar
+                }
+                """.trimIndent()
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            backingPropertyNamingRuleAssertThat(code)
+                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when a matching property or function exists")
+        }
+    }
+
+    @ParameterizedTest(name = "Suppression annotation: {0}")
+    @ValueSource(
+        strings = [
+            "ktlint:standard:backing-property-naming",
+            "PropertyName", // IntelliJ IDEA suppression
+        ],
+    )
+    fun `Given class with a disallowed name which is suppressed`(suppressionName: String) {
+        val code =
+            """
+            @Suppress("$suppressionName")
+            val foo = Foo()
+            """.trimIndent()
+        backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @KtlintDocumentationTest
+    fun `Ktlint allowed examples`() {
+        val code =
+            """
+            class Bar {
+                // Backing property
+                private val _elementList = mutableListOf<Element>()
+                val elementList: List<Element>
+                    get() = _elementList
+            }
+            """.trimIndent()
+        backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @KtlintDocumentationTest
+    fun `Ktlint disallowed examples`() {
+        val code =
+            """
+            class Bar1 {
+                // Incomplete backing property as public property 'elementList' or function `getElementList` is missing
+                private val _elementList = mutableListOf<Element>()
+            }
+            class Bar2 {
+                // Invalid backing property as '_elementList' is not a private property
+                val _elementList = mutableListOf<Element>()
+                val elementList: List<Element>
+                    get() = _elementList2
+            }
+            class Bar3 {
+                // Invalid backing property as 'elementList' is not a public property
+                // Note: code below is allowed in `android_studio` code style!
+                private val _elementList = mutableListOf<Element>()
+                internal val elementList: List<Element>
+                    get() = _elementList2
+            }
+            """.trimIndent()
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        backingPropertyNamingRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(3, 17, "Backing property is only allowed when a matching property or function exists", canBeAutoCorrected = false),
+                LintViolation(7, 9, "Backing property not allowed when 'private' modifier is missing", canBeAutoCorrected = false),
+                LintViolation(14, 17, "Backing property is only allowed when the matching property or function is public", canBeAutoCorrected = false),
+            )
+    }
+
+    @Test
+    fun `Given a property name suppressed via 'PropertyName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            class Foo {
+                @Suppress("PropertyName")
+                var FOO = "foo"
+            }
+            """.trimIndent()
+        backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
## Description

Ignore modifier of backing property in `android_studio` code style

Extract `backing-property-name` from `property-naming` rule. This allows users to disable this rule, but keep the `property-naming` rule in place.

 For `android_studio` code style the restrictions regarding the modifier of the correlated property or function is ignored entirely as the Android Kotlin Styleguide does not require it to be public.

 Closes #2528

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
