### PR TITLE
Function signature rule ignores context receiver when on separate line

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -1374,6 +1374,82 @@ class FunctionSignatureRuleTest {
             .isFormattedAs(formattedCode)
     }
 
+    @Nested
+    inner class `Issue 2800 - Given a function signature with a context receiver` {
+        @Test
+        fun `Issue 2800 - Given context receiver on a separate line then ignore the context receiver before rewriting the signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+                context(Foo)
+                fun barrrrrrrrrrrrrr(string: String) {
+                   println(string)
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2800 - Given context receiver on a separate line, followed by a comment on separate line then ignore the context receiver and comment before rewriting the signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+                context(Foo)
+                // some comment
+                fun barrrrrrrrrrrrrr(string: String) {
+                   println(string)
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2800 - Given context receiver on a separate line, followed by an EOL comment then ignore the context receiver and comment before rewriting the signature`() {
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
+                context(Foo) // some comment
+                fun barrrrrrrrrrrrrr(string: String) {
+                   println(string)
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 2800 - Given context receiver on same line then take the context receiver into account when rewriting the signature`() {
+            // Normally the
+            val code =
+                """
+                // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+                context(Foo) fun bar(string: String) {
+                   println(string)
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                // $MAX_LINE_LENGTH_MARKER          $EOL_CHAR
+                context(Foo) fun bar(
+                    string: String
+                ) {
+                   println(string)
+                }
+                """.trimIndent()
+            functionSignatureWrappingRuleAssertThat(code)
+                .setMaxLineLength()
+                .hasLintViolations(
+                    LintViolation(2, 22, "Newline expected after opening parenthesis"),
+                    LintViolation(2, 36, "Newline expected before closing parenthesis"),
+                ).isFormattedAs(formattedCode)
+        }
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""


### PR DESCRIPTION
## Description

Function signature rule ignores context receiver when on separate line

Closes #2800

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
