### PR TITLE
Make Ktlint code backwards compatible with lower Kotlin versions (down to 2.0)

### DIFF
--- a/build-logic/src/main/kotlin/KotlinCommonPlugin.kt
+++ b/build-logic/src/main/kotlin/KotlinCommonPlugin.kt
@@ -13,6 +13,8 @@ import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -27,10 +29,14 @@ abstract class KotlinCommonPlugin : Plugin<Project> {
                 JavaLanguageVersion.of(projectLibs.findVersion("java-compilation").get().requiredVersion)
             val javaTargetVersion = JavaLanguageVersion.of(projectLibs.findVersion("java-target").get().requiredVersion)
 
-            kotlinExtension.apply {
+            (kotlinExtension as KotlinJvmExtension).apply {
                 // All modules, the CLI included, must have an explicit API
                 explicitApi()
                 jvmToolchain(jdkVersion = javaCompilationVersion.asInt())
+
+                compilerOptions {
+                    apiVersion.set(KotlinVersion.KOTLIN_2_0)
+                }
             }
 
             tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->
Fixes #3061

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->
The artifacts produced by the build can useapis available in Kotlin sdlib version 2.2 leading to issues like #3061.

The proposed fix is to lower the apis ktlint's source code can reference to.

|Before|After|
|---|---|
|<img width="586" height="604" alt="image" src="https://github.com/user-attachments/assets/04568526-8965-4ea0-90a4-eabd860eecc5" />|<img width="534" height="484" alt="image" src="https://github.com/user-attachments/assets/13d573f7-f213-44f8-9f45-eabeac6b44ba" />|



## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
