### PR TITLE
Add context receiver list to `modifier-order` rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierOrderRule.kt
@@ -8,6 +8,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMPANION_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONST_KEYWORD
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTEXT_RECEIVER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DATA_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ENUM_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EXPECT_KEYWORD
@@ -68,7 +69,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
     }
 
     private fun squashAnnotations(sorted: Array<ASTNode>): List<String> {
-        val nonAnnotationModifiers = sorted.filter { it.elementType != ElementType.ANNOTATION_ENTRY }
+        val nonAnnotationModifiers = sorted.filter { it.elementType != ANNOTATION_ENTRY }
         return if (nonAnnotationModifiers.size != sorted.size) {
             listOf("@Annotation...") + nonAnnotationModifiers.map { it.text }
         } else {
@@ -81,6 +82,7 @@ public class ModifierOrderRule : StandardRule("modifier-order") {
         private val ORDERED_MODIFIERS =
             arrayOf(
                 ANNOTATION_ENTRY,
+                CONTEXT_RECEIVER_LIST,
                 PUBLIC_KEYWORD,
                 PROTECTED_KEYWORD,
                 PRIVATE_KEYWORD,


### PR DESCRIPTION
## Description

Add context receiver list to `modifier-order` rule

Closes #3027

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
