### PR TITLE
Fix null byte as default value for "--pattern-from-stdin"

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -734,13 +734,3 @@ internal fun exitKtLintProcess(status: Int): Nothing {
     logger.debug { "Exit ktlint with exit code: $status" }
     exitProcess(status)
 }
-
-private sealed class StdinOption {
-    data class Stdin(
-        val enabled: Boolean,
-    ) : StdinOption()
-
-    data class PatternsFromStdin(
-        val delimiter: String,
-    ) : StdinOption()
-}

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -173,22 +173,31 @@ class SimpleCLITest {
             }
     }
 
-    @Test
+    @ParameterizedTest(name = "Option: {0}")
+    @ValueSource(
+        strings = [
+            "--patterns-from-stdin",
+            "--patterns-from-stdin=",
+        ],
+    )
     fun `Given some code with an error and a pattern which is read in from stdin which does not select the file then return the no files matched warning`(
+        patternsFromStdin: String,
         @TempDir
         tempDir: Path,
     ) {
-        val somePatternProvidedViaStdin = "some-pattern-provided-via-stdin"
+        val pathToFile1 = "path/to/file/1.kt"
+        val pathToFile2 = "path/to/file/2.kts"
+        val somePatternProvidedViaStdin = "$pathToFile1\u0000$pathToFile2\u0000"
         CommandLineTestRunner(tempDir)
             .run(
                 "too-many-empty-lines",
-                listOf("--patterns-from-stdin"),
+                listOf(patternsFromStdin),
                 stdin = ByteArrayInputStream(somePatternProvidedViaStdin.toByteArray()),
             ) {
                 SoftAssertions()
                     .apply {
                         assertNormalExitCode()
-                        assertThat(normalOutput).containsLineMatching("No files matched [$somePatternProvidedViaStdin]")
+                        assertThat(normalOutput).containsLineMatching("No files matched [$pathToFile1, $pathToFile2]")
                     }.assertAll()
             }
     }


### PR DESCRIPTION
## Description

Fix null byte as default value for "--pattern-from-stdin"

Closes 2578

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
