### PR TITLE
Prevent that an early return followed by lambda expression results in joining the lines

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRule.kt
@@ -2,12 +2,12 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.AT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS_BODY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COLONCOLON
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.COMMA
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.DOT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EXCLEXCL
-import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACKET
@@ -16,6 +16,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.RANGE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RANGE_UNTIL
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACKET
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RETURN_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SAFE_ACCESS
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SEMICOLON
@@ -105,10 +106,12 @@ public class SpacingAroundCurlyRule :
                     if (prevLeaf.isWhiteSpaceWithNewline20 &&
                         prevLeaf != null &&
                         (
-                            prevLeaf.isPrecededBy { it.elementType == RPAR || KtTokens.KEYWORDS.contains(it.elementType) } ||
+                            prevLeaf.isPrecededBy {
+                                it.elementType == RPAR ||
+                                    (KtTokens.KEYWORDS.contains(it.elementType) && it.elementType != RETURN_KEYWORD)
+                            } ||
                                 node.parent?.elementType == CLASS_BODY ||
-                                // allow newline for lambda return type
-                                (prevLeaf.parent?.elementType == FUN && prevLeaf.nextSibling20?.elementType != LAMBDA_EXPRESSION)
+                                (node.parent?.elementType == BLOCK && prevLeaf.isPrecededBy { it.isPartOfComment20 })
                         )
                     ) {
                         prevLeaf

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
@@ -618,7 +618,7 @@ class SpacingAroundCurlyRuleTest {
     }
 
     @Test
-    fun `Issue 3125 - Given an early return followed by a lambda expression, then do not join lines `() {
+    fun `Issue 3125 - Given an early return followed by a lambda expression, then do not join lines`() {
         val code =
             """
             fun foo(bar: String?) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundCurlyRuleTest.kt
@@ -603,4 +603,29 @@ class SpacingAroundCurlyRuleTest {
             """.trimIndent()
         spacingAroundCurlyRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Given a return followed by a lambda expression, then do not wrap the lambda expression`() {
+        val code =
+            """
+            fun foo(): () -> String {
+                return {
+                    "Test"
+                }
+            }
+            """.trimIndent()
+        spacingAroundCurlyRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 3125 - Given an early return followed by a lambda expression, then do not join lines `() {
+        val code =
+            """
+            fun foo(bar: String?) {
+                bar ?: return
+                { print(bar) }
+            }
+            """.trimIndent()
+        spacingAroundCurlyRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Prevent that an early return followed by lambda expression results in joining the lines

Closes #3125

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
