### PR TITLE
Add tasks to create placeholder docs and sources jars to pass Central Portal Validation

### DIFF
--- a/build-logic/src/main/kotlin/PublicationPlugin.kt
+++ b/build-logic/src/main/kotlin/PublicationPlugin.kt
@@ -131,25 +131,27 @@ abstract class PublicationPlugin : Plugin<Project> {
     // See https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources
     private fun Project.createPlaceholderJarTasks() {
         val readmePath = "$rootDir/gradle/"
-        val sourcePlaceholderJar = tasks.register("sourcePlaceholderJar", Jar::class.java) {
-            archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
-            archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
-            archiveClassifier.set("sources")
-            from(layout.projectDirectory.file("$readmePath/README-sources.md")) {
-                into("")
-                rename { "README.md" }
+        val sourcePlaceholderJar =
+            tasks.register("sourcePlaceholderJar", Jar::class.java) {
+                archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
+                archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
+                archiveClassifier.set("sources")
+                from(layout.projectDirectory.file("$readmePath/README-sources.md")) {
+                    into("")
+                    rename { "README.md" }
+                }
             }
-        }
 
-        val docsPlaceholderJar = tasks.register("docsPlaceholderJar", Jar::class.java) {
-            archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
-            archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
-            archiveClassifier.set("javadoc")
-            from(layout.projectDirectory.file("$readmePath/README-javadoc.md")) {
-                into("")
-                rename { "README.md" }
+        val docsPlaceholderJar =
+            tasks.register("docsPlaceholderJar", Jar::class.java) {
+                archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
+                archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
+                archiveClassifier.set("javadoc")
+                from(layout.projectDirectory.file("$readmePath/README-javadoc.md")) {
+                    into("")
+                    rename { "README.md" }
+                }
             }
-        }
 
         tasks.named("publishMavenPublicationToMavenCentralRepository") {
             dependsOn(sourcePlaceholderJar, docsPlaceholderJar)

--- a/build-logic/src/main/kotlin/PublicationPlugin.kt
+++ b/build-logic/src/main/kotlin/PublicationPlugin.kt
@@ -3,6 +3,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
@@ -116,6 +117,8 @@ abstract class PublicationPlugin : Plugin<Project> {
                 sign(the<PublishingExtension>().publications["maven"])
                 isRequired = enableSigning && !version.toString().endsWith("SNAPSHOT")
             }
+
+            project.createPlaceholderJarTasks()
         }
 
     // TODO: remove this once https://github.com/gradle/gradle/issues/23572 is fixed
@@ -123,4 +126,33 @@ abstract class PublicationPlugin : Plugin<Project> {
         provider {
             if (hasProperty(name)) property(name)?.toString() else null
         }
+
+    // Create placeholder jars to satisfy Central Portal validation.
+    // See https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources
+    private fun Project.createPlaceholderJarTasks() {
+        val readmePath = "$rootDir/gradle/"
+        val sourcePlaceholderJar = tasks.register("sourcePlaceholderJar", Jar::class.java) {
+            archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
+            archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
+            archiveClassifier.set("sources")
+            from(layout.projectDirectory.file("$readmePath/README-sources.md")) {
+                into("")
+                rename { "README.md" }
+            }
+        }
+
+        val docsPlaceholderJar = tasks.register("docsPlaceholderJar", Jar::class.java) {
+            archiveBaseName.set("${localGradleProperty("POM_NAME").get()}")
+            archiveVersion.set(this@createPlaceholderJarTasks.version.toString())
+            archiveClassifier.set("javadoc")
+            from(layout.projectDirectory.file("$readmePath/README-javadoc.md")) {
+                into("")
+                rename { "README.md" }
+            }
+        }
+
+        tasks.named("publishMavenPublicationToMavenCentralRepository") {
+            dependsOn(sourcePlaceholderJar, docsPlaceholderJar)
+        }
+    }
 }

--- a/gradle/README-javadoc.md
+++ b/gradle/README-javadoc.md
@@ -1,0 +1,1 @@
+Documentation available at https://pinterest.github.io/ktlint/latest/

--- a/gradle/README-sources.md
+++ b/gradle/README-sources.md
@@ -1,0 +1,1 @@
+Source code available at https://github.com/pinterest/ktlint


### PR DESCRIPTION
## Description

Central Portal [requires](https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources) source and javadoc jars for every artifact published. Since we have our source code on GitHub and a comprehensive docs site, this PR creates empty placeholder jars which point developers to the proper URLs.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
