### PR TITLE
Fixes #1123 - Add --stdin-path to provide a virtual file location for stdin

### DIFF
--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -167,6 +167,12 @@ When combined with the `--format` option, the formatted code is written to `stdo
 ktlint --stdin -F
 ```
 
+If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
+
+```shell title="file path from stdin-path"
+ktlint --stdin --stdin-path /path/to/file/Foo.kt
+```
+
 !!! tip "Suppress logging and error output"
     Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
     Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -167,16 +167,15 @@ When combined with the `--format` option, the formatted code is written to `stdo
 ktlint --stdin -F
 ```
 
+!!! tip "Suppress logging and error output"
+Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
+Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
+
 If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
 
 ```shell title="file path from stdin-path"
 ktlint --stdin --stdin-path /path/to/file/Foo.kt
 ```
-
-!!! tip "Suppress logging and error output"
-    Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
-    Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
-
 
 ### Git hooks
 

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -309,7 +309,6 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
             lintStdin(
                 ktLintRuleEngine,
                 aggregatedReporter,
-                stdinPath,
             )
         } else {
             lintFiles(
@@ -433,17 +432,18 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
     private fun lintStdin(
         ktLintRuleEngine: KtLintRuleEngine,
         reporter: ReporterV2,
-        stdinpath: String?,
     ) {
-        val expandedStdinPath =
-            stdinpath
+        val code =
+            stdinPath
                 ?.expandTildeToFullPath()
                 ?.let { path -> Paths.get(path) }
+                ?.let { Code.fromStdin(it) }
+                ?: Code.fromStdin()
         report(
             KtLintRuleEngine.STDIN_FILE,
             process(
                 ktLintRuleEngine = ktLintRuleEngine,
-                code = Code.fromStdin(expandedStdinPath),
+                code = code,
                 baselineLintErrors = emptyList(),
             ),
             reporter,

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -269,7 +269,7 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
         val editorConfigOverride =
             EditorConfigOverride
                 .EMPTY_EDITOR_CONFIG_OVERRIDE
-                .applyIf(stdin && stdinPath == null) {
+                .applyIf(stdin && stdinPath.isNullOrBlank()) {
                     logger.debug {
                         "Add editor config override to disable 'filename' rule which can not be used in combination with reading from " +
                             "<stdin>"

--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -185,7 +185,7 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
     private val stdinPath: String? by
         option(
             "--stdin-path",
-            help = "Provide a virtual file location for stdin",
+            help = "Virtual file location for stdin. When combined with option '--format' the actual file will not be overwritten",
         )
 
     private val patternsFromStdin: String? by

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -399,6 +399,21 @@ class SimpleCLITest {
     }
 
     @Test
+    fun `Issue 1123 - Enable filename rule when --stdin and --stdin-path is used`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                testProjectName = "too-many-empty-lines",
+                arguments = listOf("--stdin", "--stdin-path", "/foo/Foo.kt"),
+                stdin = ByteArrayInputStream("fun foo() = 42".toByteArray()),
+            ) {
+                assertThat(normalOutput).doesNotContainLineMatching(Regex(".*ktlint_standard_filename: disabled.*"))
+            }
+    }
+
+    @Test
     fun `Issue 1832 - Given stdin input containing Kotlin Script resulting in a KtLintParseException when linted as Kotlin code then process the input as Kotlin Script`(
         @TempDir
         tempDir: Path,

--- a/ktlint-rule-engine/api/ktlint-rule-engine.api
+++ b/ktlint-rule-engine/api/ktlint-rule-engine.api
@@ -17,7 +17,7 @@ public final class com/pinterest/ktlint/rule/engine/api/Code$Companion {
 	public static synthetic fun fromSnippet$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public final fun fromSnippetWithPath (Ljava/lang/String;Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public static synthetic fun fromSnippetWithPath$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;Ljava/nio/file/Path;ILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
-	public final fun fromStdin ()Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public final fun fromStdin (Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 }
 
 public final class com/pinterest/ktlint/rule/engine/api/EditorConfigDefaults {

--- a/ktlint-rule-engine/api/ktlint-rule-engine.api
+++ b/ktlint-rule-engine/api/ktlint-rule-engine.api
@@ -17,6 +17,7 @@ public final class com/pinterest/ktlint/rule/engine/api/Code$Companion {
 	public static synthetic fun fromSnippet$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public final fun fromSnippetWithPath (Ljava/lang/String;Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public static synthetic fun fromSnippetWithPath$default (Lcom/pinterest/ktlint/rule/engine/api/Code$Companion;Ljava/lang/String;Ljava/nio/file/Path;ILjava/lang/Object;)Lcom/pinterest/ktlint/rule/engine/api/Code;
+	public final fun fromStdin ()Lcom/pinterest/ktlint/rule/engine/api/Code;
 	public final fun fromStdin (Ljava/nio/file/Path;)Lcom/pinterest/ktlint/rule/engine/api/Code;
 }
 

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
@@ -115,6 +115,13 @@ public class Code private constructor(
          * filesystem are ignored as the snippet is not associated with a file path. Use [Code.fromFile] for scanning a file while at the
          * same time respecting the '.editorconfig' files on the path to the file.
          */
-        public fun fromStdin(stdinPath: Path?): Code = fromSnippetWithPath(String(System.`in`.readBytes()), virtualPath = stdinPath)
+        public fun fromStdin(): Code = fromSnippetWithPath(String(System.`in`.readBytes()))
+
+        /**
+         * Create [Code] by reading the snippet from 'stdin'. The code snippet is associated with the given path. The actual file does not
+         * need to exist, neither do the contents of the actual file have to match with the content specified via 'stdin'. The
+         * '.editorconfig' files on the [virtualPath] are respected.
+         */
+        public fun fromStdin(virtualPath: Path): Code = fromSnippetWithPath(String(System.`in`.readBytes()), virtualPath = virtualPath)
     }
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/api/Code.kt
@@ -22,14 +22,14 @@ public class Code private constructor(
 ) {
     public fun fileNameOrStdin(): String =
         if (isStdIn) {
-            STDIN_FILE
+            fileName ?: STDIN_FILE
         } else {
             fileName.orEmpty()
         }
 
     public fun filePathOrStdin(): String =
         if (isStdIn) {
-            STDIN_FILE
+            filePath?.pathString ?: STDIN_FILE
         } else {
             filePath?.pathString.orEmpty()
         }
@@ -115,6 +115,6 @@ public class Code private constructor(
          * filesystem are ignored as the snippet is not associated with a file path. Use [Code.fromFile] for scanning a file while at the
          * same time respecting the '.editorconfig' files on the path to the file.
          */
-        public fun fromStdin(): Code = fromSnippet(String(System.`in`.readBytes()))
+        public fun fromStdin(stdinPath: Path?): Code = fromSnippetWithPath(String(System.`in`.readBytes()), virtualPath = stdinPath)
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

Fixes #1123

Add an optional CLI `--stdin-path` to provide a virtual file location for stdin. This allows for re-enabling the `FilenameRule` as well as supporting custom rules that rely on the file path while still using stdin.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [x] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [x] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
