### PR TITLE
ignore `.kotlin` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ build
 *.iml
 out
 /site
+# https://youtrack.jetbrains.com/issue/KT-58223/Kotlin-Gradle-plugin-shouldnt-store-data-in-project-cache-directory
 .kotlin

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.iml
 out
 /site
+.kotlin


### PR DESCRIPTION
## Description

I do not know exactly why, but this directory gets created for me when I work on this project. I know a recent kotlin update introduced this directory, but I'm not sure why its not already ignored here.


## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)