### PR TITLE
Handle trailing comments on when entries in `BlankLineBetweenWhenConditions`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions.kt
@@ -99,7 +99,15 @@ public class BlankLineBetweenWhenConditions :
         children20
             .any { it.elementType == WHEN_ENTRY && (it.textContains('\n') || it.isPrecededByComment()) }
 
-    private fun ASTNode.isPrecededByComment() = prevSibling { !it.isWhiteSpace20 }?.isPartOfComment20 ?: false
+    private fun ASTNode.isPrecededByComment(): Boolean {
+        // Check if this when-entry is preceded by a comment on its own line - not a trailing comment on the previous when-entry
+        val prevNonWhitespace = prevSibling { !it.isWhiteSpace20 }
+        if (prevNonWhitespace?.isPartOfComment20 != true) return false
+
+        // Found a comment before this when-entry, so check whether it's on its own line
+        val whitespaceBeforeComment = prevNonWhitespace.prevSibling { it.isWhiteSpace20 }
+        return whitespaceBeforeComment?.text?.contains('\n') == true
+    }
 
     private fun ASTNode.findWhitespaceAfterPreviousCodeSibling() =
         prevCodeSibling20

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
@@ -24,6 +24,20 @@ class BlankLineBetweenWhenConditionsTest {
     }
 
     @Test
+    fun `Given a when-statement with single line when-conditions and trailing comment then do no reformat`() {
+        val code =
+            """
+            val foo =
+                when (bar) {
+                    BAR1 -> "bar1" // Some comment
+                    BAR2 -> "bar2"
+                    else -> null
+                }
+            """.trimIndent()
+        blankLineAfterWhenConditionRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `Given a when-statement with single line when-conditions only which are separated by a blank line then remove the blank lines`() {
         val code =
             """


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

I have a block of code in my project like below:

```kotlin
val x = when (something) {
    "a" -> 123 // Some comment
    "b" -> 456
    else -> 789
}
```

But this gave a linting problem with the new 1.8.0 update from the `standard:blank-line-between-when-conditions` rule. When I tried to auto-format to see how it should be, I got:

```kotlin
val x = when (something) {
    "a" -> 123
    
    // Some comment
    "b" -> 456

    else -> 789
}
```

The comment was placed on the wrong entry! Personally I think trailing comments should be allowable on simple when statements like this, interested to hear opinions on this though. The misformatting of the above example makes me think this is unintentional though.

To fix, I've added some more checks to `isPrecededByComment` to make sure the check for a multiline when entry handles this case.

No existing issue for this, so far as I can see.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
