### PR TITLE
Do not rewrite a class to a single line signature in case it contains an EOL comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -169,11 +169,18 @@ public class ClassSignatureRule :
                 node.containsMultilineParameter() ||
                 (codeStyle == ktlint_official && node.containsAnnotatedParameter()) ||
                 (isMaxLineLengthSet() && classSignatureExcludingSuperTypesExceedsMaxLineLength(node, emit)) ||
-                (!isMaxLineLengthSet() && node.classSignatureExcludingSuperTypesIsMultiline())
+                (!isMaxLineLengthSet() && node.classSignatureExcludingSuperTypesIsMultiline()) ||
+                node.containsEolComment()
         fixWhiteSpacesInValueParameterList(node, emit, multiline = wrapPrimaryConstructorParameters, dryRun = false)
         fixWhitespacesInSuperTypeList(node, emit, wrappedPrimaryConstructor = wrapPrimaryConstructorParameters)
         fixClassBody(node, emit)
     }
+
+    private fun ASTNode.containsEolComment() =
+        getPrimaryConstructorParameterListOrNull()
+            ?.children()
+            ?.any { it.elementType == EOL_COMMENT }
+            ?: false
 
     private fun classSignatureExcludingSuperTypesExceedsMaxLineLength(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERT
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.intellij_idea
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue.ktlint_official
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
 import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider
 import com.pinterest.ktlint.ruleset.standard.rules.ClassSignatureRule.Companion.FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY
@@ -1780,6 +1781,57 @@ class ClassSignatureRuleTest {
                     LintViolation(3, 14, "Super type should start on a newline"),
                     LintViolation(3, 25, "No whitespace expected"),
                 ).isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
+    inner class `Issue 2689 - Given a multiline class containing an EOL comment` {
+        @Test
+        fun `Issue 2689 - Given ktlint_official code style`() {
+            val code =
+                """
+                data class Foo(
+                    // Foo
+                    val foo: String,
+                    val bar: String,
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                // Unset the property that forces the class always to be written as multiline signature
+                .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2689 - Given android_studio code style`() {
+            val code =
+                """
+                data class Foo(
+                    // Foo
+                    val foo: String,
+                    val bar: String,
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.android_studio)
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2689 - Given intellij_idea code style`() {
+            val code =
+                """
+                data class Foo(
+                    // Foo
+                    val foo: String,
+                    val bar: String,
+                )
+                """.trimIndent()
+            classSignatureWrappingRuleAssertThat(code)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.intellij_idea)
+                // Set max_line_length as other the class signature would not be rewritten to single line
+                .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 999)
+                .hasNoLintViolations()
         }
     }
 


### PR DESCRIPTION
## Description

Do not rewrite a class to a single line signature in case it contains an EOL comment.

Closes #2689

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
