### PR TITLE
Ignore nested reference expressions in `chain-method-continuation`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -141,7 +141,7 @@ public class ChainMethodContinuationRule :
         chainedExpression
             .chainOperators
             .filterNot { it.isJavaClassReferenceExpression() }
-            .filterNot { it.isSimpleReferenceExpression() }
+            .filterNot { it.isReferenceExpression() }
             .forEach { chainOperator ->
                 when {
                     chainOperator.shouldBeOnSameLineAsClosingElementOfPreviousExpressionInMethodChain() -> {
@@ -161,10 +161,14 @@ public class ChainMethodContinuationRule :
             nextCodeSibling()?.elementType == REFERENCE_EXPRESSION &&
             nextCodeSibling()?.firstChildLeafOrSelf()?.text == "java"
 
-    private fun ASTNode.isSimpleReferenceExpression() =
-        treeParent.elementType == DOT_QUALIFIED_EXPRESSION &&
-            prevCodeSibling()?.elementType == REFERENCE_EXPRESSION &&
-            nextCodeSibling()?.elementType == REFERENCE_EXPRESSION
+    private fun ASTNode.isReferenceExpression(): Boolean = treeParent.isNestedReferenceExpression()
+
+    private fun ASTNode.isNestedReferenceExpression(): Boolean =
+        elementType == DOT_QUALIFIED_EXPRESSION &&
+            children().first().let { it.elementType == REFERENCE_EXPRESSION || it.hasRightHandSideReferenceExpression() } &&
+            hasRightHandSideReferenceExpression()
+
+    private fun ASTNode.hasRightHandSideReferenceExpression() = children().last().elementType == REFERENCE_EXPRESSION
 
     private fun ChainedExpression.wrapBeforeChainOperator() =
         when {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -532,16 +532,13 @@ class ChainMethodContinuationRuleTest {
             """
             // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
             val foo1 = Foo::class.java.canonicalName
-            val foo2 = Foo::class.java
-                .canonicalName
+            val foo2 = Foo::class.java.canonicalName
                 .uppercase()
             """.trimIndent()
         chainMethodContinuationRuleAssertThat(code)
             .setMaxLineLength()
-            .hasLintViolations(
-                LintViolation(3, 27, "Expected newline before '.'"),
-                LintViolation(3, 41, "Expected newline before '.'"),
-            ).isFormattedAs(formattedCode)
+            .hasLintViolation(3, 41, "Expected newline before '.'")
+            .isFormattedAs(formattedCode)
     }
 
     @Nested
@@ -1036,6 +1033,88 @@ class ChainMethodContinuationRuleTest {
                 LintViolation(2, 44, "Expected newline before '.'"),
                 LintViolation(2, 50, "Expected newline before '.'"),
                 LintViolation(2, 54, "Expected newline before '.'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2602 - Given a chained method starting with some nested reference expressions then do not wrap the reference expressions`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+            fun buildBar1(): Foo.Bar = Foo.Bar.builder().build()
+            fun buildBar2(): Foo.Bar = Foo.bar.Bar.builder().build()
+            fun buildBar3(): Foo.Bar = Foo.bar.bar.Bar.builder().build()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+            fun buildBar1(): Foo.Bar = Foo.Bar
+                .builder()
+                .build()
+            fun buildBar2(): Foo.Bar = Foo.bar.Bar
+                .builder()
+                .build()
+            fun buildBar3(): Foo.Bar = Foo.bar.bar.Bar
+                .builder()
+                .build()
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolations(
+                LintViolation(2, 35, "Expected newline before '.'"),
+                LintViolation(2, 45, "Expected newline before '.'"),
+                LintViolation(3, 39, "Expected newline before '.'"),
+                LintViolation(3, 49, "Expected newline before '.'"),
+                LintViolation(4, 43, "Expected newline before '.'"),
+                LintViolation(4, 53, "Expected newline before '.'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a chained method having some nested reference expressions after chained method call then do not wrap the reference expressions`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+            fun buildBar1(): Foo.Bar = Foo.baz().Bar.builder().build()
+            fun buildBar2(): Foo.Bar = Foo.baz().bar.Bar.builder().build()
+            fun buildBar3(): Foo.Bar = Foo.baz().bar.bar.Bar.builder().build()
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                        $EOL_CHAR
+            fun buildBar1(): Foo.Bar = Foo
+                .baz()
+                .Bar
+                .builder()
+                .build()
+            fun buildBar2(): Foo.Bar = Foo
+                .baz()
+                .bar.Bar
+                .builder()
+                .build()
+            fun buildBar3(): Foo.Bar = Foo
+                .baz()
+                .bar.bar.Bar
+                .builder()
+                .build()
+            """.trimIndent()
+        chainMethodContinuationRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .hasLintViolations(
+                LintViolation(2, 31, "Expected newline before '.'"),
+                LintViolation(2, 37, "Expected newline before '.'"),
+                LintViolation(2, 41, "Expected newline before '.'"),
+                LintViolation(2, 51, "Expected newline before '.'"),
+                LintViolation(3, 31, "Expected newline before '.'"),
+                LintViolation(3, 37, "Expected newline before '.'"),
+                LintViolation(3, 45, "Expected newline before '.'"),
+                LintViolation(3, 55, "Expected newline before '.'"),
+                LintViolation(4, 31, "Expected newline before '.'"),
+                LintViolation(4, 37, "Expected newline before '.'"),
+                LintViolation(4, 49, "Expected newline before '.'"),
+                LintViolation(4, 59, "Expected newline before '.'"),
             ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Ignore nested reference expressions in `chain-method-continuation`

Given code:
```
fun buildBar1(): Foo.Bar = Foo.Bar.builder().baz().baz.build()

fun buildBar2(): Foo.Bar = Foo.bar.Bar.builder().baz().baz.build()

fun buildBar3(): Foo.Bar = Foo.bar.bar.Bar.builder().baz().baz.build()

fun buildBar4(): Foo.Bar = Foo.Bar.baz.builder().baz().baz.build()

fun buildBar5(): Foo.Bar = Foo.baz().bar.Bar.builder().build()
```

Is now formatted as:
```
fun buildBar1(): Foo.Bar =
    Foo.Bar
        .builder()
        .baz()
        .baz
        .build()

fun buildBar2(): Foo.Bar =
    Foo.bar.Bar
        .builder()
        .baz()
        .baz
        .build()

fun buildBar3(): Foo.Bar =
    Foo.bar.bar.Bar
        .builder()
        .baz()
        .baz
        .build()

fun buildBar4(): Foo.Bar =
    Foo.Bar.baz
        .builder()
        .baz()
        .baz
        .build()

fun buildBar5(): Foo.Bar =
    Foo
        .baz()
        .bar.Bar
        .builder()
        .build()
```

Closes #2602

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
