### PR TITLE
Clarify violation message in `filename` rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRule.kt
@@ -130,8 +130,8 @@ public class FilenameRule : StandardRule("filename") {
         if (this != className) {
             emit(
                 0,
-                "File '$this.kt' contains a single class and possibly also extension functions for that class and should be named same " +
-                    "after that class '$className.kt'",
+                "File '$this.kt' contains a single class, and possibly related top level declarations for that class. The file should be " +
+                    "named after the class, '$className.kt'",
                 false,
             )
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
@@ -75,7 +75,7 @@ class FilenameRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath("/some/path/$UNEXPECTED_FILE_NAME")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")
     }
 
     @ParameterizedTest(name = "Top level declaration: {0}")
@@ -170,7 +170,7 @@ class FilenameRuleTest {
         @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class and possibly also extension functions for that class and should be named same after that class 'Foo.kt'")
+            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")
     }
 
     @Test


### PR DESCRIPTION
## Description

Clarify violation message in `filename` rule

Closes #2998

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
