### PR TITLE
Add temporary workflow to finish (announce) release 1.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,88 @@
+name: Finish (announce) release 1.7.0
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'pinterest/ktlint'
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: 'master'
+
+      - uses: ./.github/actions/setup-gradle-build
+
+#      - name: Build executable and publish to Maven
+#        run: ./gradlew clean shadowJarExecutable publishMavenPublicationToMavenCentralRepository --no-daemon --no-parallel --no-configuration-cache
+#        env:
+#          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+#          CENTRAL_PORTAL_TOKEN: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
+#          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+#          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+#          ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+
+      - name: Validate changelog.md
+        id: validate_changelog
+        if: ${{ success() }}
+        run: |
+          FIRST_HEADING2=$(grep "^## " CHANGELOG.md | head -n 1)
+          echo "First heading2 found: $FIRST_HEADING2"
+          if [[ ! "$FIRST_HEADING2" =~ ^##[[:space:]]\[[0-9]+\.[0-9]+\.[0-9]+\][[:space:]]-[[:space:]][0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "First heading at level 2 should match '## [X.Y.Z] - [YYYY-MM-DD]'"
+            exit 1
+          fi
+
+      - name: Extract release notes
+        id: release_notes
+        if: ${{ success() }}
+        uses: ffurrer2/extract-release-notes@v2
+
+      - name: Get version
+        id: get_version
+        if: ${{ success() }}
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+#      - name: Create zip for dependency manager(s)
+#        if: ${{ success() }}
+#        run: |
+#          cd ktlint-cli/build/run
+#          mkdir -p ktlint-${{ env.version }}/bin
+#          cp ktlint ktlint-${{ env.version }}/bin
+#          zip -rm ktlint-${{ env.version }}.zip ktlint-${{ env.version }}
+
+#      - name: Create release
+#        id: github_release
+#        if: ${{ success() }}
+#        uses: softprops/action-gh-release@v2
+#        with:
+#          draft: false
+#          prerelease: false
+#          body: ${{ steps.release_notes.outputs.release_notes }}
+#          files: |
+#            ktlint-cli/build/run/*
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+#      - name: Bump Homebrew Formula
+#        if: ${{ success() }}
+#        uses: mislav/bump-homebrew-formula-action@v2
+#        env:
+#          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+#        with:
+#          formula-name: ktlint
+#          formula-path: Formula/k/ktlint.rb
+#          download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
+
+      - name: Update Release documentation
+        if: ${{ success() }}
+        run: |
+          git config user.email "ktlint@github.com"
+          git config user.name "Ktlint Release Workflow" |
+          ./.announce -y
+        env:
+          VERSION: ${{ env.version }}


### PR DESCRIPTION
## Description

The release of 1.7.0 failed at bumping the homebrew version of ktlint. As of that the release process (the announce script) has not run yet.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
