### PR TITLE
Ignore missing whitespace after trailing comma in single line parameter value list

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
@@ -107,10 +108,10 @@ public class ParameterListSpacingRule :
                 }
 
                 COMMA -> {
-                    // Comma must be followed by whitespace
+                    // Comma, except when it is the trailing comma, must be followed by whitespace
                     el
                         .nextLeaf()
-                        ?.takeIf { it.elementType != WHITE_SPACE }
+                        ?.takeUnless { it.elementType == WHITE_SPACE || it.elementType == RPAR }
                         ?.let { addMissingWhiteSpaceAfterMe(el, emit) }
                 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRuleTest.kt
@@ -511,6 +511,16 @@ class ParameterListSpacingRuleTest {
             .isFormattedAs(formattedCode)
     }
 
+    @Test
+    fun `Issue 2794 - Given a single line function signature and the last parameter is followed by a trailing comma`() {
+        val code =
+            """
+            fun foo(bar: Int,) {
+            }
+            """.trimIndent()
+        parameterListSpacingRuleAssertThat(code).hasNoLintViolations()
+    }
+
     private companion object {
         const val TOO_MANY_SPACES = "  "
     }


### PR DESCRIPTION
## Description

Ignore missing whitespace after trailing comma in single line parameter value list

Closes #2794

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
