### PR TITLE
Update publishing credentials to use new Central Portal username/token

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Build executable and publish to Maven
         run: ./gradlew clean shadowJarExecutable publishMavenPublicationToMavenCentralRepository --no-daemon --no-parallel --no-configuration-cache
         env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_TOKEN: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
           ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}

--- a/.github/workflows/publish-snapshot-build.yml
+++ b/.github/workflows/publish-snapshot-build.yml
@@ -6,8 +6,8 @@ on:
     paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
 
 env:
-  SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-  SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+  CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+  CENTRAL_PORTAL_TOKEN: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
   ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
   ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}

--- a/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-publication.gradle.kts
@@ -59,10 +59,10 @@ publishing {
             logger.lifecycle("Set publication repository for version $version to $url")
 
             credentials {
-                username = providers.gradleProperty("SONATYPE_NEXUS_USERNAME").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_USERNAME")
-                password = providers.gradleProperty("SONATYPE_NEXUS_PASSWORD").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+                username = providers.gradleProperty("CENTRAL_PORTAL_USERNAME").orNull
+                    ?: System.getenv("CENTRAL_PORTAL_USERNAME")
+                password = providers.gradleProperty("CENTRAL_PORTAL_TOKEN").orNull
+                    ?: System.getenv("CENTRAL_PORTAL_TOKEN")
             }
         }
 
@@ -71,10 +71,10 @@ publishing {
             url = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
 
             credentials {
-                username = providers.gradleProperty("SONATYPE_NEXUS_USERNAME").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_USERNAME")
-                password = providers.gradleProperty("SONATYPE_NEXUS_PASSWORD").orNull
-                    ?: System.getenv("SONATYPE_NEXUS_PASSWORD")
+                username = providers.gradleProperty("CENTRAL_PORTAL_USERNAME").orNull
+                    ?: System.getenv("CENTRAL_PORTAL_USERNAME")
+                password = providers.gradleProperty("CENTRAL_PORTAL_TOKEN").orNull
+                    ?: System.getenv("CENTRAL_PORTAL_TOKEN")
             }
         }
     }


### PR DESCRIPTION
(Depends on #3006)

## Description

OSSRH is being sunset, so our publishing flows need to be updated to use the username and token generated from Central Portal.

Secrets have already been updated in the repository.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
