### PR TITLE
Fix link to maven wrapper

### DIFF
--- a/documentation/release-latest/docs/install/integrations.md
+++ b/documentation/release-latest/docs/install/integrations.md
@@ -1,4 +1,4 @@
-## [Maven](https://github.com/shyiko/mvnw) integration
+## [Maven](https://github.com/apache/maven-wrapper) integration
 
 By adding the plugin definition below to the `<plugins>` section in the `pom.xml`:
 

--- a/documentation/snapshot/docs/install/integrations.md
+++ b/documentation/snapshot/docs/install/integrations.md
@@ -1,4 +1,4 @@
-## [Maven](https://github.com/shyiko/mvnw) integration
+## [Maven](https://github.com/apache/maven-wrapper) integration
 
 By adding the plugin definition below to the `<plugins>` section in the `pom.xml`:
 


### PR DESCRIPTION
## Description

Replace link to maven wrapper with link to official apache project.

Closes #3108

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
