### PR TITLE
[Fix]: Give release workflow write permissions

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -1,6 +1,6 @@
 name: Publish release build
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

PR #3115 changed all workflows to read-only, which is causing the release workflow to fail with a 403. This PR gives the workflow `content:write` permissions to allow it to create new releases.