### PR TITLE
Add test which breaks on WindowsOS

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -124,7 +124,8 @@ internal fun FileSystem.fileSequence(
                         if (negatedPathMatchers.none { it.matches(path) } &&
                             pathMatchers.any { it.matches(path) }
                         ) {
-                            LOGGER.trace { "- File: $path: Include" }
+                            val matchingPathMatchers = pathMatchers.filter { it.matches(path) }
+                            LOGGER.debug { "- File: $path: Include as it matches with $matchingPathMatchers" }
                             result.add(path)
                         } else {
                             LOGGER.trace { "- File: $path: Ignore" }
@@ -262,7 +263,7 @@ private fun FileSystem.toGlob(
 }
 
 /**
- * For each double star pattern in the path, create and additional path in which the double start pattern is removed.
+ * For each double star pattern in the path, create and additional path in which the double star pattern is removed.
  * In this way a pattern like some-directory/**/*.kt will match while files in some-directory or any of its
  * subdirectories.
  */
@@ -278,7 +279,7 @@ private fun String?.expandDoubleStarPatterns(): Set<String> {
                         .filter { it !== doubleStarPart }
                         .joinToString(separator = "/")
                 // The original path can contain multiple double star patterns. Replace only one double start pattern
-                // with an additional path pattern and call recursively for remain double star patterns
+                // with an additional path pattern and call recursively for remaining double star patterns
                 paths.addAll(expandedPath.expandDoubleStarPatterns())
             }
         }

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -278,7 +278,7 @@ private fun String?.expandDoubleStarPatterns(): Set<String> {
                     parts
                         .filter { it !== doubleStarPart }
                         .joinToString(separator = "/")
-                // The original path can contain multiple double star patterns. Replace only one double start pattern
+                // The original path can contain multiple double star patterns. Replace only one double star pattern
                 // with an additional path pattern and call recursively for remaining double star patterns
                 paths.addAll(expandedPath.expandDoubleStarPatterns())
             }

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -493,6 +493,28 @@ internal class FileUtilsTest {
             )
     }
 
