### PR TITLE
Prevent IllegalArgumentException when the `indent` rule is suppressed

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRule.kt
@@ -1115,7 +1115,14 @@ public class IndentationRule :
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        while (indentContextStack.peekLast()?.toASTNode == node) {
+        while (
+            // End visit of the node matches with the toAstNode on top of the stack
+            indentContextStack.peekLast()?.toASTNode == node ||
+            // When the ktlint indentation violations on child elements have been suppressed, those child elements are not visited, and the
+            // stack is therefore not cleaned up properly. So remove all elements from top of the stack until the start of an index context
+            // is found for the current node.
+            indentContextStack.peekLast()?.toASTNode?.parent { it == node } != null
+        ) {
             LOGGER.trace {
                 val indentContext = indentContextStack.peekLast()
                 val nodeIndentLevel = indentConfig.indentLevelFrom(indentContext.nodeIndent)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -5932,6 +5932,24 @@ internal class IndentationRuleTest {
         }
     }
 
+    @ParameterizedTest(name = "Suppression: {0}")
+    @ValueSource(
+        strings = [
+            "ktlint",
+            "ktlint:standard:indent",
+        ],
+    )
+    fun `Issue 3109 - Suppressing all ktlint violations may not result in failing to empty the stack`(suppression: String) {
+        val code =
+            """
+            fun foo() =
+                @Suppress("${suppression}")
+                listOf("foo")
+            """.trimIndent()
+
+        indentationRuleAssertThat(code).hasNoLintViolations()
+    }
+
     private companion object {
         val INDENT_STYLE_TAB =
             INDENT_STYLE_PROPERTY to PropertyType.IndentStyleValue.tab


### PR DESCRIPTION
## Description

The internal state of the `indent` rule was not properly cleaned up after visiting a node, for which the `indent` violations on the child nodes have been suppressed.

Closes #3109

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
