### PR TITLE
Fixed [{ }] notation for issue #2675

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
@@ -87,7 +87,7 @@ public class SpacingAroundCurlyRule :
                         prevLeaf is PsiWhiteSpace ||
                         prevLeaf?.elementType == AT ||
                         (
-                            prevLeaf?.elementType == LPAR &&
+                            (prevLeaf?.elementType == LPAR || prevLeaf?.elementType == LBRACKET) &&
                                 ((node as LeafPsiElement).parent is KtLambdaExpression || node.parent.parent is KtLambdaExpression)
                         )
                     spacingAfter = nextLeaf is PsiWhiteSpace || nextLeaf?.elementType == RBRACE

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
@@ -180,6 +180,29 @@ class SpacingAroundCurlyRuleTest {
     }
 
     @Test
+    fun `Issue 2675 - operator get with lambda`() {
+        val code =
+            """
+            val foo1 = bar[{a -> a}]
+            val foo2 = bar[{ }]
+            val foo3 = bar[{}]
+            """.trimIndent()
+
+        val formattedCode =
+            """
+            val foo1 = bar[{ a -> a }]
+            val foo2 = bar[{ }]
+            val foo3 = bar[{}]
+            """.trimIndent()
+
+        spacingAroundCurlyRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(line = 1, col = 17, detail = "Missing spacing after \"{\"", canBeAutoCorrected = true),
+                LintViolation(line = 1, col = 23, detail = "Missing spacing before \"}\"", canBeAutoCorrected = true),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given curly braces inside a string template`() {
         val code =
             """

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
@@ -180,7 +180,7 @@ class SpacingAroundCurlyRuleTest {
     }
 
     @Test
-    fun `Issue 2675 - operator get with lambda`() {
+    fun `Issue 2675 - array access expression containing a lambda expression`() {
         val code =
             """
             val foo1 = bar[{a -> a}]
@@ -197,8 +197,8 @@ class SpacingAroundCurlyRuleTest {
 
         spacingAroundCurlyRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(line = 1, col = 17, detail = "Missing spacing after \"{\"", canBeAutoCorrected = true),
-                LintViolation(line = 1, col = 23, detail = "Missing spacing before \"}\"", canBeAutoCorrected = true),
+                LintViolation(1, 17, "Missing spacing after \"{\"", canBeAutoCorrected = true),
+                LintViolation(1, 23, "Missing spacing before \"}\"", canBeAutoCorrected = true),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
@@ -128,7 +128,7 @@ class SpacingAroundSquareBracketsRuleTest {
     }
 
     @Test
-    fun `Issue 2675 - operator get with lambda`() {
+    fun `Issue 2675 - array access expression containing a lambda expression`() {
         val code =
             """
             val foo = bar[ { 123 } ]
@@ -141,8 +141,8 @@ class SpacingAroundSquareBracketsRuleTest {
 
         spacingAroundSquareBracketsRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(line = 1, col = 15, detail = "Unexpected spacing after '['", canBeAutoCorrected = true),
-                LintViolation(line = 1, col = 23, detail = "Unexpected spacing before ']'", canBeAutoCorrected = true),
+                LintViolation(1, 15, "Unexpected spacing after '['", canBeAutoCorrected = true),
+                LintViolation(1, 23, "Unexpected spacing before ']'", canBeAutoCorrected = true),
             ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class SpacingAroundSquareBracketsRuleTest {
@@ -124,5 +125,24 @@ class SpacingAroundSquareBracketsRuleTest {
             fun foo() {}
             """.trimIndent()
         spacingAroundSquareBracketsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2675 - operator get with lambda`() {
+        val code =
+            """
+            val foo = bar[ { 123 } ]
+            """.trimIndent()
+
+        val formattedCode =
+            """
+            val foo = bar[{ 123 }]
+            """.trimIndent()
+
+        spacingAroundSquareBracketsRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(line = 1, col = 15, detail = "Unexpected spacing after '['", canBeAutoCorrected = true),
+                LintViolation(line = 1, col = 23, detail = "Unexpected spacing before ']'", canBeAutoCorrected = true),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/pinterest/ktlint/issues/2675

## Description

Fixes the erroneous error for notations like `[{ }]`, as described in the issue.
The `}]` case was already handled by https://github.com/pinterest/ktlint/pull/596, but the `[{` notation needed some additional fix. There was a special exception for `({`, and since this one is similar, I added the case for LBRACKET too.

Two tests were added, one to check that notations like `[{ a -> a }]`, `[{ }]`, and `[{}]` are allowed, and a second one to check that `[ { } ]` is formatted correctly.