### PR TITLE
Prevent conflict between `multiline-expression-wrapping` and `function-signature`

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -4454,6 +4454,8 @@ Suppress or disable rule (1)
 
 Multiline expression on the right hand side of an expression are forced to start on a separate line. Expressions in return statement are excluded as that would result in a compilation error.
 
+Setting `ktlint_function_signature_body_expression_wrapping` of the `function-signature` rule takes precedence when set to `default`. This setting keeps the first line of a multiline expression body on the same line as the end of function signature as long as the max line length is not exceeded. In that case, this rule does not wrap the multiline expression. 
+
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRule.kt
@@ -50,6 +50,8 @@ import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule.Companion.FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule.FunctionBodyExpressionWrapping.default
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 /**
@@ -64,10 +66,12 @@ public class MultilineExpressionWrappingRule :
             setOf(
                 INDENT_SIZE_PROPERTY,
                 INDENT_STYLE_PROPERTY,
+                FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY,
             ),
     ),
     Rule.OfficialCodeStyle {
     private var indentConfig = DEFAULT_INDENT_CONFIG
+    private lateinit var functionBodyExpressionWrapping: FunctionSignatureRule.FunctionBodyExpressionWrapping
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         indentConfig =
@@ -75,6 +79,7 @@ public class MultilineExpressionWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
+        functionBodyExpressionWrapping = editorConfig[FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY]
     }
 
     override fun beforeVisitChildNodes(
@@ -172,6 +177,7 @@ public class MultilineExpressionWrappingRule :
         null !=
             prevCodeSibling()
                 ?.takeIf { it.elementType == EQ || it.elementType == OPERATION_REFERENCE }
+                ?.takeUnless { functionBodyExpressionWrapping == default && it.treeParent.elementType == FUN }
                 ?.takeUnless { it.isElvisOperator() }
                 ?.takeUnless {
                     it

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineExpressionWrappingRuleTest.kt
@@ -2,6 +2,8 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule.Companion.FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule.FunctionBodyExpressionWrapping.default
 import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
@@ -358,6 +360,22 @@ class MultilineExpressionWrappingRuleTest {
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
             .hasLintViolation(1, 13, "A multiline expression should start on a new line")
             .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with a multiline body expression, and the function signature body expression wrapping is set to 'default' (eg keep first line of expression on same line)`() {
+        val code =
+            """
+            fun foo() = bar(
+                "bar"
+            )
+            """.trimIndent()
+        multilineExpressionWrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .addAdditionalRuleProvider { FunctionSignatureRule() }
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.ktlint_official)
+            .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to default)
+            .hasNoLintViolations()
     }
 
     @Test


### PR DESCRIPTION
## Description

Prevent conflict between `multiline-expression-wrapping` and `function-signature`

When `function-signature` rule is configured with `ktlint_function_signature_body_expression_wrapping` set to `default` then the first line of a multiline expression body should be kept on the same line as the end of function signature, as long as max line length is not exceeded. In this case the `multiline-expression-wrapping` rule has to ignore the multiline function expression body.

Closes #2650

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