+    @Test
+    fun `Issue 2781 - Find files with correct glob for wildcards`() {
+        val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/TestOneSetup.kt"
+        val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/testMock/kotlin/TwoTest.kt"
+
+        ktlintTestFileSystem.createFile(ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName)
+        ktlintTestFileSystem.createFile(ktFileInProjectFlavoredDirectoryWithoutOverlappingName)
+
+        val foundFiles =
+            getFiles(
+                patterns = listOf("**/test*/**"),
+                rootDir = ktlintTestFileSystem.resolve(ktFileInProjectRootDirectory).parent.toAbsolutePath(),
+            )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(
+                ktFileInProjectFlavoredDirectoryWithoutOverlappingName,
+            ).doesNotContain(
+                ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName,
+            )
+    }
+
     private fun KtlintTestFileSystem.createFile(fileName: String) =
         writeFile(
             relativeDirectoryToRoot = fileName.substringBeforeLast("/", ""),

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -530,23 +530,49 @@ internal class FileUtilsTest {
 
         assertThat(foundFiles)
             .containsExactlyInAnyOrder(
-                ktFileInProjectFlavoredDirectoryWithoutOverlappingName + "c",
+                ktFileInProjectFlavoredDirectoryWithoutOverlappingName,
             ).doesNotContain(
                 ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName,
             )
     }
 
     @Test
-    fun `Issue 2781b  - Find files with correct glob for wildcards`() {
-        val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/Foo.kt"
-        val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/testMock/kotlin/Bar.kt"
+    fun `Issue 2781b - Find files with correct glob for wildcards`() {
+        val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/TestOneSetup.kt"
+        // Path "testMock" changed to "TestMock" so that results on Windows and Linux are comparable
+        val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/TestMock/kotlin/TwoTest.kt"
 
         ktlintTestFileSystem.createFile(ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName)
         ktlintTestFileSystem.createFile(ktFileInProjectFlavoredDirectoryWithoutOverlappingName)
 
         val foundFiles =
             getFiles(
-                patterns = listOf("**/test*/**"),
+                // Linux has case-sensitive path. This test should now fail on both Linux and Windows
+                patterns = listOf("**/Test*/**"),
+                rootDir = ktlintTestFileSystem.resolve(ktFileInProjectRootDirectory).parent.toAbsolutePath(),
+            )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(
+                ktFileInProjectFlavoredDirectoryWithoutOverlappingName,
+            ).doesNotContain(
+                ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName,
+            )
+    }
+
+    @Test
+    fun `Issue 2781c - Find files with correct glob for wildcards`() {
+        val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/TestOneSetup.kt"
+        // Path "testMock" changed to "TestMock" so that results on Windows and Linux are comparable
+        val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/TestMock/kotlin/TwoTest.kt"
+
+        ktlintTestFileSystem.createFile(ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName)
+        ktlintTestFileSystem.createFile(ktFileInProjectFlavoredDirectoryWithoutOverlappingName)
+
+        val foundFiles =
+            getFiles(
+                // Add wildcards to match the filename itself. Should pass on Windows and Linux
+                patterns = listOf("**/Test*/**/*.kt*"),
                 rootDir = ktlintTestFileSystem.resolve(ktFileInProjectRootDirectory).parent.toAbsolutePath(),
             )
 

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -1,7 +1,12 @@
 package com.pinterest.ktlint.cli.internal
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
+import com.pinterest.ktlint.logger.api.setDefaultLoggerModifier
 import com.pinterest.ktlint.test.KtlintTestFileSystem
+import io.github.oshai.kotlinlogging.DelegatingKLogger
+import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -15,7 +20,23 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
-private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
+@Suppress("unused")
+private val LOGGER =
+    KotlinLogging
+        .logger {}
+        .setDefaultLoggerModifier { logger -> logger.level = Level.TRACE }
+        .initKtLintKLogger()
+
+private var KLogger.level: Level?
+    get() = underlyingLogger()?.level
+    set(value) {
+        underlyingLogger()?.level = value
+    }
+
+private fun KLogger.underlyingLogger(): Logger? =
+    @Suppress("UNCHECKED_CAST")
+    (this as? DelegatingKLogger<Logger>)
+        ?.underlyingLogger
 
 /**
  * Tests for [fileSequence] method.
@@ -497,6 +518,28 @@ internal class FileUtilsTest {
     fun `Issue 2781 - Find files with correct glob for wildcards`() {
         val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/TestOneSetup.kt"
         val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/testMock/kotlin/TwoTest.kt"
+
+        ktlintTestFileSystem.createFile(ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName)
+        ktlintTestFileSystem.createFile(ktFileInProjectFlavoredDirectoryWithoutOverlappingName)
+
+        val foundFiles =
+            getFiles(
+                patterns = listOf("**/test*/**"),
+                rootDir = ktlintTestFileSystem.resolve(ktFileInProjectRootDirectory).parent.toAbsolutePath(),
+            )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(
+                ktFileInProjectFlavoredDirectoryWithoutOverlappingName + "c",
+            ).doesNotContain(
+                ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName,
+            )
+    }
+
+    @Test
+    fun `Issue 2781b  - Find files with correct glob for wildcards`() {
+        val ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName = "project1/src/mock/kotlin/Foo.kt"
+        val ktFileInProjectFlavoredDirectoryWithoutOverlappingName = "project1/src/testMock/kotlin/Bar.kt"
 
         ktlintTestFileSystem.createFile(ktFileInProjectOutsideFlavoredDirectoryWithOverlappingName)
         ktlintTestFileSystem.createFile(ktFileInProjectFlavoredDirectoryWithoutOverlappingName)


### PR DESCRIPTION
## Description

This test succeeds on MacOs, and according to OP of #2781 it breaks on Windows OS. Verify whether this test also breaks in build pipeline.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
