### PR TITLE
Validate @SinceKtlint annotations with test and uniformize existing rules

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlinx-binary-compatibiltiy-validator = "org.jetbrains.kotlinx.binary-compatibi
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-plugin-dev = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinDev" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 clikt = "com.github.ajalt.clikt:clikt:5.0.3"
 dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 ec4j = "org.ec4j.core:ec4j-core:1.1.1"

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/SinceKtlint.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/SinceKtlint.kt
@@ -2,6 +2,9 @@ package com.pinterest.ktlint.rule.engine.core.api
 
 /**
  * The version in which the rule was introduced.
+ *
+ * @param version The version in "major.minor" format (e.g., "1.2"), never including patch level
+ * @param status The status of the rule in the specified version
  */
 @Repeatable
 @Target(
@@ -14,7 +17,7 @@ package com.pinterest.ktlint.rule.engine.core.api
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.TYPEALIAS,
 )
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 public annotation class SinceKtlint(
     val version: String,

--- a/ktlint-ruleset-standard/build.gradle.kts
+++ b/ktlint-ruleset-standard/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api(projects.ktlintRuleEngineCore)
 
     testImplementation(projects.ktlintTest)
+    testImplementation(libs.kotlin.reflect)
     testRuntimeOnly(libs.logback)
 
     testImplementation(libs.junit5.jupiter)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRule.kt
@@ -16,6 +16,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
@@ -32,7 +33,8 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * https://kotlinlang.org/docs/coding-conventions.html#property-names
  * https://developer.android.com/kotlin/style-guide#backing_properties
  */
-@SinceKtlint("1.2.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class BackingPropertyNamingRule :
     StandardRule(
         id = "backing-property-naming",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -19,6 +19,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
@@ -51,7 +52,8 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
  * Wraps a binary expression whenever the expression does not fit on the line. Wrapping a binary expression should take precedence before
  * argument of function calls inside that binary expression are wrapped.
  */
-@SinceKtlint("0.50", STABLE)
+@SinceKtlint("0.50", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class BinaryExpressionWrappingRule :
     StandardRule(
         id = "binary-expression-wrapping",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * Ktlint uses the property `ij_kotlin_line_break_after_multiline_when_entry` to consistently add/remove blank line between all
  * when-conditions in the when-statement depending on whether the statement contains at least one multiline when-condition.
  */
-@SinceKtlint("1.2.0", EXPERIMENTAL)
+@SinceKtlint("1.2", EXPERIMENTAL)
 public class BlankLineBetweenWhenConditions :
     StandardRule(
         id = "blank-line-between-when-conditions",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -30,6 +30,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRu
 import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
@@ -73,7 +74,8 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
  *
  * As of that the rule is restricted to ktlint_official code style unless explicitly enabled.
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class ChainMethodContinuationRule :
     StandardRule(
         id = "chain-method-continuation",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
@@ -9,6 +9,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.OBJECT_DECLARATION
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import com.pinterest.ktlint.ruleset.standard.rules.internal.regExIgnoringDiacriticsAndStrokesOnLetters
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -22,6 +23,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
  */
 @SinceKtlint("0.48", EXPERIMENTAL)
 @SinceKtlint("0.49", EXPERIMENTAL)
+@SinceKtlint("1.0", STABLE)
 public class ClassNamingRule : StandardRule("class-naming") {
     private var allowBacktickedClassName = false
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRule.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.lexer.KtTokens
  * well as it is more consistent with name of test functions.
  */
 @SinceKtlint("0.48", EXPERIMENTAL)
-@SinceKtlint("0.49", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
 public class ClassNamingRule : StandardRule("class-naming") {
     private var allowBacktickedClassName = false

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -28,6 +28,7 @@ import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRu
 import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
@@ -68,7 +69,8 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  * In code style `ktlint_official` class headers containing 2 or more parameters are formatted as multiline signature. As the Kotlin Coding
  * conventions do not specify what is meant with a "few parameters", no default is set for other code styles.
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class ClassSignatureRule :
     StandardRule(
         id = "class-signature",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ConditionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ConditionWrappingRule.kt
@@ -4,13 +4,15 @@ import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 @Deprecated("Will be removed in Ktlint 2.0. This rule is replaced by ExpressionOperandWrappingRule")
 @Suppress("RedundantOverride")
-@SinceKtlint("1.1.0", EXPERIMENTAL)
+@SinceKtlint("1.1", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class ConditionWrappingRule : StandardRule(id = "condition-wrapping") {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         super.beforeFirstNode(editorConfig)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ExpressionOperandWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ExpressionOperandWrappingRule.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  *            bar +
  *            baz
  */
-@SinceKtlint("1.7.0", EXPERIMENTAL)
+@SinceKtlint("1.7", EXPERIMENTAL)
 public class ExpressionOperandWrappingRule :
     StandardRule(
         id = "expression-operand-wrapping",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
@@ -15,6 +15,7 @@ import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.KtlintKotlinCompiler
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
@@ -61,7 +62,8 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
  * }
  * ```
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class FunctionExpressionBodyRule :
     StandardRule(
         id = "function-expression-body",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -18,6 +18,7 @@ import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.Rule.VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
@@ -78,7 +79,8 @@ private val LOGGER = KotlinLogging.logger {}.initKtLintKLogger()
  * }
  * ```
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class FunctionLiteralRule :
     StandardRule(
         id = "function-literal",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeModifierSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeModifierSpacingRule.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_TYPE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -17,7 +18,8 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 /**
  * Lints and formats a single space between the modifier list and the function type
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class FunctionTypeModifierSpacingRule : StandardRule("function-type-modifier-spacing") {
     override fun beforeVisitChildNodes(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
@@ -8,6 +8,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIS
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
 import com.pinterest.ktlint.rule.engine.core.api.nextSibling20
@@ -17,6 +18,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 @SinceKtlint("0.45", EXPERIMENTAL)
 @SinceKtlint("0.49", EXPERIMENTAL)
+@SinceKtlint("1.0", STABLE)
 public class FunctionTypeReferenceSpacingRule : StandardRule("function-type-reference-spacing") {
     override fun beforeVisitChildNodes(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionTypeReferenceSpacingRule.kt
@@ -17,7 +17,6 @@ import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 @SinceKtlint("0.45", EXPERIMENTAL)
-@SinceKtlint("0.49", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
 public class FunctionTypeReferenceSpacingRule : StandardRule("function-type-reference-spacing") {
     override fun beforeVisitChildNodes(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocRule.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 /**
  * Disallow KDoc except of classes, functions and xxx
  */
-@SinceKtlint("1.2.0", EXPERIMENTAL)
+@SinceKtlint("1.2", EXPERIMENTAL)
 public class KdocRule :
     StandardRule(
         id = "kdoc",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
  * Conditions should not use a both '&&' and '||' operators between operators at the same level. By using parenthesis the expression is to
  * be clarified.
  */
-@SinceKtlint("1.1.0", EXPERIMENTAL)
+@SinceKtlint("1.1", EXPERIMENTAL)
 public class MixedConditionOperatorsRule :
     StandardRule("condition-wrapping"),
     Rule.Experimental {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineLoopRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MultilineLoopRule.kt
@@ -10,6 +10,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
@@ -33,7 +34,8 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 /**
  * https://developer.android.com/kotlin/style-guide#braces
  */
-@SinceKtlint("1.0", STABLE)
+@SinceKtlint("1.0", EXPERIMENTAL)
+@SinceKtlint("1.3", STABLE)
 public class MultilineLoopRule :
     StandardRule(
         id = "multiline-loop",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoBlankLineBeforeRbraceRule.kt
@@ -12,7 +12,7 @@ import com.pinterest.ktlint.rule.engine.core.api.replaceTextWith
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-@SinceKtlint("0.10.2", STABLE)
+@SinceKtlint("0.10", STABLE)
 public class NoBlankLineBeforeRbraceRule : StandardRule("no-blank-line-before-rbrace") {
     override fun beforeVisitChildNodes(
         node: ASTNode,

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRule.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.leaves
 /**
  * A block comment following another element on the same line is replaced with an EOL comment, if possible.
  */
-@SinceKtlint("0.49.1", EXPERIMENTAL)
+@SinceKtlint("0.49", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
 public class NoSingleLineBlockCommentRule :
     StandardRule(

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracing.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracing.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  *   - Bodies of the when-conditions are all aligned at same column position
  *   - Closing braces helps in separation the when-conditions
  */
-@SinceKtlint("1.4.0", EXPERIMENTAL)
+@SinceKtlint("1.4", EXPERIMENTAL)
 public class WhenEntryBracing :
     StandardRule(
         id = "when-entry-bracing",

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SinceKtlintAnnotationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SinceKtlintAnnotationTest.kt
@@ -3,76 +3,108 @@ package com.pinterest.ktlint.ruleset.standard
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.Parameter
+import org.junit.jupiter.params.ParameterizedClass
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class SinceKtlintAnnotationTest {
-    @Test
-    fun `Given all rules then each rule should have proper SinceKtlint annotations`() {
-        val ruleSetProvider = StandardRuleSetProvider()
-        val rules = ruleSetProvider.getRuleProviders().map { it.createNewRuleInstance() }
+    @ParameterizedClass(name = "{argumentSetName}")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @MethodSource("allRules")
+    @Nested
+    inner class `Given a STABLE or EXPERIMENTAL rule` {
+        @Parameter
+        lateinit var rule: Rule
 
-        val violations =
-            rules.flatMap { rule ->
-                val ruleClass = rule::class
-                val annotations = ruleClass.annotations.filterIsInstance<SinceKtlint>()
-                val isExperimental = rule is Rule.Experimental
+        @Test
+        fun `The rule has a valid version number not containing the patch level`() {
+            val actual =
+                rule
+                    .sinceKtlintAnnotations()
+                    .all { isValidVersionFormat(it.version) }
 
-                val annotationViolations =
-                    when {
-                        annotations.isEmpty() -> {
-                            listOf("${ruleClass.simpleName} has no @SinceKtlint annotations")
-                        }
+            assertThat(actual).isTrue
+        }
 
-                        isExperimental -> {
-                            val experimentalAnnotations = annotations.filter { it.status == SinceKtlint.Status.EXPERIMENTAL }
-                            val stableAnnotations = annotations.filter { it.status == SinceKtlint.Status.STABLE }
+        fun allRules(): Stream<Arguments> = rules { true }
 
-                            when {
-                                experimentalAnnotations.isEmpty() -> {
-                                    listOf(
-                                        "${ruleClass.simpleName} implements Experimental but has no EXPERIMENTAL @SinceKtlint annotation",
-                                    )
-                                }
-
-                                stableAnnotations.isNotEmpty() -> {
-                                    listOf("${ruleClass.simpleName} implements Experimental but has STABLE @SinceKtlint annotation")
-                                }
-
-                                else -> {
-                                    emptyList()
-                                }
-                            }
-                        }
-
-                        else -> {
-                            val stableAnnotations = annotations.filter { it.status == SinceKtlint.Status.STABLE }
-                            if (stableAnnotations.isEmpty()) {
-                                listOf("${ruleClass.simpleName} is stable but has no STABLE @SinceKtlint annotation")
-                            } else {
-                                emptyList()
-                            }
-                        }
-                    }
-
-                val versionViolations =
-                    annotations.mapNotNull { annotation ->
-                        if (!isValidVersionFormat(annotation.version)) {
-                            "${ruleClass.simpleName} has invalid version format '${annotation.version}' - should be 'X.Y' format without patch level"
-                        } else {
-                            null
-                        }
-                    }
-
-                annotationViolations + versionViolations
-            }
-
-        assertThat(violations)
-            .withFailMessage("Found @SinceKtlint annotation violations:\n${violations.joinToString("\n")}")
-            .isEmpty()
+        private fun isValidVersionFormat(version: String): Boolean {
+            val versionRegex = Regex("""^\d+\.\d+$""")
+            return versionRegex.matches(version)
+        }
     }
 
-    private fun isValidVersionFormat(version: String): Boolean {
-        val versionRegex = Regex("""^\d+\.\d+$""")
-        return versionRegex.matches(version)
+    @ParameterizedClass(name = "{argumentSetName}")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @MethodSource("stableRules")
+    @Nested
+    inner class `Given a STABLE rule, eg not implementing interface Experimental` {
+        @Parameter
+        lateinit var stableRule: Rule
+
+        @Test
+        fun `The rule has exactly 1 @SinceKtlint annotation with status STABLE`() {
+            val actual =
+                stableRule
+                    .sinceKtlintAnnotations()
+                    .count { it.status == SinceKtlint.Status.STABLE }
+
+            assertThat(actual).isEqualTo(1)
+        }
+
+        @Test
+        fun `The rule has at most 1 @SinceKtlint annotation with status EXPERIMENTAL`() {
+            val actual =
+                stableRule
+                    .sinceKtlintAnnotations()
+                    .count { it.status == SinceKtlint.Status.EXPERIMENTAL }
+
+            assertThat(actual).isLessThanOrEqualTo(1)
+        }
+
+        fun stableRules(): Stream<Arguments> = rules { it !is Rule.Experimental }
     }
+
+    @ParameterizedClass(name = "{argumentSetName}")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @MethodSource("experimentalRules")
+    @Nested
+    inner class `Given an EXPERIMENTAL rule, eg implementing interface Experimental` {
+        @Parameter
+        lateinit var experimentalRule: Rule
+
+        @Test
+        fun `The rule has exactly 1 @SinceKtlint annotation with status EXPERIMENTAL`() {
+            val actual =
+                experimentalRule
+                    .sinceKtlintAnnotations()
+                    .count { it.status == SinceKtlint.Status.EXPERIMENTAL }
+
+            assertThat(actual).isEqualTo(1)
+        }
+
+        @Test
+        fun `The rule should not have @SinceKtlint annotation with status STABLE`() {
+            val actual = experimentalRule.sinceKtlintAnnotations().none { it.status == SinceKtlint.Status.STABLE }
+
+            assertThat(actual).isTrue
+        }
+
+        fun experimentalRules(): Stream<Arguments> = rules { it is Rule.Experimental }
+    }
+
+    private fun Rule.sinceKtlintAnnotations(): List<SinceKtlint> = this::class.annotations.filterIsInstance<SinceKtlint>()
+
+    private fun rules(predicate2: (Rule) -> Boolean): Stream<Arguments> =
+        StandardRuleSetProvider()
+            .getRuleProviders()
+            .map { it.createNewRuleInstance() }
+            .filter { predicate2(it) }
+            .map { Arguments.argumentSet(it.ruleId.value, it) }
+            .let { argumentSets -> Stream.of(*argumentSets.toTypedArray()) }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SinceKtlintAnnotationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/SinceKtlintAnnotationTest.kt
@@ -1,0 +1,78 @@
+package com.pinterest.ktlint.ruleset.standard
+
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SinceKtlintAnnotationTest {
+    @Test
+    fun `Given all rules then each rule should have proper SinceKtlint annotations`() {
+        val ruleSetProvider = StandardRuleSetProvider()
+        val rules = ruleSetProvider.getRuleProviders().map { it.createNewRuleInstance() }
+
+        val violations =
+            rules.flatMap { rule ->
+                val ruleClass = rule::class
+                val annotations = ruleClass.annotations.filterIsInstance<SinceKtlint>()
+                val isExperimental = rule is Rule.Experimental
+
+                val annotationViolations =
+                    when {
+                        annotations.isEmpty() -> {
+                            listOf("${ruleClass.simpleName} has no @SinceKtlint annotations")
+                        }
+
+                        isExperimental -> {
+                            val experimentalAnnotations = annotations.filter { it.status == SinceKtlint.Status.EXPERIMENTAL }
+                            val stableAnnotations = annotations.filter { it.status == SinceKtlint.Status.STABLE }
+
+                            when {
+                                experimentalAnnotations.isEmpty() -> {
+                                    listOf(
+                                        "${ruleClass.simpleName} implements Experimental but has no EXPERIMENTAL @SinceKtlint annotation",
+                                    )
+                                }
+
+                                stableAnnotations.isNotEmpty() -> {
+                                    listOf("${ruleClass.simpleName} implements Experimental but has STABLE @SinceKtlint annotation")
+                                }
+
+                                else -> {
+                                    emptyList()
+                                }
+                            }
+                        }
+
+                        else -> {
+                            val stableAnnotations = annotations.filter { it.status == SinceKtlint.Status.STABLE }
+                            if (stableAnnotations.isEmpty()) {
+                                listOf("${ruleClass.simpleName} is stable but has no STABLE @SinceKtlint annotation")
+                            } else {
+                                emptyList()
+                            }
+                        }
+                    }
+
+                val versionViolations =
+                    annotations.mapNotNull { annotation ->
+                        if (!isValidVersionFormat(annotation.version)) {
+                            "${ruleClass.simpleName} has invalid version format '${annotation.version}' - should be 'X.Y' format without patch level"
+                        } else {
+                            null
+                        }
+                    }
+
+                annotationViolations + versionViolations
+            }
+
+        assertThat(violations)
+            .withFailMessage("Found @SinceKtlint annotation violations:\n${violations.joinToString("\n")}")
+            .isEmpty()
+    }
+
+    private fun isValidVersionFormat(version: String): Boolean {
+        val versionRegex = Regex("""^\d+\.\d+$""")
+        return versionRegex.matches(version)
+    }
+}


### PR DESCRIPTION
## Description

Adds comprehensive validation for @SinceKtlint annotations and fixes multiple annotation issues to support the implementation discussed in #3099.

### Changes Made

1. Added a unit test to validate all rules follow the @SinceKtlint annotation usage as expected. Checks for missing annotations, proper experimental/stable status alignment, and version format compliance. For this, I had to add kotlin-reflect as a test implementation for proper reflection support.

2. Fixed Version Format Violations (8 rules)
Corrected patch-level versions to major.minor format as required:
• NoBlankLineBeforeRbraceRule: "0.10.2" → "0.10"
• WhenEntryBracing: "1.4.0" → "1.4"
• ConditionWrappingRule: "1.1.0" → "1.1"
• BlankLineBetweenWhenConditions: "1.2.0" → "1.2"
• ExpressionOperandWrappingRule: "1.7.0" → "1.7"
• KdocRule: "1.2.0" → "1.2"
• MixedConditionOperatorsRule: "1.1.0" → "1.1"
• NoSingleLineBlockCommentRule: "0.49.1" → "0.49"

3. Added Missing STABLE Annotations (3 rules)
Rules that were promoted from experimental to stable but missing STABLE annotations:
• ClassNamingRule: Added @SinceKtlint("1.0", STABLE)
• ConditionWrappingRule: Added @SinceKtlint("1.3", STABLE)
• FunctionTypeReferenceSpacingRule: Added @SinceKtlint("1.0", STABLE)

4. Updated @SinceKtlint annotation documentation to clarify version format requirements

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
• [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
• [x] At least one commit message contains a reference Closes #<xxx> or Fixes #<xxx> (replace<xxx> with issue number)
• [x] Tests are added
• [x] KtLint format has been applied on source code itself and violations are fixed
• [x] PR title is short and clear (it is used as description in the release changelog)
• [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/
documentation)
• [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
• [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master
