### PR TITLE
Restrict access to GitHub token to "contents: read"

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,4 +1,6 @@
 name: Generate changelog
+permissions:
+  contents: read
 
 on: [ workflow_dispatch ]
 

--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -1,4 +1,6 @@
 name: Publish release build
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -1,4 +1,6 @@
 name: Publish release documentation
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/publish-snapshot-build.yml
+++ b/.github/workflows/publish-snapshot-build.yml
@@ -1,4 +1,6 @@
 name: Publish snapshot build
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/publish-snapshot-docs.yml
+++ b/.github/workflows/publish-snapshot-docs.yml
@@ -1,4 +1,6 @@
 name: Publish snapshot documentation
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/pull-request-with-code.yml
+++ b/.github/workflows/pull-request-with-code.yml
@@ -1,5 +1,7 @@
 # name must be identical to name of 'pull-request-without-code'
 name: Pull request
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/pull-request-without-code.yml
+++ b/.github/workflows/pull-request-without-code.yml
@@ -1,5 +1,7 @@
 # name must be identical to name of 'pull-request-with-code'
 name: Pull request
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
## Description

As a result of enabling [code security scanning](https://github.com/pinterest/ktlint/pull/3113), it is advised to restrict access to GitHub token. All workflows (except the code scanning itself) are now restricted to "contents: read". It is to be expected that some workflows (publish of docs, and/or releases) will break when not having enough privileges.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
