### PR TITLE
Ignore context parameters in rule `context-receiver-wrapping`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -43,6 +43,10 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 /**
  * Wrapping of context receiver to a separate line. Arguments of the context receiver are wrapped to separate line
  * whenever the max line length is exceeded.
+ *
+ * In Kotlin 2.1.21 the context parameters have been introduced as a replacement for context receiver. Like the context receiver, the
+ * context parameters are wrapped inside a context receiver list. This rule will be removed once context receivers are no longer supported
+ * by the Kotlin compiler. A new rule (ContextReceiverListWrapping) will take care of wrapping the context parameters.
  */
 @SinceKtlint("0.48", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
@@ -73,7 +77,7 @@ public class ContextReceiverWrappingRule :
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
         when {
-            node.elementType == CONTEXT_RECEIVER_LIST -> {
+            node.elementType == CONTEXT_RECEIVER_LIST && node.findChildByType(CONTEXT_RECEIVER) != null -> {
                 visitContextReceiverList(node, emit)
             }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
@@ -211,4 +211,22 @@ class ContextReceiverWrappingRuleTest {
             """.trimIndent()
         contextReceiverWrappingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 3028 - Given some functions with context receiver list on the same line as the fun keyword then only wrap context receivers to a newline`() {
+        val code =
+            """
+            context(Foo) fun foo()
+            context(_: Foo) fun foo()
+
+            context(Foooooooooooooooo<Foo, Bar>) fun fooBar()
+            context(_: Foooooooooooooooo<Foo, Bar>) fun fooBar()
+            """.trimIndent()
+        contextReceiverWrappingRuleAssertThat(code)
+            // Find violations on the context receivers, but skip the context parameters
+            .hasLintViolations(
+                LintViolation(1, 14, "Expected a newline after the context receiver"),
+                LintViolation(4, 38, "Expected a newline after the context receiver"),
+            )
+    }
 }


### PR DESCRIPTION
## Description

Ignore context parameters in rule `context-receiver-wrapping`

Closes #3028

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
