### PR TITLE
fix: don't remove arrow from lambdas that are when/if leaf nodes

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -4,13 +4,16 @@ import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ELSE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THEN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -365,7 +368,10 @@ public class FunctionLiteralRule :
     ) {
         require(arrow.elementType == ARROW)
         arrow
-            .prevSibling { it.elementType == VALUE_PARAMETER_LIST }
+            .takeIf {
+                val parent = arrow.parent(LAMBDA_EXPRESSION)?.treeParent?.elementType
+                parent != WHEN_ENTRY && parent != THEN && parent != ELSE
+            }?.prevSibling { it.elementType == VALUE_PARAMETER_LIST }
             ?.takeIf { it.findChildByType(VALUE_PARAMETER) == null && arrow.isFollowedByNonEmptyBlock() }
             ?.let {
                 emit(arrow.startOffset, "Arrow is redundant when parameter list is empty", true)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -506,4 +506,69 @@ class FunctionLiteralRuleTest {
             """.trimIndent()
         functionLiteralRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `given function literal with an arrow without parameters arrow literal as leaf of when then do not remove the arrow`() {
+        val code =
+            """
+            val foo = when {
+                1 == 2 -> { -> "hi" }
+                else -> { -> "ho" }
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `given function literal with an arrow without parameters arrow literal not as leaf of when then do remove the arrow`() {
+        val code =
+            """
+            val foo = when {
+                else -> { { -> "ho" } }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = when {
+                else -> { { "ho" } }
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolation(2, 17, "Arrow is redundant when parameter list is empty")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `given function literal with an arrow without parameters arrow literal as leaf of if then do not remove the arrow`() {
+        val code =
+            """
+            val foo = if (cond) { -> "hi" } else { -> "ho" }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `given function literal with an arrow without parameters arrow literal not as leaf of if then do remove the arrow`() {
+        val code =
+            """
+            val foo = if (cond) {
+                { -> "hi" }
+            } else {
+                { -> "ho" }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = if (cond) {
+                { "hi" }
+            } else {
+                { "ho" }
+            }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 7, "Arrow is redundant when parameter list is empty"),
+                LintViolation(4, 7, "Arrow is redundant when parameter list is empty"),
+            ).isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -508,61 +508,68 @@ class FunctionLiteralRuleTest {
     }
 
     @Test
-    fun `given function literal with an arrow without parameters arrow literal as leaf of when then do not remove the arrow`() {
+    fun `Issue 2758 - Given function literal with an arrow without parameters arrow literal as leaf of when then do not remove the arrow`() {
         val code =
             """
-            val foo = when {
-                1 == 2 -> { -> "hi" }
-                else -> { -> "ho" }
-            }
+            val foo =
+                when {
+                    false -> { -> "bar" }
+                    else -> { -> "baz" }
+                }
             """.trimIndent()
         functionLiteralRuleAssertThat(code).hasNoLintViolations()
     }
 
     @Test
-    fun `given function literal with an arrow without parameters arrow literal not as leaf of when then do remove the arrow`() {
+    fun `Issue 2758 - Given function literal with an arrow without parameters arrow literal not as leaf of when then do remove the arrow`() {
         val code =
             """
-            val foo = when {
-                else -> { { -> "ho" } }
-            }
+            val foo =
+                when {
+                    false -> { { -> "bar" } }
+                    else -> { { -> "baz" } }
+                }
             """.trimIndent()
         val formattedCode =
             """
-            val foo = when {
-                else -> { { "ho" } }
-            }
+            val foo =
+                when {
+                    false -> { { "bar" } }
+                    else -> { { "baz" } }
+                }
             """.trimIndent()
         functionLiteralRuleAssertThat(code)
-            .hasLintViolation(2, 17, "Arrow is redundant when parameter list is empty")
-            .isFormattedAs(formattedCode)
+            .hasLintViolations(
+                LintViolation(3, 22, "Arrow is redundant when parameter list is empty"),
+                LintViolation(4, 21, "Arrow is redundant when parameter list is empty"),
+            ).isFormattedAs(formattedCode)
     }
 
     @Test
-    fun `given function literal with an arrow without parameters arrow literal as leaf of if then do not remove the arrow`() {
+    fun `Issue 2758 - Given function literal with an arrow without parameters arrow literal as leaf of if then do not remove the arrow`() {
         val code =
             """
-            val foo = if (cond) { -> "hi" } else { -> "ho" }
+            val foo = if (cond) { -> "bar" } else { -> "baz" }
             """.trimIndent()
         functionLiteralRuleAssertThat(code).hasNoLintViolations()
     }
 
     @Test
-    fun `given function literal with an arrow without parameters arrow literal not as leaf of if then do remove the arrow`() {
+    fun `Issue 2758 - Given function literal with an arrow without parameters arrow literal not as leaf of if then do remove the arrow`() {
         val code =
             """
             val foo = if (cond) {
-                { -> "hi" }
+                { -> "bar" }
             } else {
-                { -> "ho" }
+                { -> "baz" }
             }
             """.trimIndent()
         val formattedCode =
             """
             val foo = if (cond) {
-                { "hi" }
+                { "bar" }
             } else {
-                { "ho" }
+                { "baz" }
             }
             """.trimIndent()
         functionLiteralRuleAssertThat(code)


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

this fixes a problem with the `function-literal` rule removing non-redundant arrows from lambdas that are direct leafs of a when-entry or then/else. Without the arrow, the expression is left as a block instead.

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
