### PR TITLE
Remove usages of getPsi()

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlin-plugin-dev = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", vers
 clikt = "com.github.ajalt.clikt:clikt:5.0.2"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 ec4j = "org.ec4j.core:ec4j-core:1.1.0"
-logging = "io.github.oshai:kotlin-logging-jvm:7.0.3"
+logging = "io.github.oshai:kotlin-logging-jvm:7.0.4"
 slf4j = "org.slf4j:slf4j-simple:2.0.16"
 poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.18.2"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,6 @@ logcaptor = "io.github.hakky54:logcaptor:2.10.1"
 janino = "org.codehaus.janino:janino:3.1.12"
 # Testing libraries
 junit5 = "org.junit.jupiter:junit-jupiter:5.11.4"
-assertj = "org.assertj:assertj-core:3.27.2"
+assertj = "org.assertj:assertj-core:3.27.3"
 sarif4k = "io.github.detekt.sarif4k:sarif4k:0.6.0"
 jimfs = "com.google.jimfs:jimfs:1.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlinDev = "2.1.10"
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 checksum = "org.gradle.crypto.checksum:1.4.0"
-shadow = "com.gradleup.shadow:8.3.5"
+shadow = "com.gradleup.shadow:8.3.6"
 kotlinx-binary-compatibiltiy-validator = "org.jetbrains.kotlinx.binary-compatibility-validator:0.17.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java-compilation = "21"
 # The java-target version is the lowest supported LTS version of Java. Jar's produced are bytecode compatible with this version.
 java-target = "8"
-kotlin = "2.1.0"
+kotlin = "2.1.10"
 kotlinDev = "2.1.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.18.2"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
 # TODO: Update "renovate.json" once logback-classic is updated to 1.4 (once java8 support for ktlint is dropped)
 logback = "ch.qos.logback:logback-classic:1.3.15"
-logcaptor = "io.github.hakky54:logcaptor:2.10.0"
+logcaptor = "io.github.hakky54:logcaptor:2.10.1"
 # Required for logback-test.xml conditional configuration so that trace-logging in unit test can be automatically enabled using an
 # environment variable
 janino = "org.codehaus.janino:janino:3.1.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ java-compilation = "21"
 # The java-target version is the lowest supported LTS version of Java. Jar's produced are bytecode compatible with this version.
 java-target = "8"
 kotlin = "2.1.10"
