### PR TITLE
Cleanup Java 24 bump 

### DIFF
--- a/.github/workflows/pull-request-with-code.yml
+++ b/.github/workflows/pull-request-with-code.yml
@@ -29,22 +29,6 @@ env:
 
 # Note that all "jobs" (build, tests) including "jobs.*.runs-on" should be kept in sync with "pull-request-without-code"
 jobs:
-  smoke-test:
-    runs-on: [windows-latest]
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - uses: ./.github/actions/setup-gradle-build
-
-      - run: java -version
-        shell: bash
-
-      - run: java -jar ktlint-dev.jar --help
-        shell: bash
-
-      - run: java --add-opens=java.base/java.lang=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar ktlint-dev.jar --log-level=trace --help
-        shell: bash
-
   build:
     strategy:
       matrix:

--- a/.github/workflows/pull-request-without-code.yml
+++ b/.github/workflows/pull-request-without-code.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        jdk: [ 8, 11, 17 ]
+        jdk: [ 8, 11, 17, 21 ]
     runs-on: ${{ matrix.os }}
     name: "[tests] OS=${{ matrix.os }}, Java=${{ matrix.jdk }}"
     steps:


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description
The https://github.com/pinterest/ktlint/pull/3049 contained commits which I pushed to my fork to test how the build behaves on windows. These can be safely removed now. 

Moreover, after https://github.com/pinterest/ktlint/pull/3035, the build-logic project uses latest kotlin version which supports Java 24, making the extra workaround unnecessary

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
