### PR TITLE
Remove unnecessary public modifiers in ktlint-ruleset-template

### DIFF
--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/CustomRuleSetProvider.kt
@@ -6,7 +6,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 
 internal val CUSTOM_RULE_SET_ID = "custom-rule-set-id"
 
-public class CustomRuleSetProvider : RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
+class CustomRuleSetProvider : RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
     override fun getRuleProviders(): Set<RuleProvider> =
         setOf(
             RuleProvider { NoVarRule() },

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -7,7 +7,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
-public class NoVarRule :
+class NoVarRule :
     Rule(
         ruleId = RuleId("$CUSTOM_RULE_SET_ID:no-var"),
         about =


### PR DESCRIPTION
## Description

Remove unnecessary public modifiers in ktlint-ruleset-template

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
