### PR TITLE
Add rule `call-expression-wrapping`, and improve wrapping in `chain-method-continuation` and `function-literal`

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -8,6 +8,58 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](configuration-ktlint.md#disable-rules).
 
+## Call expression wrapping
+
+In case a call expression does not fit on the line, the lambda expression, and/or the value argument list after a reference expression are wrapped. 
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    // Assume that the last allowed
+    // character is at the X character
+    // on the right                  X
+    val foo1 = bar() {
+        "some message"
+    }
+    val foo2 = bar(
+        "foobarrrrrrrrrrrr"
+    ) { "some message" }
+    val foo3 = bar(
+        "foobarrrrrrrrrrrr"
+    ) {
+        "some longgggggggggg message"
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    // Assume that the last allowed
+    // character is at the X character
+    // on the right                  X
+    val foo1 = bar() { "some message" }
+    val foo2 = bar("foobarrrrrrrrrrrr") { "some message" }
+    val foo3 = bar("foobarrrrrrrrrrrr") { "some longgggggggggg message" }
+    ```
+
+Rule id: `standard:call-expression-wrapping`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:call-expression-wrapping")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_call-expression-wrapping = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_call-expression-wrapping = disabled
+    ```
+
 ## Expression operand wrapping
 
 Wraps each operand in a multiline expression to a separate line.

--- a/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
+++ b/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
@@ -123,15 +123,15 @@ class FormatReporterTest {
     }
 
     companion object {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "some-rule", "This error can be autocorrected", LINT_CAN_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_NOT_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", LINT_CAN_NOT_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         val SOME_FORMAT_ERROR_IS_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", FORMAT_IS_AUTOCORRECTED)
 

--- a/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
@@ -157,13 +157,13 @@ class HtmlReporterTest {
         val out = ByteArrayOutputStream()
         val reporter = HtmlReporter(PrintStream(out, true))
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
             KtlintCliError(1, 1, "rule-1", "Error message contains a generic type like List<Int> (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
         )
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
             KtlintCliError(2, 1, "rule-2", "Error message contains special html symbols like a<b>c\"d'e&f (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),

--- a/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
+++ b/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
@@ -70,12 +70,12 @@ class PlainSummaryReporterTest {
     fun `Report other violations`() {
         val out = ByteArrayOutputStream()
         val reporter = PlainSummaryReporter(PrintStream(out, true))
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-1.kt",
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-2.kt",
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),

--- a/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
@@ -63,12 +63,12 @@ class PlainReporterTest {
     fun `Report other violations`() {
         val out = ByteArrayOutputStream()
         val reporter = PlainReporter(PrintStream(out, true))
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-1.kt",
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
         )
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-2.kt",
             KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
@@ -47,7 +47,7 @@ class SuppressionLocatorTest {
             """
             val foo = "foo" // ktlint-disable
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         assertThat(lint(code))
             .contains(
                 LintError(1, 5, STANDARD_NO_FOO_IDENTIFIER_RULE_ID, "Line should not contain a foo identifier", false),
@@ -342,7 +342,7 @@ class SuppressionLocatorTest {
                 @file:Suppress("ktlint:internal:ktlint-suppression")
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
                 LintError(1, 17, KTLINT_SUPPRESSION_RULE_ID, "Ktlint rule with id 'ktlint:internal:ktlint-suppression' is unknown or not loaded", false),
             )
@@ -355,7 +355,7 @@ class SuppressionLocatorTest {
                 /* ktlint-disable internal:ktlint-suppression */
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
                 LintError(1, 4, KTLINT_SUPPRESSION_RULE_ID, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation", true),
                 LintError(1, 19, KTLINT_SUPPRESSION_RULE_ID, "Ktlint rule with id 'internal:ktlint-suppression' is unknown or not loaded", false),
@@ -369,7 +369,7 @@ class SuppressionLocatorTest {
                 val foo = "foo" // ktlint-disable internal:ktlint-suppression
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
                 lintError(1, 5, "standard:no-foo-identifier-standard"),
                 lintError(1, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
@@ -1058,7 +1058,7 @@ class KtlintSuppressionRuleTest {
                     doSomething()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             ktlintSuppressionRuleAssertThat(code)
                 .hasLintViolations(
                     LintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. The matching 'ktlint-enable' directive is not found in same scope. Replace with @Suppress annotation", false),

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -100,6 +100,16 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/BlockCommentIniti
 	public static final fun getBLOCK_COMMENT_INITIAL_STAR_ALIGNMENT_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$Experimental {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleKt {
+	public static final fun getCALL_EXPRESSION_WRAPPING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$OfficialCodeStyle {
 	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule$Companion;
 	public fun <init> ()V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -11,6 +11,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.BinaryExpressionWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeDeclarationRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBetweenWhenConditions
 import com.pinterest.ktlint.ruleset.standard.rules.BlockCommentInitialStarAlignmentRule
+import com.pinterest.ktlint.ruleset.standard.rules.CallExpressionWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ChainMethodContinuationRule
 import com.pinterest.ktlint.ruleset.standard.rules.ChainWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.ClassNamingRule
@@ -114,6 +115,7 @@ public class StandardRuleSetProvider : RuleSetV2Provider(RuleSetId.STANDARD) {
             RuleV2InstanceProvider { BlankLineBeforeDeclarationRule() },
             RuleV2InstanceProvider { BlankLineBetweenWhenConditions() },
             RuleV2InstanceProvider { BlockCommentInitialStarAlignmentRule() },
+            RuleV2InstanceProvider { CallExpressionWrappingRule() },
             RuleV2InstanceProvider { ChainMethodContinuationRule() },
             RuleV2InstanceProvider { ChainWrappingRule() },
             RuleV2InstanceProvider { ClassNamingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRule.kt
@@ -1,0 +1,159 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleV2
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline20
+import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.leavesOnLine20
+import com.pinterest.ktlint.rule.engine.core.api.lineLength
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling
+import com.pinterest.ktlint.rule.engine.core.api.nextSibling20
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.prevSibling20
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+@SinceKtlint("2.0", SinceKtlint.Status.EXPERIMENTAL)
+public class CallExpressionWrappingRule :
+    StandardRule(
+        id = "call-expression-wrapping",
+        usesEditorConfigProperties =
+            setOf(
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
+    ),
+    RuleV2.Experimental {
+    private var indentConfig = DEFAULT_INDENT_CONFIG
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+        maxLineLength = editorConfig[MAX_LINE_LENGTH_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType == CALL_EXPRESSION) {
+            visitCallExpression(node, emit)
+        }
+    }
+
+    private fun visitCallExpression(
+        node: ASTNode,
+        emit: (Int, String, Boolean) -> AutocorrectDecision,
+    ) {
+        node
+            .findChildByType(REFERENCE_EXPRESSION)
+            ?.nextSibling { it.elementType == VALUE_ARGUMENT_LIST }
+            ?.let { visitReferenceExpressionValueArgumentList(it, emit) }
+        node
+            .findChildByType(LAMBDA_ARGUMENT)
+            ?.let { visitLambdaArgument(it, emit) }
+    }
+
+    private fun visitReferenceExpressionValueArgumentList(
+        node: ASTNode,
+        emit: (Int, String, Boolean) -> AutocorrectDecision,
+    ) {
+        require(node.elementType == VALUE_ARGUMENT_LIST)
+        if (node.textContains('\n') || node.exceedsMaxLineLength(node.lastChildLeafOrSelf20)) {
+            node
+                .findChildByType(LPAR)
+                ?.takeUnless { it.nextSibling20.isWhiteSpaceWithNewline20 }
+                ?.let { lpar ->
+                    emit(lpar.startOffset, "Expected new line after '('", true)
+                        .ifAutocorrectAllowed { lpar.upsertWhitespaceAfterMe(indentConfig.siblingIndentOf(lpar)) }
+                }
+            node
+                .findChildByType(RPAR)
+                ?.takeUnless { it.prevSibling20.isWhiteSpaceWithNewline20 }
+                ?.let { rbrace ->
+                    emit(rbrace.startOffset, "Expected new line before ')'", true)
+                        .ifAutocorrectAllowed {
+                            rbrace.upsertWhitespaceBeforeMe(indentConfig.parentIndentOf(rbrace))
+                        }
+                }
+        }
+    }
+
+    private fun visitLambdaArgument(
+        node: ASTNode,
+        emit: (Int, String, Boolean) -> AutocorrectDecision,
+    ) {
+        require(node.elementType == LAMBDA_ARGUMENT)
+        if (node.textContains('\n') || node.exceedsMaxLineLength(node.lastChildLeafOrSelf20)) {
+            val functionLiteral =
+                node
+                    .findChildByType(LAMBDA_EXPRESSION)
+                    ?.findChildByType(FUNCTION_LITERAL)
+            val arrow = functionLiteral?.findChildByType(ARROW)
+            if (arrow == null || node.exceedsMaxLineLength(arrow.lastChildLeafOrSelf20)) {
+                // Arrow not found, or does not fit on the line. Wrap after brace
+                functionLiteral
+                    ?.findChildByType(LBRACE)
+                    .takeUnless { it?.nextSibling20.isWhiteSpaceWithNewline20 }
+                    ?.let { lbrace ->
+                        emit(lbrace.startOffset, "Expected new line after '{'", true)
+                            .ifAutocorrectAllowed { lbrace.upsertWhitespaceAfterMe(indentConfig.siblingIndentOf(lbrace)) }
+                    }
+            } else {
+                arrow
+                    .takeUnless { it.nextSibling20.isWhiteSpaceWithNewline20 }
+                    ?.let {
+                        emit(arrow.startOffset + 1, "Expected new line after '->'", true)
+                            .ifAutocorrectAllowed { arrow.upsertWhitespaceAfterMe(indentConfig.siblingIndentOf(arrow)) }
+                    }
+            }
+            functionLiteral
+                ?.findChildByType(RBRACE)
+                ?.takeUnless { it.prevSibling20.isWhiteSpaceWithNewline20 }
+                ?.let { rbrace ->
+                    emit(rbrace.startOffset, "Expected new line before '}'", true)
+                        .ifAutocorrectAllowed {
+                            rbrace.upsertWhitespaceBeforeMe(indentConfig.parentIndentOf(rbrace))
+                        }
+                }
+        }
+    }
+
+    private fun ASTNode.exceedsMaxLineLength(stopAtLeaf: ASTNode): Boolean =
+        maxLineLength <
+            leavesOnLine20
+                .dropTrailingEolComment()
+                .takeWhile { it.prevLeaf != stopAtLeaf }
+                .lineLength
+}
+
+public val CALL_EXPRESSION_WRAPPING_RULE_ID: RuleId = CallExpressionWrappingRule().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -247,7 +247,7 @@ public class ChainMethodContinuationRule :
                         ?: lastChildLeafOrSelf20.nextLeaf
                 leavesOnLine20
                     .dropTrailingEolComment()
-                    .takeWhile { it != stopAtLeaf }
+                    .takeWhile { it.prevLeaf != stopAtLeaf }
                     .lineLength > maxLineLength
             }
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -200,7 +200,15 @@ public class FunctionLiteralRule :
             }.length
     }
 
-    private fun ASTNode.exceedsMaxLineLength() = maxLineLength < leavesOnLine20.dropTrailingEolComment().lineLength
+    private fun ASTNode.exceedsMaxLineLength(): Boolean {
+        require(elementType == BLOCK)
+        val stopAtLeaf = nextSibling { it.elementType == RBRACE }
+        return maxLineLength <
+            leavesOnLine20
+                .dropTrailingEolComment()
+                .takeWhile { it.prevLeaf != stopAtLeaf }
+                .lineLength
+    }
 
     private fun ASTNode.wrapFirstParameterToNewline() =
         if (isFunctionLiteralLambdaWithNonEmptyValueParameterList()) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -258,7 +258,7 @@ class AnnotationRuleTest {
                 val baz: Any
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         annotationRuleAssertThat(code)
             .withEditorConfigOverride(ANNOTATIONS_WITH_PARAMETERS_NOT_TO_BE_WRAPPED_PROPERTY to "Baz")
             .hasLintViolations(
@@ -414,7 +414,7 @@ class AnnotationRuleTest {
 
                 package foo.bar
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .hasLintViolations(
                     LintViolation(1, 26, "Expected newline after last annotation"),
@@ -772,7 +772,7 @@ class AnnotationRuleTest {
                     String
                 > = FooBar()
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .addAdditionalRuleProvider { WrappingRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -298,6 +298,53 @@ class ArgumentListWrappingRuleTest {
             ).isFormattedAs(formattedCode)
     }
 
+    @Test
+    fun `Issue 2451 - Should not wrap the argument list when wrapping AST Nodes before the argument list prevent exceeding the max line length`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+            val foo = Bar.buildernnnnnnnnnnnnnnnnnnnnnnnnnnnnnn().baz(1).build()
+
+            val foo1 = requireNotNull(bar.filter { it == "bar" }) { "some message" }
+            val foo2 = requireNotNull(bar?.filter { it == "bar" }) { "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                 $EOL_CHAR
+            val foo =
+                Bar
+                    .buildernnnnnnnnnnnnnnnnnnnnnnnnnnnnnn()
+                    .baz(1)
+                    .build()
+
+            val foo1 =
+                requireNotNull(bar.filter { it == "bar" }) {
+                    "some message"
+                }
+            val foo2 =
+                requireNotNull(bar?.filter { it == "bar" }) {
+                    "some message"
+                }
+            """.trimIndent()
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        argumentListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { CallExpressionWrappingRule() }
+            .addAdditionalRuleProvider { ChainMethodContinuationRule() }
+            .addAdditionalRuleProvider { IndentationRule() }
+            .addAdditionalRuleProvider { MultilineExpressionWrappingRule() }
+            .hasNoLintViolationsExceptInAdditionalRules()
+//            .hasLintViolations(
+//                LintViolation(line = 2, col = 59, detail = "Argument should be on a separate line (unless all arguments can fit a single line)"),
+//                LintViolation(line = 2, col = 60, detail = "Missing newline before \")\""),
+//                LintViolation(line = 4, col = 27, detail = "Argument should be on a separate line (unless all arguments can fit a single line)"),
+//                LintViolation(line = 4, col = 53, detail = "Missing newline before \")\""),
+//                LintViolation(line = 5, col = 27, detail = "Argument should be on a separate line (unless all arguments can fit a single line)"),
+//                LintViolation(line = 5, col = 54, detail = "Missing newline before \")\""),
+//            )
+            .isFormattedAs(formattedCode)
+    }
+
     @Nested
     inner class `Given a function call with too many (eg more than 8) arguments` {
         @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -39,7 +39,7 @@ class ArgumentListWrappingRuleTest {
                 c
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         argumentListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 8, "Argument should be on a separate line (unless all arguments can fit a single line)")
             .isFormattedAs(formattedCode)
@@ -326,7 +326,7 @@ class ArgumentListWrappingRuleTest {
                     "some message"
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         argumentListWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { CallExpressionWrappingRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -86,7 +86,7 @@ class BackingPropertyNamingRuleTest {
                             get() = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
@@ -110,7 +110,7 @@ class BackingPropertyNamingRuleTest {
                             get() = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
@@ -207,7 +207,7 @@ class BackingPropertyNamingRuleTest {
                         $modifier fun getElementList(): List<Element> = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
@@ -230,7 +230,7 @@ class BackingPropertyNamingRuleTest {
                         $modifier fun getElementList(): List<Element> = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
@@ -268,7 +268,7 @@ class BackingPropertyNamingRuleTest {
                         fun getElementList(bar: String): List<Element> = _elementList + bar
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when a matching property or function exists")
             }
@@ -353,7 +353,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
@@ -379,7 +379,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
@@ -486,7 +486,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
@@ -511,7 +511,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
@@ -553,7 +553,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when a matching property or function exists")
             }
@@ -638,7 +638,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
@@ -664,7 +664,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
@@ -771,7 +771,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                     .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
@@ -796,7 +796,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
                     .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
@@ -838,7 +838,7 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when a matching property or function exists")
             }
@@ -906,7 +906,7 @@ class BackingPropertyNamingRuleTest {
                     get() = _elementList2
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         backingPropertyNamingRuleAssertThat(code)
             .hasLintViolations(
                 LintViolation(3, 17, "Backing property is only allowed when a matching property or function exists", canBeAutoCorrected = false),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
@@ -59,7 +59,7 @@ class BlankLineBetweenWhenConditionsTest {
                     else -> null
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         blankLineAfterWhenConditionRuleAssertThat(code)
             .hasLintViolations(
                 LintViolation(4, 1, "Unexpected blank lines between when-condition if all when-conditions are single lines"),
@@ -95,7 +95,7 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
                         LintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
@@ -127,7 +127,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
                         LintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
@@ -163,7 +163,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
                         LintViolation(5, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
@@ -194,7 +194,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement")
                     .isFormattedAs(formattedCode)
@@ -221,7 +221,7 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement")
                     .isFormattedAs(formattedCode)
@@ -242,7 +242,7 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()
@@ -260,7 +260,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()
@@ -278,7 +278,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
@@ -1,0 +1,211 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.EOL_CHAR
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARKER
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
+import com.pinterest.ktlint.test.KtlintDocumentationTest
+import com.pinterest.ktlint.test.LintViolation
+import org.junit.jupiter.api.Test
+
+class CallExpressionWrappingRuleTest {
+    private val callExpressionWrappingRuleAssertThat =
+        assertThatRuleBuilder { CallExpressionWrappingRule() }
+            .addAdditionalRuleProvider { MaxLineLengthRule() }
+            .assertThat()
+
+    @Test
+    fun `Given some call expressions that do fit on the line then do not wrap`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER        $EOL_CHAR
+            val foo1 = bar() { "some message" }
+            val foo2 = bar() {
+                "some message"
+            }
+            val foo3 = bar() { message ->
+                "some message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line call expression, and lambda argument with parameter list that fits on the line then do not wrap`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
+            val foo = bar() { message -> "some message" }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a single line call expression for which the lambda expression does not fits on the line then wrap after opening brace of lambda expression`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar() { "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar() {
+                "some message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 17, "Expected new line after '{'"),
+                LintViolation(2, 34, "Expected new line before '}'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line call expression, and lambda argument with parameter list, and the function literal of the lambda expression does not fits on the line then wrap after the arrow`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            val foo = bar() { message -> "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            val foo = bar() { message ->
+                "some message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 28, "Expected new line after '->'"),
+                LintViolation(2, 45, "Expected new line before '}'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line call expression, and lambda argument with parameter list, and the arrow of the lambda expression does not fits on the line then wrap after opening brace of lambda expression`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+            val foo = barrrr() { message -> "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+            val foo = barrrr() {
+                message ->
+                "some message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 20, "Expected new line after '{'"),
+                LintViolation(2, 48, "Expected new line before '}'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line call expression with argument in the reference expression which does not fits on the line then wrap after opening parenthesis of the reference expression`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar("foobarrrrrrrrrrrr") { "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar(
+                "foobarrrrrrrrrrrr"
+            ) { "some message" }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 14, "Expected new line after '('"),
+                LintViolation(2, 34, "Expected new line before ')'"),
+                LintViolation(2, 36, "Expected new line after '{'"),
+                LintViolation(2, 53, "Expected new line before '}'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a single line call expression with an argument value list which does not fits on the line, and a lambda argument that after wrapping also does not fit the line then wrap both the value argument list and the lambda argument`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar("foobarrrrrrrrrrrr") { "some longggggggggg message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            val foo = bar(
+                "foobarrrrrrrrrrrr"
+            ) {
+                "some longggggggggg message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(2, 14, "Expected new line after '('"),
+                LintViolation(2, 34, "Expected new line before ')'"),
+                LintViolation(2, 36, "Expected new line after '{'"),
+                LintViolation(2, 67, "Expected new line before '}'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `xxx`() {
+        val code =
+            """
+            public fun writeFile(
+                filePath: String,
+                content: String,
+            ) {
+                operatingSystemPath(filePath)
+                    .let { path ->
+                        Files.createDirectories(path.parent)
+                        Files.write(path, content.toByteArray())
+                    }
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+//            .setMaxLineLength()
+            .hasNoLintViolations()
+    }
+
+    @KtlintDocumentationTest
+    fun `Given some examples for documentation`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            val foo1 = bar() { "some message" }
+            val foo2 = bar("foobarrrrrrrrrrrr") { "some message" }
+            val foo3 = bar("foobarrrrrrrrrrrr") { "some longgggggggggg message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            val foo1 = bar() {
+                "some message"
+            }
+            val foo2 = bar(
+                "foobarrrrrrrrrrrr"
+            ) { "some message" }
+            val foo3 = bar(
+                "foobarrrrrrrrrrrr"
+            ) {
+                "some longgggggggggg message"
+            }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .isFormattedAs(formattedCode)
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
@@ -160,26 +160,6 @@ class CallExpressionWrappingRuleTest {
             ).isFormattedAs(formattedCode)
     }
 
-    @Test
-    fun `xxx`() {
-        val code =
-            """
-            public fun writeFile(
-                filePath: String,
-                content: String,
-            ) {
-                operatingSystemPath(filePath)
-                    .let { path ->
-                        Files.createDirectories(path.parent)
-                        Files.write(path, content.toByteArray())
-                    }
-            }
-            """.trimIndent()
-        callExpressionWrappingRuleAssertThat(code)
-//            .setMaxLineLength()
-            .hasNoLintViolations()
-    }
-
     @KtlintDocumentationTest
     fun `Given some examples for documentation`() {
         val code =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -613,6 +613,7 @@ class ChainMethodContinuationRuleTest {
                 .addAdditionalRuleProvider { ArgumentListWrappingRule() }
                 .addAdditionalRuleProvider { FunctionLiteralRule() }
                 .addAdditionalRuleProvider { MaxLineLengthRule() }
+                .addAdditionalRuleProvider { IndentationRule() }
                 .hasLintViolations(
                     // Lint violation below will not be triggered during format as argument-list-wrapping rule prevents this error from occurring
                     LintViolation(2, 30, "Expected newline before '.'"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
@@ -35,7 +35,7 @@ class ClassNamingRuleTest {
                 """
                 class $className
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             classNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
         }
@@ -48,7 +48,7 @@ class ClassNamingRuleTest {
                     """
                     class `foo`
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
                 classNamingRuleAssertThat(code)
                     .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -579,7 +579,7 @@ class ClassSignatureRuleTest {
                 class Foo23<M : Map<Any, Any>>(map: M)
                 class Foo24<M : Map<Any, Any>>(map: M)
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             classSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProviders(
                     { NoMultipleSpacesRule() },

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
@@ -93,7 +93,7 @@ class CommentWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 17, "A block comment after any other element on the same line must be separated by a new line")
     }
@@ -104,7 +104,7 @@ class CommentWrappingRuleTest {
             """
             val foo /* some comment */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment in between other elements on the same line is disallowed")
     }
@@ -117,7 +117,7 @@ class CommentWrappingRuleTest {
             some comment
             */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment starting on same line as another element and ending on another line before another element is disallowed")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
@@ -34,7 +34,7 @@ class EnumEntryNameCaseRuleTest {
                 _FOO
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"")
     }
@@ -60,7 +60,7 @@ class EnumEntryNameCaseRuleTest {
                 Foo_Bar,
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""),
@@ -105,7 +105,7 @@ class EnumEntryNameCaseRuleTest {
 
         @Test
         fun `Given that 'ktlint_enum_entry_name_casing' is set to 'UPPER_CASES', then allow only upper cases`() {
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             enumEntryNameCaseRuleAssertThat(code)
                 .withEditorConfigOverride(ENUM_ENTRY_NAME_CASING_PROPERTY to upper_cases)
                 .hasLintViolationWithoutAutoCorrect(3, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\"")
@@ -113,7 +113,7 @@ class EnumEntryNameCaseRuleTest {
 
         @Test
         fun `Given that 'ktlint_enum_entry_name_casing' is set to 'CAMEL_CASES', then allow only camel cases`() {
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             enumEntryNameCaseRuleAssertThat(code)
                 .withEditorConfigOverride(ENUM_ENTRY_NAME_CASING_PROPERTY to camel_cases)
                 .hasLintViolationWithoutAutoCorrect(2, 5, "Enum entry name should be upper camel-case like \"EnumEntry\"")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
@@ -72,7 +72,7 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing a single declaration of a class type then the filename should match the class name`(code: String) {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath("/some/path/$UNEXPECTED_FILE_NAME")
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")
@@ -86,7 +86,7 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing one top level declaration then the file should be named after the identifier`(code: String) {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'")
@@ -167,7 +167,7 @@ class FilenameRuleTest {
             class Foo
             $otherTopLevelDeclaration
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
             .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -635,7 +635,7 @@ class FunctionLiteralRuleTest {
                     "some message"
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { IndentationRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -475,8 +475,6 @@ class FunctionLiteralRuleTest {
             .hasLintViolations(
                 LintViolation(2, 14, "Newline expected after opening brace"),
                 LintViolation(2, 44, "Newline expected before closing brace"),
-                LintViolation(3, 22, "Newline expected after opening brace"),
-                LintViolation(3, 31, "Newline expected before closing brace"),
                 LintViolation(3, 42, "Newline expected after opening brace"),
                 LintViolation(3, 61, "Newline expected before closing brace"),
                 LintViolation(3, 67, "Newline expected after opening brace"),
@@ -617,5 +615,36 @@ class FunctionLiteralRuleTest {
                 }
             """.trimIndent()
         functionLiteralRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 2451 - Given a function literal that does not fit the line then wrap after the opening brace`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                      $EOL_CHAR
+            val foo1 = requireNotNull(bar.filter { it == "bar" }) { "some message" }
+            val foo2 = requireNotNull(bar?.filter { it == "bar" }) { "some message" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER                                      $EOL_CHAR
+            val foo1 =
+                requireNotNull(bar.filter { it == "bar" }) { "some message" }
+            val foo2 =
+                requireNotNull(bar?.filter { it == "bar" }) {
+                    "some message"
+                }
+            """.trimIndent()
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        functionLiteralRuleAssertThat(code)
+            .setMaxLineLength()
+            .addAdditionalRuleProvider { IndentationRule() }
+            .addAdditionalRuleProvider { PropertyWrappingRule() }
+            .hasLintViolations(
+                LintViolation(line = 2, col = 55, detail = "Newline expected after opening brace"),
+                LintViolation(line = 2, col = 72, detail = "Newline expected before closing brace"),
+                LintViolation(line = 3, col = 56, detail = "Newline expected after opening brace"),
+                LintViolation(line = 3, col = 73, detail = "Newline expected before closing brace"),
+            ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -42,7 +42,7 @@ class FunctionNamingRuleTest {
                 """
                 fun `Some name`() {}
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
         }
@@ -78,7 +78,7 @@ class FunctionNamingRuleTest {
                 """
                 fun do_something() {}
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
         }
@@ -121,7 +121,7 @@ class FunctionNamingRuleTest {
             """
             fun $functionName() = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         functionNamingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -219,7 +219,7 @@ class FunctionSignatureRuleTest {
             private fun f9(a: Any, b: Any): /* some comment */ String = "some-result"
             private fun f10(a: Any, b: Any): String /* some comment */ = "some-result"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
@@ -247,7 +247,7 @@ class FunctionSignatureRuleTest {
             private fun f6(a: /* some comment */ Any, b: Any): String = "some-result"
             private fun f7(a: Any /* some comment */, b: Any): String = "some-result"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
@@ -657,7 +657,7 @@ class FunctionSignatureRuleTest {
                 fun f28(block: (T) -> String) = "some-result"
                 fun f29(block: (T) -> String) = "some-result"
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             functionSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProviders(
                     { NoMultipleSpacesRule() },

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
@@ -62,7 +62,7 @@ class IfElseBracingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(IF_ELSE_BRACING_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
@@ -138,7 +138,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(4, 12, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -236,7 +236,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -258,7 +258,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -281,7 +281,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
@@ -303,7 +303,7 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(7, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -324,7 +324,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(5, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -345,7 +345,7 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolation(3, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
@@ -382,7 +382,7 @@ class IfElseBracingRuleTest {
             """
             val foo = if (false) {} else { bar() }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
             .hasLintViolation(1, 22, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
@@ -180,7 +180,7 @@ class IfElseWrappingRuleTest {
                     if (true) { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(2, 15, "A single line if-statement should be kept simple. The 'THEN' may not be wrapped in a block.")
         }
@@ -193,7 +193,7 @@ class IfElseWrappingRuleTest {
                     if (true) bar() else { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(2, 26, "A single line if-statement should be kept simple. The 'ELSE' may not be wrapped in a block.")
         }
@@ -207,7 +207,7 @@ class IfElseWrappingRuleTest {
             } else {
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -225,7 +225,7 @@ class IfElseWrappingRuleTest {
                 )
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -3386,7 +3386,7 @@ internal class IndentationRuleTest {
                 ${TAB}line2
                     $MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             indentationRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 11, "Indentation of multiline string should not contain both tab(s) and space(s)")
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
@@ -64,7 +64,7 @@ class KdocWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         kdocWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 17, "A KDoc comment after any other element on the same line must be separated by a new line")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRuleTest.kt
@@ -12,7 +12,7 @@ class MixedConditionOperatorsRuleTest {
             """
             val foo = bar1 && bar2 || bar3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 11, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
     }
@@ -25,7 +25,7 @@ class MixedConditionOperatorsRuleTest {
                 bar2 ||
                 bar3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 11, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
     }
@@ -45,7 +45,7 @@ class MixedConditionOperatorsRuleTest {
             """
             val foo = bar1 && (bar2 || bar3 && bar4) && bar5
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 20, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
@@ -52,7 +52,7 @@ class NoConsecutiveCommentsRuleTest {
             /** KDoc 1 */
             /* Block comment 2 */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         noConsecutiveBlankLinesRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(NO_CONSECUTIVE_COMMENTS_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
@@ -118,7 +118,7 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
@@ -159,7 +159,7 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
@@ -200,7 +200,7 @@ class NoConsecutiveCommentsRuleTest {
                 // EOL comment
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by an EOL comment unless separated by a blank line")
@@ -226,7 +226,7 @@ class NoConsecutiveCommentsRuleTest {
                 /* Block comment */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a block comment unless separated by a blank line")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
@@ -67,7 +67,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 val foo = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 16, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)
@@ -83,7 +83,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 fun foo() = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 19, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -145,7 +145,7 @@ class ParameterListWrappingRuleTest {
                 c: Any
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 13, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)
@@ -306,7 +306,7 @@ class ParameterListWrappingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(2, 11, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -98,7 +98,7 @@ class PropertyNamingRuleTest {
             val foo = Foo()
             val FOO_BAR = FooBar()
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -113,7 +113,7 @@ class PropertyNamingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -275,7 +275,7 @@ class PropertyNamingRuleTest {
                 val FOO_BAR = "FOO-BAR" // Class properties always start with lowercase, const is not allowed
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
             .hasLintViolations(
                 LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed", canBeAutoCorrected = false),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
@@ -13,7 +13,7 @@ class TypeArgumentCommentRuleTest {
             """
             fun Foo<out /* some comment */ Any>.foo() {}
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 13, "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.")
     }
@@ -25,7 +25,7 @@ class TypeArgumentCommentRuleTest {
             fun Foo<out // some comment
             Any>.foo() {}
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 13, "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
@@ -13,7 +13,7 @@ class TypeParameterCommentRuleTest {
             """
             class Foo<in /* some comment */ Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 14, "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.")
     }
@@ -25,7 +25,7 @@ class TypeParameterCommentRuleTest {
             class Foo<in // some comment
             Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 14, "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.")
     }
@@ -53,7 +53,7 @@ class TypeParameterCommentRuleTest {
                 >
             class Foo2<Bar /* some comment */ >
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 9, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
@@ -70,7 +70,7 @@ class TypeParameterCommentRuleTest {
                 Bar>
             class FooBar2<Foo, /* some comment */ Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 10, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
@@ -14,7 +14,7 @@ class ValueArgumentCommentRuleTest {
                 bar /* some comment */ = "bar"
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         valueArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(2, 9, "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.")
     }
@@ -28,7 +28,7 @@ class ValueArgumentCommentRuleTest {
                     = "bar"
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         valueArgumentCommentRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(2, 9, "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.")
     }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
@@ -79,7 +79,7 @@ class ValueParameterCommentRuleTest {
                 val bar: /** some comment */ Bar
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(3, 9, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
@@ -102,7 +102,7 @@ class ValueParameterCommentRuleTest {
                 val bar: Bar /* some comment */
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracingTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracingTest.kt
@@ -61,7 +61,7 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
@@ -102,7 +102,7 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
@@ -146,7 +146,7 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
@@ -184,7 +184,7 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
@@ -121,7 +121,7 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
             .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")
@@ -136,7 +136,7 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
             .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
@@ -38,7 +38,7 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
@@ -109,7 +109,7 @@ class ImportOrderingRuleIdeaTest {
             import android.view.ViewGroup
             import java.util.List
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
@@ -146,7 +146,7 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F // comment 3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
             .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")


### PR DESCRIPTION
## Description

Improve wrapping of complicated lines where chained methods are combined with call expressions containing arguments that potentially are chained methods. Now that the rule execution order is changed to process all rules on the same AST Node, before proceeding to the next AST Node, it became possible to improve the wrapping of constructs like below.

```
// Assume that the last allowed character is
// at the X character on the right                        X
val foo = Bar.buildernnnnnnnnnnnnnnnnnnnnnnnnnnnnnn().baz(1).build()

val foo1 = requireNotNull(bar.filter { it == "bar" }) { "some message" }
val foo2 = requireNotNull(bar?.filter { it == "bar" }) { "some message" }
```

which is now formatted as:
```
// Assume that the last allowed character is
// at the X character on the right                        X
val foo =
    Bar
        .buildernnnnnnnnnnnnnnnnnnnnnnnnnnnnnn()
        .baz(1)
        .build()

val foo1 =
    requireNotNull(bar.filter { it == "bar" }) {
        "some message"
    }
val foo2 =
    requireNotNull(bar?.filter { it == "bar" }) {
        "some message"
    }
```

Closes #2451
## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
