### PR TITLE
Fix typo `when-entry-spacing` → `when-entry-bracing`

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -341,20 +341,20 @@ This rule is not incorporated in the Kotlin Coding conventions, nor in the Andro
         }
     ```
 
-Rule id: `standard:when-entry-spacing`
+Rule id: `standard:when-entry-bracing`
 
 Suppress or disable rule (1)
 { .annotate }
 
 1. Suppress rule in code with annotation below:
     ```kotlin
-    @Suppress("ktlint:standard:when-entry-spacing")
+    @Suppress("ktlint:standard:when-entry-bracing")
     ```
    Enable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_when-entry-spacing = enabled
+    ktlint_standard_when-entry-bracing = enabled
     ```
    Disable rule via `.editorconfig`
     ```editorconfig
-    ktlint_standard_when-entry-spacing = disabled
+    ktlint_standard_when-entry-bracing = disabled
     ```


### PR DESCRIPTION
## Description

Fix a typo in the docs regarding the `when-entry-bracing` rule.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
