### PR TITLE
[Bugfix] `int` to `Int` migration

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -1041,7 +1041,7 @@ If at least one branch of an if-else statement or an if-else-if statement is wra
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
-    fun foo(value: int) {
+    fun foo(value: Int) {
         if (value > 0) {
             doSomething()
         } else if (value < 0) {
@@ -1055,7 +1055,7 @@ If at least one branch of an if-else statement or an if-else-if statement is wra
 === "[:material-heart-off-outline:](#) Disallowed"
 
     ```kotlin
-    fun foo(value: int) {
+    fun foo(value: Int) {
         if (value > 0)
             doSomething()
         else if (value < 0) {

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -1041,7 +1041,7 @@ If at least one branch of an if-else statement or an if-else-if statement is wra
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
-    fun foo(value: int) {
+    fun foo(value: Int) {
         if (value > 0) {
             doSomething()
         } else if (value < 0) {
@@ -1055,7 +1055,7 @@ If at least one branch of an if-else statement or an if-else-if statement is wra
 === "[:material-heart-off-outline:](#) Disallowed"
 
     ```kotlin
-    fun foo(value: int) {
+    fun foo(value: Int) {
         if (value > 0)
             doSomething()
         else if (value < 0) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -338,10 +338,10 @@ class AnnotationRuleTest {
         val code =
             """
             fun foo(
-                a: int,
-                @Bar1 b: int,
-                @Bar1 @Bar2 c: int,
-                @Bar3("bar3") @Bar1 d: int
+                a: Int,
+                @Bar1 b: Int,
+                @Bar1 @Bar2 c: Int,
+                @Bar3("bar3") @Bar1 d: Int
             ) {}
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
@@ -608,7 +608,8 @@ class AnnotationRuleTest {
         annotationRuleAssertThat(code).hasNoLintViolations()
     }
 
-    @Nested inner class `Array syntax annotations, Issue #1765` {
+    @Nested
+    inner class `Array syntax annotations, Issue #1765` {
         @Test
         fun `annotation preceded by array syntax annotation`() {
             val code =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
@@ -196,7 +196,7 @@ class IfElseBracingRuleTest {
     inner class `Given an IF with ELSE-IF` {
         private val formattedCode =
             """
-            fun foo(value: int) {
+            fun foo(value: Int) {
                 if (value > 0) {
                     doSomething()
                 } else if (value < 0) {
@@ -211,7 +211,7 @@ class IfElseBracingRuleTest {
         fun `Given all branches without-braces then do not reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0)
                         doSomething()
                     else if (value < 0) doSomethingElse()
@@ -227,7 +227,7 @@ class IfElseBracingRuleTest {
         fun `Given if { -- } else if -- else -- then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0) {
                         doSomething()
                     } else if (value < 0)
@@ -249,7 +249,7 @@ class IfElseBracingRuleTest {
         fun `Given if -- else if { -- } else -- then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0)
                         doSomething()
                     else if (value < 0) {
@@ -271,7 +271,7 @@ class IfElseBracingRuleTest {
         fun `Given if -- else if -- else { -- } then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0)
                         doSomething()
                     else if (value < 0)
@@ -294,7 +294,7 @@ class IfElseBracingRuleTest {
         fun `Given if { -- } else if { -- } else -- then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0) {
                         doSomething()
                     } else if (value < 0) {
@@ -314,7 +314,7 @@ class IfElseBracingRuleTest {
         fun `Given if { -- } else if -- else { -- } then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0) {
                         doSomething()
                     } else if (value < 0)
@@ -335,7 +335,7 @@ class IfElseBracingRuleTest {
         fun `Given if -- else if { -- } else { -- } then reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0)
                         doSomething()
                     else if (value < 0) {
@@ -356,7 +356,7 @@ class IfElseBracingRuleTest {
         fun `Given all branches with braces then do not reformat`() {
             val code =
                 """
-                fun foo(value: int) {
+                fun foo(value: Int) {
                     if (value > 0) {
                         doSomething()
                     } else if (value < 0) {


### PR DESCRIPTION

<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->
Replaced occurrences of `int` with `Int` in Kotlin code snippets to align with Kotlin's type system, which uses non-primitive types. The previous examples contained errors due to the use of `int`, which does not exist in Kotlin. This change ensures the code is syntactically correct and consistent with Kotlin's type conventions.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [x] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [x] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
