### PR TITLE
Temporarily change publish release build flow to release version 1.7.2

### DIFF
--- a/.github/workflows/publish-release-build.yml
+++ b/.github/workflows/publish-release-build.yml
@@ -5,7 +5,7 @@ permissions:
 on:
   push:
     tags:
-      - '*.*.*'
+      - '1.7.2'
 
 jobs:
   publish:
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          ref: 'master'
+          ref: 'master-1.7.2'
 
       - uses: ./.github/actions/setup-gradle-build
 
@@ -70,21 +70,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump Homebrew Formula
-        if: ${{ success() }}
-        uses: mislav/bump-homebrew-formula-action@v2
-        env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
-        with:
-          formula-name: ktlint
-          formula-path: Formula/k/ktlint.rb
-          download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
+#      - name: Bump Homebrew Formula
+#        if: ${{ success() }}
+#        uses: mislav/bump-homebrew-formula-action@v2
+#        env:
+#          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+#        with:
+#          formula-name: ktlint
+#          formula-path: Formula/k/ktlint.rb
+#          download-url: https://github.com/pinterest/ktlint/releases/download/${{ env.version }}/ktlint-${{ env.version }}.zip
 
-      - name: Update Release documentation
-        if: ${{ success() }}
-        run: |
-          git config user.email "ktlint@github.com"
-          git config user.name "Ktlint Release Workflow" |
-          ./.announce -y
-        env:
-          VERSION: ${{ env.version }}
+#      - name: Update Release documentation
+#        if: ${{ success() }}
+#        run: |
+#          git config user.email "ktlint@github.com"
+#          git config user.name "Ktlint Release Workflow" |
+#          ./.announce -y
+#        env:
+#          VERSION: ${{ env.version }}


### PR DESCRIPTION
## Description

Temporarily change publish release build flow to release version 1.7.2 while 1.8.0 has already been released.

[Klint `1.7.0` and `1.7.1` can not be used in Ktlint Intellij Plugin](https://github.com/nbadal/ktlint-intellij-plugin/issues/767) due to a breaking change which was fixed in #3063. That fix was only released in ktlint `1.8.0`. As a result of this the klint `1.7.0` and `1.7.1` rulesets can not be used in the Ktlint Intellij Plugin starting from version `0.30.0`. As an exception to our general releasing policy, ktlint `1.7.2` will be released including all changes up until (and including) #3036.

Homebrew formula is not updated, and no documentation is generated for the release.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
