### PR TITLE
Fix false positive when primary constructor has no arguments and a secondary constructor exists

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
@@ -266,6 +267,19 @@ public class ClassSignatureRule :
                 // Allow:
                 //     class Foo constructor() { ... }
                 it.prevCodeSibling()?.elementType == CONSTRUCTOR_KEYWORD
+            }?.takeUnless {
+                // Allow
+                //     class Foo() {
+                //         constructor(foo: String): this() {
+                //             println(foo)
+                //         }
+                //     }
+                node
+                    .findChildByType(CLASS_BODY)
+                    ?.findChildByType(ElementType.SECONDARY_CONSTRUCTOR)
+                    ?.findChildByType(ElementType.CONSTRUCTOR_DELEGATION_CALL)
+                    ?.firstChildNode
+                    ?.elementType == ElementType.CONSTRUCTOR_DELEGATION_REFERENCE
             }?.let { parameterList ->
                 if (!dryRun) {
                     emit(parameterList.startOffset, "No parenthesis expected", true)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1837,15 +1837,15 @@ class ClassSignatureRuleTest {
 
     @Test
     fun `Issue 2690 - Given an empty primary constructor and secondary constructor with delegation reference`() {
-      val code =
-          """
-          class Foo() {
-              constructor(foo: String) : this() {
-                  // N/A
-              }
-          }
-          """.trimIndent()
-      classSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
+        val code =
+            """
+            class Foo() {
+                constructor(foo: String) : this() {
+                    // N/A
+                }
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
     private companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1783,6 +1783,19 @@ class ClassSignatureRuleTest {
         }
     }
 
+    @Test
+    fun `Issue 2690 - Given an empty primary constructor and secondary constructor with delegation reference`() {
+        val code =
+            """
+            class Foo() {
+                constructor(foo: String) : this() {
+                    // N/A
+                }
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""


### PR DESCRIPTION
## Description

Fix false positive when primary constructor has no arguments and a secondary constructor exists

Closes #2690

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
