### PR TITLE
Add missing space between `fun` keyword and identifier when latter is wrapped between backticks

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunKeywordSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunKeywordSpacingRuleTest.kt
@@ -36,4 +36,19 @@ class FunKeywordSpacingRuleTest {
             .hasLintViolation(1, 4, "Single space expected after the fun keyword")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2879 - Given a function with name between backticks then the fun keyword and name should be separated by a space`() {
+        val code =
+            """
+            fun`foo or bar`() = "foo"
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun `foo or bar`() = "foo"
+            """.trimIndent()
+        funKeywordSpacingRuleAssertThat(code)
+            .hasLintViolation(1, 4, "Space expected between the fun keyword and backtick")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Add missing space between `fun` keyword and identifier when latter is wrapped between backticks

Closes #2879

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
