### PR TITLE
Fix unwanted whitespace between super class constructor and its argument list

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -584,6 +584,21 @@ public class ClassSignatureRule :
                 }
         }
 
+        // Disallow:
+        //    class Foo : Bar<String> ("foobar")
+        superTypes
+            .filter { it.elementType == SUPER_TYPE_CALL_ENTRY }
+            .forEach { superTypeCallEntry ->
+                superTypeCallEntry
+                    .findChildByType(WHITE_SPACE)
+                    ?.let { whitespace ->
+                        emit(whitespace.startOffset, "No whitespace expected", true)
+                        if (autoCorrect) {
+                            whitespace.treeParent.removeChild(whitespace)
+                        }
+                    }
+            }
+
         return whiteSpaceCorrection
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
@@ -9,6 +9,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -46,7 +47,8 @@ public class SpacingAroundParensRule : StandardRule("paren-spacing") {
                                 node.treeParent?.treeParent?.elementType != FUNCTION_TYPE ||
                                 // Super keyword needs special-casing
                                 prevLeaf.prevLeaf()?.elementType == SUPER_KEYWORD ||
-                                prevLeaf.prevLeaf()?.treeParent?.elementType == PRIMARY_CONSTRUCTOR
+                                prevLeaf.prevLeaf()?.treeParent?.elementType == PRIMARY_CONSTRUCTOR ||
+                                prevLeaf.prevLeaf()?.treeParent?.elementType == TYPE_ARGUMENT_LIST
                         ) &&
                         (
                             node.treeParent?.elementType == VALUE_PARAMETER_LIST ||

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1734,6 +1734,55 @@ class ClassSignatureRuleTest {
             .hasNoLintViolations()
     }
 
+    @Nested
+    inner class `Issue 2630 - White space in super type call entry` {
+        @Test
+        fun `Issue 2630 - Given a super type call entry without type argument list`() {
+            val code =
+                """
+                class Foo1 : Bar("foobar")
+                class Foo2 : Bar ("foobar")
+                class Foo3 : Bar
+                    ("foobar")
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo1 : Bar("foobar")
+                class Foo2 : Bar("foobar")
+                class Foo3 : Bar("foobar")
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(2, 17, "No whitespace expected"),
+                    LintViolation(3, 14, "Super type should start on a newline"),
+                    LintViolation(3, 17, "No whitespace expected"),
+                ).isFormattedAs(formattedCode)
+        }
+
+        @Test
+        fun `Issue 2630 - Given a super type call entry with type argument list`() {
+            val code =
+                """
+                class Foo1 : Bar<String>("foobar")
+                class Foo2 : Bar<String> ("foobar")
+                class Foo3 : Bar<String>
+                    ("foobar")
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Foo1 : Bar<String>("foobar")
+                class Foo2 : Bar<String>("foobar")
+                class Foo3 : Bar<String>("foobar")
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .hasLintViolations(
+                    LintViolation(2, 25, "No whitespace expected"),
+                    LintViolation(3, 14, "Super type should start on a newline"),
+                    LintViolation(3, 25, "No whitespace expected"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
@@ -29,6 +29,40 @@ class SpacingAroundParensRuleTest {
     }
 
     @Test
+    fun `Given class with superclass constructor call`() {
+        val code =
+            """
+            open class Bar(param: String)
+            class Foo : Bar ("test")
+            """.trimIndent()
+        val formattedCode =
+            """
+            open class Bar(param: String)
+            class Foo : Bar("test")
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code)
+            .hasLintViolation(2, 16, "Unexpected spacing before \"(\"")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given class with superclass constructor call with type parameter`() {
+        val code =
+            """
+            open class Bar<T>(param: T)
+            class Foo : Bar<String> ("test")
+            """.trimIndent()
+        val formattedCode =
+            """
+            open class Bar<T>(param: T)
+            class Foo : Bar<String>("test")
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code)
+            .hasLintViolation(2, 24, "Unexpected spacing before \"(\"")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given a variable declaration with unexpected spacing around the opening parenthesis of the expression`() {
         val code =
             """


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

Adds support for detecting whitespace before a value argument list when it follows the type argument list of a constructor call.

This is needed to correctly detect and remove the excess whitespace in the following sample:

```kotlin
class MyClass : MySuper<String> ("hello")
```

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] ~~At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)~~
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] ~~[Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change~~
- [ ] ~~[Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master~~
