### PR TITLE
Release testing bugs 1.2.0

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -104,8 +104,19 @@ Consistently add or remove blank lines between when-conditions in a when-stateme
             else -> null
         }
 
+    // ij_kotlin_line_break_after_multiline_when_entry = true
+    val foo3 =
+        when (bar) {
+            BAR1 -> "bar1"
+
+            // BAR2 comment
+            BAR2 -> "bar2"
+
+            else -> null
+        }
+
     // ij_kotlin_line_break_after_multiline_when_entry = false
-    val foo2 =
+    val foo4 =
         when (bar) {
             BAR1 -> "bar1"
             BAR2 -> {
@@ -138,8 +149,17 @@ Consistently add or remove blank lines between when-conditions in a when-stateme
             else -> null
         }
 
+    // ij_kotlin_line_break_after_multiline_when_entry = true (missing newline after BAR1, and BAR2)
+    val foo3 =
+        when (bar) {
+            BAR1 -> "bar1"
+            // BAR2 comment
+            BAR2 -> "bar2"
+            else -> null
+        }
+
     // ij_kotlin_line_break_after_multiline_when_entry = false (unexpected newline after BAR2)
-    val foo2 =
+    val foo4 =
         when (bar) {
             BAR1 -> "bar1"
             BAR2 -> {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -148,6 +148,7 @@ public class ArgumentListWrappingRule :
             //         2
             //     )
             child.treeParent.hasTypeArgumentListInFront() -> -1
+
             // IDEA quirk:
             // foo
             //     .bar = Baz(
@@ -161,6 +162,7 @@ public class ArgumentListWrappingRule :
             //         2
             //     )
             child.treeParent.isPartOfDotQualifiedAssignmentExpression() -> -1
+
             else -> 0
         }.let {
             if (child.treeParent.isOnSameLineAsControlFlowKeyword()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
@@ -10,10 +10,12 @@ import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.ec4j.core.model.PropertyType
@@ -92,7 +94,11 @@ public class BlankLineBetweenWhenConditions :
 
     private fun ASTNode.containsBlankLine(): Boolean = elementType == WHITE_SPACE && text.count { it == '\n' } > 1
 
-    private fun ASTNode.hasAnyMultilineWhenCondition() = children().any { it.elementType == WHEN_ENTRY && it.textContains('\n') }
+    private fun ASTNode.hasAnyMultilineWhenCondition() =
+        children()
+            .any { it.elementType == WHEN_ENTRY && (it.textContains('\n') || it.isPrecededByComment()) }
+
+    private fun ASTNode.isPrecededByComment() = prevSibling { !it.isWhiteSpace() }?.isPartOfComment() ?: false
 
     private fun ASTNode.findWhitespaceAfterPreviousCodeSibling() =
         prevCodeSibling()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -224,6 +224,7 @@ public class ParameterListWrappingRule :
             //         param2: R
             //     )
             child.treeParent.isFunWithTypeParameterListInFront() -> -1
+
             else -> 0
         }.let {
             if (child.elementType == VALUE_PARAMETER) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
-class BackingPropertyRuleTest {
+class BackingPropertyNamingRuleTest {
     private val backingPropertyNamingRuleAssertThat = assertThatRule { BackingPropertyNamingRule() }
 
     @Nested

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
@@ -122,7 +122,7 @@ class BlankLineBetweenWhenConditionsTest {
             }
 
             @Test
-            fun `Given xx a when-condition preceded by a comment and the when-condition needs to be preceded by blank line then add this line before the comment`() {
+            fun `Given a when-condition with a single line body on the next line then add blank lines`() {
                 val code =
                     """
                     val foo =
@@ -178,6 +178,33 @@ class BlankLineBetweenWhenConditionsTest {
                             // Some comment
                             else ->
                                 null
+                        }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                blankLineAfterWhenConditionRuleAssertThat(code)
+                    .hasLintViolation(4, 1, "Add a blank line between all when-condition in case at least one multiline when-condition is found in the statement")
+                    .isFormattedAs(formattedCode)
+            }
+
+            @Test
+            fun `Given a simple when-statement in which a when condition is preceded by a comment then add blank lines between the when-conditions`() {
+                val code =
+                    """
+                    val foo =
+                        when (bar) {
+                            BAR -> "bar"
+                            // Some comment
+                            else -> null
+                        }
+                    """.trimIndent()
+                val formattedCode =
+                    """
+                    val foo =
+                        when (bar) {
+                            BAR -> "bar"
+
+                            // Some comment
+                            else -> null
                         }
                     """.trimIndent()
                 @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateIndentRuleTest.kt
@@ -470,4 +470,22 @@ class StringTemplateIndentRuleTest {
             """.trimIndent().replaceStringTemplatePlaceholder()
         stringTemplateIndentRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Given a string template on same line as closing parenthesis of multiline function signature`() {
+        // Interpret "$." in code sample below as "$". It is used whenever the code which has to be inspected should
+        // actually contain a string template. Using "$" instead of "$." would result in a String in which the string
+        // templates would have been evaluated before the code would actually be processed by the rule.
+        val code =
+            """
+            fun foo(
+                bar: String
+            ) = $MULTILINE_STRING_QUOTE
+                Bar: $.bar
+                $MULTILINE_STRING_QUOTE.trimIndent()
+            """.trimIndent()
+        stringTemplateIndentRuleAssertThat(code)
+            .addAdditionalRuleProvider { MultilineExpressionWrappingRule() }
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Resolved bug found during release testing:

* A when-condition preceded by a comment should be treated as a multiline condition and as of that lead to adding blank lines between the when-conditions
* Rename BackingPropertyRuleTest to BackingPropertyNamingRuleTest
* Prevent conflict between string-template-indent and `multiline-expression` when function body expression is a multiline string template

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
