### PR TITLE
Suppress warning "sun.misc.Unsafe::objectFieldOffset" in Ktlint CLI (Java24+)

### DIFF
--- a/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -64,5 +64,7 @@ tasks.withType<Test>().configureEach {
     ) {
         // workaround for https://github.com/pinterest/ktlint/issues/1618. Java 11 started printing warning logs. Java 16 throws an error
         jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+        // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ tasks.register<JavaExec>("ktlintFormat") {
     classpath = ktlint
     mainClass = "com.pinterest.ktlint.Main"
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     args(
         "-F",
         "**/src/**/*.kt",

--- a/documentation/release-latest/docs/install/integrations.md
+++ b/documentation/release-latest/docs/install/integrations.md
@@ -132,6 +132,8 @@ tasks.register("ktlintFormat", JavaExec) {
     classpath = configurations.ktlint
     mainClass = "com.pinterest.ktlint.Main"
     jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args "-F", "src/**/*.kt", "**.kts", "!**/build/**"
 }
@@ -184,6 +186,8 @@ tasks.register<JavaExec>("ktlintFormat") {
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args(
         "-F",

--- a/documentation/snapshot/docs/install/integrations.md
+++ b/documentation/snapshot/docs/install/integrations.md
@@ -132,6 +132,8 @@ tasks.register("ktlintFormat", JavaExec) {
     classpath = configurations.ktlint
     mainClass = "com.pinterest.ktlint.Main"
     jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args "-F", "src/**/*.kt", "**.kts", "!**/build/**"
 }
@@ -184,6 +186,8 @@ tasks.register<JavaExec>("ktlintFormat") {
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args(
         "-F",

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -98,6 +98,9 @@ val shadowJarExecutable by tasks.registering(DefaultTask::class) {
                 # Add --add-opens for java version 16 and above
                 X=$( [ "${"$"}JV" -ge "16" ] && echo "--add-opens java.base/java.lang=ALL-UNNAMED" || echo "")
 
+                # Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+                X=$( [ "${"$"}JV" -ge "24" ] && echo "--sun-misc-unsafe-memory-access=allow" || echo "")
+
                 exec java ${"$"}X -Xmx512m -jar "$0" "$@"
 
                 """.trimIndent(),

--- a/ktlint-cli/src/main/scripts/ktlint.bat
+++ b/ktlint-cli/src/main/scripts/ktlint.bat
@@ -8,3 +8,7 @@ if not defined JAR_PATH set JAR_PATH=%~dp0ktlint
 
 REM The --add-opens argument is needed for java 16+ (see https://github.com/pinterest/ktlint/issues/1986)
 java --add-opens=java.base/java.lang=ALL-UNNAMED -jar "%JAR_PATH%" %*
+
+REM With Java24+
+REM Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+REM java --sun-misc-unsafe-memory-access=allow -jar "%JAR_PATH%" %*

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -141,9 +141,18 @@ class CommandLineTestRunner(
                     add("java")
 
                     val javaVersion = System.getProperty("java.specification.version").javaVersionAsInt()
-                    if (javaVersion != null) {
-                        // https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers
-                        if (javaVersion >= 16) {
+                    when {
+                        javaVersion == null -> {
+                            Unit
+                        }
+
+                        javaVersion >= 24 -> {
+                            // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+                            add("--sun-misc-unsafe-memory-access=allow")
+                        }
+
+                        javaVersion >= 16 -> {
+                            // https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers
                             add("--add-opens=java.base/java.lang=ALL-UNNAMED")
                         }
                     }


### PR DESCRIPTION
## Description

Suppress warning "sun.misc.Unsafe::objectFieldOffset" in Ktlint CLI on Java24+ as the problem occurs in class "org.jetbrains.kotlin.com.intellij.util.containers.Unsafe"

At other places in code and documentation, information about this warning is added as comment, as the warning can only be suppressed when actually running on Java 24+.

Closes #2793

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
