### PR TITLE
Bump `poko-gradle-plugin` with a workaround (enforce compatible Kotlin version)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    // TODO: Remove if the build is migrated to Gradle 9
     kotlin("jvm") version libs.versions.kotlin.get() apply false // Enforce higher Kotlin version to make `poko-gradle-plugin` compatible.
     `kotlin-dsl`
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    kotlin("jvm") version libs.versions.kotlin.get() apply false // Enforce higher Kotlin version to make `poko-gradle-plugin` compatible.
     `kotlin-dsl`
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 ec4j = "org.ec4j.core:ec4j-core:1.1.1"
 logging = "io.github.oshai:kotlin-logging-jvm:7.0.7"
 slf4j = "org.slf4j:slf4j-simple:2.0.17"
-poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.18.7"
+poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.19.0"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
 # TODO: Update "renovate.json" once logback-classic is updated to 1.4 (once java8 support for ktlint is dropped)
 logback = "ch.qos.logback:logback-classic:1.3.15"


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->
For the `build-logic` project `kotlin-dsl` plugin (5.2.0) sets its own recommended kotlin version (`2.0.21`), which is not compatible with latest poko plugin. Our options are:
1. Bump kotlin-dsl plugin to latest [6.1.2](https://plugins.gradle.org/plugin/org.gradle.kotlin.kotlin-dsl) which hopefully will depend on higher kotlin version - 🔴 doesn't work out of the box, because develocity plugin is not yet compatible
2. Make the build resolve higher kotlin version for the `build-logic` project 
3. Migrate away from kotlin-dsl 😛 This types of incompatibilities is one of the reason why I personally prefer not to use kotlin-dsl 😅 

This PR implements option 2). 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
