### PR TITLE
Return exit code 1 in case violations have been found but file is unchanged

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -508,6 +508,11 @@ internal class KtlintCommandLine :
                             }
                         } ?: NO_AUTOCORRECT
                 }.also { formattedFileContent ->
+                    if (ktlintCliErrors.isNotEmpty() && code.content == formattedFileContent) {
+                        // In very rare cases it is possible that Lint violations are detected but that they have opposite effects and the
+                        // file gets not altered at all. This is to be treated as unfixable error.
+                        containsUnfixedLintErrors.set(true)
+                    }
                     if (forceLintAfterFormat && code.content != formattedFileContent) {
                         // Rerun lint to check that the formatted code can still be successfully parsed.
                         try {
@@ -721,7 +726,7 @@ internal class KtlintCommandLine :
                         q.put(executorService.submit(task))
                     }
                     q.put(pill)
-                } catch (e: InterruptedException) {
+                } catch (_: InterruptedException) {
                     // we've been asked to stop consuming sequence
                 } finally {
                     executorService.shutdown()


### PR DESCRIPTION
## Description

Return exit code 1 in case violations have been found but file is unchanged

In very rare cases it is possible that Lint violations are detected while formatting but that they have opposite effects and the file gets not altered at all. As the logging already might contain the message "Format was not able to resolve all violations which (theoretically) can be autocorrected in file ..." the format may not return with exit code 0.

Closes #2795

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added ==> No test added. When this can be caused with default rulesets (like in #2794) this means that the rules must be fixed so that this does not occur.
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
