### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
 <a href="https://kotlinlang.slack.com/messages/CKS3XG0LS"><img src="https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack" alt="Join the chat at https://kotlinlang.slack.com"/></a>
 <a href="https://github.com/pinterest/ktlint/actions/workflows/publish-snapshot-build.yml"><img src="https://github.com/pinterest/ktlint/actions/workflows/publish-snapshot-build.yml/badge.svg" alt="Build status"></a>
-<a href="https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/com.pinterest.ktlint/ktlint-cli?smo=true"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
 <a href="https://jitpack.io/#pinterest/ktlint"><img src="https://jitpack.io/v/pinterest/ktlint.svg" alt="JitPack"></a>
 <a href="https://formulae.brew.sh/formula/ktlint"><img src="https://img.shields.io/homebrew/v/ktlint.svg" alt="HomeBrew"></a>
 <a href="LICENSE"><img src="https://img.shields.io/github/license/pinterest/ktlint.svg" alt="License"></a>

--- a/documentation/release-latest/docs/index.md
+++ b/documentation/release-latest/docs/index.md
@@ -8,7 +8,7 @@
 <p align="center">
 <a href="https://kotlinlang.slack.com/messages/CKS3XG0LS"><img src="https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack" alt="Join the chat at https://kotlinlang.slack.com"/></a>
 <a href="https://github.com/pinterest/ktlint/actions?query=workflow%3A%22Publish+snapshot+build%22"><img src="https://github.com/pinterest/ktlint/workflows/Publish%20snapshot%20build/badge.svg" alt="Build status snapshot"></a>
-<a href="https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/com.pinterest.ktlint/ktlint-cli?smo=true"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
 <a href="https://pinterest.github.io/ktlint/"><img src="https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081.svg" alt="ktlint"></a>
 </p>
 <p align="center">

--- a/documentation/snapshot/docs/index.md
+++ b/documentation/snapshot/docs/index.md
@@ -8,7 +8,7 @@
 <p align="center">
 <a href="https://kotlinlang.slack.com/messages/CKS3XG0LS"><img src="https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack" alt="Join the chat at https://kotlinlang.slack.com"/></a>
 <a href="https://github.com/pinterest/ktlint/actions?query=workflow%3A%22Publish+snapshot+build%22"><img src="https://github.com/pinterest/ktlint/workflows/Publish%20snapshot%20build/badge.svg" alt="Build status snapshot"></a>
-<a href="https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/com.pinterest.ktlint/ktlint-cli?smo=true"><img src="https://img.shields.io/maven-central/v/com.pinterest.ktlint/ktlint-cli.svg" alt="Maven Central"></a>
 <a href="https://pinterest.github.io/ktlint/"><img src="https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081.svg" alt="ktlint"></a>
 </p>
 <p align="center">


### PR DESCRIPTION
 ## Description

  Fix broken Maven Central links that fail the broken-link checker after releases.

  Changed `search.maven.org` to `central.sonatype.com` in README and documentation files.

  All links updated from:
  - Old: `https://search.maven.org/artifact/com.pinterest.ktlint/ktlint-cli`
  - New: `https://central.sonatype.com/artifact/com.pinterest.ktlint/ktlint-cli?smo=true`

Closes  #3184

  ## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
