### PR TITLE
Report and fix a single line condition wrapped between parentheses with an unexpected newline

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
@@ -183,7 +183,7 @@ public class SpacingAroundParensRule : StandardRule("paren-spacing") {
             ?.takeUnless { it.prevSibling()?.elementType == LPAR }
             ?.siblings(false)
             ?.takeWhile { it.elementType != LPAR }
-            ?.none { it.isWhiteSpaceWithNewline() }
+            ?.none { it.textContains('\n') }
             ?: false
 
     private fun ASTNode.fixUnexpectedSpacingAround(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
@@ -268,4 +268,94 @@ class SpacingAroundParensRuleTest {
             .hasLintViolation(1, 28, "Unexpected spacing before \"(\"")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 2943x - Given unexpected newline before RPAR in condition`() {
+        val code =
+            """
+            fun foo() {
+                if (true
+                ) {
+                    // do something
+                } else {
+                    // do something else
+                }
+                while (true
+                ) {
+                    // do something
+                }
+                do while (true
+                ) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                if (true) {
+                    // do something
+                } else {
+                    // do something else
+                }
+                while (true) {
+                    // do something
+                }
+                do while (true) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 13, "Unexpected spacing before \")\""),
+                LintViolation(8, 16, "Unexpected spacing before \")\""),
+                LintViolation(12, 19, "Unexpected spacing before \")\""),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 2943 - Given unexpected newline after LPAR in condition`() {
+        val code =
+            """
+            fun foo() {
+                if (
+                true) {
+                    // do something
+                } else {
+                    // do something else
+                }
+                while (
+                    true) {
+                    // do something
+                }
+                do while (
+                    true) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                if (true) {
+                    // do something
+                } else {
+                    // do something else
+                }
+                while (true) {
+                    // do something
+                }
+                do while (true) {
+                    // do something
+                }
+            }
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 9, "Unexpected spacing after \"(\""),
+                LintViolation(8, 12, "Unexpected spacing after \"(\""),
+                LintViolation(12, 15, "Unexpected spacing after \"(\""),
+            ).isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Report and fix a single line condition wrapped between parentheses with an unexpected newline

The condition should
* not be preceded, nor followed by whitespace
* be preceded *and* followed by whitespace containing a newline

Closes #2943

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
