### PR TITLE
Fix "unset" value for property ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -489,7 +489,7 @@ public class ChainMethodContinuationRule :
         private val chainOperatorTokenSet = TokenSet.create(DOT, SAFE_ACCESS)
         private val groupClosingElementType = TokenSet.create(CLOSING_QUOTE, RBRACE, RBRACKET, RPAR)
 
-        private const val FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET = 4
+        private const val FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET = Int.MAX_VALUE
         public val FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY: EditorConfigProperty<Int> =
             EditorConfigProperty(
                 type =
@@ -500,7 +500,7 @@ public class ChainMethodContinuationRule :
                         PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
                         setOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "unset"),
                     ),
-                defaultValue = FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET,
+                defaultValue = 4,
                 propertyMapper = { property, _ ->
                     if (property?.isUnset == true) {
                         FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY_UNSET

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -1117,4 +1117,16 @@ class ChainMethodContinuationRuleTest {
                 LintViolation(4, 59, "Expected newline before '.'"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2712 - Given some code having more chain operators than the default, but with ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than unset`() {
+        val code =
+            """
+            val foo = listOf(1, 2, 3).plus(4).plus(5).plus(6).plus(7).plus(8)
+            """.trimIndent()
+        require(code.count { it == '.' } > FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY.defaultValue)
+        chainMethodContinuationRuleAssertThat(code)
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix "unset" value for property ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than

When value is set to "unset" the number of chain operators on a single line is not restricted as long as the max line length is not exceeded.

Closes #2712

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
