### PR TITLE
2696 no unused imports

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/CodeFormatter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/CodeFormatter.kt
@@ -128,13 +128,6 @@ internal class CodeFormatter(
                 .also { autocorrectDecision ->
                     // Ignore decision of the API Consumer in case the error can not be autocorrected
                     val autocorrect = autocorrectDecision == ALLOW_AUTOCORRECT && canBeAutoCorrected
-                    if (autocorrect) {
-                        /*
-                         * Rebuild the suppression locator after each change in the AST as the offsets of the suppression hints might
-                         * have changed.
-                         */
-                        rebuildSuppressionLocator()
-                    }
                     errors.add(
                         Pair(
                             lintError,

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class SuppressionLocatorBuilderTest {
+class SuppressionLocatorTest {
     @Test
     fun `Given that NoFooIdentifierRule finds a violation (eg verifying that the test rules actually works)`() {
         val code =


### PR DESCRIPTION
## Description

Imports which are only used in code blocks which are suppressed for ktlint should not be reported as unused as removal results in compilation errors.

Refactored the code so that a rule can be marked with interface `IgnoreKtlintSuppressions` to indicate that all suppression for this rule are to be ignored.

The former SuppressionLocator lambda and object SuppressionLocatorBuilder are now replaced with the class SuppressionLocator. Upon each check whether a ASTNode has to be suppressed, it is also determined whether it is needed to rebuild the suppression hints. This is only needed when the code that is represented by the AST has been changed.

The CodeFormatter no longer has to rebuild the suppression locator after autocorrect. This responsibility is now moved into the RuleExecutionContext and SuppressionLocator itself.

Closes #2696 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
