### PR TITLE
Change @SinceKtlint retention to RUNTIME

### DIFF
--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/SinceKtlint.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/SinceKtlint.kt
@@ -14,7 +14,7 @@ package com.pinterest.ktlint.rule.engine.core.api
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.TYPEALIAS,
 )
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 public annotation class SinceKtlint(
     val version: String,


### PR DESCRIPTION
## Description

This PR changes the @SinceKtlint annotation retention from BINARY to RUNTIME. The main purpose of this is to enable version-based filtering of rules at runtime as discussed in #3099 and https://github.com/JLLeitschuh/ktlint-gradle/issues/942

Change made:
• Modified @Retention(AnnotationRetention.BINARY) to @Retention(AnnotationRetention.RUNTIME) in SinceKtlint.kt

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
• [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
• [x] At least one commit message contains a reference Closes #<xxx> or Fixes #<xxx> (replace<xxx> with issue number)
• [ ] Tests are added
• [x] KtLint format has been applied on source code itself and violations are fixed
• [x] PR title is short and clear (it is used as description in the release changelog)
• [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
• [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
• [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master

Let me know if you'd like any specific documentation around this.