### PR TITLE
Prevent conflict when curly closing brace is followed by range (until) operator

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -179,7 +179,7 @@ public class StandardRuleSetProvider : RuleSetProviderV3(RuleSetId.STANDARD) {
             RuleProvider { SpacingAroundOperatorsRule() },
             RuleProvider { SpacingAroundParensRule() },
             RuleProvider { SpacingAroundRangeOperatorRule() },
-            RuleProvider { SpacingAroundUnaryOperatorRule() }, //
+            RuleProvider { SpacingAroundUnaryOperatorRule() },
             RuleProvider { SpacingBetweenDeclarationsWithAnnotationsRule() },
             RuleProvider { SpacingBetweenDeclarationsWithCommentsRule() },
             RuleProvider { SpacingBetweenFunctionNameAndOpeningParenthesisRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -179,7 +179,7 @@ public class StandardRuleSetProvider : RuleSetProviderV3(RuleSetId.STANDARD) {
             RuleProvider { SpacingAroundOperatorsRule() },
             RuleProvider { SpacingAroundParensRule() },
             RuleProvider { SpacingAroundRangeOperatorRule() },
-            RuleProvider { SpacingAroundUnaryOperatorRule() },
+            RuleProvider { SpacingAroundUnaryOperatorRule() }, //
             RuleProvider { SpacingBetweenDeclarationsWithAnnotationsRule() },
             RuleProvider { SpacingBetweenDeclarationsWithCommentsRule() },
             RuleProvider { SpacingBetweenFunctionNameAndOpeningParenthesisRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
@@ -11,6 +11,8 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACKET
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RANGE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RANGE_UNTIL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACKET
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
@@ -182,7 +184,9 @@ public class SpacingAroundCurlyRule :
                 nextElementType == EXCLEXCL ||
                 nextElementType == LBRACKET ||
                 nextElementType == LPAR ||
-                nextElementType == COLONCOLON
+                nextElementType == COLONCOLON ||
+                nextElementType == RANGE ||
+                nextElementType == RANGE_UNTIL
         )
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
@@ -562,4 +562,22 @@ class SpacingAroundCurlyRuleTest {
                 .isFormattedAs(formattedCode)
         }
     }
+
+    @Test
+    fun `Issue 2359 - Given RBRACE followed by range operator then do not emit`() {
+        val code =
+            """
+            val foo = emptyList<String>().count { true }..1
+            """.trimIndent()
+        spacingAroundCurlyRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2359 - Given RBRACE followed by range until operator then do not emit`() {
+        val code =
+            """
+            val foo = emptyList<String>().count { true }..<2
+            """.trimIndent()
+        spacingAroundCurlyRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Prevent conflict between `curly-spacing` and `range-spacing` when curly closing brace is followed by range (until) operator

Closes #2539 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
