### PR TITLE
Add CLI option '--ignore-autocorrect-failures'

### DIFF
--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -541,4 +541,45 @@ class SimpleCLITest {
                 assertThat(normalOutput.joinToString(separator = "\n")).contains(code)
             }
     }
+
+    @Nested
+    inner class `Autocorrect violations` {
+        @Test
+        fun `Issue 3150 - Report violations that cannot be auto-corrected`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "ignore-autocorrect-failures",
+                    arguments = listOf("--format"),
+                ) {
+                    SoftAssertions()
+                        .apply {
+                            assertErrorExitCode()
+                            assertThat(normalOutput)
+                                .containsLineMatching(Regex(".*\\(cannot be auto-corrected\\) \\(standard:filename\\).*"))
+                        }.assertAll()
+                }
+        }
+
+        @Test
+        fun `Issue 3150 - Ignore violations that cannot be auto-corrected`(
+            @TempDir
+            tempDir: Path,
+        ) {
+            CommandLineTestRunner(tempDir)
+                .run(
+                    "ignore-autocorrect-failures",
+                    arguments = listOf("--format", "--ignore-autocorrect-failures"),
+                ) {
+                    SoftAssertions()
+                        .apply {
+                            assertNormalExitCode()
+                            assertThat(normalOutput)
+                                .doesNotContainLineMatching(Regex(".*\\(cannot be auto-corrected\\) \\(standard:filename\\).*"))
+                        }.assertAll()
+                }
+        }
+    }
 }

--- a/ktlint-cli/src/test/resources/cli/ignore-autocorrect-failures/Foo.kt
+++ b/ktlint-cli/src/test/resources/cli/ignore-autocorrect-failures/Foo.kt
@@ -1,0 +1,2 @@
+// This file is name incorrectly as it is not named after the only class in it. Incorrectly named files cannot be autocorrected
+class Bar


### PR DESCRIPTION
## Description

Add CLI option '--ignore-autocorrect-failures' to suppress violations that cannot be autocorrected

Closes #3150

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
