### PR TITLE
Add configuration setting for constant names in `property-naming` rule

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -1505,6 +1505,13 @@ Enforce naming of property.
 
 This rule is suppressed whenever the IntelliJ IDEA inspection suppression `PropertyName`, `ConstPropertyName`, `ObjectPropertyName` or `PrivatePropertyName` is used.
 
+| Configuration setting                                                                                                                          |    ktlint_official     |     intellij_idea      |     android_studio     |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|:----------------------:|:----------------------:|:----------------------:|
+| `ktlint_property_naming_constant_naming`<br/><i>The naming style ('screaming_snake_case', or 'pascal_case') to be applied on constant properties.</i> | `screaming_snake_case` | `screaming_snake_case` | `screaming_snake_case` |
+
+!!! note
+    When using Compose, you might want to configure the `ktlint_property_naming_constant_naming-naming` rule with `.editorconfig` property `ktlint_property_naming_constant_naming = pascal_case`.
+
 Rule id: `standard:property-naming`
 
 Suppress or disable rule (1)

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -716,9 +716,24 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/ParameterWrapping
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
-	public static final field SERIAL_VERSION_UID_PROPERTY_NAME Ljava/lang/String;
+	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion;
 	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion {
+	public final fun getCONSTANT_NAMING_PROPERTY ()Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfigProperty;
+	public final fun getCONSTANT_NAMING_PROPERTY_TYPE ()Lorg/ec4j/core/model/PropertyType$LowerCasingPropertyType;
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion$ConstantNamingStyle : java/lang/Enum {
+	public static final field pascal_case Lcom/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion$ConstantNamingStyle;
+	public static final field screaming_snake_case Lcom/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion$ConstantNamingStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getRegEx ()Lkotlin/text/Regex;
+	public static fun valueOf (Ljava/lang/String;)Lcom/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion$ConstantNamingStyle;
+	public static fun values ()[Lcom/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule$Companion$ConstantNamingStyle;
 }
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleKt {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -1,5 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.ruleset.standard.rules.PropertyNamingRule.Companion.ConstantNamingStyle.pascal_case
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.KtlintDocumentationTest
 import com.pinterest.ktlint.test.LintViolation
@@ -47,16 +48,47 @@ class PropertyNamingRuleTest {
     }
 
     @Test
-    fun `Given a const property name not in screaming case notation then do emit`() {
+    fun `Given the default constant naming style, and a const property name not in screaming case notation then do emit`() {
         val code =
             """
             const val foo = "foo"
+            const val FOO = "foo"
             const val FOO_BAR_2 = "foo-bar-2"
             const val ŸÈŠ_THÎS_IS_ALLOWED_123 = "Yes this is allowed"
+            const val Foo = "foo"
+            const val FooBar2 = "foo-bar-2"
+            const val ŸèšThîsIsAllowed123 = "Yes this is allowed"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 11, "Property name should use the screaming snake case notation when the value can not be changed")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(5, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(6, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(7, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+            )
+    }
+
+    @Test
+    fun `Given the pascal_case constant naming style, and a const property name not in pascal_case notation then do emit`() {
+        val code =
+            """
+            const val foo = "foo"
+            const val FOO = "foo"
+            const val FOO_BAR_2 = "foo-bar-2"
+            const val ŸÈŠ_THÎS_IS_ALLOWED_123 = "Yes this is allowed"
+            const val Foo = "foo"
+            const val FooBar2 = "foo-bar-2"
+            const val ŸèšThîsIsAllowed123 = "Yes this is allowed"
+            """.trimIndent()
+        propertyNamingRuleAssertThat(code)
+            .withEditorConfigOverride(PropertyNamingRule.CONSTANT_NAMING_PROPERTY to pascal_case)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                // FOO cannot be reported as not meeting the pascal case requirement as it could be an abbreviation of 3 separate words
+                // starting with 'F', 'O' and 'O' respectively
+                LintViolation(3, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(4, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+            )
     }
 
     @Test


### PR DESCRIPTION
## Description

Add configuration setting for constant names in `property-naming` rule

Compose requires constant names to follow the PascalCase convention instead of the SCREAMING_SNAKE_CASE convention.

Closes #2637

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
