### PR TITLE
Fix rule id in documentation

### DIFF
--- a/documentation/release-latest/docs/rules/experimental.md
+++ b/documentation/release-latest/docs/rules/experimental.md
@@ -8,9 +8,9 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](../configuration-ktlint/#disabled-rules).
 
-## Blank lines between when-conditions
+## Blank line between when-conditions
 
-Consistently add or remove blank lines between when-conditions in a when-statement. A blank line is only added between when-conditions if the when-statement contains at lease one multiline when-condition. If a when-statement only contains single line when-conditions, then the blank lines between the when-conditions are removed.
+Consistently add or remove blank line between when-conditions in a when-statement. A blank line is only added between when-conditions if the when-statement contains at lease one multiline when-condition. If a when-statement only contains single line when-conditions, then the blank lines between the when-conditions are removed.
 
 !!! note
     Ktlint uses `.editorconfig` property `ij_kotlin_line_break_after_multiline_when_entry` but applies it also on single line entries to increase consistency.
@@ -107,22 +107,22 @@ Consistently add or remove blank lines between when-conditions in a when-stateme
 |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
 | `ij_kotlin_line_break_after_multiline_when_entry`<br/><i>Despite its name, forces a blank line between single line and multiline when-entries when at least one multiline when-entry is found in the when-statement.</i> |      `true`       |    `true`     |     `true`     |
 
-Rule id: `standard:blank-lines-between-when-conditions`
+Rule id: `standard:blank-line-between-when-conditions`
 
 Suppress or disable rule (1)
 { .annotate }
 
 1. Suppress rule in code with annotation below:
     ```kotlin
-    @Suppress("ktlint:standard:blank-lines-between-when-conditions")
+    @Suppress("ktlint:standard:blank-line-between-when-conditions")
     ```
    Enable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_blank-lines-between-when-conditions = enabled
+    ktlint_standard_blank-line-between-when-conditions = enabled
     ```
    Disable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_blank-lines-between-when-conditions = disabled
+    ktlint_standard_blank-line-between-when-conditions = disabled
     ```
 
 ## KDoc

--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -8,9 +8,9 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](../configuration-ktlint/#disabled-rules).
 
-## Blank lines between when-conditions
+## Blank line between when-conditions
 
-Consistently add or remove blank lines between when-conditions in a when-statement. A blank line is only added between when-conditions if the when-statement contains at lease one multiline when-condition. If a when-statement only contains single line when-conditions, then the blank lines between the when-conditions are removed.
+Consistently add or remove blank line between when-conditions in a when-statement. A blank line is only added between when-conditions if the when-statement contains at lease one multiline when-condition. If a when-statement only contains single line when-conditions, then the blank lines between the when-conditions are removed.
 
 !!! note
     Ktlint uses `.editorconfig` property `ij_kotlin_line_break_after_multiline_when_entry` but applies it also on single line entries to increase consistency.
@@ -107,22 +107,22 @@ Consistently add or remove blank lines between when-conditions in a when-stateme
 |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
 | `ij_kotlin_line_break_after_multiline_when_entry`<br/><i>Despite its name, forces a blank line between single line and multiline when-entries when at least one multiline when-entry is found in the when-statement.</i> |      `true`       |    `true`     |     `true`     |
 
-Rule id: `standard:blank-lines-between-when-conditions`
+Rule id: `standard:blank-line-between-when-conditions`
 
 Suppress or disable rule (1)
 { .annotate }
 
 1. Suppress rule in code with annotation below:
     ```kotlin
-    @Suppress("ktlint:standard:blank-lines-between-when-conditions")
+    @Suppress("ktlint:standard:blank-line-between-when-conditions")
     ```
    Enable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_blank-lines-between-when-conditions = enabled
+    ktlint_standard_blank-line-between-when-conditions = enabled
     ```
    Disable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_blank-lines-between-when-conditions = disabled
+    ktlint_standard_blank-line-between-when-conditions = disabled
     ```
 
 ## KDoc


### PR DESCRIPTION
## Description

Change rule id `blank-lines-between-when-conditions` to `blank-line-between-when-conditions` in documentation.

Closes #2765

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
