### PR TITLE
Ignore renovate updates for JUnit v6 as it requires Java17+

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,14 @@
     {
       "matchPackageNames": ["ch.qos.logback:logback-classic"],
       "allowedVersions": "<1.4.0"
+    },
+    {
+      "matchPackageNames": ["org.junit.platform:junit-platform-launcher"],
+      "allowedVersions": "<6.0.0"
+    },
+    {
+      "matchPackageNames": ["org.junit.jupiter:junit-jupiter"],
+      "allowedVersions": "<6.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Description

Ignore renovate updates for JUnit v6 as it requires Java17+

Ktlint supports java 8 and 11 during 1.x lifetime

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
