### PR TITLE
Fix globs ending with `**`

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -296,7 +296,7 @@ private fun String?.expandDoubleStarPatterns(): Set<String> {
             // trailing "**" matches any file in the directory.
             // Given pattern "**/Test*/**" the file "src/Foo/TestFoo.kt" should not be matched, and file "src/TestFoo/FooTest.kt" is
             // matched. If the original pattern would be expanded with additional pattern "**/Test*" then both files would have been
-            //  matched.
+            // matched.
             it === parts.last()
         }.forEach { doubleStarPart ->
             run {

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -296,7 +296,7 @@ private fun String?.expandDoubleStarPatterns(): Set<String> {
             // trailing "**" matches any file in the directory.
             // Given pattern "**/Test*/**" the file "src/Foo/TestFoo.kt" should not be matched, and file "src/TestFoo/FooTest.kt" is
             // matched. If the original pattern would be expanded with additional pattern "**/Test*" then both files would have been
-            // matched.
+            //  matched.
             it === parts.last()
         }.forEach { doubleStarPart ->
             run {

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/internal/FileUtilsTest.kt
@@ -1,7 +1,12 @@
 package com.pinterest.ktlint.cli.internal
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
+import com.pinterest.ktlint.logger.api.setDefaultLoggerModifier
 import com.pinterest.ktlint.test.KtlintTestFileSystem
+import io.github.oshai.kotlinlogging.DelegatingKLogger
+import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -15,7 +20,22 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
-private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
+private val LOGGER =
+    KotlinLogging
+        .logger {}
+        .setDefaultLoggerModifier { it.level = Level.TRACE }
+        .initKtLintKLogger()
+
+private var KLogger.level: Level?
+    get() = underlyingLogger()?.level
+    set(value) {
+        underlyingLogger()?.level = value
+    }
+
+private fun KLogger.underlyingLogger(): Logger? =
+    @Suppress("UNCHECKED_CAST")
+    (this as? DelegatingKLogger<Logger>)
+        ?.underlyingLogger
 
 /**
  * Tests for [fileSequence] method.
@@ -491,6 +511,25 @@ internal class FileUtilsTest {
                 ktFileRootDirectory,
                 ktsFileRootDirectory,
             )
+    }
+
+    @Test
+    fun `Issue 2781 - Given a glob containing a subdirectory matcher with wildcard, and ending with a double star then the subdirectory wildcard may not be used to match the filename`() {
+        val ktFileInProjectOutsideTargetedDirectory = "project1/src/TestFoo.kt"
+        val ktFileInProjectInsideTargetedDirectory = "project1/src/Foo/FooTest.kt"
+
+        ktlintTestFileSystem.createFile(ktFileInProjectOutsideTargetedDirectory)
+        ktlintTestFileSystem.createFile(ktFileInProjectInsideTargetedDirectory)
+
+        val foundFiles =
+            getFiles(
+                patterns = listOf("**/*Foo*/**"),
+                rootDir = ktlintTestFileSystem.resolve(ktFileInProjectRootDirectory).parent.toAbsolutePath(),
+            )
+
+        assertThat(foundFiles)
+            .containsExactlyInAnyOrder(ktFileInProjectInsideTargetedDirectory)
+            .doesNotContain(ktFileInProjectOutsideTargetedDirectory)
     }
 
     private fun KtlintTestFileSystem.createFile(fileName: String) =


### PR DESCRIPTION
## Description

Fix globs ending with `**`

According to https://git-scm.com/docs/gitignore a trailing `**` in a glob has to match with any file in the directory that matches the glob without that trailing `**`.

Given glob "**/Test*/**" the file "src/Foo/TestFoo.kt" should not be matched, and file "src/TestFoo/FooTest.kt" is matched. If the original pattern would be expanded with additional pattern "**/Test*" then both files would have been matched.

Closes #2781

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
