### PR TITLE
Suppress `backing-property-naming` rule with `@Suppress("LocalVariableName")`

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
@@ -261,6 +261,7 @@ internal class SuppressionLocator(
                 "RemoveCurlyBracesFromTemplate" to listOf("standard:string-template"),
                 "ClassName" to listOf("standard:class-naming"),
                 "FunctionName" to listOf("standard:function-naming"),
+                "LocalVariableName" to listOf("standard:backing-property-naming"),
                 "PackageName" to listOf("standard:package-name"),
                 "PropertyName" to listOf("standard:property-naming", "standard:backing-property-naming"),
                 "ConstPropertyName" to listOf("standard:property-naming"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -359,4 +359,17 @@ class BackingPropertyNamingRuleTest {
             """.trimIndent()
         backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2779 - Given a property name suppressed via 'LocalVariableName' then also suppress the ktlint violation`() {
+        val code =
+            """
+            @Suppress("LocalVariableName")
+            fun test() {
+                val _test = "test"
+                println(_test)
+            }
+            """.trimIndent()
+        backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Suppress `backing-property-naming` rule with `@Suppress("LocalVariableName")`

Closes #2779

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
