### PR TITLE
failing test: chain-method-continuation fail for fully qualified call

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -920,6 +920,11 @@ class ChainMethodContinuationRuleTest {
             fun foo(bar: FooBar.() -> Unit) {}
             """,
             """
+            fun foo(): Foo {
+                return dev.foo.p1.p2.Foo("bar")
+            }
+            """,
+            """
             /**
              * Some comment with [Foo.Bar] reference
              */


### PR DESCRIPTION
Just found an issue with `chain-method-continuation`, raising a PR with the repro only for now.

Happy to work on the fix if someone points me in the right direction.

Repro for https://github.com/pinterest/ktlint/issues/2797