### PR TITLE
Ignore `max_line_length` property unless `max-line-length` rule is enabled 

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -103,6 +103,10 @@ Wraps binary expression at the operator reference whenever the binary expression
     }
     ```
 
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
+
 Rule id: `standard:binary-expression-wrapping`
 
 Suppress or disable rule (1)
@@ -306,6 +310,7 @@ The `.` in `java.class` is ignored when wrapping on chain operators.
 | Configuration setting                                                                                                                                                                                                                                                                                                                                                                                  | ktlint_official | intellij_idea | android_studio |
 |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
 | `ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than`<br/><i>Force wrapping of chained methods in case an expression contains at least the specified number of chain operators. If a chained method contains nested expressions, the chain operators of the inner expression are not taken into account. Use value `unset` (default) to disable this setting.</i> |        4        |       4       |       4        |
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i>                                                                                                                                                                          |       140       |     `off`     |     `100`      |
 
 
 Rule id: `standard:chain-method-continuation`
@@ -559,6 +564,7 @@ The other code styles allow an infinite amount of parameters on the same line (a
 | Configuration setting                                                                                                                                                                                                                                                                                                                       | ktlint_official | intellij_idea | android_studio |
 |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
 | `ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than`<br/><i>Force wrapping of the parameters of the class signature in case it contains at least the specified number of parameters, even in case the entire class signature would fit on a single line. Use value `unset` to disable this setting.</i> |        1        |    `unset`    |    `unset`     |
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i>                                                                                                               |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:class-signature`
 
@@ -808,6 +814,10 @@ If the function literal contains multiple parameters and at least one parameter 
         }
     ```
 
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
+
 Rule id: `standard:function-literal`
 
 Suppress or disable rule (1)
@@ -977,6 +987,10 @@ Rewrites the function signature to a single line when possible (e.g. when not ex
         "some-result"
             .uppercase()
     ```
+
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:function-signature`
 
@@ -1854,7 +1868,9 @@ Rule id: `standard:ktlint-suppression`
 
 ## Max line length
 
-Ensures that lines do not exceed the maximum length of a line. This rule does not apply in a number of situations. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
+Ensures that lines do not exceed the maximum length of a line as specified in `.editorconfig` property `max_line_length`.
+
+This rule does not apply in a number of situations. The `.editorconfig` property `ktlint_ignore_back_ticked_identifier` can be set to ignore identifiers which are enclosed in backticks, which for example is very useful when you want to allow longer names for unit tests.
 
 === "[:material-heart:](#) Ktlint"
 
@@ -1889,10 +1905,10 @@ Ensures that lines do not exceed the maximum length of a line. This rule does no
     ```
 
 
-| Configuration setting                                                                                               | ktlint_official | intellij_idea | android_studio |
-|:--------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
-| `ktlint_ignore_back_ticked_identifier`<br/><i>Defines whether the backticked identifier (``) should be ignored.</i> |     `false`     |    `false`    |    `false`     |
-| `max_line_length`<br/><i>Maximum length of a (regular) line.</i>                                                    |       140       |     `off`     |     `100`      |
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_ignore_back_ticked_identifier`<br/><i>Defines whether the backticked identifier (``) should be ignored.</i>                                                                                                           |     `false`     |    `false`    |    `false`     |
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:max-line-length`
 
@@ -2968,6 +2984,10 @@ Consistent spacing around the function return type.
         String = "some-result"
     ```
 
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
+
 Rule id: `standard:function-return-type-spacing`
 
 Suppress or disable rule (1)
@@ -3345,6 +3365,10 @@ Consistent spacing inside the parameter list.
     fun foo(
     ) = "some-result"
     ```
+
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:parameter-list-spacing`
 
@@ -4124,9 +4148,10 @@ All arguments should be on the same line, or every argument should be on a separ
         )
     ```
 
