### PR TITLE
Remove HEADER_KEYWORD & IMPL_KEYWORD

### DIFF
--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -187,11 +187,9 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ElementType {
 	public final fun getGT ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getGTEQ ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getHASH ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
-	public final fun getHEADER_KEYWORD ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIDENTIFIER ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIF ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIF_KEYWORD ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
-	public final fun getIMPL_KEYWORD ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIMPORT_ALIAS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIMPORT_DIRECTIVE ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getIMPORT_KEYWORD ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ElementType.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ElementType.kt
@@ -271,8 +271,6 @@ public object ElementType {
     public val INFIX_KEYWORD: IElementType = KtTokens.INFIX_KEYWORD
     public val CONST_KEYWORD: IElementType = KtTokens.CONST_KEYWORD
     public val SUSPEND_KEYWORD: IElementType = KtTokens.SUSPEND_KEYWORD
-    public val HEADER_KEYWORD: IElementType = KtTokens.HEADER_KEYWORD
-    public val IMPL_KEYWORD: IElementType = KtTokens.IMPL_KEYWORD
     public val EXPECT_KEYWORD: IElementType = KtTokens.EXPECT_KEYWORD
     public val ACTUAL_KEYWORD: IElementType = KtTokens.ACTUAL_KEYWORD
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -108,7 +108,6 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
                 OPERATOR_KEYWORD,
                 DATA_KEYWORD,
                 // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
-                // HEADER_KEYWORD, IMPL_KEYWORD
             )
         private val tokenSet = TokenSet.create(*ORDERED_MODIFIERS)
     }


### PR DESCRIPTION
## Description
Remove calls to `KtTokens.HEADER_KEYWORD` & `KtTokens.IMPL_KEYWORD`. These have been removed from Kotlin effective Kotlin 2.1.0-Beta1.

Without this change, projects that use ktlint-rule-engine-core as a dependency cannot build when upgraded to Kotlin-2.1.0-Beta1.

References:
* https://youtrack.jetbrains.com/issue/KT-52315/Legacy-keywords-header-impl-break-enum-definitions
* https://github.com/JetBrains/kotlin/commit/76592dcb556f811c476fcb3912a910bbd19ffe3b#diff-acd77bf153b196d3b53b21fcd27f3971151fba10645714064933d6a916b2a4b2

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
