### PR TITLE
Do not insert a trailing comma in a multiline when-entry containing a guard

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -1066,4 +1066,28 @@ class TrailingCommaOnDeclarationSiteRuleTest {
             .hasLintViolation(3, 17, "Missing trailing comma and newline before \"->\"")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2817 - Given when condition with guard clause`() {
+        val code =
+            """
+            val x1 =
+                when (true) {
+                    true if foo("a") -> true
+                    else -> false
+                }
+            val x2 =
+                when (true) {
+                    true if foo(
+                        "a",
+                    )
+                    -> true
+
+                    else -> false
+                }
+            """.trimIndent()
+        trailingCommaOnDeclarationSiteRuleAssertThat(code)
+            .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not insert a trailing comma in a multiline when-entry containing a guard

Closes #2817

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