-| Configuration setting                                                             | ktlint_official | intellij_idea | android_studio |
-|:----------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
-| `ktlint_argument_list_wrapping_ignore_when_parameter_count_greater_or_equal_than` |     `unset`     |       8       |       8        |
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `ktlint_argument_list_wrapping_ignore_when_parameter_count_greater_or_equal_than`                                                                                                                                             |     `unset`     |       8       |       8        |
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:argument-list-wrapping`
 
@@ -4333,6 +4358,10 @@ Wraps the content receiver list to a separate line regardless of maximum line le
     context(Foooooooooooooooo<Foo, Bar>)
     fun fooBar()
     ```
+
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:context-receiver-wrapping`
 
@@ -4560,6 +4589,10 @@ When class/function signature doesn't fit on a single line, each parameter must 
     )
     ```
 
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
+
 Rule id: `standard:parameter-list-wrapping`
 
 Suppress or disable rule (1)
@@ -4626,6 +4659,10 @@ When a function or class parameter doesn't fit on a single line, wrap the type o
     )
     ```
 
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
+
 Rule id: `standard:parameter-wrapping`
 
 Suppress or disable rule (1)
@@ -4663,6 +4700,10 @@ When a property doesn't fit on a single line, wrap the type or value to a separa
     // at the X character on the right           X
     val aVariableWithALooooooooooooongName: String
     ```
+
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:property-wrapping`
 
@@ -4761,6 +4802,10 @@ Inserts missing newlines (for example between parentheses of a multi-line functi
         b,
         c)
     ```
