### PR TITLE
Fix false positive in `class-signature` when EOL comment is between a class annotation and other class modifier

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -149,7 +149,8 @@ public class ClassSignatureRule :
                     currentNode = iterator.next()
                     if (currentNode.elementType != ANNOTATION &&
                         currentNode.elementType != ANNOTATION_ENTRY &&
-                        currentNode.elementType != WHITE_SPACE
+                        currentNode.elementType != WHITE_SPACE &&
+                        currentNode.elementType != EOL_COMMENT
                     ) {
                         return currentNode
                     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1849,6 +1849,20 @@ class ClassSignatureRuleTest {
         classSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
+    @Test
+    fun `Issue 2755 - Given a class preceded by an annotation, and EOL comment, and another class modifier then ignore the EOL comment in determination of class signature length`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                           $EOL_CHAR
+            @Suppress("UnnecessaryAbstractClass") // some comment
+            abstract class Bar(val baz1: String, val baz2: String)
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
+            .hasNoLintViolations()
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""


### PR DESCRIPTION
## Description

Fix false positive in `class-signature` when EOL comment is between a class annotation and other class modifier

Closes #2755

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
