### PR TITLE
Do not remove an empty value parameter list from a call expression when it is nested

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/UnnecessaryParenthesesBeforeTrailingLambdaRule.kt
@@ -33,7 +33,8 @@ public class UnnecessaryParenthesesBeforeTrailingLambdaRule : StandardRule("unne
         if (node.isEmptyArgumentList() &&
             node.isPartOf(CALL_EXPRESSION) &&
             node.isNotPrecededByCallExpressionEndingWithLambdaArgument() &&
-            node.nextCodeSibling()?.elementType == LAMBDA_ARGUMENT
+            node.nextCodeSibling()?.elementType == LAMBDA_ARGUMENT &&
+            node.prevCodeSibling()?.elementType != CALL_EXPRESSION
         ) {
             emit(
                 node.startOffset,


### PR DESCRIPTION
## Description

Do not remove an empty value parameter list from a call expression when it is nested. Doing so results in code which no longer compiles.

Closes #3016

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
