### PR TITLE
Fix signing for releases

### DIFF
--- a/.github/workflows/pull-request-with-code.yml
+++ b/.github/workflows/pull-request-with-code.yml
@@ -24,9 +24,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
   CLI_TEST_MAX_DURATION_IN_SECONDS: 10
 
 # Note that all "jobs" (build, tests) including "jobs.*.runs-on" should be kept in sync with "pull-request-without-code"


### PR DESCRIPTION
## Description

PR #3068 updated the build to use vanniktech's maven-publish plugin which is mostly working but was not signing the release artifacts.

This PR updates the `PublicationPlugin` to look for the properly-named gradle properties. Additionally, the check for the absence of the `useGpg` property was slightly incorrect because `null` != `"false"`, so it was failing on CI trying to use the gpg command instead of the in-memory keys.

Locally, I set `ORG_GRADLE_PROJECT` environment variables which match the ones set by the release workflow, then ran `./gradlew publishMavenPublicationToMavenCentralRepository --dry-run` and confirmed the signing tasks were present in the task list.

```
<snip>
:ktlint-cli:generateMetadataFileForMavenPublication SKIPPED
:ktlint-cli:generatePomFileForMavenPublication SKIPPED
:ktlint-cli:prepareMavenCentralPublishing SKIPPED
:ktlint-cli:signMavenPublication SKIPPED
:ktlint-cli:publishMavenPublicationToMavenCentralRepository SKIPPED
<snip>
```
