### PR TITLE
Fix false alert `Format was not able to resolve all violations which (theoretically) can be autocorrected`

### DIFF
--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/api/BaselineCLITest.kt
@@ -49,6 +49,7 @@ class BaselineCLITest {
                     projectName,
                     listOf(
                         "--baseline=$baselinePath",
+                        "--format",
                         "TestBaselineFile.kt.test",
                         "some/path/to/TestBaselineFile.kt.test",
                     ),
@@ -65,6 +66,10 @@ class BaselineCLITest {
                                         ".*Baseline file '$baselinePath' contains 4 reference\\(s\\) to rule ids without a rule set id. " +
                                             "For those references the rule set id 'standard' is assumed. It is advised to regenerate " +
                                             "this baseline file.*",
+                                    ),
+                                ).doesNotContainLineMatching(
+                                    Regex(
+                                        ".*Format was not able to resolve all violations which \\(theoretically\\) can be autocorrected in file.*",
                                     ),
                                 )
                         }.assertAll()

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/CodeFormatter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/CodeFormatter.kt
@@ -55,7 +55,9 @@ internal class CodeFormatter(
                 mutated =
                     format(autocorrectHandler, code).let { ruleErrors ->
                         errors.addAll(ruleErrors)
-                        ruleErrors.any { it.first.canBeAutoCorrected }
+                        // Check if at least one error can be autocorrected, and fixing this error has been approved by the autocorrect
+                        // handler
+                        ruleErrors.any { it.first.canBeAutoCorrected && it.second }
                     }
                 formatRunCount++
             } while (mutated && formatRunCount < maxFormatRunsPerFile)
@@ -116,10 +118,6 @@ internal class CodeFormatter(
         executeRule(rule, autocorrectHandler) { offset, errorMessage, canBeAutoCorrected ->
             val (line, col) = positionInTextLocator(offset)
             val lintError = LintError(line, col, rule.ruleId, errorMessage, canBeAutoCorrected)
-            // In trace mode report the violation immediately. The order in which violations are actually found might be
-            // different from the order in which they are reported. For debugging purposes it can be helpful to know the
-            // exact order in which violations are being solved.
-            LOGGER.trace { "Format violation: ${lintError.logMessage(code)}" }
 
             // Always request the autocorrectDecision, even in case it is already known that the LintError can not be autocorrected. In
             // this way the API Consumer can still use data from the LintError for other purposes.
@@ -128,6 +126,12 @@ internal class CodeFormatter(
                 .also { autocorrectDecision ->
                     // Ignore decision of the API Consumer in case the error can not be autocorrected
                     val autocorrect = autocorrectDecision == ALLOW_AUTOCORRECT && canBeAutoCorrected
+                    if (autocorrect) {
+                        // In trace mode report the violation immediately. The order in which violations are actually found might be
+                        // different from the order in which they are reported. For debugging purposes it can be helpful to know the
+                        // exact order in which violations are being solved.
+                        LOGGER.trace { "Format violation: ${lintError.logMessage(code)}" }
+                    }
                     errors.add(
                         Pair(
                             lintError,


### PR DESCRIPTION
## Description

The warning "Format was not able to resolve all violations" should not be logged in case the code only contains lint violations which may not be autocorrected according to the AutoCorrectHandler.

Closes #2726 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
