### PR TITLE
Add missing --code-style flag in CLI documentation

### DIFF
--- a/documentation/release-latest/docs/install/cli.md
+++ b/documentation/release-latest/docs/install/cli.md
@@ -134,10 +134,10 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig` file can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-# Specify the code style(ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
-ktlint generateEditorConfig ktlint_official
+# Specify the code style (ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
+ktlint generateEditorConfig --code-style ktlint_official
 # or
-ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig --code-style android_studio
 ```
 
 Normally the `.editorconfig` file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -134,10 +134,10 @@ Some rules can be tweaked via the [`editorconfig file`](../../rules/configuratio
 A scaffold of the `.editorconfig` file can be generated with command below. Note: that the generated file only contains configuration settings which are actively used by the [rules which are loaded](#rule-sets):
 
 ```shell title="Generate .editorconfig"
-# Specify the code style(ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
-ktlint generateEditorConfig ktlint_official
+# Specify the code style (ktlint_official, intellij_idea or android_studio) to be used when generating the .editorconfig
+ktlint generateEditorConfig --code-style ktlint_official
 # or
-ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig android_studio
+ktlint --ruleset=/path/to/custom-ruleset.jar generateEditorConfig --code-style android_studio
 ```
 
 Normally the `.editorconfig` file is located in the root of your project directory. In case the file is located in a sub folder of the project, the settings of that file only applies to that subdirectory and its folders (recursively). Ktlint automatically detects and reads all `.editorconfig` files in your project.


### PR DESCRIPTION
## Description

This adds the missing `--code-style` flag from the command line docs.

Currently, running `ktlint generateEditorConfig intellij_idea` will generate error:

```bash
Error: got unexpected extra argument (intellij_idea)
Error: missing option --code-style
```

![CleanShot 2025-01-04 at 16 00 08@2x](https://github.com/user-attachments/assets/2b1314ad-e973-408b-a0fa-3bb222635774)

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)