### PR TITLE
Fix conflict between `modifier-list-spacing` and `context-receiver-list-wrapping`

### DIFF
--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -476,6 +476,7 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOpe
 
 public final class com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRule.kt
@@ -3,12 +3,19 @@ package com.pinterest.ktlint.ruleset.standard.rules
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONTEXT_RECEIVER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -24,7 +31,30 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  */
 @SinceKtlint("0.45", EXPERIMENTAL)
 @SinceKtlint("0.49", STABLE)
-public class ModifierListSpacingRule : StandardRule("modifier-list-spacing") {
+public class ModifierListSpacingRule :
+    StandardRule(
+        id = "modifier-list-spacing",
+        visitorModifiers =
+            setOf(
+                VisitorModifier.RunAfterRule(ANNOTATION_RULE_ID, REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED),
+                VisitorModifier.RunAfterRule(MODIFIER_ORDER_RULE_ID, REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED),
+            ),
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+            ),
+    ) {
+    private var indentConfig = DEFAULT_INDENT_CONFIG
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+    }
+
     override fun beforeVisitChildNodes(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
@@ -48,33 +78,47 @@ public class ModifierListSpacingRule : StandardRule("modifier-list-spacing") {
         node
             .nextSibling { it.isWhiteSpace20 && it.nextLeaf?.isPartOfComment20 != true }
             ?.takeUnless {
-                // Regardless of element type, a single white space is always ok and does not need to be checked.
-                it.text == " "
-            }?.takeUnless {
                 // A single newline after a comment is always ok and does not need further checking.
                 it.text.trim(' ', '\t').contains('\n') && it.prevLeaf?.isPartOfComment20 == true
             }?.let { whitespace ->
-                if (node.isAnnotationElement() ||
-                    (node.elementType == MODIFIER_LIST && node.lastChildNode.isAnnotationElement())
-                ) {
-                    if (whitespace.text.contains("\n\n")) {
-                        emit(whitespace.startOffset, "Single newline expected after annotation", true)
-                            .ifAutocorrectAllowed {
-                                whitespace.replaceTextWith("\n".plus(whitespace.text.substringAfterLast("\n")))
-                            }
-                    } else if (!whitespace.text.contains('\n') && whitespace.text != " ") {
-                        emit(whitespace.startOffset, "Single whitespace or newline expected after annotation", true)
+                when {
+                    node.isAnnotation() -> {
+                        if (whitespace.text.contains("\n\n")) {
+                            emit(whitespace.startOffset, "Single newline expected after annotation", true)
+                                .ifAutocorrectAllowed {
+                                    whitespace.replaceTextWith("\n".plus(whitespace.text.substringAfterLast("\n")))
+                                }
+                        } else if (!whitespace.text.contains('\n') && whitespace.text != " ") {
+                            emit(whitespace.startOffset, "Single whitespace or newline expected after annotation", true)
+                                .ifAutocorrectAllowed { whitespace.replaceTextWith(" ") }
+                        }
+                        Unit
+                    }
+
+                    node.isContextReceiverList() -> {
+                        if (!whitespace.text.contains("\n")) {
+                            emit(whitespace.startOffset, "Single newline expected after context receiver list", true)
+                                .ifAutocorrectAllowed {
+                                    whitespace.replaceTextWith(indentConfig.parentIndentOf(node))
+                                }
+                        }
+                    }
+
+                    whitespace.text != " " -> {
+                        emit(whitespace.startOffset, "Single whitespace expected after modifier", true)
                             .ifAutocorrectAllowed { whitespace.replaceTextWith(" ") }
                     }
-                    Unit
-                } else {
-                    emit(whitespace.startOffset, "Single whitespace expected after modifier", true)
-                        .ifAutocorrectAllowed { whitespace.replaceTextWith(" ") }
                 }
             }
     }
 
+    private fun ASTNode.isAnnotation(): Boolean =
+        isAnnotationElement() || (elementType == MODIFIER_LIST && lastChildNode.isAnnotationElement())
+
     private fun ASTNode?.isAnnotationElement() = this != null && (elementType == ANNOTATION || elementType == ANNOTATION_ENTRY)
+
+    private fun ASTNode.isContextReceiverList(): Boolean =
+        elementType == CONTEXT_RECEIVER_LIST || (elementType == MODIFIER_LIST && lastChildNode.isContextReceiverList())
 }
 
 public val MODIFIER_LIST_SPACING_RULE_ID: RuleId = ModifierListSpacingRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ModifierListSpacingRuleTest.kt
@@ -185,4 +185,58 @@ class ModifierListSpacingRuleTest {
             """.trimIndent()
         modifierListSpacingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 3065 - Given a context parameter on same line as function then wrap to new line after context parameter`() {
+        val code =
+            """
+            class Bar {
+                context(Foo) fun foo()
+                context(_: Foo) fun foo()
+
+                context(Foooooooooooooooo<Foo, Bar>) fun fooBar()
+                context(_: Foooooooooooooooo<Foo, Bar>) fun fooBar()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Bar {
+                context(Foo)
+                fun foo()
+                context(_: Foo)
+                fun foo()
+
+                context(Foooooooooooooooo<Foo, Bar>)
+                fun fooBar()
+                context(_: Foooooooooooooooo<Foo, Bar>)
+                fun fooBar()
+            }
+            """.trimIndent()
+        modifierListSpacingRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(2, 17, "Single newline expected after context receiver list"),
+                LintViolation(3, 20, "Single newline expected after context receiver list"),
+                LintViolation(5, 41, "Single newline expected after context receiver list"),
+                LintViolation(6, 44, "Single newline expected after context receiver list"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given an annotation, a context parameter, and other modifiers on a single line in incorrect order`() {
+        val code =
+            """
+            @Suppress("DEPRECATED") open context(_: Foo) public fun foo() {}
+            """.trimIndent()
+        val formattedCode =
+            """
+            @Suppress("DEPRECATED")
+            context(_: Foo)
+            public open fun foo() {}
+            """.trimIndent()
+        modifierListSpacingRuleAssertThat(code)
+            .addAdditionalRuleProvider { ModifierOrderRule() }
+            .addAdditionalRuleProvider { AnnotationRule() }
+            .hasLintViolation(1, 45, "Single newline expected after context receiver list")
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Fix conflict between `modifier-list-spacing` and `context-receiver-list-wrapping`

Wrapping of a context receiver list in `modifier-list-spacing` may not conflict with the wrapping in `context-receiver-list-wrapping`

Closes #3065

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
