### PR TITLE
Fix slow response of the git pre commit hook as generated by ktlint

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/FileUtils.kt
@@ -40,13 +40,18 @@ internal fun FileSystem.fileSequence(
     patterns: List<String>,
     rootDir: Path = Paths.get(".").toAbsolutePath().normalize(),
 ): Sequence<Path> {
+    if (patterns.isEmpty()) {
+        LOGGER.trace { "No patterns provided. Will not expand any globs." }
+        return emptySequence()
+    }
+
     val result = mutableListOf<Path>()
 
     val (existingFiles, patternsExclusiveExistingFiles) =
         patterns.partition {
             try {
                 Files.isRegularFile(rootDir.resolve(it))
-            } catch (e: InvalidPathException) {
+            } catch (_: InvalidPathException) {
                 // Windows throws an exception when you pass a glob to Path#resolve.
                 false
             }
@@ -89,7 +94,7 @@ internal fun FileSystem.fileSequence(
                     .resolve(pattern)
                     .normalize()
             commonRootDir = commonRootDir.findCommonParentDir(patternDir)
-        } catch (e: InvalidPathException) {
+        } catch (_: InvalidPathException) {
             // Windows throws an exception when you pass a glob to Path#resolve.
         }
     }
@@ -222,7 +227,7 @@ private fun FileSystem.toGlob(
                         LOGGER.trace { "Expanding resolved path '$resolvedPath` to patterns: [$it]" }
                     }
             }
-        } catch (e: InvalidPathException) {
+        } catch (_: InvalidPathException) {
             if (onWindowsOS) {
                 //  Windows throws an exception when passing a wildcard (*) to Path#resolve.
                 pathWithoutNegationPrefix


### PR DESCRIPTION
## Description

When no kotlin files have been changed the list of patterns provided via stdin by the 'git diff' command is empty. Running ktlint then takes considerably longer as the entire project directory is traversed looking for kotlin files. But no such files will be found as the list of provided patterns is empty. So the project tree should only be traversed for a non-empty list of patterns.

Closes 2976

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
