### PR TITLE
Fix handling of EOL-comment in `paren-spacing`

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRule.kt
@@ -184,7 +184,7 @@ public class SpacingAroundParensRule : StandardRule("paren-spacing") {
             ?.takeUnless { it.prevSibling20?.elementType == LPAR }
             ?.siblings(false)
             ?.takeWhile { it.elementType != LPAR }
-            ?.none { it.textContains('\n') }
+            ?.none { it.textContains('\n') || it.elementType == EOL_COMMENT }
             ?: false
 
     private fun ASTNode.fixUnexpectedSpacingAround(

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/SpacingAroundParensRuleTest.kt
@@ -358,4 +358,39 @@ class SpacingAroundParensRuleTest {
                 LintViolation(12, 15, "Unexpected spacing after \"(\""),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 3227 - Given an EOL comment before RPAR then do not remove the newline`() {
+        val code =
+            """
+            fun main() {
+                1.plus(1 // test
+                ).plus(2 // test2
+                ).plus(42)
+            }
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a function call with multiple arguments and an EOL comment on the last one then do not remove the newline before RPAR`() {
+        val code =
+            """
+            val foo = fn(
+                1, 2 // comment
+            )
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a function call with an EOL comment immediately after LPAR then do not remove the newline after it`() {
+        val code =
+            """
+            val foo = fn( // comment
+                1
+            )
+            """.trimIndent()
+        spacingAroundParensRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Take EOL-comments after argument in function call into account when checking the parenthesis spacing.

Fixes #3227 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
