### PR TITLE
Update publishing URLs to point to Central Portal OSSRH staging API

### DIFF
--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -51,8 +51,8 @@ publishing {
 
     repositories {
         maven {
-            val releasesRepoUrl = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            val snapshotsRepoUrl = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+            val releasesRepoUrl = URI.create("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+            val snapshotsRepoUrl = URI.create("https://central.sonatype.com/repository/maven-snapshots/")
             name = "mavenCentral"
             url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
 

--- a/documentation/release-latest/docs/install/snapshot-build.md
+++ b/documentation/release-latest/docs/install/snapshot-build.md
@@ -10,7 +10,7 @@ so by changing version of ktlint to `<latest-version>-SNAPSHOT` + adding a repo:
 ...
 <repository>
     <id>sonatype-snapshots</id>
-    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <snapshots>
         <enabled>true</enabled>
     </snapshots>
@@ -26,7 +26,7 @@ so by changing version of ktlint to `<latest-version>-SNAPSHOT` + adding a repo:
 ```groovy
 repositories {
   maven {
-    url "https://oss.sonatype.org/content/repositories/snapshots"
+    url "https://central.sonatype.com/repository/maven-snapshots/"
   }
 }
 ```


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

OSSRH is being sunset at the end of this month. Following the documents [here](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) and [here](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/), I am updating the publishing URLs to the OSSRH staging APIs until we can evaluate a new Central Portal gradle plugin to use.

Separately, I will be updating the authentication credentials. (#3007)

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
