### PR TITLE
Do not wrap a context receiver in a function parameter type reference

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -4343,9 +4343,9 @@ Suppress or disable rule (1)
     ktlint_standard_condition-wrapping = disabled
     ```
 
-### Content receiver wrapping
+### Context receiver wrapping
 
-Wraps the content receiver list to a separate line regardless of maximum line length. If the maximum line length is configured and is exceeded, wrap the context receivers and if needed its projection types to separate lines.
+Wraps the context receiver list to a separate line regardless of maximum line length. If the maximum line length is configured and is exceeded, wrap the context receivers and if needed its projection types to separate lines.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -4343,9 +4343,9 @@ Suppress or disable rule (1)
     ktlint_standard_condition-wrapping = disabled
     ```
 
-### Content receiver wrapping
+### Context receiver wrapping
 
-Wraps the content receiver list to a separate line regardless of maximum line length. If the maximum line length is configured and is exceeded, wrap the context receivers and if needed its projection types to separate lines.
+Wraps the context receiver list of a function to a separate line regardless of maximum line length. If the maximum line length is configured and is exceeded, wrap the context receivers and if needed its projection types to separate lines.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
@@ -199,4 +199,16 @@ class ContextReceiverWrappingRuleTest {
                 LintViolation(2, 36, "Newline expected before closing parenthesis as max line length is violated"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2854 - Given a function parameter with a context receiver then do not wrap after the context receiver`() {
+        val code =
+            """
+            fun bar1(foo: context(Foo) () -> Unit = { foobar() }) {}
+            fun bar2(
+                foo: context(Foo) () -> Unit = { foobar() }
+            ) {}
+            """.trimIndent()
+        contextReceiverWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not wrap a context receiver in a function parameter type reference

Closes #2854

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
