### PR TITLE
Fix indentation for a Note block in documentation

### DIFF
--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -3930,7 +3930,7 @@ Suppress or disable rule (1)
     ```
 
 !!! Note
-This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ### Type argument list spacing
 

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -3930,7 +3930,7 @@ Suppress or disable rule (1)
     ```
 
 !!! Note
-This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
 
 ### Type argument list spacing
 


### PR DESCRIPTION
<!-- Thanks for opening a new PR!

Before you click submit, please consult the Checklist below. Note, that you still can add new commits to your branch before submitting the PR.
-->

## Description

<!--Describe what was done and why (mandatory). The description should help the reviewer to understand what the PR is about and which decisions have been made.

If the PR solves an issue then provide a link to that issue using format `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
-->

One Note block in the documentation was missing indentation, so the content was not included in the Note block.

This PR adds the missing indentation to align it with other Note blocks.

### Before

<img width="706" height="129" alt="Screenshot 2025-12-18 at 9 50 54 AM" src="https://github.com/user-attachments/assets/cb154209-04b6-456b-9e28-60565c305f00" />

### After

<img width="705" height="102" alt="Screenshot 2025-12-18 at 9 51 39 AM" src="https://github.com/user-attachments/assets/fb63c36d-3711-43f6-889e-34946e12c028" />

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
