### PR TITLE
Avoid parallel uploads to Maven Central repository

### DIFF
--- a/.github/workflows/publish-snapshot-build.yml
+++ b/.github/workflows/publish-snapshot-build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [master]
     paths: ['**/*.kt', '**/*.kts', '**/*.properties', '**/*.toml']
+  workflow_dispatch:
 
 env:
   ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
@@ -18,13 +19,54 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.repository == 'pinterest/ktlint'
+    concurrency:
+      group: publish-snapshot
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - uses: ./.github/actions/setup-gradle-build
 
-      - name: Publish snapshot to Maven
-        run: ./gradlew clean publishMavenPublicationToMavenCentralRepository
+      - name: Publish snapshot to Maven (with retries, no parallel uploads)
+        run: |
+          set -euo pipefail
 
-      - name: Publish Kotlin-dev snapshot to Maven
-        run: ./gradlew -PkotlinDev clean publishMavenPublicationToMavenCentralRepository
+          retry() {
+            max_attempts=6
+            base_delay=5
+            for i in $(seq 1 $max_attempts); do
+              echo "Publish attempt $i/$max_attempts"
+              ./gradlew clean publishMavenPublicationToMavenCentralRepository --no-parallel -Dorg.gradle.workers.max=1 && return 0
+              if [ "$i" -eq "$max_attempts" ]; then
+                echo "Publish failed after $i attempts"
+                return 1
+              fi
+              sleep_time=$(( base_delay * 2 ** (i - 1) + (RANDOM % 5) ))
+              echo "Sleeping $sleep_time seconds before next attempt"
+              sleep $sleep_time
+            done
+          }
+
+          retry
+
+      - name: Publish Kotlin-dev snapshot to Maven (with retries, no parallel uploads)
+        run: |
+          set -euo pipefail
+
+          retry() {
+            max_attempts=6
+            base_delay=5
+            for i in $(seq 1 $max_attempts); do
+              echo "Publish (kotlin-dev) attempt $i/$max_attempts"
+              ./gradlew -PkotlinDev clean publishMavenPublicationToMavenCentralRepository --no-parallel -Dorg.gradle.workers.max=1 && return 0
+              if [ "$i" -eq "$max_attempts" ]; then
+                echo "Publish (kotlin-dev) failed after $i attempts"
+                return 1
+              fi
+              sleep_time=$(( base_delay * 2 ** (i - 1) + (RANDOM % 5) ))
+              echo "Sleeping $sleep_time seconds before next attempt"
+              sleep $sleep_time
+            done
+          }
+
+          retry


### PR DESCRIPTION
## Description

Avoid parallel uploads to Maven Central repository as it (sometimes) leads to error 429 (Too many request).

[fully generated by co-pilot]

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