-kotlinDev = "2.1.0"
+kotlinDev = "2.1.10"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -56,7 +56,8 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static synthetic fun prevLeaf$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun prevSibling (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static synthetic fun prevSibling$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
-	public static final fun recursiveChildren (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun recursiveChildren (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Lkotlin/sequences/Sequence;
+	public static synthetic fun recursiveChildren$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
 	public static final fun remove (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)V
 	public static final fun replaceWith (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)V
 	public static final fun upsertWhitespaceAfterMe (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Ljava/lang/String;)V

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -533,7 +533,6 @@ public final class com/pinterest/ktlint/rule/engine/core/api/TokenSets {
 	public static final field INSTANCE Lcom/pinterest/ktlint/rule/engine/core/api/TokenSets;
 	public final fun getCOMMENTS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 	public final fun getCONTROL_FLOW_KEYWORDS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
-	public final fun getEXPRESSIONS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigPropertyKt {

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -5,6 +5,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
+	public static final fun getCOMMENT_TOKENS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun hasModifier (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun hasNewLineInClosedRange (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
@@ -14,6 +15,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun isLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/reflect/KClass;)Z
 	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
+	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;)Z
 	public static final fun isPartOfComment (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isPartOfCompositeElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun isPartOfString (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -7,6 +7,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun getCOMMENT_TOKENS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
+	public static final fun getPrevSiblingIgnoringWhitespaceAndComments (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun hasModifier (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun hasNewLineInClosedRange (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun indent (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Ljava/lang/String;

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -5,7 +5,6 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
-	public static final fun getCOMMENT_TOKENS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun getPrevSiblingIgnoringWhitespaceAndComments (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun hasModifier (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
@@ -527,6 +526,12 @@ public final class com/pinterest/ktlint/rule/engine/core/api/SinceKtlint$Status 
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/pinterest/ktlint/rule/engine/core/api/SinceKtlint$Status;
 	public static fun values ()[Lcom/pinterest/ktlint/rule/engine/core/api/SinceKtlint$Status;
+}
+
+public final class com/pinterest/ktlint/rule/engine/core/api/TokenSets {
+	public static final field INSTANCE Lcom/pinterest/ktlint/rule/engine/core/api/TokenSets;
+	public final fun getCOMMENTS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
+	public final fun getEXPRESSIONS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/editorconfig/CodeStyleEditorConfigPropertyKt {

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -56,6 +56,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static synthetic fun prevLeaf$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun prevSibling (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static synthetic fun prevSibling$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
+	public static final fun recursiveChildren (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
 	public static final fun remove (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)V
 	public static final fun replaceWith (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)V
 	public static final fun upsertWhitespaceAfterMe (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Ljava/lang/String;)V

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -3,10 +3,11 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun beforeCodeSibling (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun betweenCodeSiblings (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun endOffset (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
+	public static final fun findChildByTypeRecursively (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;Z)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun firstChildLeafOrSelf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun getColumn (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
-	public static final fun getPrevSiblingIgnoringWhitespaceAndComments (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun hasModifier (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun hasNewLineInClosedRange (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun indent (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Ljava/lang/String;
@@ -531,6 +532,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/SinceKtlint$Status 
 public final class com/pinterest/ktlint/rule/engine/core/api/TokenSets {
 	public static final field INSTANCE Lcom/pinterest/ktlint/rule/engine/core/api/TokenSets;
 	public final fun getCOMMENTS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
+	public final fun getCONTROL_FLOW_KEYWORDS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 	public final fun getEXPRESSIONS ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/TokenSet;
 }
 

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -14,6 +14,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun indent (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Ljava/lang/String;
 	public static synthetic fun indent$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Ljava/lang/String;
 	public static final fun isCodeLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
+	public static final fun isDeclaration (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isKtAnnotated (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/reflect/KClass;)Z

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -3,6 +3,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun beforeCodeSibling (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun betweenCodeSiblings (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun children (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
+	public static final fun dummyPsiElement (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
 	public static final fun endOffset (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)I
 	public static final fun findChildByTypeRecursively (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;Z)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
 	public static final fun findCompositeParentElementOfType (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;
@@ -13,6 +14,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun indent (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Ljava/lang/String;
 	public static synthetic fun indent$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Ljava/lang/String;
 	public static final fun isCodeLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
+	public static final fun isKtAnnotated (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isLeaf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/reflect/KClass;)Z
 	public static final fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.psiUtil.leaves
+import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.util.prefixIfNot
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 import kotlin.reflect.KClass
@@ -574,3 +575,9 @@ public fun ASTNode.replaceWith(node: ASTNode) {
 public fun ASTNode.remove() {
     treeParent.removeChild(this)
 }
+
+public fun ASTNode.getPrevSiblingIgnoringWhitespaceAndComments(): ASTNode? =
+    siblings(forward = false)
+        .filter {
+            !it.isWhiteSpace() && !COMMENT_TOKENS.contains(it.elementType)
+        }.firstOrNull()

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.rule.engine.core.api
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REGULAR_STRING_PART
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAL_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VARARG_KEYWORD
@@ -25,11 +26,13 @@ import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.lexer.KtKeywordToken
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtDeclarationImpl
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementType
+import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 import org.jetbrains.kotlin.util.prefixIfNot
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 import kotlin.contracts.ExperimentalContracts
@@ -669,3 +672,9 @@ private fun createDummyKtFile(): KtFile {
         disposable.dispose()
     }
 }
+
+/**
+ * Returns true if the receiver is not null and it represents a declaration
+ * [KtScriptInitializer] is considered a type of declaration in terms of it being a subtype of [KtDeclarationImpl] even though SCRIPT_INITIALIZER is not included in DECLARATION_TYPES. We consider SCRIPT_INITIALIZER a declaration here to match previous behavior of ktlint in older versions.
+ */
+public fun ASTNode?.isDeclaration() = this != null && (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER)

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -230,8 +230,11 @@ public fun ASTNode.isPartOfComment(): Boolean =
 
 public fun ASTNode.children(): Sequence<ASTNode> = generateSequence(firstChildNode) { node -> node.treeNext }
 
-public fun ASTNode.recursiveChildren(): Sequence<ASTNode> =
+public fun ASTNode.recursiveChildren(includeSelf: Boolean = false): Sequence<ASTNode> =
     sequence {
+        if (includeSelf) {
+            yield(this@recursiveChildren)
+        }
         children().forEach {
             yield(it)
             yieldAll(it.recursiveChildren())

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.lexer.KtKeywordToken
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.psi.KtAnnotated
-import org.jetbrains.kotlin.psi.KtDeclarationImpl
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.leaves
@@ -675,6 +674,8 @@ private fun createDummyKtFile(): KtFile {
 
 /**
  * Returns true if the receiver is not null and it represents a declaration
- * [KtScriptInitializer] is considered a type of declaration in terms of it being a subtype of [KtDeclarationImpl] even though SCRIPT_INITIALIZER is not included in DECLARATION_TYPES. We consider SCRIPT_INITIALIZER a declaration here to match previous behavior of ktlint in older versions.
+ * [KtScriptInitializer] and [KtPropertyAccessor] are considered a types of declarations since they inherit of [org.jetbrains.kotlin.psi.KtDeclaration] even though their respective [IElementType]s are not included in DECLARATION_TYPES. We consider these declarations here to match previous behavior of ktlint in older versions, which was based on the psi type hierarchy
  */
-public fun ASTNode?.isDeclaration() = this != null && (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER)
+public fun ASTNode?.isDeclaration() =
+    this != null &&
+        (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER || elementType == ElementType.PROPERTY_ACCESSOR)

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -8,24 +8,19 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VARARG_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAR_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import org.jetbrains.kotlin.KtNodeType
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
-import org.jetbrains.kotlin.com.intellij.lang.Language
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.com.intellij.openapi.Disposable
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFile
-import org.jetbrains.kotlin.com.intellij.psi.AbstractFileViewProvider
-import org.jetbrains.kotlin.com.intellij.psi.FileViewProvider
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.com.intellij.psi.PsiReference
-import org.jetbrains.kotlin.com.intellij.psi.impl.PsiManagerImpl
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
-import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.lexer.KtKeywordToken
 import org.jetbrains.kotlin.lexer.KtToken
@@ -600,8 +595,8 @@ public fun ASTNode.remove() {
 }
 
 /**
- * Searches the receiver [ASTNode] recursively, returning the first child with type [elementType]. If none are found, returns [null].
- * If [includeSelf] is [true], includes the receiver in the search. The receiver would then be the first element searched, so it is
+ * Searches the receiver [ASTNode] recursively, returning the first child with type [elementType]. If none are found, returns `null`.
+ * If [includeSelf] is `true`, includes the receiver in the search. The receiver would then be the first element searched, so it is
  * guaranteed to be returned if it has type [elementType].
  */
 public fun ASTNode.findChildByTypeRecursively(
@@ -644,7 +639,7 @@ public fun ASTNode.dummyPsiElement(): PsiElement =
             // Create a dummy Psi element based on the current node, so that we can store the Psi Type for this ElementType.
             // Creating this cache entry once per elementType is cheaper than accessing the psi for every node.
             when (elementType) {
-                is KtFileElementType -> KtFile(dummyFileViewProvider, false)
+                is KtFileElementType -> createDummyKtFile()
                 is KtKeywordToken -> this as PsiElement
                 is KtNodeType -> (elementType as KtNodeType).createPsi(this)
                 is KtStubElementType<*, *> -> (elementType as KtStubElementType<*, *>).createPsiFromAst(this)
@@ -653,66 +648,24 @@ public fun ASTNode.dummyPsiElement(): PsiElement =
             }
         }
 
-private val dummyFileViewProvider by lazy {
-    object : AbstractFileViewProvider(
-        PsiManagerImpl(
-            MockProject(
-                null,
-                object : Disposable {
-                    override fun dispose() {
-                        TODO("Not yet implemented")
-                    }
-                },
-            ),
-        ),
-        LightVirtualFile(),
-        false,
-    ) {
-        override fun getPsiInner(p0: Language?): PsiFile? {
-            TODO("Not yet implemented")
-        }
+private fun createDummyKtFile(): KtFile {
+    val disposable = Disposer.newDisposable()
+    try {
+        val project =
+            KotlinCoreEnvironment
+                .createForProduction(
+                    disposable,
+                    CompilerConfiguration(),
+                    EnvironmentConfigFiles.JVM_CONFIG_FILES,
+                ).project as MockProject
 
-        override fun getCachedPsi(p0: Language): PsiFile? {
-            TODO("Not yet implemented")
-        }
-
-        override fun getCachedPsiFiles(): List<PsiFile?> {
-            TODO("Not yet implemented")
-        }
-
-        override fun getKnownTreeRoots(): List<FileASTNode?> {
-            TODO("Not yet implemented")
-        }
-
-        override fun getBaseLanguage(): Language {
-            TODO("Not yet implemented")
-        }
-
-        private val languages = setOf(KotlinLanguage.INSTANCE)
-
-        override fun getLanguages(): Set<Language> = languages
-
-        override fun getAllFiles(): List<PsiFile?> {
-            TODO("Not yet implemented")
-        }
-
-        override fun findElementAt(p0: Int): PsiElement? {
-            TODO("Not yet implemented")
-        }
-
-        override fun findReferenceAt(p0: Int): PsiReference? {
-            TODO("Not yet implemented")
-        }
-
-        override fun findElementAt(
-            p0: Int,
-            p1: Class<out Language?>,
-        ): PsiElement? {
-            TODO("Not yet implemented")
-        }
-
-        override fun createCopy(p0: VirtualFile): FileViewProvider {
-            TODO("Not yet implemented")
-        }
+        return PsiFileFactory
+            .getInstance(project)
+            .createFileFromText("dummy-file.kt", KotlinLanguage.INSTANCE, "") as KtFile
+    } finally {
+        // Dispose explicitly to (possibly) prevent memory leak
+        // https://discuss.kotlinlang.org/t/memory-leak-in-kotlincoreenvironment-and-kotlintojvmbytecodecompiler/21950
+        // https://youtrack.jetbrains.com/issue/KT-47044
+        disposable.dispose()
     }
 }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -8,7 +8,6 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VARARG_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAR_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
@@ -223,7 +222,11 @@ public fun ASTNode.isLeaf(): Boolean = firstChildNode == null
  */
 public fun ASTNode.isCodeLeaf(): Boolean = isLeaf() && !isWhiteSpace() && !isPartOfComment()
 
-public fun ASTNode.isPartOfComment(): Boolean = parent(strict = false) { it.psi is PsiComment } != null
+public fun ASTNode.isPartOfComment(): Boolean =
+    parent(strict = false) {
+        val eType = it.elementType
+        eType == ElementType.BLOCK_COMMENT || eType == ElementType.EOL_COMMENT || eType == ElementType.KDOC
+    } != null
 
 public fun ASTNode.children(): Sequence<ASTNode> = generateSequence(firstChildNode) { node -> node.treeNext }
 

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -230,9 +230,7 @@ public fun ASTNode.isLeaf(): Boolean = firstChildNode == null
  */
 public fun ASTNode.isCodeLeaf(): Boolean = isLeaf() && !isWhiteSpace() && !isPartOfComment()
 
-public fun ASTNode.isPartOfComment(): Boolean = isPartOf(COMMENT_TOKENS)
-
-public val COMMENT_TOKENS: TokenSet = TokenSet.create(ElementType.BLOCK_COMMENT, ElementType.EOL_COMMENT, ElementType.KDOC)
+public fun ASTNode.isPartOfComment(): Boolean = isPartOf(TokenSets.COMMENTS)
 
 public fun ASTNode.children(): Sequence<ASTNode> = generateSequence(firstChildNode) { node -> node.treeNext }
 
@@ -579,5 +577,5 @@ public fun ASTNode.remove() {
 public fun ASTNode.getPrevSiblingIgnoringWhitespaceAndComments(): ASTNode? =
     siblings(forward = false)
         .filter {
-            !it.isWhiteSpace() && !COMMENT_TOKENS.contains(it.elementType)
+            !it.isWhiteSpace() && !TokenSets.COMMENTS.contains(it.elementType)
         }.firstOrNull()

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -571,9 +571,16 @@ public fun ASTNode.remove() {
     treeParent.removeChild(this)
 }
 
+/**
+ * Searches the receiver [ASTNode] recursively, returning the first child with type [elementType]. If none are found, returns [null].
+ * If [includeSelf] is [true], includes the receiver in the search. The receiver would then be the first element searched, so it is guaranteed to be returned if it has type [elementType].
+ */
 public fun ASTNode.findChildByTypeRecursively(
     elementType: IElementType,
     includeSelf: Boolean,
 ): ASTNode? = recursiveChildren(includeSelf).firstOrNull { it.elementType == elementType }
 
+/**
+ * Returns the end offset of the text of this [ASTNode]
+ */
 public fun ASTNode.endOffset(): Int = textRange.endOffset

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint.rule.engine.core.api
 
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REGULAR_STRING_PART
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAL_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VARARG_KEYWORD
@@ -673,9 +672,6 @@ private fun createDummyKtFile(): KtFile {
 }
 
 /**
- * Returns true if the receiver is not null and it represents a declaration
- * [KtScriptInitializer] and [KtPropertyAccessor] are considered a types of declarations since they inherit of [org.jetbrains.kotlin.psi.KtDeclaration] even though their respective [IElementType]s are not included in DECLARATION_TYPES. We consider these declarations here to match previous behavior of ktlint in older versions, which was based on the psi type hierarchy
+ * Returns true if the receiver is not null, and it represents a declaration
  */
-public fun ASTNode?.isDeclaration() =
-    this != null &&
-        (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER || elementType == ElementType.PROPERTY_ACCESSOR)
+public fun ASTNode?.isDeclaration(): Boolean = this != null && elementType in KtTokenSets.DECLARATION_TYPES

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -588,7 +588,8 @@ public fun ASTNode.remove() {
 
 /**
  * Searches the receiver [ASTNode] recursively, returning the first child with type [elementType]. If none are found, returns [null].
- * If [includeSelf] is [true], includes the receiver in the search. The receiver would then be the first element searched, so it is guaranteed to be returned if it has type [elementType].
+ * If [includeSelf] is [true], includes the receiver in the search. The receiver would then be the first element searched, so it is
+ * guaranteed to be returned if it has type [elementType].
  */
 public fun ASTNode.findChildByTypeRecursively(
     elementType: IElementType,

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -230,6 +230,14 @@ public fun ASTNode.isPartOfComment(): Boolean =
 
 public fun ASTNode.children(): Sequence<ASTNode> = generateSequence(firstChildNode) { node -> node.treeNext }
 
+public fun ASTNode.recursiveChildren(): Sequence<ASTNode> =
+    sequence {
+        children().forEach {
+            yield(it)
+            yieldAll(it.recursiveChildren())
+        }
+    }
+
 /**
  * Updates or inserts a new whitespace element with [text] before the given node. If the node itself is a whitespace
  * then its contents is replaced with [text]. If the node is a (nested) composite element, the whitespace element is

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -17,6 +17,8 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.util.prefixIfNot
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.reflect.KClass
 
 public fun ASTNode.nextLeaf(
@@ -214,7 +216,13 @@ public fun ASTNode.findCompositeParentElementOfType(iElementType: IElementType):
 
 public fun ASTNode.isPartOfString(): Boolean = parent(STRING_TEMPLATE, strict = false) != null
 
-public fun ASTNode?.isWhiteSpace(): Boolean = this != null && elementType == WHITE_SPACE
+@OptIn(ExperimentalContracts::class)
+public fun ASTNode?.isWhiteSpace(): Boolean {
+    contract {
+        returns(true) implies (this@isWhiteSpace != null)
+    }
+    return this != null && elementType == WHITE_SPACE
+}
 
 public fun ASTNode?.isWhiteSpaceWithNewline(): Boolean = this != null && elementType == WHITE_SPACE && textContains('\n')
 

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
@@ -1,0 +1,38 @@
+package com.pinterest.ktlint.rule.engine.core.api
+
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+
+public object TokenSets {
+    public val COMMENTS: TokenSet = TokenSet.create(ElementType.BLOCK_COMMENT, ElementType.EOL_COMMENT, ElementType.KDOC)
+    public val EXPRESSIONS: TokenSet =
+        TokenSet.create(
+            ElementType.LAMBDA_EXPRESSION,
+            ElementType.FUNCTION_LITERAL,
+            ElementType.ANNOTATED_EXPRESSION,
+            ElementType.REFERENCE_EXPRESSION,
+            ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
+            ElementType.OPERATION_REFERENCE,
+            ElementType.LABEL,
+            ElementType.LABEL_QUALIFIER,
+            ElementType.THIS_EXPRESSION,
+            ElementType.SUPER_EXPRESSION,
+            ElementType.BINARY_EXPRESSION,
+            ElementType.BINARY_WITH_TYPE,
+            ElementType.IS_EXPRESSION,
+            ElementType.PREFIX_EXPRESSION,
+            ElementType.POSTFIX_EXPRESSION,
+            ElementType.LABELED_EXPRESSION,
+            ElementType.CALL_EXPRESSION,
+            ElementType.ARRAY_ACCESS_EXPRESSION,
+            ElementType.INDICES,
+            ElementType.DOT_QUALIFIED_EXPRESSION,
+            ElementType.CALLABLE_REFERENCE_EXPRESSION,
+            ElementType.CLASS_LITERAL_EXPRESSION,
+            ElementType.SAFE_ACCESS_EXPRESSION,
+            ElementType.OBJECT_LITERAL,
+            ElementType.WHEN,
+            ElementType.COLLECTION_LITERAL_EXPRESSION,
+            ElementType.TYPE_CODE_FRAGMENT,
+            ElementType.EXPRESSION_CODE_FRAGMENT,
+        )
+}

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
@@ -1,78 +1,31 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARRAY_ACCESS_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_WITH_TYPE
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALLABLE_REFERENCE_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_LITERAL_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DO_KEYWORD
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.EXPRESSION_CODE_FRAGMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FOR_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF_KEYWORD
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.INDICES
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABELED_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL_QUALIFIER
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_LITERAL
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.THIS_EXPRESSION
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CODE_FRAGMENT
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TRY_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHILE_KEYWORD
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.lexer.KtTokens
 
 public object TokenSets {
-    public val COMMENTS: TokenSet = TokenSet.create(BLOCK_COMMENT, EOL_COMMENT, KDOC)
-    public val EXPRESSIONS: TokenSet =
-        TokenSet.create(
-            ANNOTATED_EXPRESSION,
-            ARRAY_ACCESS_EXPRESSION,
-            BINARY_EXPRESSION,
-            BINARY_WITH_TYPE,
-            CALLABLE_REFERENCE_EXPRESSION,
-            CALL_EXPRESSION,
-            CLASS_LITERAL_EXPRESSION,
-            COLLECTION_LITERAL_EXPRESSION,
-            DOT_QUALIFIED_EXPRESSION,
-            ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
-            EXPRESSION_CODE_FRAGMENT,
-            FUNCTION_LITERAL,
-            INDICES,
-            IS_EXPRESSION,
-            LABEL,
-            LABELED_EXPRESSION,
-            LABEL_QUALIFIER,
-            LAMBDA_EXPRESSION,
-            OBJECT_LITERAL,
-            OPERATION_REFERENCE,
-            POSTFIX_EXPRESSION,
-            PREFIX_EXPRESSION,
-            REFERENCE_EXPRESSION,
-            SAFE_ACCESS_EXPRESSION,
-            SUPER_EXPRESSION,
-            THIS_EXPRESSION,
-            TYPE_CODE_FRAGMENT,
-            WHEN,
-        )
+    public val COMMENTS: TokenSet = KtTokens.COMMENTS
+
+    /**
+     *
+     * Reference: This is a subset of [KotlinExpressionParsing.EXPRESSION_FIRST]
+     */
     public val CONTROL_FLOW_KEYWORDS: TokenSet =
         TokenSet.create(
-            DO_KEYWORD,
-            IF_KEYWORD,
+            IF_KEYWORD, // if
+            WHEN_KEYWORD, // when
+            TRY_KEYWORD, // try
+            OBJECT_KEYWORD, // object
+            // loop
+            FOR_KEYWORD,
             WHILE_KEYWORD,
+            DO_KEYWORD,
         )
 }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/TokenSets.kt
@@ -1,38 +1,78 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARRAY_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_WITH_TYPE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALLABLE_REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.DO_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.EXPRESSION_CODE_FRAGMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IF_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.INDICES
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.KDOC
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABELED_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL_QUALIFIER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.POSTFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PREFIX_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SUPER_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THIS_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_CODE_FRAGMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHILE_KEYWORD
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 
 public object TokenSets {
-    public val COMMENTS: TokenSet = TokenSet.create(ElementType.BLOCK_COMMENT, ElementType.EOL_COMMENT, ElementType.KDOC)
+    public val COMMENTS: TokenSet = TokenSet.create(BLOCK_COMMENT, EOL_COMMENT, KDOC)
     public val EXPRESSIONS: TokenSet =
         TokenSet.create(
-            ElementType.LAMBDA_EXPRESSION,
-            ElementType.FUNCTION_LITERAL,
-            ElementType.ANNOTATED_EXPRESSION,
-            ElementType.REFERENCE_EXPRESSION,
-            ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
-            ElementType.OPERATION_REFERENCE,
-            ElementType.LABEL,
-            ElementType.LABEL_QUALIFIER,
-            ElementType.THIS_EXPRESSION,
-            ElementType.SUPER_EXPRESSION,
-            ElementType.BINARY_EXPRESSION,
-            ElementType.BINARY_WITH_TYPE,
-            ElementType.IS_EXPRESSION,
-            ElementType.PREFIX_EXPRESSION,
-            ElementType.POSTFIX_EXPRESSION,
-            ElementType.LABELED_EXPRESSION,
-            ElementType.CALL_EXPRESSION,
-            ElementType.ARRAY_ACCESS_EXPRESSION,
-            ElementType.INDICES,
-            ElementType.DOT_QUALIFIED_EXPRESSION,
-            ElementType.CALLABLE_REFERENCE_EXPRESSION,
-            ElementType.CLASS_LITERAL_EXPRESSION,
-            ElementType.SAFE_ACCESS_EXPRESSION,
-            ElementType.OBJECT_LITERAL,
-            ElementType.WHEN,
-            ElementType.COLLECTION_LITERAL_EXPRESSION,
-            ElementType.TYPE_CODE_FRAGMENT,
-            ElementType.EXPRESSION_CODE_FRAGMENT,
+            ANNOTATED_EXPRESSION,
+            ARRAY_ACCESS_EXPRESSION,
+            BINARY_EXPRESSION,
+            BINARY_WITH_TYPE,
+            CALLABLE_REFERENCE_EXPRESSION,
+            CALL_EXPRESSION,
+            CLASS_LITERAL_EXPRESSION,
+            COLLECTION_LITERAL_EXPRESSION,
+            DOT_QUALIFIED_EXPRESSION,
+            ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
+            EXPRESSION_CODE_FRAGMENT,
+            FUNCTION_LITERAL,
+            INDICES,
+            IS_EXPRESSION,
+            LABEL,
+            LABELED_EXPRESSION,
+            LABEL_QUALIFIER,
+            LAMBDA_EXPRESSION,
+            OBJECT_LITERAL,
+            OPERATION_REFERENCE,
+            POSTFIX_EXPRESSION,
+            PREFIX_EXPRESSION,
+            REFERENCE_EXPRESSION,
+            SAFE_ACCESS_EXPRESSION,
+            SUPER_EXPRESSION,
+            THIS_EXPRESSION,
+            TYPE_CODE_FRAGMENT,
+            WHEN,
+        )
+    public val CONTROL_FLOW_KEYWORDS: TokenSet =
+        TokenSet.create(
+            DO_KEYWORD,
+            IF_KEYWORD,
+            WHILE_KEYWORD,
         )
 }

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -1089,6 +1089,37 @@ class ASTNodeExtensionTest {
         }
     }
 
+    @Nested
+    inner class FindChildByTypeRecursively {
+        @Test
+        fun `Given a node with a target type return non-null`() {
+            val code =
+                """
+                class MyClass {
+                    fun foo() = 42    
+                }
+                """.trimIndent()
+            val result =
+                transformCodeToAST(code)
+                    .findChildByTypeRecursively(FUN, includeSelf = false)
+            assertThat(result).isNotNull()
+        }
+
+        @Test
+        fun `Given a node without a target type return null`() {
+            val code =
+                """
+                class MyClass {
+                       
+                }
+                """.trimIndent()
+            val result =
+                transformCodeToAST(code)
+                    .findChildByTypeRecursively(FUN, includeSelf = false)
+            assertThat(result).isNull()
+        }
+    }
+
     private inline fun String.transformAst(block: FileASTNode.() -> Unit): FileASTNode =
         transformCodeToAST(this)
             .apply(block)

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
@@ -25,6 +26,7 @@ import org.assertj.core.api.Assertions.assertThatNoException
 import org.assertj.core.api.Assertions.entry
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -1096,7 +1098,7 @@ class ASTNodeExtensionTest {
             val code =
                 """
                 class MyClass {
-                    fun foo() = 42    
+                    fun foo() = 42
                 }
                 """.trimIndent()
             val result =
@@ -1110,7 +1112,7 @@ class ASTNodeExtensionTest {
             val code =
                 """
                 class MyClass {
-                       
+
                 }
                 """.trimIndent()
             val result =
@@ -1118,6 +1120,24 @@ class ASTNodeExtensionTest {
                     .findChildByTypeRecursively(FUN, includeSelf = false)
             assertThat(result).isNull()
         }
+    }
+
+    @Test
+    fun `Given a simple class declaration without body then the declaration itself is derived from KtAnnotated while its child elements are not derived from KtAnnotated`() {
+        val code =
+            """
+            class Foo
+            """.trimIndent()
+
+        val actual = transformCodeToAST(code).findChildByType(CLASS)!!
+
+        assertThat(actual.isKtAnnotated()).isTrue()
+        assertThat(actual.findChildByType(CLASS_KEYWORD)!!.isKtAnnotated()).isFalse()
+        assertThat(actual.findChildByType(IDENTIFIER)!!.isKtAnnotated()).isFalse()
+
+        assertThat(actual.isPsiType<KtAnnotated>()).isTrue()
+        assertThat(actual.findChildByType(CLASS_KEYWORD)!!.isPsiType<KtAnnotated>()).isFalse()
+        assertThat(actual.findChildByType(IDENTIFIER)!!.isPsiType<KtAnnotated>()).isFalse()
     }
 
     private inline fun String.transformAst(block: FileASTNode.() -> Unit): FileASTNode =

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KtlintSuppression.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KtlintSuppression.kt
@@ -11,13 +11,13 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.findChildByTypeRecursively
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isRoot
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
-import com.pinterest.ktlint.rule.engine.core.api.recursiveChildren
 import com.pinterest.ktlint.rule.engine.core.api.replaceWith
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -202,8 +202,7 @@ private fun ASTNode.existingSuppressions() =
         ?: getValueArguments()
 
 private fun ASTNode.existingSuppressionsFromNamedArgumentOrNull(): Set<String>? =
-    recursiveChildren()
-        .firstOrNull { it.elementType == ElementType.COLLECTION_LITERAL_EXPRESSION }
+    findChildByTypeRecursively(ElementType.COLLECTION_LITERAL_EXPRESSION, includeSelf = false)
         ?.run {
             children()
                 .filter { it.elementType == ElementType.STRING_TEMPLATE }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocator.kt
@@ -1,11 +1,11 @@
 package com.pinterest.ktlint.rule.engine.internal
 
-import com.pinterest.ktlint.rule.engine.core.api.COMMENT_TOKENS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
 import com.pinterest.ktlint.rule.engine.core.api.IgnoreKtlintSuppressions
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.parent
@@ -59,7 +59,7 @@ internal class SuppressionLocator(
         rootNode.recursiveChildren(includeSelf = true).forEach { node ->
             val eType = node.elementType
             when {
-                COMMENT_TOKENS.contains(eType) -> {
+                TokenSets.COMMENTS.contains(eType) -> {
                     node
                         .createSuppressionHintFromComment()
                         ?.let { commentSuppressionsHints.add(it) }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.IgnoreKtlintSuppressions
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.findChildByTypeRecursively
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
@@ -17,7 +18,6 @@ import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.parent
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
-import com.pinterest.ktlint.rule.engine.core.api.recursiveChildren
 import com.pinterest.ktlint.rule.engine.core.api.remove
 import com.pinterest.ktlint.rule.engine.core.api.replaceWith
 import com.pinterest.ktlint.rule.engine.internal.KTLINT_SUPPRESSION_ID_ALL_RULES
@@ -106,10 +106,8 @@ public class KtlintSuppressionRule(
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
         node
-            .recursiveChildren(includeSelf = true)
-            .firstOrNull {
-                it.elementType == ElementType.LITERAL_STRING_TEMPLATE_ENTRY
-            }?.let { literalStringTemplateEntry ->
+            .findChildByTypeRecursively(ElementType.LITERAL_STRING_TEMPLATE_ENTRY, includeSelf = true)
+            ?.let { literalStringTemplateEntry ->
                 val prefixedSuppression =
                     literalStringTemplateEntry
                         .text

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRule.kt
@@ -124,9 +124,7 @@ public class KtlintSuppressionRule(
                         .ifAutocorrectAllowed {
                             node
                                 .createLiteralStringTemplateEntry(prefixedSuppression)
-                                ?.let {
-                                    literalStringTemplateEntry.replaceWith(it)
-                                }
+                                ?.let { literalStringTemplateEntry.replaceWith(it) }
                         }
                 }
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
@@ -43,11 +44,9 @@ import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
-import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
@@ -346,11 +345,10 @@ public class AnnotationRule :
 
     private fun ASTNode.isNotReceiverTargetAnnotation() = getAnnotationUseSiteTarget() != AnnotationUseSiteTarget.RECEIVER
 
-    private fun ASTNode.getAnnotationUseSiteTarget() =
-        psi
-            .safeAs<KtAnnotationEntry>()
-            ?.useSiteTarget
-            ?.getAnnotationUseSiteTarget()
+    private fun ASTNode.getAnnotationUseSiteTarget(): AnnotationUseSiteTarget? =
+        takeIf { it.elementType == ElementType.ANNOTATION_ENTRY }
+            ?.findChildByType(ElementType.ANNOTATION_TARGET)
+            ?.let { USE_SITE_TARGETS[it.text] }
 
     private fun ASTNode.isAnnotationEntryWithValueArgumentList() = getAnnotationEntryValueArgumentList() != null
 
@@ -469,6 +467,7 @@ public class AnnotationRule :
                 FILE_ANNOTATION_LIST,
                 MODIFIER_LIST,
             )
+        val USE_SITE_TARGETS = AnnotationUseSiteTarget.entries.associate { it.renderName to it }
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -1,10 +1,10 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_TARGET
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLON
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_KEYWORD
@@ -346,8 +346,8 @@ public class AnnotationRule :
     private fun ASTNode.isNotReceiverTargetAnnotation() = getAnnotationUseSiteTarget() != AnnotationUseSiteTarget.RECEIVER
 
     private fun ASTNode.getAnnotationUseSiteTarget(): AnnotationUseSiteTarget? =
-        takeIf { it.elementType == ElementType.ANNOTATION_ENTRY }
-            ?.findChildByType(ElementType.ANNOTATION_TARGET)
+        takeIf { it.elementType == ANNOTATION_ENTRY }
+            ?.findChildByType(ANNOTATION_TARGET)
             ?.let { USE_SITE_TARGETS[it.text] }
 
     private fun ASTNode.isAnnotationEntryWithValueArgumentList() = getAnnotationEntryValueArgumentList() != null
@@ -467,7 +467,7 @@ public class AnnotationRule :
                 FILE_ANNOTATION_LIST,
                 MODIFIER_LIST,
             )
-        val USE_SITE_TARGETS = AnnotationUseSiteTarget.entries.associate { it.renderName to it }
+        val USE_SITE_TARGETS = AnnotationUseSiteTarget.entries.associateBy { it.renderName }
     }
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
@@ -79,7 +79,7 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
                 },
                 {
                     // Disallow multiple white spaces as well as comments
-                    if (it.psi is PsiWhiteSpace) {
+                    if (it.isWhiteSpace()) {
                         val s = it.text
                         // Ensure at least one occurrence of two line breaks
                         s.indexOf("\n") != s.lastIndexOf("\n")
@@ -90,8 +90,7 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
             )
         if (next != null) {
             if (node.elementType != ElementType.FILE_ANNOTATION_LIST && next.isPartOfComment()) {
-                val psi = node.psi
-                emit(psi.endOffset, ERROR_MESSAGE, true)
+                emit(node.textRange.endOffset, ERROR_MESSAGE, true)
                     .ifAutocorrectAllowed {
                         // Special-case autocorrection when the annotation is separated from the annotated construct
                         // by a comment: we need to swap the order of the comment and the annotation

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationSpacingRule.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.endOffset
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
@@ -90,7 +91,7 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
             )
         if (next != null) {
             if (node.elementType != ElementType.FILE_ANNOTATION_LIST && next.isPartOfComment()) {
-                emit(node.textRange.endOffset, ERROR_MESSAGE, true)
+                emit(node.endOffset(), ERROR_MESSAGE, true)
                     .ifAutocorrectAllowed {
                         // Special-case autocorrection when the annotation is separated from the annotated construct
                         // by a comment: we need to swap the order of the comment and the annotation
@@ -120,8 +121,7 @@ public class AnnotationSpacingRule : StandardRule("annotation-spacing") {
         if (whiteSpaces.isNotEmpty() && node.elementType != ElementType.FILE_ANNOTATION_LIST) {
             // Check to make sure there are multi breaks between annotations
             if (whiteSpaces.any { psi -> psi.textToCharArray().count { it == '\n' } > 1 }) {
-                val psi = node.psi
-                emit(psi.endOffset, ERROR_MESSAGE, true)
+                emit(node.endOffset(), ERROR_MESSAGE, true)
                     .ifAutocorrectAllowed {
                         removeIntraLineBreaks(node, annotations.last())
                         removeExtraLineBreaks(node)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BINARY_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
@@ -20,6 +19,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRu
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
@@ -284,17 +284,12 @@ public class ArgumentListWrappingRule :
 
     private fun ASTNode.isOnSameLineAsControlFlowKeyword(): Boolean {
         var prevLeaf = prevLeaf() ?: return false
-        while (!prevLeaf.isControlFlowKeyword) {
+        while (prevLeaf.elementType !in TokenSets.CONTROL_FLOW_KEYWORDS) {
             if (prevLeaf.isWhiteSpaceWithNewline()) return false
             prevLeaf = prevLeaf.prevLeaf() ?: return false
         }
         return true
     }
-
-    private val ASTNode.isControlFlowKeyword: Boolean get() =
-        elementType == ElementType.IF_KEYWORD ||
-            elementType == ElementType.WHILE_KEYWORD ||
-            elementType == ElementType.DO_KEYWORD
 
     public companion object {
         private const val UNSET_IGNORE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY = Int.MAX_VALUE

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -24,6 +24,7 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isDeclaration
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
@@ -32,7 +33,6 @@ import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * Insert a blank line before declarations. No blank line is inserted before between a class or method signature and the first declaration
@@ -148,7 +148,7 @@ public class BlankLineBeforeDeclarationRule :
         }
 
         node
-            .takeIf { it.elementType in KtTokenSets.DECLARATION_TYPES }
+            .takeIf { it.isDeclaration() }
             ?.takeIf {
                 val prevLeaf = it.prevLeaf()
                 prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
@@ -30,10 +31,8 @@ import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
-import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
@@ -181,10 +180,8 @@ public class BlankLineBeforeDeclarationRule :
             treeParent
                 .takeIf { it.elementType == BLOCK && it.treeParent.elementType == FUNCTION_LITERAL }
                 ?.treeParent
-                ?.psi
-                ?.safeAs<KtFunctionLiteral>()
-                ?.bodyExpression
-                ?.node
+                ?.takeIf { it.elementType == ElementType.FUNCTION_LITERAL }
+                ?.findChildByType(ElementType.BLOCK)
                 ?.children()
                 ?.firstOrNull { !it.isWhiteSpace() && !it.isPartOfComment() }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -33,8 +33,8 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunctionLiteral
+import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * Insert a blank line before declarations. No blank line is inserted before between a class or method signature and the first declaration
@@ -150,7 +150,7 @@ public class BlankLineBeforeDeclarationRule :
         }
 
         node
-            .takeIf { it.psi is KtDeclaration }
+            .takeIf { KtTokenSets.DECLARATION_TYPES.contains(it.elementType) }
             ?.takeIf {
                 val prevLeaf = it.prevLeaf()
                 prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -149,16 +149,16 @@ public class BlankLineBeforeDeclarationRule :
 
         node
             .takeIf { it.isDeclaration() }
-            ?.takeIf {
-                val prevLeaf = it.prevLeaf()
-                prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))
-            }?.let { insertBeforeNode ->
+            ?.takeUnless { it.prevLeaf().isBlankLine() }
+            ?.let { insertBeforeNode ->
                 emit(insertBeforeNode.startOffset, "Expected a blank line for this declaration", true)
                     .ifAutocorrectAllowed {
                         insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent()))
                     }
             }
     }
+
+    private fun ASTNode?.isBlankLine() = this == null || text.startsWith("\n\n")
 
     private fun ASTNode.isFirstCodeSiblingInClassBody() =
         this ==

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
@@ -149,7 +148,7 @@ public class BlankLineBeforeDeclarationRule :
         }
 
         node
-            .takeIf { KtTokenSets.DECLARATION_TYPES.contains(it.elementType) }
+            .takeIf { it.elementType in KtTokenSets.DECLARATION_TYPES }
             ?.takeIf {
                 val prevLeaf = it.prevLeaf()
                 prevLeaf != null && (!prevLeaf.isWhiteSpace() || !prevLeaf.text.startsWith("\n\n"))
@@ -180,8 +179,8 @@ public class BlankLineBeforeDeclarationRule :
             treeParent
                 .takeIf { it.elementType == BLOCK && it.treeParent.elementType == FUNCTION_LITERAL }
                 ?.treeParent
-                ?.takeIf { it.elementType == ElementType.FUNCTION_LITERAL }
-                ?.findChildByType(ElementType.BLOCK)
+                ?.takeIf { it.elementType == FUNCTION_LITERAL }
+                ?.findChildByType(BLOCK)
                 ?.children()
                 ?.firstOrNull { !it.isWhiteSpace() && !it.isPartOfComment() }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -39,6 +39,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PR
 import com.pinterest.ktlint.rule.engine.core.api.hasModifier
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isLeaf
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
@@ -54,7 +55,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 
 /**
  * Formats the class signature according to https://kotlinlang.org/docs/coding-conventions.html#class-headers
@@ -651,7 +651,7 @@ public class ClassSignatureRule :
     private fun List<ASTNode>.collectLeavesRecursively(): List<ASTNode> = flatMap { it.collectLeavesRecursively() }
 
     private fun ASTNode.collectLeavesRecursively(): List<ASTNode> =
-        if (psi is LeafElement) {
+        if (isLeaf()) {
             listOf(this)
         } else {
             children()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
@@ -13,7 +14,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.internal.regExIgnoringDiacrit
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
-import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtPsiUtil
 
 /**
  * https://kotlinlang.org/docs/coding-conventions.html#property-names
@@ -57,8 +58,9 @@ public class EnumEntryNameCaseRule :
         if (node !is CompositeElement) {
             return
         }
-        val enumEntry = node.psi as? KtEnumEntry ?: return
-        val name = enumEntry.name ?: return
+        if (node.elementType != ElementType.ENUM_ENTRY) return
+        val nameNode = node.findChildByType(ElementType.IDENTIFIER) ?: return
+        val name = KtPsiUtil.unquoteIdentifier(nameNode.text)
 
         if (!name.matches(enumEntryCasingRegex)) {
             emit(node.startOffset, enumEntryCasingViolation, false)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumWrappingRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
@@ -17,6 +18,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.hasModifier
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
@@ -29,7 +31,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtClass
 
 /**
  *
@@ -61,7 +62,7 @@ public class EnumWrappingRule :
     ) {
         node
             .takeIf { node.elementType == CLASS }
-            ?.takeIf { (node.psi as KtClass).isEnum() }
+            ?.takeIf { node.hasModifier(ElementType.ENUM_KEYWORD) }
             ?.findChildByType(CLASS_BODY)
             ?.let { classBody ->
                 visitEnumClass(classBody, emit)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -38,6 +38,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PR
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isCodeLeaf
+import com.pinterest.ktlint.rule.engine.core.api.isLeaf
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.nextCodeLeaf
@@ -56,7 +57,6 @@ import com.pinterest.ktlint.ruleset.standard.rules.FunctionSignatureRule.Functio
 import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser.EnumValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
@@ -700,7 +700,7 @@ public class FunctionSignatureRule :
     private fun List<ASTNode>.collectLeavesRecursively(): List<ASTNode> = flatMap { it.collectLeavesRecursively() }
 
     private fun ASTNode.collectLeavesRecursively(): List<ASTNode> =
-        if (psi is LeafElement) {
+        if (isLeaf()) {
             listOf(this)
         } else {
             children()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -2,6 +2,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.COMMENT_TOKENS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
@@ -124,7 +125,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.ec4j.core.model.PropertyType
 import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.leaves
@@ -1191,7 +1191,7 @@ public class IndentationRule :
         }
 
         nextLeaf
-            ?.parent(strict = false) { it.psi is PsiComment }
+            ?.parent(strict = false) { COMMENT_TOKENS.contains(it.elementType) }
             ?.let { comment ->
                 if (text.endsWith("\n")) {
                     processedButNoIndentationChangedNeeded()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1191,7 +1191,7 @@ public class IndentationRule :
         }
 
         nextLeaf
-            ?.parent(strict = false) { TokenSets.COMMENTS.contains(it.elementType) }
+            ?.parent(strict = false) { it.elementType in TokenSets.COMMENTS }
             ?.let { comment ->
                 if (text.endsWith("\n")) {
                     processedButNoIndentationChangedNeeded()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -2,7 +2,6 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.COMMENT_TOKENS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
@@ -91,6 +90,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.column
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
@@ -1191,7 +1191,7 @@ public class IndentationRule :
         }
 
         nextLeaf
-            ?.parent(strict = false) { COMMENT_TOKENS.contains(it.elementType) }
+            ?.parent(strict = false) { TokenSets.COMMENTS.contains(it.elementType) }
             ?.let { comment ->
                 if (text.endsWith("\n")) {
                     processedButNoIndentationChangedNeeded()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
@@ -16,6 +17,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RULE_EXECUTION_PRO
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RuleExecution
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.ktLintRuleExecutionPropertyName
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
+import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine
@@ -26,11 +28,7 @@ import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.kdoc.psi.api.KDoc
-import org.jetbrains.kotlin.psi.KtImportDirective
-import org.jetbrains.kotlin.psi.KtPackageDirective
 
 @SinceKtlint("0.9", STABLE)
 public class MaxLineLengthRule :
@@ -82,9 +80,9 @@ public class MaxLineLengthRule :
             .takeIf { it is LeafPsiElement }
             ?.takeIf { it.nextLeaf() == null || it.nextLeaf().isWhiteSpaceWithNewline() }
             ?.takeIf { it.lineLength() > maxLineLength }
-            ?.takeUnless { it.isPartOf(KtPackageDirective::class) }
-            ?.takeUnless { it.isPartOf(KtImportDirective::class) }
-            ?.takeUnless { it.isPartOf(KDoc::class) }
+            ?.takeUnless { it.isPartOf(ElementType.PACKAGE_DIRECTIVE) }
+            ?.takeUnless { it.isPartOf(ElementType.IMPORT_DIRECTIVE) }
+            ?.takeUnless { it.isPartOf(ElementType.KDOC) }
             ?.takeUnless { it.isPartOfRawMultiLineString() }
             ?.takeUnless { it.isLineOnlyContainingSingleTemplateString() }
             ?.takeUnless { it.elementType == COMMA && it.prevLeaf()?.isLineOnlyContainingSingleTemplateString() ?: false }
@@ -130,7 +128,7 @@ public class MaxLineLengthRule :
             ?: false
 
     private fun ASTNode.isLineOnlyContainingComment() =
-        isPartOf(PsiComment::class) &&
+        isPartOfComment() &&
             (prevLeaf() == null || prevLeaf().isWhiteSpaceWithNewline())
 
     public companion object {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ABSTRACT_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ACTUAL_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
@@ -34,8 +35,6 @@ import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtDeclarationModifierList
 
 @SinceKtlint("0.7", STABLE)
 public class ModifierOrderRule : StandardRule("modifier-order") {
@@ -43,7 +42,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node.psi is KtDeclarationModifierList) {
+        if (node.elementType == ElementType.MODIFIER_LIST) {
             val modifierArr = node.getChildren(tokenSet)
             val sorted = modifierArr.copyOf().apply { sortWith(compareBy { ORDERED_MODIFIERS.indexOf(it.elementType) }) }
             if (!modifierArr.contentEquals(sorted)) {
@@ -69,7 +68,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
     }
 
     private fun squashAnnotations(sorted: Array<ASTNode>): List<String> {
-        val nonAnnotationModifiers = sorted.filter { it.psi !is KtAnnotationEntry }
+        val nonAnnotationModifiers = sorted.filter { it.elementType != ElementType.ANNOTATION_ENTRY }
         return if (nonAnnotationModifiers.size != sorted.size) {
             listOf("@Annotation...") + nonAnnotationModifiers.map { it.text }
         } else {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyClassBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoEmptyClassBodyRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
@@ -15,7 +16,6 @@ import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.remove
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 
 @SinceKtlint("0.9", STABLE)
 public class NoEmptyClassBodyRule : StandardRule("no-empty-class-body") {
@@ -28,7 +28,7 @@ public class NoEmptyClassBodyRule : StandardRule("no-empty-class-body") {
                 n.elementType == LBRACE &&
                     n.nextLeaf { it.elementType != WHITE_SPACE }?.elementType == RBRACE
             } == true &&
-            !node.isPartOf(KtObjectLiteralExpression::class) &&
+            !node.isPartOf(ElementType.OBJECT_LITERAL) &&
             node
                 .treeParent
                 .firstChildNode

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSemicolonsRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_ENTRY
@@ -26,13 +27,10 @@ import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
-import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtDoWhileExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 @SinceKtlint("0.1", STABLE)
 public class NoSemicolonsRule :
@@ -84,11 +82,10 @@ public class NoSemicolonsRule :
 
             this is PsiWhiteSpace -> {
                 nextLeaf {
-                    val psi = it.psi
                     it !is PsiWhiteSpace &&
                         it !is PsiComment &&
-                        psi.getStrictParentOfType<KDoc>() == null &&
-                        psi.getStrictParentOfType<KtAnnotationEntry>() == null
+                        it.parent(ElementType.KDOC) == null &&
+                        it.parent(ElementType.ANNOTATION_ENTRY) == null
                 }.let { nextLeaf ->
                     nextLeaf == null ||
                         // \s+ and then eof

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoTrailingSpacesRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
@@ -13,7 +14,6 @@ import com.pinterest.ktlint.rule.engine.core.api.parent
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 
 @SinceKtlint("0.1", STABLE)
 public class NoTrailingSpacesRule : StandardRule("no-trailing-spaces") {
@@ -74,7 +74,7 @@ public class NoTrailingSpacesRule : StandardRule("no-trailing-spaces") {
         }
     }
 
-    private fun ASTNode.isPartOfKDoc() = parent(strict = false) { it.psi is KDoc } != null
+    private fun ASTNode.isPartOfKDoc() = parent(strict = false) { it.elementType == ElementType.KDOC } != null
 
     private fun ASTNode.hasTrailingSpacesBeforeNewline() = text.contains(SPACE_OR_TAB_BEFORE_NEWLINE_REGEX)
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.BY_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT_QUALIFIED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
@@ -23,15 +24,13 @@ import com.pinterest.ktlint.rule.engine.core.api.nextSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.rule.engine.core.api.remove
-import com.pinterest.ktlint.rule.engine.core.util.safeAs
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.kdoc.lexer.KDocTokens.MARKDOWN_LINK
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
-import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
@@ -85,14 +84,20 @@ public class NoUnusedImportsRule :
             }
 
             MARKDOWN_LINK -> {
-                node
-                    .psi
-                    .safeAs<KDocLink>()
-                    ?.let { kdocLink ->
-                        val linkText = kdocLink.getLinkText().removeBackticksAndTrim()
-                        ref.add(Reference(linkText.split('.').first(), false))
-                        ref.add(Reference(linkText.split('.').last(), false))
+                // Both of these are copied from from org.jetbrains.kotlin.kdoc.psi.impl.KDocLink, to avoid having to getPsi()
+                fun ASTNode.getLinkTextRange(): TextRange {
+                    val text = text
+                    if (text.startsWith('[') && text.endsWith(']')) {
+                        return TextRange(1, text.length - 1)
                     }
+                    return TextRange(0, text.length)
+                }
+
+                fun ASTNode.getLinkText(): String = getLinkTextRange().substring(text)
+
+                val linkText = node.getLinkText().removeBackticksAndTrim()
+                ref.add(Reference(linkText.split('.').first(), false))
+                ref.add(Reference(linkText.split('.').last(), false))
             }
 
             REFERENCE_EXPRESSION, OPERATION_REFERENCE -> {
@@ -110,7 +115,7 @@ public class NoUnusedImportsRule :
                             ref.add(
                                 Reference(
                                     it.removeBackticksAndTrim(),
-                                    node.psi.parentDotQualifiedExpression() != null,
+                                    node.parentDotQualifiedExpression() != null,
                                 ),
                             )
                         }
@@ -281,9 +286,21 @@ public class NoUnusedImportsRule :
 
     private fun String.isComponentN() = COMPONENT_N_REGEX.matches(this)
 
-    private fun PsiElement.parentDotQualifiedExpression(): KtDotQualifiedExpression? {
-        val callOrThis = (parent as? KtCallExpression)?.takeIf { it.calleeExpression == this } ?: this
-        return (callOrThis.parent as? KtDotQualifiedExpression)?.takeIf { it.selectorExpression == callOrThis }
+    private fun ASTNode.parentDotQualifiedExpression(): KtDotQualifiedExpression? {
+        val callOrThis =
+            treeParent
+                .takeIf { it.elementType == ElementType.CALL_EXPRESSION }
+                ?.takeIf { it.findChildByType(EXPRESSION_SET) == this }
+                ?: this
+        return (
+            callOrThis.treeParent
+                ?.takeIf {
+                    it.elementType == ElementType.DOT_QUALIFIED_EXPRESSION
+                }?.psi as? KtDotQualifiedExpression
+        )?.takeIf {
+            it.selectorExpression?.node ==
+                callOrThis
+        }
     }
 
     private fun String.removeBackticksAndTrim() = replace("`", "").trim()
@@ -321,6 +338,38 @@ public class NoUnusedImportsRule :
                 "iterator",
                 // by (https://github.com/shyiko/ktlint/issues/54)
                 "getValue", "setValue",
+            )
+
+        val EXPRESSION_SET =
+            TokenSet.create(
+                ElementType.LAMBDA_EXPRESSION,
+                ElementType.FUNCTION_LITERAL,
+                ElementType.ANNOTATED_EXPRESSION,
+                ElementType.REFERENCE_EXPRESSION,
+                ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
+                ElementType.OPERATION_REFERENCE,
+                ElementType.LABEL,
+                ElementType.LABEL_QUALIFIER,
+                ElementType.THIS_EXPRESSION,
+                ElementType.SUPER_EXPRESSION,
+                ElementType.BINARY_EXPRESSION,
+                ElementType.BINARY_WITH_TYPE,
+                ElementType.IS_EXPRESSION,
+                ElementType.PREFIX_EXPRESSION,
+                ElementType.POSTFIX_EXPRESSION,
+                ElementType.LABELED_EXPRESSION,
+                ElementType.CALL_EXPRESSION,
+                ElementType.ARRAY_ACCESS_EXPRESSION,
+                ElementType.INDICES,
+                ElementType.DOT_QUALIFIED_EXPRESSION,
+                ElementType.CALLABLE_REFERENCE_EXPRESSION,
+                ElementType.CLASS_LITERAL_EXPRESSION,
+                ElementType.SAFE_ACCESS_EXPRESSION,
+                ElementType.OBJECT_LITERAL,
+                ElementType.WHEN,
+                ElementType.COLLECTION_LITERAL_EXPRESSION,
+                ElementType.TYPE_CODE_FRAGMENT,
+                ElementType.EXPRESSION_CODE_FRAGMENT,
             )
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -14,6 +14,7 @@ import com.pinterest.ktlint.rule.engine.core.api.IgnoreKtlintSuppressions
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isRoot
@@ -29,7 +30,6 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
-import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.kdoc.lexer.KDocTokens.MARKDOWN_LINK
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
@@ -290,7 +290,7 @@ public class NoUnusedImportsRule :
         val callOrThis =
             treeParent
                 .takeIf { it.elementType == ElementType.CALL_EXPRESSION }
-                ?.takeIf { it.findChildByType(EXPRESSION_SET) == this }
+                ?.takeIf { it.findChildByType(TokenSets.EXPRESSIONS) == this }
                 ?: this
         return (
             callOrThis.treeParent
@@ -338,38 +338,6 @@ public class NoUnusedImportsRule :
                 "iterator",
                 // by (https://github.com/shyiko/ktlint/issues/54)
                 "getValue", "setValue",
-            )
-
-        val EXPRESSION_SET =
-            TokenSet.create(
-                ElementType.LAMBDA_EXPRESSION,
-                ElementType.FUNCTION_LITERAL,
-                ElementType.ANNOTATED_EXPRESSION,
-                ElementType.REFERENCE_EXPRESSION,
-                ElementType.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION,
-                ElementType.OPERATION_REFERENCE,
-                ElementType.LABEL,
-                ElementType.LABEL_QUALIFIER,
-                ElementType.THIS_EXPRESSION,
-                ElementType.SUPER_EXPRESSION,
-                ElementType.BINARY_EXPRESSION,
-                ElementType.BINARY_WITH_TYPE,
-                ElementType.IS_EXPRESSION,
-                ElementType.PREFIX_EXPRESSION,
-                ElementType.POSTFIX_EXPRESSION,
-                ElementType.LABELED_EXPRESSION,
-                ElementType.CALL_EXPRESSION,
-                ElementType.ARRAY_ACCESS_EXPRESSION,
-                ElementType.INDICES,
-                ElementType.DOT_QUALIFIED_EXPRESSION,
-                ElementType.CALLABLE_REFERENCE_EXPRESSION,
-                ElementType.CLASS_LITERAL_EXPRESSION,
-                ElementType.SAFE_ACCESS_EXPRESSION,
-                ElementType.OBJECT_LITERAL,
-                ElementType.WHEN,
-                ElementType.COLLECTION_LITERAL_EXPRESSION,
-                ElementType.TYPE_CODE_FRAGMENT,
-                ElementType.EXPRESSION_CODE_FRAGMENT,
             )
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -14,7 +14,6 @@ import com.pinterest.ktlint.rule.engine.core.api.IgnoreKtlintSuppressions
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
-import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
 import com.pinterest.ktlint.rule.engine.core.api.isRoot
@@ -286,7 +285,6 @@ public class NoUnusedImportsRule :
     private fun ASTNode.parentCallExpressionOrNull() =
         treeParent
             .takeIf { it.elementType == ElementType.CALL_EXPRESSION }
-            ?.takeIf { it.findChildByType(TokenSets.EXPRESSIONS) == this }
 
     private fun ASTNode.isDotQualifiedExpression() =
         treeParent

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -90,9 +90,10 @@ public class PropertyNamingRule :
                 it == SERIAL_VERSION_UID_PROPERTY_NAME
             }?.takeUnless { it.matches(constantNamingProperty.regEx) }
             ?.let {
+                val expectedNaming = constantNamingProperty.name.replace("_", " ")
                 emit(
                     identifier.startOffset,
-                    "Property name should use the screaming snake case notation when the value can not be changed",
+                    "Property name should use the $expectedNaming notation when the value can not be changed",
                     false,
                 )
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundDoubleColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundDoubleColonRule.kt
@@ -39,7 +39,7 @@ public class SpacingAroundDoubleColonRule : StandardRule("double-colon-spacing")
                         // String::length, ::isOdd
                         if (node.treePrev == null) { // compose(length, ::isOdd), val predicate = ::isOdd
                             removeSingleWhiteSpace = true
-                            !prevLeaf.textContains('\n') && prevLeaf.psi.textLength > 1
+                            !prevLeaf.textContains('\n') && prevLeaf.textLength > 1
                         } else { // String::length, List<String>::isEmpty
                             !prevLeaf.textContains('\n')
                         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundOperatorsRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANDAND
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DIV
@@ -41,7 +42,6 @@ import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
-import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtOperationExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 
@@ -118,7 +118,7 @@ public class SpacingAroundOperatorsRule : StandardRule("op-spacing") {
 
     private fun ASTNode.isImport() =
         // import *
-        isPartOf(KtImportDirective::class)
+        isPartOf(ElementType.IMPORT_DIRECTIVE)
 
     private companion object {
         private val OPERATORS =

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -1,12 +1,14 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.getPrevSiblingIgnoringWhitespaceAndComments
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
@@ -16,11 +18,9 @@ import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.leaves
+import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35106
@@ -32,7 +32,7 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node.psi is KtDeclaration && node.isAnnotated()) {
+        if (KtTokenSets.DECLARATION_TYPES.contains(node.elementType) && node.isAnnotated()) {
             visitDeclaration(node, emit)
         }
     }
@@ -42,9 +42,8 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
         node
-            .psi
-            ?.getPrevSiblingIgnoringWhitespaceAndComments(withItself = false)
-            ?.takeIf { it is KtDeclaration }
+            ?.getPrevSiblingIgnoringWhitespaceAndComments()
+            ?.takeIf { KtTokenSets.DECLARATION_TYPES.contains(it.elementType) }
             ?.takeIf { prevDeclaration -> hasNoBlankLineBetweenDeclarations(node, prevDeclaration) }
             ?.let {
                 val prevLeaf = node.prevCodeLeaf()?.nextLeaf { it.isWhiteSpace() }!!
@@ -61,16 +60,16 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
     private fun ASTNode.isAnnotated(): Boolean =
         findChildByType(MODIFIER_LIST)
             ?.children()
-            ?.any { it.psi is KtAnnotationEntry }
+            ?.any { it.elementType == ElementType.ANNOTATION_ENTRY }
             ?: false
 
     private fun hasNoBlankLineBetweenDeclarations(
         node: ASTNode,
-        prevDeclaration: PsiElement,
+        prevDeclaration: ASTNode,
     ) = node
         .leaves(false)
         .takeWhile { it.isWhiteSpace() || it.isPartOfComment() }
-        .takeWhile { it.psi != prevDeclaration }
+        .takeWhile { it != prevDeclaration }
         .none { it.isBlankLine() }
 
     private fun ASTNode.isBlankLine() = isWhiteSpace() && text.count { it == '\n' } > 1

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.isDeclaration
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
@@ -19,7 +20,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.psiUtil.leaves
-import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35106
@@ -31,7 +31,7 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node.elementType in KtTokenSets.DECLARATION_TYPES && node.isAnnotated()) {
+        if (node.isDeclaration() && node.isAnnotated()) {
             visitDeclaration(node, emit)
         }
     }
@@ -42,7 +42,7 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
     ) {
         node
             .prevCodeSibling()
-            ?.takeIf { it.elementType in KtTokenSets.DECLARATION_TYPES }
+            ?.takeIf { it.isDeclaration() }
             ?.takeIf { prevDeclaration -> hasNoBlankLineBetweenDeclarations(node, prevDeclaration) }
             ?.let {
                 val prevLeaf = node.prevCodeLeaf()?.nextLeaf { it.isWhiteSpace() }!!

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRule.kt
@@ -8,17 +8,16 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
-import com.pinterest.ktlint.rule.engine.core.api.getPrevSiblingIgnoringWhitespaceAndComments
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.nextLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
@@ -32,7 +31,7 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (KtTokenSets.DECLARATION_TYPES.contains(node.elementType) && node.isAnnotated()) {
+        if (node.elementType in KtTokenSets.DECLARATION_TYPES && node.isAnnotated()) {
             visitDeclaration(node, emit)
         }
     }
@@ -42,8 +41,8 @@ public class SpacingBetweenDeclarationsWithAnnotationsRule : StandardRule("spaci
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
         node
-            ?.getPrevSiblingIgnoringWhitespaceAndComments()
-            ?.takeIf { KtTokenSets.DECLARATION_TYPES.contains(it.elementType) }
+            .prevCodeSibling()
+            ?.takeIf { it.elementType in KtTokenSets.DECLARATION_TYPES }
             ?.takeIf { prevDeclaration -> hasNoBlankLineBetweenDeclarations(node, prevDeclaration) }
             ?.let {
                 val prevLeaf = node.prevCodeLeaf()?.nextLeaf { it.isWhiteSpace() }!!

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -42,7 +42,7 @@ public class SpacingBetweenDeclarationsWithCommentsRule : StandardRule("spacing-
     ) {
         node
             .treeParent
-            .prevSibling()
+            .prevSibling { it.prevSibling().isDeclaration() }
             .takeIf { it.isWhiteSpace() && it.text.count { it == '\n' } < 2 }
             ?.let { whiteSpace ->
                 emit(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
@@ -9,7 +8,6 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isDeclaration
-import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
@@ -30,31 +28,37 @@ public class SpacingBetweenDeclarationsWithCommentsRule : StandardRule("spacing-
     ) {
         node
             .takeIf { it.elementType in TokenSets.COMMENTS }
-            ?.takeIf { it.treeParent.isDeclaration() }
-            ?.let { node ->
-                val declarationNode = node.treeParent
-                val isTailComment = node.startOffset > declarationNode.startOffset
-                if (isTailComment || !declarationNode.prevCodeSibling().isDeclaration()) return
+            ?.takeUnless { it.isTailComment() }
+            ?.treeParent
+            ?.takeIf { it.isDeclaration() }
+            ?.takeIf { it.prevCodeSibling().isDeclaration() }
+            ?.let { visitCommentedDeclaration(it, emit) }
+    }
 
-                val prevSibling = declarationNode.prevSibling { !it.isWhiteSpace() }
-                if (prevSibling != null &&
-                    prevSibling.elementType != FILE &&
-                    !prevSibling.isPartOfComment()
-                ) {
-                    val prevNode = declarationNode.prevSibling()
-                    if (prevNode.isWhiteSpace() && prevNode.text.count { it == '\n' } < 2) {
-                        emit(
-                            node.startOffset,
-                            "Declarations and declarations with comments should have an empty space between.",
-                            true,
-                        ).ifAutocorrectAllowed {
-                            val indent = node.prevLeaf()?.text?.trim('\n') ?: ""
-                            (prevNode as LeafElement).rawReplaceWithText("\n\n$indent")
-                        }
+    private fun ASTNode.isTailComment() = startOffset > treeParent.startOffset
+
+    private fun visitCommentedDeclaration(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        node
+            .prevSibling()
+            ?.takeUnless { it.isBlankLine() }
+            ?.let { prevSibling ->
+                emit(node.startOffset, "Declarations and declarations with comments should have an empty space between.", true)
+                    .ifAutocorrectAllowed {
+                        val indent =
+                            node
+                                .prevLeaf()
+                                ?.text
+                                ?.trim('\n')
+                                ?: ""
+                        (prevSibling as LeafElement).rawReplaceWithText("\n\n$indent")
                     }
-                }
             }
     }
+
+    private fun ASTNode.isBlankLine() = isWhiteSpace() && text.startsWith("\n\n")
 }
 
 public val SPACING_BETWEEN_DECLARATIONS_WITH_COMMENTS_RULE_ID: RuleId = SpacingBetweenDeclarationsWithCommentsRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -1,6 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
@@ -15,6 +16,7 @@ import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.psi.KtDeclarationImpl
 import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
@@ -56,7 +58,11 @@ public class SpacingBetweenDeclarationsWithCommentsRule : StandardRule("spacing-
             }
     }
 
-    private fun ASTNode?.isDeclaration() = this != null && elementType in KtTokenSets.DECLARATION_TYPES
+    /**
+     * [KtScriptInitializer] is considered a type of declaration in terms of it being a subtype of [KtDeclarationImpl] even though SCRIPT_INITIALIZER is not included in DECLARATION_TYPES. We consider SCRIPT_INITIALIZER a declaration here to match previous behavior of ktlint in older versions.
+     */
+    private fun ASTNode?.isDeclaration() =
+        this != null && (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER)
 }
 
 public val SPACING_BETWEEN_DECLARATIONS_WITH_COMMENTS_RULE_ID: RuleId = SpacingBetweenDeclarationsWithCommentsRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -1,23 +1,21 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
+import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.psi.KtDeclaration
-import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35088
@@ -29,29 +27,36 @@ public class SpacingBetweenDeclarationsWithCommentsRule : StandardRule("spacing-
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node is PsiComment) {
-            val declaration = node.parent as? KtDeclaration ?: return
-            val isTailComment = node.startOffset > declaration.startOffset
-            if (isTailComment || declaration.getPrevSiblingIgnoringWhitespaceAndComments() !is KtDeclaration) return
+        node
+            .takeIf { it.elementType in TokenSets.COMMENTS }
+            .takeIf { node.prevLeaf().isWhiteSpaceWithNewline() }
+            .takeUnless { node.startOffset > (node.treeParent?.startOffset ?: node.startOffset) }
+            ?.takeIf { it.treeParent.isDeclaration() }
+            ?.takeIf { it.treeParent.prevCodeSibling().isDeclaration() }
+            ?.let { visitCommentBeforeDeclaration(node, emit) }
+    }
 
-            val prevSibling = declaration.node.prevSibling { it.elementType != WHITE_SPACE }
-            if (prevSibling != null &&
-                prevSibling.elementType != FILE &&
-                prevSibling !is PsiComment
-            ) {
-                if (declaration.prevSibling is PsiWhiteSpace && declaration.prevSibling.text.count { it == '\n' } < 2) {
-                    emit(
-                        node.startOffset,
-                        "Declarations and declarations with comments should have an empty space between.",
-                        true,
-                    ).ifAutocorrectAllowed {
-                        val indent = node.prevLeaf()?.text?.trim('\n') ?: ""
-                        (declaration.prevSibling.node as LeafPsiElement).rawReplaceWithText("\n\n$indent")
-                    }
+    private fun visitCommentBeforeDeclaration(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        node
+            .treeParent
+            .prevSibling()
+            .takeIf { it.isWhiteSpace() && it.text.count { it == '\n' } < 2 }
+            ?.let { whiteSpace ->
+                emit(
+                    node.startOffset,
+                    "Declarations and declarations with comments should have an empty space between.",
+                    true,
+                ).ifAutocorrectAllowed {
+                    val indent = node.prevLeaf()?.text?.trim('\n') ?: ""
+                    (whiteSpace as LeafElement).rawReplaceWithText("\n\n$indent")
                 }
             }
-        }
     }
+
+    private fun ASTNode?.isDeclaration() = this != null && elementType in KtTokenSets.DECLARATION_TYPES
 }
 
 public val SPACING_BETWEEN_DECLARATIONS_WITH_COMMENTS_RULE_ID: RuleId = SpacingBetweenDeclarationsWithCommentsRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRule.kt
@@ -1,13 +1,13 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.isDeclaration
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.rule.engine.core.api.prevCodeSibling
@@ -16,8 +16,6 @@ import com.pinterest.ktlint.rule.engine.core.api.prevSibling
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
-import org.jetbrains.kotlin.psi.KtDeclarationImpl
-import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
 
 /**
  * @see https://youtrack.jetbrains.com/issue/KT-35088
@@ -57,12 +55,6 @@ public class SpacingBetweenDeclarationsWithCommentsRule : StandardRule("spacing-
                 }
             }
     }
-
-    /**
-     * [KtScriptInitializer] is considered a type of declaration in terms of it being a subtype of [KtDeclarationImpl] even though SCRIPT_INITIALIZER is not included in DECLARATION_TYPES. We consider SCRIPT_INITIALIZER a declaration here to match previous behavior of ktlint in older versions.
-     */
-    private fun ASTNode?.isDeclaration() =
-        this != null && (elementType in KtTokenSets.DECLARATION_TYPES || elementType == SCRIPT_INITIALIZER)
 }
 
 public val SPACING_BETWEEN_DECLARATIONS_WITH_COMMENTS_RULE_ID: RuleId = SpacingBetweenDeclarationsWithCommentsRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StatementWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/StatementWrappingRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf
+import com.pinterest.ktlint.rule.engine.core.api.hasModifier
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
@@ -34,8 +35,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 
 @SinceKtlint("0.50", EXPERIMENTAL)
@@ -163,7 +162,7 @@ public class StatementWrappingRule :
 
     private inline val ASTNode.isEnumClassOnSingleLine: Boolean
         get() =
-            if (psi.isEnumClass) {
+            if (isEnumClass) {
                 val lastChildLeaf = lastChildLeafOrSelf()
                 // Ignore the leading comment
                 noNewLineInClosedRange(firstCodeLeafOrNull!!, lastChildLeaf)
@@ -182,8 +181,8 @@ public class StatementWrappingRule :
                 }?.firstOrNull()
                 ?.firstChildLeafOrSelf()
 
-    private inline val PsiElement.isEnumClass: Boolean
-        get() = (this as? KtClass)?.isEnum() ?: false
+    private inline val ASTNode.isEnumClass: Boolean
+        get() = elementType == ElementType.CLASS && hasModifier(ElementType.ENUM_KEYWORD)
 
     private inline val ASTNode.indentAsChild: String
         get() = indent().plus(indentConfig.indent)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -41,6 +41,7 @@ import org.ec4j.core.model.PropertyType.PropertyValueParser
 import org.jetbrains.kotlin.KtNodeTypes.WHEN_ENTRY_GUARD
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
@@ -324,7 +325,7 @@ public class TrailingCommaOnDeclarationSiteRule :
                                     .treeParent
                                     .indent()
                             if (leafBeforeArrowOrNull.isWhiteSpace()) {
-                                (leafBeforeArrowOrNull.psi as LeafPsiElement).rawReplaceWithText(indent)
+                                (leafBeforeArrowOrNull as LeafElement).rawReplaceWithText(indent)
                             } else {
                                 inspectNode
                                     .prevCodeLeaf()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -3,7 +3,6 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision.NO_AUTOCORRECT
-import com.pinterest.ktlint.rule.engine.core.api.COMMENT_TOKENS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
@@ -50,6 +49,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRu
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
+import com.pinterest.ktlint.rule.engine.core.api.TokenSets
 import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
@@ -386,7 +386,7 @@ public class WrappingRule :
                     // value(
                     // ), // a comment
                     // c, d
-                    nextSibling.treeNext?.treeNext?.let { !COMMENT_TOKENS.contains(it.elementType) } != false
+                    nextSibling.treeNext?.treeNext?.let { !TokenSets.COMMENTS.contains(it.elementType) } != false
                 ) {
                     requireNewlineAfterLeaf(nextSibling, emit)
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -3,6 +3,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.logger.api.initKtLintKLogger
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision.NO_AUTOCORRECT
+import com.pinterest.ktlint.rule.engine.core.api.COMMENT_TOKENS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
@@ -78,7 +79,6 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
@@ -386,7 +386,7 @@ public class WrappingRule :
                     // value(
                     // ), // a comment
                     // c, d
-                    nextSibling.treeNext?.treeNext?.psi !is PsiComment
+                    nextSibling.treeNext?.treeNext?.let { !COMMENT_TOKENS.contains(it.elementType) } != false
                 ) {
                     requireNewlineAfterLeaf(nextSibling, emit)
                 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -83,11 +83,11 @@ class PropertyNamingRuleTest {
         propertyNamingRuleAssertThat(code)
             .withEditorConfigOverride(PropertyNamingRule.CONSTANT_NAMING_PROPERTY to pascal_case)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(1, 11, "Property name should use the pascal case notation when the value can not be changed"),
                 // FOO cannot be reported as not meeting the pascal case requirement as it could be an abbreviation of 3 separate words
                 // starting with 'F', 'O' and 'O' respectively
-                LintViolation(3, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
-                LintViolation(4, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(3, 11, "Property name should use the pascal case notation when the value can not be changed"),
+                LintViolation(4, 11, "Property name should use the pascal case notation when the value can not be changed"),
             )
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithAnnotationsRuleTest.kt
@@ -306,4 +306,30 @@ class SpacingBetweenDeclarationsWithAnnotationsRuleTest {
             .hasLintViolation(3, 1, "Declarations and declarations with annotations should have an empty space between.")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2901 - Given a variable with property accessors not separated by a blank line, and the second accessor is annotated then add a blank in between`() {
+        val code =
+            """
+            public var foo: Boolean
+                get() = false
+                @Foo
+                set(value) {
+                    foo = value
+                }
+            """.trimIndent()
+        val formattedCode =
+            """
+            public var foo: Boolean
+                get() = false
+
+                @Foo
+                set(value) {
+                    foo = value
+                }
+            """.trimIndent()
+        spacingBetweenDeclarationsWithAnnotationsRuleAssertThat(code)
+            .hasLintViolation(3, 1, "Declarations and declarations with annotations should have an empty space between.")
+            .isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingBetweenDeclarationsWithCommentsRuleTest.kt
@@ -135,4 +135,16 @@ class SpacingBetweenDeclarationsWithCommentsRuleTest {
             """.trimIndent()
         spacingBetweenDeclarationsWithCommentsRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Given consecutive declarations, and the second declaration contains an inner comment on a separate line then do nothing`() {
+        val code =
+            """
+            val bar = "bar"
+            val foo =
+                // Some comment
+                "foo"
+            """.trimIndent()
+        spacingBetweenDeclarationsWithCommentsRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("com.gradle.develocity") version "3.19"
+    id("com.gradle.develocity") version "3.19.1"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 


### PR DESCRIPTION
## Description

I observed a performance bottleneck in `com.pinterest.ktlint.rule.engine.core.api.isPartOfComment`.  CPU profiling showed a significant amount of time being wasted doing stuff related to checking for cancellation, like IntelliJ GUI stuff.
<img width="1264" alt="Screenshot 2024-12-08 at 11 58 25 AM" src="https://github.com/user-attachments/assets/35bcdf90-d144-4f17-bb08-5b7b706660f4">

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 


This PR doesn't include new tests, doesn't reference an issue, and doesn't change documentaiton. It is a performance optimization.

According to IntelliJ's Usages, there are about 65 other usages of `ASTNode.getPsi()` in the ktlint codebase. I'm not sure if all of them could be removed, but maybe we could try to remove as many of them as possible? If this PR looks good, I suggest we follow up by doing that.
