### PR TITLE
Fix indent of function parameter with multiline expression in `android_studio`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -441,7 +441,7 @@ public class IndentationRule :
             ?.textContains('\n') == true
 
     private fun visitValueArgument(node: ASTNode) {
-        if (codeStyle == ktlint_official) {
+        if (codeStyle == ktlint_official || codeStyle == CodeStyleValue.android_studio) {
             // Deviate from standard IntelliJ IDEA formatting to allow formatting below:
             //     val foo = foo(
             //         parameterName =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5099,35 +5099,38 @@ internal class IndentationRuleTest {
                 .setMaxLineLength()
                 .isFormattedAs(formattedCode)
         }
+    }
 
-        @Test
-        fun `Issue 1217 - Given a function parameter with a multiline expression starting on a new line`() {
-            val code =
-                """
-                val foo = foo(
-                    parameterName =
+    @ParameterizedTest(name = "Description: {0}")
+    @ValueSource(strings = ["ktlint_official", "android_studio"])
+    fun `Issue 1217 & 3062 - Given a function parameter with a multiline expression starting on a new line`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            val foo = foo(
+                parameterName =
+                "The quick brown fox "
+                    .plus("jumps ")
+                    .plus("over the lazy dog"),
+            )
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = foo(
+                parameterName =
                     "The quick brown fox "
                         .plus("jumps ")
                         .plus("over the lazy dog"),
-                )
-                """.trimIndent()
-            val formattedCode =
-                """
-                val foo = foo(
-                    parameterName =
-                        "The quick brown fox "
-                            .plus("jumps ")
-                            .plus("over the lazy dog"),
-                )
-                """.trimIndent()
-            indentationRuleAssertThat(code)
-                .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolations(
-                    LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
-                    LintViolation(4, 1, "Unexpected indentation (8) (should be 12)"),
-                    LintViolation(5, 1, "Unexpected indentation (8) (should be 12)"),
-                ).isFormattedAs(formattedCode)
-        }
+            )
+            """.trimIndent()
+        indentationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue)
+            .hasLintViolations(
+                LintViolation(3, 1, "Unexpected indentation (4) (should be 8)"),
+                LintViolation(4, 1, "Unexpected indentation (8) (should be 12)"),
+                LintViolation(5, 1, "Unexpected indentation (8) (should be 12)"),
+            ).isFormattedAs(formattedCode)
     }
 
     @Nested


### PR DESCRIPTION
## Description

Fix indent of function parameter with multiline expression in `android_studio` code style similar to `ktlint_official`.

Closes #3062

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
