### PR TITLE
Do not wrap an operation reference after an annotated expression to a separate new line

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -13,6 +13,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.GT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
@@ -231,6 +232,7 @@ public class AnnotationRule :
 
             node
                 .takeIf { it.elementType == ANNOTATED_EXPRESSION }
+                ?.takeUnless { it.nextCodeSibling()?.elementType == OPERATION_REFERENCE }
                 ?.lastChildLeafOrSelf()
                 ?.nextCodeLeaf()
                 ?.prevLeaf()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -1104,4 +1104,15 @@ class AnnotationRuleTest {
             .withEditorConfigOverride(ANNOTATIONS_WITH_PARAMETERS_NOT_TO_BE_WRAPPED_PROPERTY to "*")
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 2955 - Given an annotated expression followed by an operation reference`() {
+        val code =
+            """
+            fun foo() =
+                @Suppress("DEPRECATION")
+                false != true
+            """.trimIndent()
+        annotationRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not wrap an operation reference after an annotated expression to a separate new line

For most operation references this leads to code that cannot be compiled. For logical operators like && and || it does compile but leads to ugly formatting.

Closes #2955

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
