### PR TITLE
Keep `no-unused-import` as opt-in

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -2786,12 +2786,12 @@ Suppress or disable rule (1)
 ## No unused imports
 
 !!! important
-    Starting from KtLint `1.7.0` this rule no longer runs by default. In some cases the rule marks imports as unused, while after removal of the import the code no longer compiles. This rule will be removed in KtLint `2.0`. See [issue](https://github.com/pinterest/ktlint/issues/3038) for more background. 
-    If you insist on running the rule despite its shortcomings, you need to enable the rule in the `.editorconfig` by adding:
+    Starting from KtLint `1.7.0` this rule no longer runs by default. In some cases the rule marks imports as unused, while after removal of the import the code no longer compiles.
+    If you insist on running the rule despite its [shortcomings](https://github.com/pinterest/ktlint/issues/3038), you need to enable the rule in the `.editorconfig` by adding:
     ```
     ktlint_standard_no-unused-imports = enabled
     ```
-
+    Newly reported shortcomings to this rule are not guaranteed to be fixed by maintainers of KtLint.
 
 Rule id: `standard:no-unused-imports`
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -2786,12 +2786,12 @@ Suppress or disable rule (1)
 ## No unused imports
 
 !!! important
-    Starting from KtLint `1.7.0` this rule no longer runs by default. In some cases the rule marks imports as unused, while after removal of the import the code no longer compiles. This rule will be removed in KtLint `2.0`. See [issue](https://github.com/pinterest/ktlint/issues/3038) for more background. 
-    If you insist on running the rule despite its shortcomings, you need to enable the rule in the `.editorconfig` by adding:
+    Starting from KtLint `1.7.0` this rule no longer runs by default. In some cases the rule marks imports as unused, while after removal of the import the code no longer compiles.
+    If you insist on running the rule despite its [shortcomings](https://github.com/pinterest/ktlint/issues/3038), you need to enable the rule in the `.editorconfig` by adding:
     ```
     ktlint_standard_no-unused-imports = enabled
     ```
-
+    Newly reported shortcomings to this rule are not guaranteed to be fixed by maintainers of KtLint.
 
 Rule id: `standard:no-unused-imports`
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoUnusedImportsRule.kt
@@ -37,11 +37,11 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.resolve.ImportPath
 
 @SinceKtlint("0.2", STABLE)
-@Deprecated(
-    "Marked for removal in Ktlint 2.0.0. When the rule marks an import falsely as unused, it results in code that can not be compiled.",
-)
 public class NoUnusedImportsRule :
     StandardRule("no-unused-imports"),
+    // This rule is an opt-in rule as occasionally an import is falsely marked as unused, and after removal results in code that cannot be
+    // compiled. Upon request of the community (https://github.com/pinterest/ktlint/issues/3038) the rule will not be removed, but kept as
+    // an opt-in rule.
     OnlyWhenEnabledInEditorconfig,
     // Prevent that imports which are only used inside code that is suppressed are (falsely) reported as unused.
     IgnoreKtlintSuppressions {


### PR DESCRIPTION
## Description

Remove deprecation on `no-unused-import`. The rule will be kept as opt-in. Future support on new shortcomings on this rule might not be supported by maintainers of the project.

Follow-up on #3038

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
