### PR TITLE
Fix false positive in `no-semi` rule for enum class without enum entries

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRuleTest.kt
@@ -473,4 +473,35 @@ class NoSemicolonsRuleTest {
             """.trimIndent()
         noSemicolonsRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2771 - Given an enum class without enum entry, and containing some code after the semi then do not report a lint error`() {
+        val code =
+            """
+            enum class Foo {
+                ;
+
+                fun foo() {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        noSemicolonsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2771 - Given an enum class without enum entry, and some comment before and some code after the semi then do not report a lint error`() {
+        val code =
+            """
+            enum class Foo {
+                // NO-OP
+                ;
+
+                fun foo() {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        noSemicolonsRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix false positive in `no-semi` rule for enum class without enum entries

Closes #2771

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
