### PR TITLE
Catch java.lang.NoSuchFieldError when looking for WHEN_ENTRY_GUARD in kotlin version 2.0.1

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -103,7 +103,7 @@ internal class RuleExecutionContext private constructor(
                 } else {
                     executeRuleWithoutAutocorrectApproveHandlerOnNodeRecursively(node, rule, autocorrectHandler, emitAndApprove)
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 if (autocorrectHandler is NoneAutocorrectHandler) {
                     val (line, col) = positionInTextLocator(node.startOffset)
                     throw RuleExecutionException(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -258,7 +258,7 @@ public class TrailingCommaOnDeclarationSiteRule :
         val trailingCommaNode = prevLeaf?.findPreviousTrailingCommaNodeOrNull()
         val trailingCommaState =
             when {
-                hasWhenGuard() -> {
+                hasWhenEntryGuard() -> {
                     // The compiler won't allow any comma in the when-entry in case it contains a guard clause
                     TrailingCommaState.NOT_EXISTS
                 }
@@ -444,7 +444,16 @@ public class TrailingCommaOnDeclarationSiteRule :
         return codeLeaf?.takeIf { it.elementType == COMMA }
     }
 
-    private fun ASTNode.hasWhenGuard() = elementType == WHEN_ENTRY && children().any { it.elementType == WHEN_ENTRY_GUARD }
+    private fun ASTNode.hasWhenEntryGuard() = elementType == WHEN_ENTRY && hasWhenEntryGuardKotlin21()
+
+    private fun ASTNode.hasWhenEntryGuardKotlin21(): Boolean =
+        // TODO: Remove try-catch wrapping once kotlin version is upgraded to 2.1 or above
+        try {
+            children().any { it.elementType == WHEN_ENTRY_GUARD }
+        } catch (e: NoSuchFieldError) {
+            // Prior to Kotlin 2.1 the WHEN_ENTRY_GUARD can not be retrieved successfully.
+            false
+        }
 
     private fun containsLineBreakInLeavesRange(
         from: PsiElement,


### PR DESCRIPTION
## Description

Catch java.lang.NoSuchFieldError when looking for WHEN_ENTRY_GUARD in kotlin version 2.0.1

As this exception was not caught in the rule, and also not in the RuleExecutionContext it terminated linting/formatting of files containing a WHEN_ENTRY with an exception. In the Ktlint CLI this exception was swallowed. In ktlint-intellij-plugin the exception was recorded and became visible to users.

Closes #2856

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
