### PR TITLE
Fix not checking for spacing around binary operators inside unary expression

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
@@ -31,6 +31,7 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
+import com.pinterest.ktlint.rule.engine.core.api.parent
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
@@ -39,6 +40,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtOperationExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 
 @SinceKtlint("0.1", STABLE)
@@ -107,7 +109,7 @@ public class SpacingAroundOperatorsRule : StandardRule("op-spacing") {
         }
     }
 
-    private fun ASTNode.isUnaryOperator() = isPartOf(KtPrefixExpression::class)
+    private fun ASTNode.isUnaryOperator() = parent { it.psi is KtOperationExpression }?.psi is KtPrefixExpression
 
     private fun ASTNode.isSpreadOperator() =
         // fn(*array)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRuleTest.kt
@@ -314,4 +314,28 @@ class SpacingAroundOperatorsRuleTest {
                 LintViolation(4, 41, "Missing spacing after \"andThen\""),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a binary operator inside a unary expression`() {
+        val code =
+            """
+            val foo1 = !(null?:true)
+            val foo2 = !(null?: true)
+            val foo3 = !(null ?:true)
+            val foo4 = !(null ?: true)
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo1 = !(null ?: true)
+            val foo2 = !(null ?: true)
+            val foo3 = !(null ?: true)
+            val foo4 = !(null ?: true)
+            """.trimIndent()
+        spacingAroundOperatorsRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(1, 18, "Missing spacing around \"?:\""),
+                LintViolation(2, 18, "Missing spacing before \"?:\""),
+                LintViolation(3, 21, "Missing spacing after \"?:\""),
+            ).isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

Fixes #2652

For the [operator spacing](https://pinterest.github.io/ktlint/latest/rules/standard/#operator-spacing) standard rule, instead of checking for whether any ancestor element is a KtPrefixExpression, check whether the closest ancestor that is a KtOperationExpression is a KtPrefixExpression.

This change will identify the case where the operator is inside a binary expression inside a prefix expression as **not** being a unary operator, and hence subject to the operator spacing checks.

* PREFIX_EXPRESSION
  * PARENTHESIZED
    * BINARY_EXPRESSION
      * OPERATION_REFERENCE
        * PsiElement(ELVIS)

The closest ancestor of KtPrefixExpression and KtBinaryExpression seems to be KtOperationExpression, so I've opted to use that as the predicate when searching through the ancestors. KtExpressionImpl seems to cover a lot more expression types. Alternatively, it might be possible to specifically search for the closest parent that is either KtPrefixExpression or KtBinaryExpression?

* `abstract class KtExpressionImpl : KtElementImpl(node), KtExpression`
* `interface KtOperationExpression extends KtExpression`
  * `abstract class KtUnaryExpression extends KtExpressionImpl implements KtOperationExpression`
    * `class KtPrefixExpression extends KtUnaryExpression`
    * `class KtPostfixExpression extends KtUnaryExpression`
  * `class KtBinaryExpression extends KtExpressionImpl implements KtOperationExpression`
  * `class KtIsExpression extends KtExpressionImpl implements KtOperationExpression`

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
