### PR TITLE
Do not indent string template starting at first position of line

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1410,7 +1410,7 @@ private class StringTemplateIndenter(
                         }
                     }
             }
-    } //
+    }
 
     private fun ASTNode.isRawStringLiteralFunctionBodyExpression() =
         (prevLeaf()?.elementType != WHITE_SPACE || prevLeaf()?.text == " ") &&

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1410,7 +1410,7 @@ private class StringTemplateIndenter(
                         }
                     }
             }
-    }
+    } //
 
     private fun ASTNode.isRawStringLiteralFunctionBodyExpression() =
         (prevLeaf()?.elementType != WHITE_SPACE || prevLeaf()?.text == " ") &&

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRule.kt
@@ -240,20 +240,26 @@ public class StringTemplateIndentRule :
                         } else {
                             it.text.splitIndentAt(prefixLength)
                         }
+                    val expectedIndent =
+                        if (it.isIndentBeforeClosingQuote() || prefixLength > 0) {
+                            newIndent
+                        } else {
+                            ""
+                        }
                     if (currentIndent.contains(wrongIndentChar)) {
                         checkAndFixWrongIndentationChar(
                             node = it,
                             oldIndent = currentIndent,
-                            newIndent = newIndent,
+                            newIndent = expectedIndent,
                             newContent = currentContent,
                             emit = emit,
                             autoCorrect = autoCorrect,
                         )
-                    } else if (currentIndent != newIndent) {
+                    } else if (currentIndent != expectedIndent) {
                         checkAndFixIndent(
                             node = it,
                             oldIndentLength = currentIndent.length,
-                            newIndent = newIndent,
+                            newIndent = expectedIndent,
                             newContent = currentContent,
                             autoCorrect = autoCorrect,
                             emit = emit,
@@ -314,11 +320,7 @@ public class StringTemplateIndentRule :
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        emit(
-            node.startOffset + oldIndentLength,
-            "Unexpected indent of raw string literal",
-            true,
-        )
+        emit(node.startOffset + oldIndentLength, "Unexpected indent of raw string literal", true)
         if (autoCorrect) {
             if (node.elementType == CLOSING_QUOTE) {
                 (node as LeafPsiElement).rawInsertBeforeMe(


### PR DESCRIPTION
## Description

Do not indent string template starting at first position of line

Also, the `indent` rule should not change unexpected indentation characters inside a string template but leave this up to the `string-template-indent` rule. As a result the `indent` rule could be a bit simplified.

Closes #2350

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
