### PR TITLE
Wrap the expression body in case `.editorconfig` property `ktlint_function_signature_body_expression_wrapping` is set to `always`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -563,6 +563,10 @@ public class FunctionSignatureRule :
                         }
                     val mergeWithFunctionSignature =
                         when {
+                            functionBodyExpressionWrapping == always -> {
+                                false
+                            }
+
                             firstLineOfBodyExpression.length < maxLengthRemainingForFirstLineOfBodyExpression -> {
                                 (functionBodyExpressionWrapping == default && !functionBodyExpressionNodes.isMultilineStringTemplate()) ||
                                     (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size == 1) ||
@@ -588,7 +592,8 @@ public class FunctionSignatureRule :
                     !whiteSpaceBeforeFunctionBodyExpression.textContains('\n')
                 ) {
                     if (node.isMultilineFunctionSignatureWithoutExplicitReturnType(lastNodeOfFunctionSignatureWithBodyExpression) &&
-                        firstLineOfBodyExpression.length + 1 <= maxLengthRemainingForFirstLineOfBodyExpression
+                        firstLineOfBodyExpression.length + 1 <= maxLengthRemainingForFirstLineOfBodyExpression &&
+                        functionBodyExpressionWrapping != always
                     ) {
                         if (whiteSpaceBeforeFunctionBodyExpression == null ||
                             whiteSpaceBeforeFunctionBodyExpression.text != " "


### PR DESCRIPTION
## Description

Wrap the expression body in case `.editorconfig` property `ktlint_function_signature_body_expression_wrapping` is set to `always`. This setting should precedence above merging the first line of the expression body with the closing parenthesis of a function without return type.

Closes #2872

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