+
+| Configuration setting                                                                                                                                                                                                         | ktlint_official | intellij_idea | android_studio |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------:|:-------------:|:--------------:|
+| `max_line_length`<br/><i>Maximum length of a (regular) line. This property is ignored in case the `max-line-length` rule is disabled, or when using Ktlint via a third party integration that does not provide this rule.</i> |       140       |     `off`     |     `100`      |
 
 Rule id: `standard:wrapping`
 

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -418,6 +418,7 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleKt {
 	public static final fun getMAX_LINE_LENGTH_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+	public static final fun maxLineLength (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)I
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/Rule$Experimental {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -92,7 +92,7 @@ public class ArgumentListWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
         ignoreWhenParameterCountGreaterOrEqualThanProperty = editorConfig[IGNORE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY]
     }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -70,7 +70,7 @@ public class BinaryExpressionWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -99,7 +99,7 @@ public class ChainMethodContinuationRule :
         if (indentConfig.disabled) {
             stopTraversalOfAST()
         }
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
         forceMultilineWhenChainOperatorCountGreaterOrEqualThanProperty =
             editorConfig[FORCE_MULTILINE_WHEN_CHAIN_OPERATOR_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY]
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -100,7 +100,7 @@ public class ClassSignatureRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(
@@ -467,7 +467,7 @@ public class ClassSignatureRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
         wrappedPrimaryConstructor: Boolean,
     ): Int {
-        var whiteSpaceCorrection = 0
+        val whiteSpaceCorrection = 0
 
         val superTypes = node.superTypes() ?: return 0
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -58,7 +58,7 @@ public class ContextReceiverWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -96,7 +96,7 @@ public class FunctionLiteralRule :
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         codeStyle = editorConfig[CODE_STYLE_PROPERTY]
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
         indentConfig =
             IndentConfig(
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRule.kt
@@ -29,7 +29,7 @@ public class FunctionReturnTypeSpacingRule :
     private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -104,7 +104,7 @@ public class FunctionSignatureRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -47,7 +47,7 @@ public class ParameterListSpacingRule :
     private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -60,7 +60,7 @@ public class ParameterListWrappingRule :
 
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         codeStyle = editorConfig[CODE_STYLE_PROPERTY]
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
         indentConfig =
             IndentConfig(
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
@@ -65,7 +65,7 @@ public class ParameterWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
@@ -63,7 +63,7 @@ public class PropertyWrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -126,7 +126,7 @@ public class WrappingRule :
                 indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
                 tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
             )
-        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+        maxLineLength = editorConfig.maxLineLength()
     }
 
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -20,6 +20,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.ClassSignatureRule.Companion.
 class ArgumentListWrappingRuleTest {
     private val argumentListWrappingRuleAssertThat =
         assertThatRuleBuilder { ArgumentListWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
             .addRequiredRuleProviderDependenciesFrom(StandardRuleSetProvider())
             .assertThat()
 
@@ -311,7 +312,7 @@ class ArgumentListWrappingRuleTest {
             argumentListWrappingRuleAssertThat(code)
                 .setMaxLineLength()
                 .withEditorConfigOverride(IGNORE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 8)
-                .hasNoLintViolations()
+                .hasNoLintViolationsExceptInAdditionalRules()
         }
 
         @Test
@@ -942,8 +943,10 @@ class ArgumentListWrappingRuleTest {
             .addAdditionalRuleProvider { ClassSignatureRule() }
             .addRequiredRuleProviderDependenciesFrom(StandardRuleSetProvider())
             .withEditorConfigOverride(CLASS_SIGNATURE_FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
-            .hasLintViolationForAdditionalRule(5, 37, "Super type should start on a newline")
-            .hasLintViolations(
+            .hasLintViolationsForAdditionalRule(
+                LintViolation(5, 37, "Super type should start on a newline"),
+                LintViolation(5, 56, "Exceeded max line length (55)", canBeAutoCorrected = false),
+            ).hasLintViolations(
                 LintViolation(5, 44, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(5, 47, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(5, 88, "Missing newline before \")\""),
@@ -977,6 +980,7 @@ class ArgumentListWrappingRuleTest {
             .hasLintViolationsForAdditionalRule(
                 LintViolation(3, 12, "Newline expected after '{'"),
                 LintViolation(3, 12, "Missing newline after \"{\""),
+                LintViolation(3, 45, "Exceeded max line length (44)", canBeAutoCorrected = false),
                 LintViolation(3, 50, "Newline expected before '}'"),
                 // Lint violation below only occurs during linting. Resolving violations above, prevents the next violation from occurring
                 LintViolation(3, 59, "Line is exceeding max line length. Break line after 'returns' in binary expression"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
@@ -3,13 +3,16 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
 import org.junit.jupiter.api.Test
 
 class BinaryExpressionWrappingRuleTest {
-    private val binaryExpressionWrappingRuleAssertThat = assertThatRule { BinaryExpressionWrappingRule() }
+    private val binaryExpressionWrappingRuleAssertThat =
+        assertThatRuleBuilder { BinaryExpressionWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given a property with a binary expression on same line as equals, and it exceeds the max line length then wrap before the expression`() {
@@ -192,7 +195,7 @@ class BinaryExpressionWrappingRuleTest {
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test
@@ -293,16 +296,20 @@ class BinaryExpressionWrappingRuleTest {
             ).hasLintViolationsForAdditionalRules(
                 LintViolation(2, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(2, 32, "Missing newline before \")\""),
+                LintViolation(2, 32, "Exceeded max line length (31)", canBeAutoCorrected = false),
                 LintViolation(3, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(3, 23, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(3, 32, "Missing newline before \")\""),
+                LintViolation(3, 32, "Exceeded max line length (31)", canBeAutoCorrected = false),
                 LintViolation(3, 33, "Missing newline before \")\""),
                 LintViolation(4, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(4, 23, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(4, 32, "Exceeded max line length (31)", canBeAutoCorrected = false),
                 LintViolation(4, 46, "Missing newline before \")\""),
                 LintViolation(4, 47, "Missing newline before \")\""),
                 LintViolation(5, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),
                 LintViolation(5, 23, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(5, 32, "Exceeded max line length (31)", canBeAutoCorrected = false),
                 LintViolation(5, 47, "Missing newline before \")\""),
                 LintViolation(5, 48, "Missing newline before \")\""),
             ).isFormattedAs(formattedCode)
@@ -433,6 +440,7 @@ class BinaryExpressionWrappingRuleTest {
             .hasLintViolationsForAdditionalRule(
                 LintViolation(3, 12, "Missing newline after \"{\""),
                 LintViolation(3, 21, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(3, 45, "Exceeded max line length (44)", canBeAutoCorrected = false),
                 LintViolation(3, 48, "Missing newline before \")\""),
             ).hasLintViolations(
                 LintViolation(3, 12, "Newline expected after '{'"),
@@ -455,7 +463,7 @@ class BinaryExpressionWrappingRuleTest {
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test
@@ -489,6 +497,6 @@ class BinaryExpressionWrappingRuleTest {
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class ChainMethodContinuationRuleTest {
     private val chainMethodContinuationRuleAssertThat =
         assertThatRuleBuilder { ChainMethodContinuationRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
             .addRequiredRuleProviderDependenciesFrom(StandardRuleSetProvider())
             .assertThat()
 
@@ -613,6 +614,7 @@ class ChainMethodContinuationRuleTest {
                 .setMaxLineLength()
                 .addAdditionalRuleProvider { ArgumentListWrappingRule() }
                 .addAdditionalRuleProvider { FunctionLiteralRule() }
+                .addAdditionalRuleProvider { MaxLineLengthRule() }
                 .hasLintViolations(
                     // Lint violation below will not be triggered during format as argument-list-wrapping rule prevents this error from occurring
                     LintViolation(2, 30, "Expected newline before '.'"),
@@ -650,6 +652,7 @@ class ChainMethodContinuationRuleTest {
                 .addAdditionalRuleProvider { FunctionLiteralRule() }
                 .addAdditionalRuleProvider { MultilineExpressionWrappingRule() }
                 .addAdditionalRuleProvider { IndentationRule() }
+                .addAdditionalRuleProvider { MaxLineLengthRule() }
                 .isFormattedAs(formattedCode)
                 .hasLintViolations(
                     // Lint violation below will not be triggered during format as argument-list-wrapping rule prevents this error from occurring

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class ClassSignatureRuleTest {
     private val classSignatureWrappingRuleAssertThat =
         assertThatRuleBuilder { ClassSignatureRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
             .addRequiredRuleProviderDependenciesFrom(StandardRuleSetProvider())
             .assertThat()
 
@@ -56,7 +57,7 @@ class ClassSignatureRuleTest {
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
-                .hasNoLintViolations()
+                .hasNoLintViolationsExceptInAdditionalRules()
         }
 
         @Test
@@ -733,7 +734,7 @@ class ClassSignatureRuleTest {
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test
@@ -1828,7 +1829,7 @@ class ClassSignatureRuleTest {
                 )
                 """.trimIndent()
             classSignatureWrappingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to CodeStyleValue.intellij_idea)
+                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                 // Set max_line_length as other the class signature would not be rewritten to single line
                 .withEditorConfigOverride(MAX_LINE_LENGTH_PROPERTY to 999)
                 .hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
@@ -1,14 +1,16 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class ContextReceiverWrappingRuleTest {
     private val contextReceiverWrappingRuleAssertThat =
-        KtLintAssertThat.assertThatRule { ContextReceiverWrappingRule() }
+        assertThatRuleBuilder { ContextReceiverWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given a function without modifiers and with a context receiver on the same line as the fun keyword then wrap the fun keyword to a newline`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionReturnTypeSpacingRuleTest.kt
@@ -2,11 +2,14 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import org.junit.jupiter.api.Test
 
 class FunctionReturnTypeSpacingRuleTest {
-    private val functionReturnTypeSpacingRuleAssertThat = assertThatRule { FunctionReturnTypeSpacingRule() }
+    private val functionReturnTypeSpacingRuleAssertThat =
+        assertThatRuleBuilder { FunctionReturnTypeSpacingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given a function signature without whitespace between the closing parenthesis and the colon of the return type then do not reformat`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource
 class FunctionSignatureRuleTest {
     private val functionSignatureWrappingRuleAssertThat =
         assertThatRuleBuilder { FunctionSignatureRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
             .addRequiredRuleProviderDependenciesFrom(StandardRuleSetProvider())
             .assertThat()
 
@@ -224,9 +225,18 @@ class FunctionSignatureRuleTest {
             .setMaxLineLength()
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
+                LintViolation(2, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
+                LintViolation(3, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
+                LintViolation(4, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(5, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(5, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(6, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(6, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(7, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(7, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
+                LintViolation(8, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
+                LintViolation(9, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
+                LintViolation(10, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
             ).hasNoLintViolationsExceptInAdditionalRules()
     }
 
@@ -1031,7 +1041,7 @@ class FunctionSignatureRuleTest {
             .setMaxLineLength()
             .withEditorConfigOverride(FUNCTION_BODY_EXPRESSION_WRAPPING_PROPERTY to bodyExpressionWrapping)
             .addAdditionalRuleProvider { IndentationRule() }
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Nested
@@ -1142,7 +1152,7 @@ class FunctionSignatureRuleTest {
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Nested
@@ -1157,7 +1167,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
-                .hasNoLintViolations()
+                .hasNoLintViolationsExceptInAdditionalRules()
         }
 
         @Test
@@ -1170,7 +1180,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
-                .hasNoLintViolations()
+                .hasNoLintViolationsExceptInAdditionalRules()
         }
 
         @Test
@@ -1184,7 +1194,7 @@ class FunctionSignatureRuleTest {
                 """.trimIndent()
             functionSignatureWrappingRuleAssertThat(code)
                 .setMaxLineLength()
-                .hasNoLintViolations()
+                .hasNoLintViolationsExceptInAdditionalRules()
         }
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5058,6 +5058,7 @@ internal class IndentationRuleTest {
                 """.trimIndent()
             indentationRuleAssertThat(code)
                 .addAdditionalRuleProvider { ParameterWrappingRule() }
+                .addAdditionalRuleProvider { MaxLineLengthRule() }
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .setMaxLineLength()
                 .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRuleTest.kt
@@ -1,12 +1,21 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RuleExecution.disabled
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RuleExecution.enabled
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleExecutionEditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ec4j.toPropertyWithValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ktLintRuleExecutionPropertyName
 import com.pinterest.ktlint.ruleset.standard.rules.MaxLineLengthRule.Companion.IGNORE_BACKTICKED_IDENTIFIER_PROPERTY
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -225,5 +234,52 @@ class MaxLineLengthRuleTest {
         maxLineLengthRuleAssertThat(code)
             .setMaxLineLength()
             .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given max_line_length property is set and max-line-length rule is enabled then return the max_line_length`() {
+        val editorConfig =
+            EditorConfig(
+                mapOf(
+                    MAX_LINE_LENGTH to MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue(SOME_MAX_LINE_LENGTH.toString()),
+                    KTLINT_RULE_EXECUTION_PROPERTY_NAME to MAX_LINE_LENGTH_RULE_EXECUTION_PROPERTY.toPropertyWithValue(enabled.name),
+                ),
+            )
+
+        assertThat(editorConfig.maxLineLength()).isEqualTo(SOME_MAX_LINE_LENGTH)
+    }
+
+    @Test
+    fun `Given max_line_length property is set and max-line-length rule is disabled then return Int MAX_VALUE`() {
+        val editorConfig =
+            EditorConfig(
+                mapOf(
+                    MAX_LINE_LENGTH to MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue(SOME_MAX_LINE_LENGTH.toString()),
+                    KTLINT_RULE_EXECUTION_PROPERTY_NAME to MAX_LINE_LENGTH_RULE_EXECUTION_PROPERTY.toPropertyWithValue(disabled.name),
+                ),
+            )
+
+        assertThat(editorConfig.maxLineLength()).isEqualTo(Int.MAX_VALUE)
+    }
+
+    @Test
+    fun `Given intellij_idea code style, and max_line_length property equals 'unset' and max-line-length rule is enabled then return Int MAX_VALUE`() {
+        val editorConfig =
+            EditorConfig(
+                mapOf(
+                    MAX_LINE_LENGTH to MAX_LINE_LENGTH_PROPERTY.toPropertyWithValue("unset"),
+                    CODE_STYLE_PROPERTY.name to CODE_STYLE_PROPERTY.toPropertyWithValue(CodeStyleValue.intellij_idea.name),
+                    KTLINT_RULE_EXECUTION_PROPERTY_NAME to MAX_LINE_LENGTH_RULE_EXECUTION_PROPERTY.toPropertyWithValue(enabled.name),
+                ),
+            )
+
+        assertThat(editorConfig.maxLineLength()).isEqualTo(Int.MAX_VALUE)
+    }
+
+    private companion object {
+        const val MAX_LINE_LENGTH = "max_line_length"
+        const val SOME_MAX_LINE_LENGTH = 123
+        val KTLINT_RULE_EXECUTION_PROPERTY_NAME = MAX_LINE_LENGTH_RULE_ID.ktLintRuleExecutionPropertyName()
+        val MAX_LINE_LENGTH_RULE_EXECUTION_PROPERTY = MAX_LINE_LENGTH_RULE_ID.createRuleExecutionEditorConfigProperty()
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
@@ -2,12 +2,15 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class ParameterListSpacingRuleTest {
-    private val parameterListSpacingRuleAssertThat = assertThatRule { ParameterListSpacingRule() }
+    private val parameterListSpacingRuleAssertThat =
+        assertThatRuleBuilder { ParameterListSpacingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given a function signature which does not contain redundant spaces then do no reformat`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.EnumSource
 class ParameterListWrappingRuleTest {
     private val parameterListWrappingRuleAssertThat =
         assertThatRuleBuilder { ParameterListWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
             // Keep formatted code readable
             .addAdditionalRuleProvider { IndentationRule() }
             .assertThat()
@@ -77,7 +78,7 @@ class ParameterListWrappingRuleTest {
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .setMaxLineLength()
-            .hasNoLintViolations()
+            .hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
@@ -1,13 +1,16 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 internal class ParameterWrappingRuleTest {
-    private val parameterWrappingRuleAssertThat = KtLintAssertThat.assertThatRule { ParameterWrappingRule() }
+    private val parameterWrappingRuleAssertThat =
+        assertThatRuleBuilder { ParameterWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given that the variable name and the following colon do not fit on the same line as val or var keyword then wrap after the colon`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
@@ -1,13 +1,16 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.test.KtLintAssertThat
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Test
 
 internal class PropertyWrappingRuleTest {
-    private val propertyWrappingRuleAssertThat = KtLintAssertThat.assertThatRule { PropertyWrappingRule() }
+    private val propertyWrappingRuleAssertThat =
+        assertThatRuleBuilder { PropertyWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given that the variable name and the following colon do not fit on the same line as val or var keyword then wrap after the colon`() {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -3,7 +3,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
 import com.pinterest.ktlint.test.TAB
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class WrappingRuleTest {
-    private val wrappingRuleAssertThat = assertThatRule { WrappingRule() }
+    private val wrappingRuleAssertThat =
+        assertThatRuleBuilder { WrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
 
     @Test
     fun `Given a multiline string containing a string-template as parameter value but then wrap the value to a start and end on separate lines`() {


### PR DESCRIPTION
IMPORTANT: Potential breaking change for API Consumers that provide the `max_line_length` property but not enabling/providing the `max-line-length` rule of the Ktlint standard rule set.

## Description

Ignore `max_line_length` property unless `max-line-length` rule is enabled. Align EditorConfig settings for `max_line_length` and enable/disabling the `max-line-length` rule

Rules should only consider the maximum line length in case property `max_line_length` is set to a value between 0 and `MAX_INTEGER - 1`, and the `max-line-length` rule is provided to the KtLintRuleEngine, and the `max-line-length` rule is enabled.

It should not be enforced that property `max_line_length` should have value `unset` or `off` whenever the `max-line-length` rule is disabled, or not provided to the KtLintRuleEngine. This property is also used by IntelliJ IDEA to display the right margin where lines should be wrapped. A user should be able to disable enforce max line length wrapping in ktlint, while still seeing the margin line in the editor.

Closes #2743

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
