### PR TITLE
Move logic of missing whitespace before block comment to NoSingleLineBlockCommentRule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRule.kt
@@ -95,14 +95,6 @@ public class CommentWrappingRule :
                             "A block comment after any other element on the same line must be separated by a new line",
                             false,
                         )
-                    } else {
-                        emit(
-                            node.startOffset,
-                            "A single line block comment after a code element on the same line must be replaced with an EOL comment",
-                            true,
-                        ).ifAutocorrectAllowed {
-                            node.upsertWhitespaceBeforeMe(" ")
-                        }
                     }
                 }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
@@ -2,15 +2,12 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class NoSingleLineBlockCommentRuleTest {
-    private val noSingleLineBlockCommentRuleAssertThat =
-        assertThatRuleBuilder { NoSingleLineBlockCommentRule() }
-            .addAdditionalRuleProvider { CommentWrappingRule() }
-            .assertThat()
+    private val noSingleLineBlockCommentRuleAssertThat = assertThatRule { NoSingleLineBlockCommentRule() }
 
     @Test
     fun `Given a single line block comment then replace it with an EOL comment`() {
@@ -41,24 +38,6 @@ class NoSingleLineBlockCommentRuleTest {
              */
             """.trimIndent()
         noSingleLineBlockCommentRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `Given a single line block comment that is to be wrapped before replacing it with an EOL comment`() {
-        val code =
-            """
-            /* Some comment */ val foo = "foo"
-            """.trimIndent()
-        val formattedCode =
-            """
-            // Some comment
-            val foo = "foo"
-            """.trimIndent()
-        noSingleLineBlockCommentRuleAssertThat(code)
-            .hasLintViolationForAdditionalRule(1, 20, "A block comment may not be followed by any other element on that same line")
-            // Can not check for the lint violation below as it will only be thrown while formatting with comment wrapping
-            //   A single line block comment must be replaced with an EOL comment
-            .isFormattedAs(formattedCode)
     }
 
     @Nested
@@ -139,15 +118,6 @@ class NoSingleLineBlockCommentRuleTest {
         noSingleLineBlockCommentRuleAssertThat(code)
             .hasLintViolation(1, 17, "Replace the block comment with an EOL comment")
             .isFormattedAs(formattedCode)
-    }
-
-    @Test
-    fun `Given a single line block comment in between code elements on the same line does not raise a lint error`() {
-        val code =
-            """
-            val foo /* some comment */ = "foo"
-            """.trimIndent()
-        noSingleLineBlockCommentRuleAssertThat(code).hasNoLintViolationsExceptInAdditionalRules()
     }
 
     @Test


### PR DESCRIPTION
## Description

Move logic of missing whitespace before block comment to NoSingleLineBlockCommentRule

In #2000 the `NoSingleLineBlockCommentRule` was extracted from the `CommentWrappingRule`. Some logic was left behind in the old rule, causing an exception when running with other code style than `ktlint_official`. As a result, the dependency from `NoSingleLineBlockCommentRule` on `CommentWrappingRule` is also no longer needed.

Closes #2936

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
