### PR TITLE
Allow backing property to be defined in the companion object (`backing-property-naming`)

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -1253,10 +1253,18 @@ Allows property names to start with `_` in case the property is a backing proper
 
     ```kotlin
     class Bar {
-        // Backing property
+        // Backing property as normal class member
         private val _elementList = mutableListOf<Element>()
         val elementList: List<Element>
             get() = _elementList
+
+        // Backing property defined in companion object
+        val elementList2: List<Element>
+            get() = _elementList2
+
+        companion object {
+            private val _elementList2 = mutableListOf<Element>()
+        }
     }
     ```
 === "[:material-heart-off-outline:](#) Disallowed"

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -17,258 +17,831 @@ class BackingPropertyNamingRuleTest {
     private val backingPropertyNamingRuleAssertThat = assertThatRule { BackingPropertyNamingRule() }
 
     @Nested
-    inner class `Given a backing property correlating with a property` {
-        @ParameterizedTest(name = "Correlated property name: {0}")
-        @ValueSource(
-            strings = [
-                "foo",
-                "føø",
-            ],
-        )
-        fun `Given a valid property name then do not emit`(propertyName: String) {
-            val code =
-                """
-                class Foo {
-                    private var _$propertyName = "some-value"
+    inner class `Given a backing property defined as normal class member` {
+        @Nested
+        inner class `Given a correlated property` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @ValueSource(
+                strings = [
+                    "foo",
+                    "føø",
+                ],
+            )
+            fun `Given the correlated property is defined as class member then do not emit`(propertyName: String) {
+                val code =
+                    """
+                    class Foo {
+                        private var _$propertyName = "some-value"
 
-                    val $propertyName: String
-                        get() = _$propertyName
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+                        val $propertyName: String
+                            get() = _$propertyName
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        val elementList: List<Element>
+                            get() = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        public val elementList: List<Element>
+                            get() = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated property is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
         }
 
-        @Test
-        fun `Given that the correlated property is implicitly public then do not emit`() {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+        @Nested
+        inner class `Given a co=related function` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @CsvSource(
+                value = [
+                    "foo,getFoo",
+                    "føø,getFøø",
+                ],
+            )
+            fun `Given a valid backing property then do not emit`(
+                propertyName: String,
+                functionName: String,
+            ) {
+                val code =
+                    """
+                    class Foo {
+                        private var _$propertyName = "some-value"
 
-                    val elementList: List<Element>
-                        get() = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
-        }
+                        fun $functionName(): String = _$propertyName
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @Test
-        fun `Given that the correlated property is explicitly public then do not emit`() {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @Test
+            fun `Given that the correlated function is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
 
-                    public val elementList: List<Element>
-                        get() = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
-        }
+                        fun getElementList(): List<Element> = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given ktlint_official code style, and the correlated property is non-public then emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @Test
+            fun `Given that the correlated function is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
 
-                    $modifier val elementList: List<Element>
-                        get() = _elementList
-                }
-                """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
-        }
+                        public fun getElementList(): List<Element> = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given intellij_idea code style, and the correlated property is non-public then emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
 
-                    $modifier val elementList: List<Element>
-                        get() = _elementList
-                }
-                """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
-        }
+                        $modifier fun getElementList(): List<Element> = _elementList
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given android_studio code style, and the correlated property is non-public then do not emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
 
-                    $modifier val elementList: List<Element>
-                        get() = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
-                .hasNoLintViolations()
+                        $modifier fun getElementList(): List<Element> = _elementList
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated function is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        $modifier fun getElementList(): List<Element> = _elementList
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated function has at least 1 parameter then emit`() {
+                val code =
+                    """
+                    class Foo {
+                        private val _elementList = mutableListOf<Element>()
+
+                        fun getElementList(bar: String): List<Element> = _elementList + bar
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when a matching property or function exists")
+            }
         }
     }
 
     @Nested
-    inner class `Given a backing property correlating with a function` {
-        @ParameterizedTest(name = "Correlated property name: {0}")
-        @CsvSource(
-            value = [
-                "foo,getFoo",
-                "føø,getFøø",
-            ],
-        )
-        fun `Given a valid backing property then do not emit`(
-            propertyName: String,
-            functionName: String,
-        ) {
-            val code =
-                """
-                class Foo {
-                    private var _$propertyName = "some-value"
+    inner class `Given a private backing property defined in a non-private companion object` {
+        @Nested
+        inner class `Given a correlated property` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @ValueSource(
+                strings = [
+                    "foo",
+                    "føø",
+                ],
+            )
+            fun `Given the correlated property is defined as class member then do not emit`(propertyName: String) {
+                val code =
+                    """
+                    class Foo {
+                        val $propertyName: String
+                            get() = _$propertyName
 
-                    fun $functionName(): String = _$propertyName
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+                        companion object {
+                            private var _$propertyName = "some-value"
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        val elementList: List<Element>
+                            get() = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        public val elementList: List<Element>
+                            get() = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated property is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
         }
 
-        @Test
-        fun `Given that the correlated function is implicitly public then do not emit`() {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+        @Nested
+        inner class `Given a co=related function` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @CsvSource(
+                value = [
+                    "foo,getFoo",
+                    "føø,getFøø",
+                ],
+            )
+            fun `Given a valid backing property then do not emit`(
+                propertyName: String,
+                functionName: String,
+            ) {
+                val code =
+                    """
+                    class Foo {
+                        fun $functionName(): String = _$propertyName
 
-                    fun getElementList(): List<Element> = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+                        companion object {
+                            private var _$propertyName = "some-value"
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated function is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        fun getElementList(): List<Element> = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated function is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        public fun getElementList(): List<Element> = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated function is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated function has at least 1 parameter then emit`() {
+                val code =
+                    """
+                    class Foo {
+                        fun getElementList(bar: String): List<Element> = _elementList + bar
+
+                        companion object {
+                            private val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when a matching property or function exists")
+            }
+        }
+    }
+
+    @Nested
+    inner class `Given a backing property defined in a private companion object` {
+        @Nested
+        inner class `Given a correlated property` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @ValueSource(
+                strings = [
+                    "foo",
+                    "føø",
+                ],
+            )
+            fun `Given the correlated property is defined as class member then do not emit`(propertyName: String) {
+                val code =
+                    """
+                    class Foo {
+                        val $propertyName: String
+                            get() = _$propertyName
+
+                        private companion object {
+                            var _$propertyName = "some-value"
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        val elementList: List<Element>
+                            get() = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated property is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        public val elementList: List<Element>
+                            get() = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated property is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated property is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier val elementList: List<Element>
+                            get() = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
         }
 
-        @Test
-        fun `Given that the correlated function is explicitly public then do not emit`() {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+        @Nested
+        inner class `Given a co=related function` {
+            @ParameterizedTest(name = "Correlated property name: {0}")
+            @CsvSource(
+                value = [
+                    "foo,getFoo",
+                    "føø,getFøø",
+                ],
+            )
+            fun `Given a valid backing property then do not emit`(
+                propertyName: String,
+                functionName: String,
+            ) {
+                val code =
+                    """
+                    class Foo {
+                        fun $functionName(): String = _$propertyName
 
-                    public fun getElementList(): List<Element> = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
-        }
+                        private companion object {
+                            var _$propertyName = "some-value"
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given ktlint_official code style, and the correlated function is non-public then emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @Test
+            fun `Given that the correlated function is implicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        fun getElementList(): List<Element> = _elementList
 
-                    $modifier fun getElementList(): List<Element> = _elementList
-                }
-                """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
-        }
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given intellij_idea code style, and the correlated function is non-public then emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @Test
+            fun `Given that the correlated function is explicitly public then do not emit`() {
+                val code =
+                    """
+                    class Foo {
+                        public fun getElementList(): List<Element> = _elementList
 
-                    $modifier fun getElementList(): List<Element> = _elementList
-                }
-                """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
-        }
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()
+            }
 
-        @ParameterizedTest(name = "Modifier: {0}")
-        @ValueSource(
-            strings = [
-                "private",
-                "protected",
-                "internal",
-            ],
-        )
-        fun `Given android_studio code style, and the correlated function is non-public then do not emit`(modifier: String) {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given ktlint_official code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
 
-                    $modifier fun getElementList(): List<Element> = _elementList
-                }
-                """.trimIndent()
-            backingPropertyNamingRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
-                .hasNoLintViolations()
-        }
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
+                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
+            }
 
-        @Test
-        fun `Given that the correlated function has at least 1 parameter then emit`() {
-            val code =
-                """
-                class Foo {
-                    private val _elementList = mutableListOf<Element>()
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given intellij_idea code style, and the correlated function is non-public then emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
 
-                    fun getElementList(bar: String): List<Element> = _elementList + bar
-                }
-                """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
-            backingPropertyNamingRuleAssertThat(code)
-                .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when a matching property or function exists")
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
+                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
+            }
+
+            @ParameterizedTest(name = "Modifier: {0}")
+            @ValueSource(
+                strings = [
+                    "private",
+                    "protected",
+                    "internal",
+                ],
+            )
+            fun `Given android_studio code style, and the correlated function is non-public then do not emit`(modifier: String) {
+                val code =
+                    """
+                    class Foo {
+                        $modifier fun getElementList(): List<Element> = _elementList
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                backingPropertyNamingRuleAssertThat(code)
+                    .withEditorConfigOverride(CODE_STYLE_PROPERTY to android_studio)
+                    .hasNoLintViolations()
+            }
+
+            @Test
+            fun `Given that the correlated function has at least 1 parameter then emit`() {
+                val code =
+                    """
+                    class Foo {
+                        fun getElementList(bar: String): List<Element> = _elementList + bar
+
+                        private companion object {
+                            val _elementList = mutableListOf<Element>()
+                        }
+                    }
+                    """.trimIndent()
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                backingPropertyNamingRuleAssertThat(code)
+                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when a matching property or function exists")
+            }
         }
     }
 
@@ -298,6 +871,14 @@ class BackingPropertyNamingRuleTest {
                 private val _elementList = mutableListOf<Element>()
                 val elementList: List<Element>
                     get() = _elementList
+
+                // Backing property defined in companion object
+                val elementList2: List<Element>
+                    get() = _elementList2
+
+                companion object {
+                    private val _elementList2 = mutableListOf<Element>()
+                }
             }
             """.trimIndent()
         backingPropertyNamingRuleAssertThat(code).hasNoLintViolations()


### PR DESCRIPTION
## Description

Allow backing property to be defined in the companion object (`backing-property-naming`)

Closes #2877

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
