### PR TITLE
Prevent exception in `binary-expression-wrapping` rule

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -468,7 +468,7 @@ private fun Sequence<ASTNode>.dropTrailingEolComment(): Sequence<ASTNode> =
     }
 
 internal fun ASTNode.getFirstLeafOnLineOrSelf() =
-    prevLeaf { it.textContains('\n') || it.prevLeaf() == null }
+    prevLeaf { (it.textContains('\n') && !it.isPartOfComment()) || it.prevLeaf() == null }
         ?: this
 
 internal fun ASTNode.getLastLeafOnLineOrNull() = nextLeaf { it.textContains('\n') }?.prevLeaf()

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -948,6 +948,25 @@ class ASTNodeExtensionTest {
         assertThat(actual).contains(code)
     }
 
+    @Test
+    fun `Issue 2602 - Given that getFirstLeafOnLineOrSelf is called for a block comment containing a new line then do not throw a null pointer exception`() {
+        val code =
+            """
+            val foo = /* some
+                comment */ "foo"
+            """.trimIndent()
+
+        val actual =
+            transformCodeToAST(code)
+                .lastChildLeafOrSelf()
+                .getFirstLeafOnLineOrSelf()
+                .text
+
+        // The newline (and indentation spaces) before the word "comment" inside the block comment is entirely ignored. As there are no
+        // whitespace nodes containing a newline, this piece of code is considered to be a oneliner starting with the word "val".
+        assertThat(actual).contains("val")
+    }
+
     @Nested
     inner class HasModifier {
         @Test

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -14,6 +14,7 @@ import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine
+import com.pinterest.ktlint.rule.engine.core.api.lineLengthWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.parent
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
@@ -100,25 +101,12 @@ public class MaxLineLengthRule :
     }
 
     private fun ASTNode.lineLength() =
-        leavesOnLine(excludeEolComment = false)
-            .sumOf {
-                when {
-                    it.isWhiteSpaceWithNewline() -> {
-                        it.text.substringAfterLast('\n').length
-                    }
-
+        leavesOnLine(false)
+            .filterNot {
+                ignoreBackTickedIdentifier &&
                     it.elementType == IDENTIFIER &&
-                        it.text.matches(BACKTICKED_IDENTIFIER_REGEX) &&
-                        ignoreBackTickedIdentifier
-                    -> {
-                        0
-                    }
-
-                    else -> {
-                        it.textLength
-                    }
-                }
-            }
+                    it.text.matches(BACKTICKED_IDENTIFIER_REGEX)
+            }.lineLengthWithoutNewlinePrefix()
 
     private fun ASTNode.isPartOfRawMultiLineString() =
         parent(STRING_TEMPLATE, strict = false)


### PR DESCRIPTION
## Description

Prevent exception in `binary-expression-wrapping` rule in case it is preceded on the same line by a block comment containing a newline character

Function `leavesOnLine` calls function `getFirstLeafOnLineOrSelf` which finds the first leaf on the line by looking for newline character. A block comment containing a newline character resulted in considering that block comment to be the first element on the line, even in case it was preceded by other elements on the same line.

Due to this change, the `max-line-length` rule failed, which has been resolved by refactoring the calculation of the line length.

Closes #2601

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
