### PR TITLE
Handle trailing space on preceding line in call to `lineLengthWithoutNewlinePrefix`

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -502,7 +502,7 @@ public fun ASTNode.lineLength(excludeEolComment: Boolean = false): Int = leavesO
  */
 public fun Sequence<ASTNode>.lineLengthWithoutNewlinePrefix(): Int {
     val first = firstOrNull() ?: return 0
-    require(first.text.startsWith('\n') || first.prevLeaf() == null) {
+    require(first.textContains('\n') || first.prevLeaf() == null) {
         "First node in non-empty sequence must be a whitespace containing a newline"
     }
     return joinToString(separator = "") { it.text }

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -18,7 +18,9 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.test.SPACE
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatNoException
 import org.assertj.core.api.Assertions.entry
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
@@ -760,6 +762,30 @@ class ASTNodeExtensionTest {
                 "    fun foo3".length,
                 "        val foo4".length,
             )
+        }
+
+        @Suppress("DEPRECATION")
+        @Test
+        fun `xxGiven some lines containing identifiers at different indentation levels then get line length exclusive the leading newline characters until and including the identifier`() {
+            val code =
+                """
+                val foo1 = "foo1"$SPACE
+                val foo2 = "foo2"
+                """.trimIndent()
+
+            assertThatNoException()
+                .isThrownBy {
+                    transformCodeToAST(code)
+                        .firstChildLeafOrSelf()
+                        .leaves()
+                        .filter { it.elementType == IDENTIFIER }
+                        .map { identifier ->
+                            identifier
+                                .leavesOnLine()
+                                .takeWhile { it.prevLeaf() != identifier }
+                                .lineLengthWithoutNewlinePrefix()
+                        }.toList()
+                }
         }
     }
 


### PR DESCRIPTION
## Description

If first line in code below ends with a trailing space, an exception was thrown when calling method `lineLengthWithoutNewlinePrefix` for a node on line 2:
```
val foo1 = "foo1"
val foo2 = "foo2"
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
