### PR TITLE
Ignore simple reference expressions in `chain-method-continuation`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -141,6 +141,7 @@ public class ChainMethodContinuationRule :
         chainedExpression
             .chainOperators
             .filterNot { it.isJavaClassReferenceExpression() }
+            .filterNot { it.isSimpleReferenceExpression() }
             .forEach { chainOperator ->
                 when {
                     chainOperator.shouldBeOnSameLineAsClosingElementOfPreviousExpressionInMethodChain() -> {
@@ -159,6 +160,11 @@ public class ChainMethodContinuationRule :
             prevCodeSibling()?.elementType == CLASS_LITERAL_EXPRESSION &&
             nextCodeSibling()?.elementType == REFERENCE_EXPRESSION &&
             nextCodeSibling()?.firstChildLeafOrSelf()?.text == "java"
+
+    private fun ASTNode.isSimpleReferenceExpression() =
+        treeParent.elementType == DOT_QUALIFIED_EXPRESSION &&
+            prevCodeSibling()?.elementType == REFERENCE_EXPRESSION &&
+            nextCodeSibling()?.elementType == REFERENCE_EXPRESSION
 
     private fun ChainedExpression.wrapBeforeChainOperator() =
         when {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -1011,4 +1011,31 @@ class ChainMethodContinuationRuleTest {
                 LintViolation(6, 46, "Exceeded max line length (45)", false),
             ).hasNoLintViolationsExceptInAdditionalRules()
     }
+
+    @Test
+    fun `Issue 2455 - Given a chained method including some simple reference expressions then do not wrap simple reference expressions`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun buildBar(): Foo.Bar = Foo.Bar.builder().baz().baz.build()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun buildBar(): Foo.Bar = Foo.Bar
+                .builder()
+                .baz()
+                .baz
+                .build()
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolations(
+                LintViolation(2, 34, "Expected newline before '.'"),
+                LintViolation(2, 44, "Expected newline before '.'"),
+                LintViolation(2, 50, "Expected newline before '.'"),
+                LintViolation(2, 54, "Expected newline before '.'"),
+            ).isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Simple reference expressions like properties and enum values should be ignored by this rule as they are no method calls.

Closes #2455

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
