### PR TITLE
Fix false positive when empty parameter list is in between trailing lambda's of a nested call expression

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
@@ -2,7 +2,9 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
@@ -14,6 +16,7 @@ import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
@@ -27,8 +30,9 @@ public class UnnecessaryParenthesesBeforeTrailingLambdaRule : StandardRule("unne
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node.isPartOf(CALL_EXPRESSION) &&
-            node.isEmptyArgumentList() &&
+        if (node.isEmptyArgumentList() &&
+            node.isPartOf(CALL_EXPRESSION) &&
+            node.isNotPrecededByCallExpressionEndingWithLambdaArgument() &&
             node.nextCodeSibling()?.elementType == LAMBDA_ARGUMENT
         ) {
             emit(
@@ -46,6 +50,17 @@ public class UnnecessaryParenthesesBeforeTrailingLambdaRule : StandardRule("unne
             children()
                 .filterNot { it.elementType == LPAR || it.elementType == RPAR }
                 .none()
+
+    private fun ASTNode.isNotPrecededByCallExpressionEndingWithLambdaArgument() =
+        prevCodeSibling()
+            ?.takeIf { it.elementType == CALL_EXPRESSION }
+            ?.lastChildNode
+            ?.takeIf { it.elementType == LAMBDA_ARGUMENT }
+            ?.lastChildNode
+            ?.takeIf { it.elementType == LAMBDA_EXPRESSION }
+            ?.lastChildNode
+            ?.let { it.elementType != FUNCTION_LITERAL }
+            ?: true
 }
 
 public val UNNECESSARY_PARENTHESES_BEFORE_TRAILING_LAMBDA_RULE_ID: RuleId = UnnecessaryParenthesesBeforeTrailingLambdaRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRuleTest.kt
@@ -23,4 +23,15 @@ class UnnecessaryParenthesesBeforeTrailingLambdaRuleTest {
             .hasLintViolation(2, 24, "Empty parentheses in function call followed by lambda are unnecessary")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2884 - Given some a call expression ending with a lambda argument, followed by an empty argument list followed by another lambda argument then do not remove empty parameter list`() {
+        val code =
+            """
+            fun fooBar(foo: () -> String): (() -> String) -> String = { bar -> foo().plus("  ").plus(bar()) }
+
+            val foobar = fooBar { "Hello" }() { "world" }
+            """.trimIndent()
+        unnecessaryParenthesesBeforeTrailingLambdaRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix false positive when empty parameter list is in between trailing lambda's of a nested call expression

Given code below:
```
fun fooBar(foo: () -> String): (() -> String) -> String = { bar -> foo().plus("  ").plus(bar()) }

val foobar = fooBar { "Hello" }() { "world" }
```
then the empty parameter list may ot be removed as it results in a compile error.

Closes #2884

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
