### PR TITLE
Allow comment before parameter list in function literal (`function-literal`)

### DIFF
--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -597,4 +597,30 @@ class FunctionLiteralRuleTest {
                 LintViolation(4, 7, "Arrow is redundant when parameter list is empty"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2850 - Given function literal with a comment before the parameter list which contains a redundant parameter then do remove the redundant parameter but keep the comment`() {
+        val code =
+            """
+            val foo1 =
+                {
+                    // some comment
+                    foo: String -> "foo = " + foo
+                }
+            val foo2 =
+                { // some comment
+                    foo: String -> "foo = " + foo
+                }
+            val foo3 =
+                {
+                    /* some comment */
+                    foo: String -> "foo = " + foo
+                }
+            val foo4 =
+                { /* some comment */
+                    foo: String -> "foo = " + foo
+                }
+            """.trimIndent()
+        functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Allow comment before parameter list in function literal (`function-literal`)

Merging an EOL comment before the parameter list with the actual parameter list results in code that no longer compiles.

Closes #2850

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
