### PR TITLE
Support suppressing backing-property-naming via ObjectPropertyName

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
@@ -264,7 +264,7 @@ internal class SuppressionLocator(
                 "PackageName" to listOf("standard:package-name"),
                 "PropertyName" to listOf("standard:property-naming", "standard:backing-property-naming"),
                 "ConstPropertyName" to listOf("standard:property-naming"),
-                "ObjectPropertyName" to listOf("standard:property-naming"),
+                "ObjectPropertyName" to listOf("standard:property-naming", "standard:backing-property-naming"),
                 "PrivatePropertyName" to listOf("standard:property-naming"),
                 "UnusedImport" to listOf("standard:no-unused-imports"),
             )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -277,6 +277,7 @@ class BackingPropertyNamingRuleTest {
         strings = [
             "ktlint:standard:backing-property-naming",
             "PropertyName", // IntelliJ IDEA suppression
+            "ObjectPropertyName", // IntelliJ IDEA suppression
         ],
     )
     fun `Given a property with a disallowed name which is suppressed`(suppressionName: String) {


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

Follow up #2741.

Allow the usages in Compose like:

```kt
import androidx.compose.ui.graphics.vector.ImageVector

val Folder: ImageVector
    get() {
        // ...
        return _folder!!
    }

@Suppress("ObjectPropertyName")
private var _folder: ImageVector? = null
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
