### PR TITLE
Do not insert a whitespace element as first or last child inside a composite element

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -238,13 +238,17 @@ public fun ASTNode.upsertWhitespaceBeforeMe(text: String) {
             return replaceWhitespaceWith(text)
         }
         val previous = treePrev ?: prevLeaf()
-        if (previous != null && previous.elementType == WHITE_SPACE) {
-            previous.replaceWhitespaceWith(text)
-        } else {
-            if (treeParent.firstChildNode == this) {
+        when {
+            previous?.elementType == WHITE_SPACE -> {
+                previous.replaceWhitespaceWith(text)
+            }
+
+            treeParent.firstChildNode == this -> {
                 // Never insert a whitespace node as first node in a composite node
                 treeParent.upsertWhitespaceBeforeMe(text)
-            } else {
+            }
+
+            else -> {
                 PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
                     (psi as LeafElement).rawInsertBeforeMe(psiWhiteSpace)
                 }
@@ -289,13 +293,17 @@ public fun ASTNode.upsertWhitespaceAfterMe(text: String) {
             return replaceWhitespaceWith(text)
         }
         val next = treeNext ?: nextLeaf()
-        if (next != null && next.elementType == WHITE_SPACE) {
-            next.replaceWhitespaceWith(text)
-        } else {
-            if (treeParent.lastChildNode == this) {
+        when {
+            next?.elementType == WHITE_SPACE -> {
+                next.replaceWhitespaceWith(text)
+            }
+
+            treeParent.lastChildNode == this -> {
                 // Never insert a whitespace as last node in a composite node
                 treeParent.upsertWhitespaceAfterMe(text)
-            } else {
+            }
+
+            else -> {
                 PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
                     (psi as LeafElement).rawInsertAfterMe(psiWhiteSpace)
                 }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -241,8 +241,13 @@ public fun ASTNode.upsertWhitespaceBeforeMe(text: String) {
         if (previous != null && previous.elementType == WHITE_SPACE) {
             previous.replaceWhitespaceWith(text)
         } else {
-            PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                (psi as LeafElement).rawInsertBeforeMe(psiWhiteSpace)
+            if (treeParent.firstChildNode == this) {
+                // Never insert a whitespace node as first node in a composite node
+                treeParent.upsertWhitespaceBeforeMe(text)
+            } else {
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
+                    (psi as LeafElement).rawInsertBeforeMe(psiWhiteSpace)
+                }
             }
         }
     } else {
@@ -287,15 +292,20 @@ public fun ASTNode.upsertWhitespaceAfterMe(text: String) {
         if (next != null && next.elementType == WHITE_SPACE) {
             next.replaceWhitespaceWith(text)
         } else {
-            PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
-                (psi as LeafElement).rawInsertAfterMe(psiWhiteSpace)
+            if (treeParent.lastChildNode == this) {
+                // Never insert a whitespace as last node in a composite node
+                treeParent.upsertWhitespaceAfterMe(text)
+            } else {
+                PsiWhiteSpaceImpl(text).also { psiWhiteSpace ->
+                    (psi as LeafElement).rawInsertAfterMe(psiWhiteSpace)
+                }
             }
         }
     } else {
         when (val nextSibling = nextSibling()) {
             null -> {
                 // Never insert a whitespace element as last child node in a composite node. Instead, upsert just after the composite node
-                treeParent.upsertWhitespaceAfterMe(text)
+                treeParent?.upsertWhitespaceAfterMe(text)
             }
 
             is LeafElement -> {

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIVATE_KEYWORD
@@ -457,6 +458,31 @@ class ASTNodeExtensionTest {
 
             assertThat(actual).isEqualTo(formattedCode)
         }
+
+        @Test
+        fun `Issue 2688 - Given a class without a space between the identifier and the left curly brace then insert the whitespace at the correct position in the AST`() {
+            val code =
+                """
+                class Foo{
+                    // some comment
+                }
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        findChildByType(CLASS)
+                            ?.findChildByType(CLASS_BODY)
+                            ?.findChildByType(LBRACE)
+                            ?.upsertWhitespaceBeforeMe(" ")
+                    }.findChildByType(CLASS)
+                    ?.findChildByType(CLASS_BODY)
+                    ?.prevSibling()
+                    ?.let { it.elementType == WHITE_SPACE && it.text == " " }
+                    ?: false
+
+            assertThat(actual).isTrue()
+        }
     }
 
     @Nested
@@ -603,6 +629,31 @@ class ASTNodeExtensionTest {
                     }.text
 
             assertThat(actual).isEqualTo(formattedCode)
+        }
+
+        @Test
+        fun `Issue 2688 - Given a class without a space between the identifier and the left curly brace then insert the whitespace at the correct position in the AST`() {
+            val code =
+                """
+                fun foo(){
+                    // some comment
+                }
+                """.trimIndent()
+
+            val actual =
+                code
+                    .transformAst {
+                        findChildByType(FUN)
+                            ?.findChildByType(VALUE_PARAMETER_LIST)
+                            ?.findChildByType(RPAR)
+                            ?.upsertWhitespaceAfterMe(" ")
+                    }.findChildByType(FUN)
+                    ?.findChildByType(VALUE_PARAMETER_LIST)
+                    ?.nextSibling()
+                    ?.let { it.elementType == WHITE_SPACE && it.text == " " }
+                    ?: false
+
+            assertThat(actual).isTrue()
         }
     }
 


### PR DESCRIPTION
## Description

Prevent inserting a whitespace element as first or last element in a composite node. In such cases insert the whitespace just before or after the composite element (recursively if needed). 

#2688 shows an example in which two different rules were inserting a whitespace at the same position in the code fragment but at different places in the AST. As a result two spaces were added to the formatted code instead of one.

Closes #2688

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
