### PR TITLE
The suppression "--sun-misc-unsafe-memory-access=allow" should not override the suppression for "--add-opens=java.base/java.lang=ALL-UNNAMED"

### DIFF
--- a/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-kotlin-common.gradle.kts
@@ -62,9 +62,9 @@ tasks.withType<Test>().configureEach {
             .languageVersion
             .canCompileOrRun(JavaLanguageVersion.of(11))
     ) {
-        // workaround for https://github.com/pinterest/ktlint/issues/1618. Java 11 started printing warning logs. Java 16 throws an error
-        jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+        jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
         // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-        // jvmArgs("--sun-misc-unsafe-memory-access=allow")
+        // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,9 +51,10 @@ tasks.register<JavaExec>("ktlintFormat") {
     description = "Check Kotlin code style and format"
     classpath = ktlint
     mainClass = "com.pinterest.ktlint.Main"
-    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
-    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
+    // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
+    // Suppress "sun.misc.Unsafe::objectFieldOffset" on Java24 (warning) (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     args(
         "-F",
         "**/src/**/*.kt",

--- a/documentation/release-latest/docs/install/integrations.md
+++ b/documentation/release-latest/docs/install/integrations.md
@@ -131,10 +131,10 @@ tasks.register("ktlintFormat", JavaExec) {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     mainClass = "com.pinterest.ktlint.Main"
-    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
-    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
-    // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
+    // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
+    // Suppress "sun.misc.Unsafe::objectFieldOffset" on Java24 (warning) (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     args "-F", "src/**/*.kt", "**.kts", "!**/build/**"
 }
 ```
@@ -185,9 +185,10 @@ tasks.register<JavaExec>("ktlintFormat") {
     description = "Check Kotlin code style and format"
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
-    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
+    // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
+    // Suppress "sun.misc.Unsafe::objectFieldOffset" on Java24 (warning) (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args(
         "-F",

--- a/documentation/snapshot/docs/install/integrations.md
+++ b/documentation/snapshot/docs/install/integrations.md
@@ -131,9 +131,10 @@ tasks.register("ktlintFormat", JavaExec) {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     mainClass = "com.pinterest.ktlint.Main"
-    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
-    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
+    // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
+    // Suppress "sun.misc.Unsafe::objectFieldOffset" on Java24 (warning) (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args "-F", "src/**/*.kt", "**.kts", "!**/build/**"
 }
@@ -185,9 +186,10 @@ tasks.register<JavaExec>("ktlintFormat") {
     description = "Check Kotlin code style and format"
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
-    // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-    // jvmArgs("--sun-misc-unsafe-memory-access=allow")
+    // Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED") // Java 11+
+    // Suppress "sun.misc.Unsafe::objectFieldOffset" on Java24 (warning) (https://github.com/pinterest/ktlint/issues/2973)
+    // jvmArgs("--sun-misc-unsafe-memory-access=allow") // Java 24+
     // see https://pinterest.github.io/ktlint/install/cli/#command-line-usage for more information
     args(
         "-F",

--- a/ktlint-cli/build.gradle.kts
+++ b/ktlint-cli/build.gradle.kts
@@ -95,11 +95,11 @@ val shadowJarExecutable by tasks.registering(DefaultTask::class) {
                 # versions, e.g. 1.8 = Java 8
                 JV=$(java -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*".*/\1/p')
 
-                # Add --add-opens for java version 16 and above
-                X=$( [ "${"$"}JV" -ge "16" ] && echo "--add-opens java.base/java.lang=ALL-UNNAMED" || echo "")
+                # Suppress "An illegal reflective access operation has occurred" on Java 11 (warning) / Java 16 (error) (https://github.com/pinterest/ktlint/issues/1618)
+                X=$( [ "${"$"}JV" -ge "11" ] && echo "--add-opens java.base/java.lang=ALL-UNNAMED" || echo "")
 
                 # Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-                X=$( [ "${"$"}JV" -ge "24" ] && echo "--sun-misc-unsafe-memory-access=allow" || echo "")
+                X=$( [ "${"$"}JV" -ge "24" ] && echo "${"$"}X --sun-misc-unsafe-memory-access=allow" || echo "")
 
                 exec java ${"$"}X -Xmx512m -jar "$0" "$@"
 

--- a/ktlint-cli/src/main/scripts/ktlint.bat
+++ b/ktlint-cli/src/main/scripts/ktlint.bat
@@ -11,4 +11,4 @@ java --add-opens=java.base/java.lang=ALL-UNNAMED -jar "%JAR_PATH%" %*
 
 REM With Java24+
 REM Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-REM java --sun-misc-unsafe-memory-access=allow -jar "%JAR_PATH%" %*
+REM java --add-opens=java.base/java.lang=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar "%JAR_PATH%" %*

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/CommandLineTestRunner.kt
@@ -140,22 +140,19 @@ class CommandLineTestRunner(
                     // KtLint is not an executable command on Windows OS
                     add("java")
 
-                    val javaVersion = System.getProperty("java.specification.version").javaVersionAsInt()
-                    when {
-                        javaVersion == null -> {
-                            Unit
+                    System
+                        .getProperty("java.specification.version")
+                        .javaVersionAsInt()
+                        ?.let { javaVersion ->
+                            if (javaVersion >= 16) {
+                                // https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers
+                                add("--add-opens=java.base/java.lang=ALL-UNNAMED")
+                            }
+                            if (javaVersion >= 24) {
+                                // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
+                                add("--sun-misc-unsafe-memory-access=allow")
+                            }
                         }
-
-                        javaVersion >= 24 -> {
-                            // Suppress warning "sun.misc.Unsafe::objectFieldOffset" on Java24+ (https://github.com/pinterest/ktlint/issues/2973)
-                            add("--sun-misc-unsafe-memory-access=allow")
-                        }
-
-                        javaVersion >= 16 -> {
-                            // https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers
-                            add("--add-opens=java.base/java.lang=ALL-UNNAMED")
-                        }
-                    }
                     add("-jar")
                 }
 


### PR DESCRIPTION
## Description

Follow-up on #2793 (#3040)

The suppression "--sun-misc-unsafe-memory-access=allow" should not override the suppression for "--add-opens=java.base/java.lang=ALL-UNNAMED"

Closes #2793

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
