### PR TITLE
Fix incorrect error message in PropertyNamingRule when enforcing PascalCase

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRule.kt
@@ -90,9 +90,10 @@ public class PropertyNamingRule :
                 it == SERIAL_VERSION_UID_PROPERTY_NAME
             }?.takeUnless { it.matches(constantNamingProperty.regEx) }
             ?.let {
+                val expectedNaming = constantNamingProperty.name.replace("_", " ")
                 emit(
                     identifier.startOffset,
-                    "Property name should use the screaming snake case notation when the value can not be changed",
+                    "Property name should use the $expectedNaming notation when the value can not be changed",
                     false,
                 )
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -83,11 +83,11 @@ class PropertyNamingRuleTest {
         propertyNamingRuleAssertThat(code)
             .withEditorConfigOverride(PropertyNamingRule.CONSTANT_NAMING_PROPERTY to pascal_case)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(1, 11, "Property name should use the pascal case notation when the value can not be changed"),
                 // FOO cannot be reported as not meeting the pascal case requirement as it could be an abbreviation of 3 separate words
                 // starting with 'F', 'O' and 'O' respectively
-                LintViolation(3, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
-                LintViolation(4, 11, "Property name should use the screaming snake case notation when the value can not be changed"),
+                LintViolation(3, 11, "Property name should use the pascal case notation when the value can not be changed"),
+                LintViolation(4, 11, "Property name should use the pascal case notation when the value can not be changed"),
             )
     }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where PropertyNamingRule correctly enforced PascalCase but incorrectly suggested using ScreamingSnakeCase in the error message.

What was done?
	•	Updated the error message in visitConstProperty() to correctly reflect the configured naming style.
	•	Updated test accordingly to expect the updated error message.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
