### PR TITLE
Fix replacement of redundant curly braces

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StringTemplateRuleTest.kt
@@ -345,4 +345,27 @@ class StringTemplateRuleTest {
             """.trimIndent()
         stringTemplateRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2615 - Given a string template with redundant curly braces then do not remove the corresponding import`() {
+        // Interpret "$." in code samples below as "$". It is used whenever the code which has to be inspected should
+        // actually contain a string template. Using "$" instead of "$." would result in a String in which the string
+        // templates would have been evaluated before the code would actually be processed by the rule.
+        val code =
+            """
+            import java.io.File.separator
+
+            val s = "$.{separator} is a file separator"
+            """.trimIndent().replaceStringTemplatePlaceholder()
+        val formattedCode =
+            """
+            import java.io.File.separator
+
+            val s = "$.separator is a file separator"
+            """.trimIndent().replaceStringTemplatePlaceholder()
+        stringTemplateRuleAssertThat(code)
+            .addAdditionalRuleProvider { NoUnusedImportsRule() }
+            .hasNoLintViolationsForRuleId(NO_UNUSED_IMPORTS_RULE_ID)
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Due to incorrect construction of the string template, it could happen that an import is removed as it was falsely flagged as unused as the "$" was added as prefix in the identifier.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
