### PR TITLE
Ignore properties starting with `_` in `backing-property-naming` rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.INTERNAL_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OVERRIDE_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIVATE_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PROTECTED_KEYWORD
@@ -53,7 +54,10 @@ public class BackingPropertyNamingRule :
         property
             .findChildByType(IDENTIFIER)
             ?.takeIf { it.text.startsWith("_") }
-            ?.let { identifier ->
+            ?.takeUnless {
+                // Do not report overridden properties as they can only be changed by changing the base property
+                it.treeParent.hasModifier(OVERRIDE_KEYWORD)
+            }?.let { identifier ->
                 visitBackingProperty(identifier, emit)
             }
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -344,4 +344,18 @@ class BackingPropertyNamingRuleTest {
             """.trimIndent()
         backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2748 - Given an override property with name starting with '_' then do not report a violation`() {
+        val code =
+            """
+            // The property "__foo" in example below can be defined in an external dependency, which can not be changed. Even in case it is
+            // a (internal) dependency that can be changed, the violation should only be reported at the base property, but on the overrides
+            val fooBar =
+                object : FooBar {
+                    override val __foo = "foo"
+                }
+            """.trimIndent()
+        backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Name of an overridden property can only be changed by changing the name of the base property.

Closes #2748

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
