### PR TITLE
Revert changing log level in FileUtils.kt

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -1,11 +1,6 @@
 package com.pinterest.ktlint.cli.internal
 
-import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
-import com.pinterest.ktlint.logger.api.setDefaultLoggerModifier
-import io.github.oshai.kotlinlogging.DelegatingKLogger
-import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.kotlin.util.prefixIfNot
 import java.io.File
@@ -25,22 +20,7 @@ import kotlin.io.path.pathString
 import kotlin.io.path.relativeToOrSelf
 import kotlin.system.measureTimeMillis
 
-private val LOGGER =
-    KotlinLogging
-        .logger {}
-        .setDefaultLoggerModifier { it.level = Level.TRACE }
-        .initKtLintKLogger()
-
-private var KLogger.level: Level?
-    get() = underlyingLogger()?.level
-    set(value) {
-        underlyingLogger()?.level = value
-    }
-
-private fun KLogger.underlyingLogger(): Logger? =
-    @Suppress("UNCHECKED_CAST")
-    (this as? DelegatingKLogger<Logger>)
-        ?.underlyingLogger
+private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
 
 private val ROOT_DIR_PATH: Path = Paths.get("").toAbsolutePath()
 


### PR DESCRIPTION
## Description

Revert changing log level in FileUtils.kt

Follow up on #2787

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
