### PR TITLE
Do not run `no-unused-imports` rule by default

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -2558,8 +2558,13 @@ Suppress or disable rule (1)
 
 ## No unused imports
 
-!!! warning
-    This rule is not able to detect *all* unused imports as mentioned in this [issue comment](https://github.com/pinterest/ktlint/issues/1754#issuecomment-1368201667).
+!!! important
+    Starting from KtLint `1.7.0` this rule no longer runs by default. In some cases the rule marks imports as unused, while after removal of the import the code no longer compiles. This rule will be removed in KtLint `2.0`. See [issue](https://github.com/pinterest/ktlint/issues/3038) for more background. 
+    If you insist on running the rule despite its shortcomings, you need to enable the rule in the `.editorconfig` by adding:
+    ```
+    ktlint_standard_no-unused-imports = enabled
+    ```
+
 
 Rule id: `standard:no-unused-imports`
 

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -482,6 +482,9 @@ public abstract interface class com/pinterest/ktlint/rule/engine/core/api/Rule$E
 public abstract interface class com/pinterest/ktlint/rule/engine/core/api/Rule$OfficialCodeStyle {
 }
 
+public abstract interface class com/pinterest/ktlint/rule/engine/core/api/Rule$OnlyWhenEnabledInEditorconfig {
+}
+
 public abstract class com/pinterest/ktlint/rule/engine/core/api/Rule$VisitorModifier {
 }
 

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/Rule.kt
@@ -277,4 +277,11 @@ public open class Rule(
      * in Ktlint internally only. It may be subject to change at any time without providing any backward compatibility.
      */
     public interface OfficialCodeStyle
+
+    /**
+     * This interface marks a rule to be run only on explicitly enabled in the `.editorconfig`. This can be used to mark a rule as
+     * deprecated, or when a rule is not applicable for general use.
+     * This interface should not be used on a rule that is also marked with [Experimental], or [OfficialCodeStyle].
+     */
+    public interface OnlyWhenEnabledInEditorconfig
 }

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilter.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilter.kt
@@ -106,6 +106,10 @@ private class RuleExecutionFilter(
                 isOfficialCodeStyleEnabled(rule)
             }
 
+            rule is Rule.OnlyWhenEnabledInEditorconfig -> {
+                ruleExecution(rule.ruleId.ktLintRuleExecutionPropertyName()) == RuleExecution.disabled
+            }
+
             else -> {
                 isRuleSetEnabled(rule)
             }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rulefilter/RuleExecutionRuleFilterTest.kt
@@ -192,6 +192,31 @@ class RuleExecutionRuleFilterTest {
         assertThat(actual).isEmpty()
     }
 
+    @Test
+    fun `Given a rule that only should be run when enabled explicitly, and the rule execution property is not set, then do not execute the rule`() {
+        val actual =
+            runWithRuleExecutionRuleFilter(
+                RuleProvider { OnlyWhenEnabledInEditorconfigRule(STANDARD_RULE_A) },
+                editorConfig = EditorConfig(),
+            ).toRuleIds()
+
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `Given a rule that only should be run when enabled explicitly, and the rule execution property is enabled, then do execute the rule`() {
+        val actual =
+            runWithRuleExecutionRuleFilter(
+                RuleProvider { OnlyWhenEnabledInEditorconfigRule(STANDARD_RULE_A) },
+                editorConfig =
+                    EditorConfig(
+                        ktLintRuleExecutionEditorConfigProperty(STANDARD_RULE_A, RuleExecution.enabled),
+                    ),
+            ).toRuleIds()
+
+        assertThat(actual).containsExactly(STANDARD_RULE_A)
+    }
+
     /**
      * Create a [RuleExecutionRuleFilter] for a given set of [RuleProvider]s and an [EditorConfig].
      */
@@ -255,4 +280,12 @@ class RuleExecutionRuleFilterTest {
             about = About(),
         ),
         Rule.Experimental
+
+    private open class OnlyWhenEnabledInEditorconfigRule(
+        ruleId: RuleId,
+    ) : Rule(
+            ruleId = ruleId,
+            about = About(),
+        ),
+        Rule.OnlyWhenEnabledInEditorconfig
 }

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -657,7 +657,7 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/NoUnitReturnRuleK
 	public static final fun getNO_UNIT_RETURN_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
-public final class com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/IgnoreKtlintSuppressions {
+public final class com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/IgnoreKtlintSuppressions, com/pinterest/ktlint/rule/engine/core/api/Rule$OnlyWhenEnabledInEditorconfig {
 	public fun <init> ()V
 	public fun afterVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -11,6 +11,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.IgnoreKtlintSuppressions
+import com.pinterest.ktlint.rule.engine.core.api.Rule.OnlyWhenEnabledInEditorconfig
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
@@ -36,8 +37,12 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.resolve.ImportPath
 
 @SinceKtlint("0.2", STABLE)
+@Deprecated(
+    "Marked for removal in Ktlint 2.0.0. When the rule marks an import falsely as unused, it results in code that can not be compiled.",
+)
 public class NoUnusedImportsRule :
     StandardRule("no-unused-imports"),
+    OnlyWhenEnabledInEditorconfig,
     // Prevent that imports which are only used inside code that is suppressed are (falsely) reported as unused.
     IgnoreKtlintSuppressions {
     private val ref =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRuleTest.kt
@@ -1,13 +1,18 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.RuleExecution
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.createRuleExecutionEditorConfigProperty
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class NoUnusedImportsRuleTest {
-    private val noUnusedImportsRuleAssertThat = assertThatRule { NoUnusedImportsRule() }
+    private val noUnusedImportsRuleAssertThat =
+        assertThatRuleBuilder { NoUnusedImportsRule() }
+            .withEditorConfigOverride(NO_UNUSED_IMPORTS_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
+            .assertThat()
 
     @Test
     fun `Given that the first import is unused than the file should not start with a linebreak`() {


### PR DESCRIPTION
## Description

Do not run `no-unused-imports` rule by default

Closes #3038

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
