### PR TITLE
Suppress `property-name` rule for `ObjectPropertyName` or `PrivatePropertyName`

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -586,7 +586,7 @@ Enforce naming of property.
     }
     ```
 
-This rule can also be suppressed with the IntelliJ IDEA inspection suppression `PropertyName` or `ConstPropertyName`.
+This rule is suppressed whenever the IntelliJ IDEA inspection suppression `PropertyName`, `ConstPropertyName`, `ObjectPropertyName` or `PrivatePropertyName` is used.
 
 Rule id: `property-naming` (`standard` rule set)
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorBuilder.kt
@@ -43,6 +43,8 @@ internal object SuppressionLocatorBuilder {
             "PackageName" to "standard:package-name",
             "PropertyName" to "standard:property-naming",
             "ConstPropertyName" to "standard:property-naming",
+            "ObjectPropertyName" to "standard:property-naming",
+            "PrivatePropertyName" to "standard:property-naming",
             "UnusedImport" to "standard:no-unused-imports",
         )
     private val SUPPRESS_ANNOTATIONS = setOf("Suppress", "SuppressWarnings")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -286,4 +286,26 @@ class PropertyNamingRuleTest {
             """.trimIndent()
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2612 - Given a property name suppressed via 'PrivatePropertyName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            class Foo {
+                @Suppress("PrivatePropertyName")
+                private val Bar = "Bar"
+            }
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2612 - Given a property name suppressed via 'ObjectPropertyName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            @Suppress("ObjectPropertyName")
+            private const val _Foo_Bar = ""
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

When Intellij IDEA suppressions `ObjectPropertyName` or `PrivatePropertyName` are used, then also suppress ktlint `property-naming` rule.

Closes #2612

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
