### PR TITLE
Set languageVersion to KOTLIN_2_0 to ensure metadata compatibility with Kotlin 2.0

### DIFF
--- a/build-logic/src/main/kotlin/KotlinCommonPlugin.kt
+++ b/build-logic/src/main/kotlin/KotlinCommonPlugin.kt
@@ -36,6 +36,7 @@ abstract class KotlinCommonPlugin : Plugin<Project> {
 
                 compilerOptions {
                     apiVersion.set(KotlinVersion.KOTLIN_2_0)
+                    languageVersion.set(KotlinVersion.KOTLIN_2_0)
                 }
             }
 

--- a/ktlint-cli-reporter-core/api/ktlint-cli-reporter-core.api
+++ b/ktlint-cli-reporter-core/api/ktlint-cli-reporter-core.api
@@ -32,10 +32,10 @@ public abstract interface class com/pinterest/ktlint/cli/reporter/core/api/Repor
 }
 
 public abstract interface class com/pinterest/ktlint/cli/reporter/core/api/ReporterV2 {
-	public fun after (Ljava/lang/String;)V
-	public fun afterAll ()V
-	public fun before (Ljava/lang/String;)V
-	public fun beforeAll ()V
+	public abstract fun after (Ljava/lang/String;)V
+	public abstract fun afterAll ()V
+	public abstract fun before (Ljava/lang/String;)V
+	public abstract fun beforeAll ()V
 	public abstract fun onLintError (Ljava/lang/String;Lcom/pinterest/ktlint/cli/reporter/core/api/KtlintCliError;)V
 }
 

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -510,8 +510,8 @@ public final class com/pinterest/ktlint/rule/engine/core/api/Rule$VisitorModifie
 }
 
 public abstract interface class com/pinterest/ktlint/rule/engine/core/api/RuleAutocorrectApproveHandler {
-	public fun afterVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
-	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+	public abstract fun afterVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+	public abstract fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
 }
 
 public final class com/pinterest/ktlint/rule/engine/core/api/RuleAutocorrectApproveHandler$DefaultImpls {


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

This addresses the discussion in #3063, as apiVersion is not enough (for some use cases) to ensure full 2.0 compatibility. This CR adds languageVersion, which I've tested internally (against a few thousand packages) and it works as expected.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
