### PR TITLE
Respect suppressions on "ktlint:standard:max-line-length"

### DIFF
--- a/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
+++ b/ktlint-cli-reporter-format/src/test/kotlin/com/pinterest/ktlint/cli/reporter/format/FormatReporterTest.kt
@@ -123,15 +123,15 @@ class FormatReporterTest {
     }
 
     companion object {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "some-rule", "This error can be autocorrected", LINT_CAN_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         val SOME_LINT_ERROR_CAN_NOT_BE_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", LINT_CAN_NOT_BE_AUTOCORRECTED)
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         val SOME_FORMAT_ERROR_IS_AUTOCORRECTED =
             KtlintCliError(1, 1, "rule-1", "This error can *not* be autocorrected", FORMAT_IS_AUTOCORRECTED)
 

--- a/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
+++ b/ktlint-cli-reporter-html/src/test/kotlin/com/pinterest/ktlint/cli/reporter/html/HtmlReporterTest.kt
@@ -157,16 +157,28 @@ class HtmlReporterTest {
         val out = ByteArrayOutputStream()
         val reporter = HtmlReporter(PrintStream(out, true))
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
-            KtlintCliError(1, 1, "rule-1", "Error message contains a generic type like List<Int> (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
+            KtlintCliError(
+                1,
+                1,
+                "rule-1",
+                "Error message contains a generic type like List<Int> (cannot be auto-corrected)",
+                LINT_CAN_BE_AUTOCORRECTED,
+            ),
         )
 
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "/file1.kt",
-            KtlintCliError(2, 1, "rule-2", "Error message contains special html symbols like a<b>c\"d'e&f (cannot be auto-corrected)", LINT_CAN_BE_AUTOCORRECTED),
+            KtlintCliError(
+                2,
+                1,
+                "rule-2",
+                "Error message contains special html symbols like a<b>c\"d'e&f (cannot be auto-corrected)",
+                LINT_CAN_BE_AUTOCORRECTED,
+            ),
         )
 
         reporter.afterAll()

--- a/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
+++ b/ktlint-cli-reporter-plain-summary/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainSummaryReporterTest.kt
@@ -70,15 +70,27 @@ class PlainSummaryReporterTest {
     fun `Report other violations`() {
         val out = ByteArrayOutputStream()
         val reporter = PlainSummaryReporter(PrintStream(out, true))
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-1.kt",
-            KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
+            KtlintCliError(
+                18,
+                51,
+                "",
+                "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()",
+                KOTLIN_PARSE_EXCEPTION,
+            ),
         )
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-2.kt",
-            KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
+            KtlintCliError(
+                18,
+                51,
+                "",
+                "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()",
+                KOTLIN_PARSE_EXCEPTION,
+            ),
         )
         @Suppress("ktlint:standard:argument-list-wrapping")
         reporter.onLintError(

--- a/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
+++ b/ktlint-cli-reporter-plain/src/test/kotlin/com/pinterest/ktlint/cli/reporter/plain/PlainReporterTest.kt
@@ -63,15 +63,27 @@ class PlainReporterTest {
     fun `Report other violations`() {
         val out = ByteArrayOutputStream()
         val reporter = PlainReporter(PrintStream(out, true))
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-1.kt",
-            KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
+            KtlintCliError(
+                18,
+                51,
+                "",
+                "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()",
+                KOTLIN_PARSE_EXCEPTION,
+            ),
         )
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         reporter.onLintError(
             "file-2.kt",
-            KtlintCliError(18, 51, "", "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()", KOTLIN_PARSE_EXCEPTION),
+            KtlintCliError(
+                18,
+                51,
+                "",
+                "Not a valid Kotlin file (18:51 unexpected tokens (use ';' to separate expressions on the same line)) (cannot be auto-corrected) ()",
+                KOTLIN_PARSE_EXCEPTION,
+            ),
         )
         @Suppress("ktlint:standard:argument-list-wrapping")
         reporter.onLintError(

--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -34,6 +34,7 @@ public final class com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionKt 
 	public static final fun getRecursiveChildren20 (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Lkotlin/sequences/Sequence;
 	public static final fun hasModifier (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;)Z
 	public static final fun hasNewLineInClosedRange (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
+	public static final fun hasNoMaxLineLengthSuppression (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z
 	public static final fun indent (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Z)Ljava/lang/String;
 	public static synthetic fun indent$default (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZILjava/lang/Object;)Ljava/lang/String;
 	public static final fun isCode (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;)Z

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -1,9 +1,12 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAL_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VARARG_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VAR_KEYWORD
@@ -24,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.psiUtil.leaves
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementType
 import org.jetbrains.kotlin.psi.stubs.elements.KtTokenSets
@@ -1136,3 +1140,18 @@ public fun ASTNode?.isDeclaration(): Boolean = isDeclaration20
  */
 public val ASTNode?.isDeclaration20: Boolean
     get(): Boolean = this != null && elementType in KtTokenSets.DECLARATION_TYPES
+
+/**
+ * Verified that the [ASTNode], nor any of its parents, is annotated with a suppression of the ktlint rule `max-line-length`.
+ */
+public fun ASTNode.hasNoMaxLineLengthSuppression(): Boolean =
+    parents()
+        .filter { it.elementType == MODIFIER_LIST }
+        .none { modifierList ->
+            modifierList
+                .findChildByType(ANNOTATION_ENTRY)
+                ?.findChildByType(VALUE_ARGUMENT_LIST)
+                ?.children20
+                ?.any { it.elementType == VALUE_ARGUMENT && it.text == "ktlint:standard:max-line-length" }
+                ?: false
+        }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtension.kt
@@ -1,8 +1,10 @@
 package com.pinterest.ktlint.rule.engine.core.api
 
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATED_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
@@ -1041,8 +1043,6 @@ public fun ASTNode.findChildByTypeRecursively(
 
 /**
  * Searches the receiver [ASTNode] recursively, returning the first child with type [elementType]. If none are found, returns `null`.
- * If [includeSelf] is `true`, includes the receiver in the search. The receiver would then be the first element searched, so it is
- * guaranteed to be returned if it has type [elementType].
  */
 public fun ASTNode.findChildByTypeRecursively(elementType: IElementType): ASTNode? =
     recursiveChildren20.firstOrNull { it.elementType == elementType }
@@ -1145,13 +1145,18 @@ public val ASTNode?.isDeclaration20: Boolean
  * Verified that the [ASTNode], nor any of its parents, is annotated with a suppression of the ktlint rule `max-line-length`.
  */
 public fun ASTNode.hasNoMaxLineLengthSuppression(): Boolean =
-    parents()
-        .filter { it.elementType == MODIFIER_LIST }
-        .none { modifierList ->
-            modifierList
-                .findChildByType(ANNOTATION_ENTRY)
-                ?.findChildByType(VALUE_ARGUMENT_LIST)
-                ?.children20
-                ?.any { it.elementType == VALUE_ARGUMENT && it.text == "ktlint:standard:max-line-length" }
-                ?: false
-        }
+    !isAnnotatedWithMaxLineLengthSuppression() &&
+        parents().none { it.isAnnotatedWithMaxLineLengthSuppression() }
+
+private fun ASTNode.isAnnotatedWithMaxLineLengthSuppression(): Boolean =
+    (elementType == ANNOTATED_EXPRESSION && containsMaxLineLengthSuppression()) ||
+        findChildByType(MODIFIER_LIST).containsMaxLineLengthSuppression() ||
+        (isRoot20 && findChildByType(FILE_ANNOTATION_LIST)?.containsMaxLineLengthSuppression() == true)
+
+private fun ASTNode?.containsMaxLineLengthSuppression(): Boolean =
+    this
+        ?.findChildByType(ANNOTATION_ENTRY)
+        ?.findChildByType(VALUE_ARGUMENT_LIST)
+        ?.children20
+        ?.any { it.elementType == VALUE_ARGUMENT && it.text == "\"ktlint:standard:max-line-length\"" }
+        ?: false

--- a/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
+++ b/ktlint-rule-engine-core/src/test/kotlin/com/pinterest/ktlint/rule/engine/core/api/ASTNodeExtensionTest.kt
@@ -17,6 +17,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.PRIVATE_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.THROW
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.TYPE_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
@@ -1141,6 +1142,129 @@ class ASTNodeExtensionTest {
         assertThat(actual.isPsiType<KtAnnotated>()).isTrue()
         assertThat(actual.findChildByType(CLASS_KEYWORD)!!.isPsiType<KtAnnotated>()).isFalse()
         assertThat(actual.findChildByType(IDENTIFIER)!!.isPsiType<KtAnnotated>()).isFalse()
+    }
+
+    @Nested
+    inner class HasNoMaxLineLengthSuppression {
+        val ktlintRuleEngine =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        RuleV2InstanceProvider { DummyRule() },
+                    ),
+            )
+
+        @Test
+        fun `Given an ASTNode, and all of its parents are not annotated with suppression then return true`() {
+            val code =
+                """
+                class Foo {
+                    fun bar() =
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = ktlintRuleEngine.transformToAst(Code.fromSnippet(code)).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isTrue()
+        }
+
+        @Test
+        fun `Given an ASTNode annotated with suppression for other rule than max-line-length, then return true`() {
+            val code =
+                """
+                class Foo {
+                    fun bar() =
+                         @Suppress("ktlint:standard:some-rule")
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = ktlintRuleEngine.transformToAst(Code.fromSnippet(code)).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isTrue()
+        }
+
+        @Test
+        fun `Given an expression annotated with suppression for max-line-length rule, then return false`() {
+            val code =
+                """
+                class Foo {
+                    fun bar() =
+                         @Suppress("ktlint:standard:max-line-length")
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = transformCodeToAST(code).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isFalse()
+        }
+
+        @Test
+        fun `Given an expression annotated with suppression for multiple rules including max-line-length rule, then return false`() {
+            val code =
+                """
+                class Foo {
+                    fun bar() =
+                         @Suppress("ktlint:standard:abc", "ktlint:standard:max-line-length", "ktlint:standard:xyz")
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = transformCodeToAST(code).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isFalse()
+        }
+
+        @Test
+        fun `Given an expression, for which a parent is annotated with suppression for max-line-length rule, then return false`() {
+            val code =
+                """
+                class Foo {
+                     @Suppress("ktlint:standard:max-line-length")
+                    fun bar() =
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = transformCodeToAST(code).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isFalse()
+        }
+
+        @Test
+        fun `Given an expression, for which a grandparent is annotated with suppression for max-line-length rule, then return false`() {
+            val code =
+                """
+                @Suppress("ktlint:standard:max-line-length")
+                class Foo {
+                    fun bar() =
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = transformCodeToAST(code).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isFalse()
+        }
+
+        @Test
+        fun `Given a file annotated with suppression for max-line-length rule, then return false`() {
+            val code =
+                """
+                @file:Suppress("ktlint:standard:max-line-length")
+
+                class Foo {
+                    fun bar() =
+                         throw RuntimeException("some very long message")
+                }
+                """.trimIndent()
+
+            val actual = transformCodeToAST(code).findChildByTypeRecursively(THROW)!!
+
+            assertThat(actual.hasNoMaxLineLengthSuppression()).isFalse()
+        }
     }
 
     private inline fun String.transformAst(block: FileASTNode.() -> Unit): FileASTNode =

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/SuppressionLocatorTest.kt
@@ -47,7 +47,7 @@ class SuppressionLocatorTest {
             """
             val foo = "foo" // ktlint-disable
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         assertThat(lint(code))
             .contains(
                 LintError(1, 5, STANDARD_NO_FOO_IDENTIFIER_RULE_ID, "Line should not contain a foo identifier", false),
@@ -342,9 +342,15 @@ class SuppressionLocatorTest {
                 @file:Suppress("ktlint:internal:ktlint-suppression")
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
-                LintError(1, 17, KTLINT_SUPPRESSION_RULE_ID, "Ktlint rule with id 'ktlint:internal:ktlint-suppression' is unknown or not loaded", false),
+                LintError(
+                    1,
+                    17,
+                    KTLINT_SUPPRESSION_RULE_ID,
+                    "Ktlint rule with id 'ktlint:internal:ktlint-suppression' is unknown or not loaded",
+                    false,
+                ),
             )
         }
 
@@ -355,10 +361,22 @@ class SuppressionLocatorTest {
                 /* ktlint-disable internal:ktlint-suppression */
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
-                LintError(1, 4, KTLINT_SUPPRESSION_RULE_ID, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation", true),
-                LintError(1, 19, KTLINT_SUPPRESSION_RULE_ID, "Ktlint rule with id 'internal:ktlint-suppression' is unknown or not loaded", false),
+                LintError(
+                    1,
+                    4,
+                    KTLINT_SUPPRESSION_RULE_ID,
+                    "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation",
+                    true,
+                ),
+                LintError(
+                    1,
+                    19,
+                    KTLINT_SUPPRESSION_RULE_ID,
+                    "Ktlint rule with id 'internal:ktlint-suppression' is unknown or not loaded",
+                    false,
+                ),
             )
         }
 
@@ -369,12 +387,24 @@ class SuppressionLocatorTest {
                 val foo = "foo" // ktlint-disable internal:ktlint-suppression
                 """.trimIndent()
             val actual = lint(code = code, ignoreKtlintSuppressionRule = false)
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             assertThat(actual).containsExactly(
                 lintError(1, 5, "standard:no-foo-identifier-standard"),
                 lintError(1, 5, "$NON_STANDARD_RULE_SET_ID:no-foo-identifier"),
-                LintError(1, 20, KTLINT_SUPPRESSION_RULE_ID, "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation", true),
-                LintError(1, 35, KTLINT_SUPPRESSION_RULE_ID, "Ktlint rule with id 'internal:ktlint-suppression' is unknown or not loaded", false),
+                LintError(
+                    1,
+                    20,
+                    KTLINT_SUPPRESSION_RULE_ID,
+                    "Directive 'ktlint-disable' is deprecated. Replace with @Suppress annotation",
+                    true,
+                ),
+                LintError(
+                    1,
+                    35,
+                    KTLINT_SUPPRESSION_RULE_ID,
+                    "Ktlint rule with id 'internal:ktlint-suppression' is unknown or not loaded",
+                    false,
+                ),
             )
         }
     }

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/internal/rules/KtlintSuppressionRuleTest.kt
@@ -1058,10 +1058,15 @@ class KtlintSuppressionRuleTest {
                     doSomething()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             ktlintSuppressionRuleAssertThat(code)
                 .hasLintViolations(
-                    LintViolation(2, 8, "Directive 'ktlint-disable' is deprecated. The matching 'ktlint-enable' directive is not found in same scope. Replace with @Suppress annotation", false),
+                    LintViolation(
+                        2,
+                        8,
+                        "Directive 'ktlint-disable' is deprecated. The matching 'ktlint-enable' directive is not found in same scope. Replace with @Suppress annotation",
+                        false,
+                    ),
                     LintViolation(6, 8, "Directive 'ktlint-enable' is obsolete after migrating to suppress annotations"),
                 ).isFormattedAs(formattedCode)
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
@@ -114,10 +115,8 @@ public class ArgumentListWrappingRule :
         if (textContains('\n')) return false
         require(this.elementType == VALUE_ARGUMENT_LIST)
         val stopAtLeaf = findChildByType(RPAR)?.firstChildLeafOrSelf20
-        return maxLineLength <
-            leavesOnLine20
-                .takeWhile { it.prevLeaf != stopAtLeaf }
-                .lineLength
+        return hasNoMaxLineLengthSuppression() &&
+            maxLineLength < leavesOnLine20.takeWhile { it.prevLeaf != stopAtLeaf }.lineLength
     }
 
     private fun intendedIndent(child: ASTNode): String =

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -28,6 +28,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isCode
 import com.pinterest.ktlint.rule.engine.core.api.isLeaf20
@@ -247,12 +248,14 @@ public class BinaryExpressionWrappingRule :
     private fun ASTNode.isOnLineExceedingMaxLineLength() = maxLineLength < leavesOnLine20.dropTrailingEolComment().lineLength
 
     private fun ASTNode.causesMaxLineLengthToBeExceeded() =
-        lastChildLeafOrSelf20.let { lastChildLeaf ->
-            leavesOnLine20
-                .dropTrailingEolComment()
-                .takeWhile { it.prevLeaf != lastChildLeaf }
-                .lineLength
-        } > maxLineLength
+        hasNoMaxLineLengthSuppression() &&
+            lastChildLeafOrSelf20
+                .let { lastChildLeaf ->
+                    leavesOnLine20
+                        .dropTrailingEolComment()
+                        .takeWhile { it.prevLeaf != lastChildLeaf }
+                        .lineLength
+                } > maxLineLength
 }
 
 private fun IElementType.anyOf(vararg elementType: IElementType): Boolean = elementType.contains(this)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRule.kt
@@ -245,7 +245,8 @@ public class BinaryExpressionWrappingRule :
             }
     }
 
-    private fun ASTNode.isOnLineExceedingMaxLineLength() = maxLineLength < leavesOnLine20.dropTrailingEolComment().lineLength
+    private fun ASTNode.isOnLineExceedingMaxLineLength() =
+        hasNoMaxLineLengthSuppression() && maxLineLength < leavesOnLine20.dropTrailingEolComment().lineLength
 
     private fun ASTNode.causesMaxLineLengthToBeExceeded() =
         hasNoMaxLineLengthSuppression() &&

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRule.kt
@@ -1,7 +1,7 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
-import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.ARROW
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
@@ -9,20 +9,24 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.LPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RBRACE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RPAR
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIST
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.RuleV2
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline20
 import com.pinterest.ktlint.rule.engine.core.api.lastChildLeafOrSelf20
@@ -36,6 +40,8 @@ import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceAfterMe
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.psi.psiUtil.parents
 
 @SinceKtlint("2.0", SinceKtlint.Status.EXPERIMENTAL)
 public class CallExpressionWrappingRule :
@@ -149,7 +155,8 @@ public class CallExpressionWrappingRule :
     }
 
     private fun ASTNode.exceedsMaxLineLength(stopAtLeaf: ASTNode): Boolean =
-        maxLineLength <
+        hasNoMaxLineLengthSuppression() &&
+            maxLineLength <
             leavesOnLine20
                 .dropTrailingEolComment()
                 .takeWhile { it.prevLeaf != stopAtLeaf }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt
@@ -39,6 +39,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isCode
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
@@ -245,10 +246,11 @@ public class ChainMethodContinuationRule :
                         .last()
                         .startOfLambdaArgumentInCallExpressionOrNull()
                         ?: lastChildLeafOrSelf20.nextLeaf
-                leavesOnLine20
-                    .dropTrailingEolComment()
-                    .takeWhile { it.prevLeaf != stopAtLeaf }
-                    .lineLength > maxLineLength
+                hasNoMaxLineLengthSuppression() &&
+                    leavesOnLine20
+                        .dropTrailingEolComment()
+                        .takeWhile { it.prevLeaf != stopAtLeaf }
+                        .lineLength > maxLineLength
             }
         }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -37,6 +37,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.hasModifier
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
@@ -188,7 +189,7 @@ public class ClassSignatureRule :
             actualClassSignatureLength +
                 // Calculate the white space correction in case the signature would be rewritten to a single line
                 fixWhiteSpacesInValueParameterList(node, emit, multiline = false, dryRun = true)
-        return length > maxLineLength
+        return node.hasNoMaxLineLengthSuppression() && length > maxLineLength
     }
 
     private fun ASTNode.classSignatureExcludingSuperTypesIsMultiline() =
@@ -598,7 +599,7 @@ public class ClassSignatureRule :
             actualClassSignatureLength +
                 // Calculate the white space correction in case the signature would be rewritten to a single line
                 fixWhiteSpacesInValueParameterList(node, emit, multiline = false, dryRun = true)
-        return length > maxLineLength
+        return node.hasNoMaxLineLengthSuppression() && length > maxLineLength
     }
 
     private fun ASTNode.hasMultilinePrimaryConstructor() =

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -163,7 +163,11 @@ public class ClassSignatureRule :
             node.hasTooManyParameters() ||
                 node.containsMultilineParameter() ||
                 (codeStyle == ktlint_official && node.containsAnnotatedParameter()) ||
-                (isMaxLineLengthSet() && classSignatureExcludingSuperTypesExceedsMaxLineLength(node, emit)) ||
+                (
+                    isMaxLineLengthSet() &&
+                        node.hasNoMaxLineLengthSuppression() &&
+                        classSignatureExcludingSuperTypesExceedsMaxLineLength(node, emit)
+                ) ||
                 (!isMaxLineLengthSet() && node.classSignatureExcludingSuperTypesIsMultiline()) ||
                 node.containsEolComment()
         fixWhiteSpacesInValueParameterList(node, emit, multiline = wrapPrimaryConstructorParameters, dryRun = false)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverListWrappingRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
@@ -106,6 +107,7 @@ public class ContextReceiverListWrappingRule :
 
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run before indenting.
         if (!node.textContains('\n') &&
+            node.hasNoMaxLineLengthSuppression() &&
             node.indentWithoutNewlinePrefix.length + node.textLength > maxLineLength
         ) {
             node
@@ -158,6 +160,7 @@ public class ContextReceiverListWrappingRule :
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run
         // before indenting.
         if (!contextReceiverText.contains('\n') &&
+            node.hasNoMaxLineLengthSuppression() &&
             node.indentWithoutNewlinePrefix.length + contextReceiverText.length > maxLineLength
         ) {
             node

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRule.kt
@@ -23,6 +23,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
@@ -107,6 +108,7 @@ public class ContextReceiverWrappingRule :
 
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run before indenting.
         if (!node.textContains('\n') &&
+            node.hasNoMaxLineLengthSuppression() &&
             node.indentWithoutNewlinePrefix.length + node.textLength > maxLineLength
         ) {
             node
@@ -157,6 +159,7 @@ public class ContextReceiverWrappingRule :
         // Check line length assuming that the context receiver is indented correctly. Wrapping rule must however run
         // before indenting.
         if (!contextReceiverText.contains('\n') &&
+            node.hasNoMaxLineLengthSuppression() &&
             node.indentWithoutNewlinePrefix.length + contextReceiverText.length > maxLineLength
         ) {
             node

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionExpressionBodyRule.kt
@@ -22,7 +22,6 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERT
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -72,7 +71,6 @@ public class FunctionExpressionBodyRule :
                 CODE_STYLE_PROPERTY,
                 INDENT_SIZE_PROPERTY,
                 INDENT_STYLE_PROPERTY,
-                MAX_LINE_LENGTH_PROPERTY,
             ),
     ) {
     private var codeStyle = CODE_STYLE_PROPERTY.defaultValue

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRule.kt
@@ -28,6 +28,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.findParentByType
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -171,7 +172,7 @@ public class FunctionLiteralRule :
                 .plus(1) // space before parameter list
                 .plus(lengthOfParameterListWhenOnSingleLine())
                 .plus(3) // space after parameter list followed by ->
-        return lineLength > maxLineLength
+        return hasNoMaxLineLengthSuppression() && lineLength > maxLineLength
     }
 
     private fun ASTNode.lineLengthIncludingLbrace(): Int {
@@ -203,7 +204,8 @@ public class FunctionLiteralRule :
     private fun ASTNode.exceedsMaxLineLength(): Boolean {
         require(elementType == BLOCK)
         val stopAtLeaf = nextSibling { it.elementType == RBRACE }
-        return maxLineLength <
+        return hasNoMaxLineLengthSuppression() &&
+            maxLineLength <
             leavesOnLine20
                 .dropTrailingEolComment()
                 .takeWhile { it.prevLeaf != stopAtLeaf }
@@ -211,7 +213,7 @@ public class FunctionLiteralRule :
     }
 
     private fun ASTNode.wrapFirstParameterToNewline() =
-        if (isFunctionLiteralLambdaWithNonEmptyValueParameterList()) {
+        if (isFunctionLiteralLambdaWithNonEmptyValueParameterList() && hasNoMaxLineLengthSuppression()) {
             // Disallow when max line is exceeded:
             //    val foo = someCallExpression { someLongParameterName ->
             //        bar()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -203,7 +203,8 @@ public class FunctionSignatureRule :
             //     ): SomeVeryLongTypeName =
             //         SomeVeryLongTypeName(...)
             // Leave it up to the max-line-length rule to detect those violations so that the developer can handle it manually.
-            val rewriteFunctionSignatureWithParameters = node.countParameters() > 0 && singleLineFunctionSignatureLength > maxLineLength
+            val rewriteFunctionSignatureWithParameters =
+                node.countParameters() > 0 && (node.hasNoMaxLineLengthSuppression() && singleLineFunctionSignatureLength > maxLineLength)
             if (forceMultilineSignature || rewriteFunctionSignatureWithParameters) {
                 fixWhiteSpacesInValueParameterList(node, emit, multiline = true, dryRun = false)
                 if (node.findChildByType(EQ) == null) {
@@ -384,7 +385,7 @@ public class FunctionSignatureRule :
                     if (whiteSpaceBeforeIdentifier == null ||
                         whiteSpaceBeforeIdentifier.text != expectedParameterIndent
                     ) {
-                        if (!dryRun && node.hasNoMaxLineLengthSuppression()) {
+                        if (!dryRun) {
                             emit(
                                 firstParameterInList.startOffset,
                                 "Newline expected after opening parenthesis",
@@ -496,7 +497,7 @@ public class FunctionSignatureRule :
                     if (whiteSpaceBeforeClosingParenthesis == null ||
                         whiteSpaceBeforeClosingParenthesis.text != newlineAndIndent
                     ) {
-                        if (!dryRun && valueParameterList.hasNoMaxLineLengthSuppression()) {
+                        if (!dryRun) {
                             emit(
                                 closingParenthesis!!.startOffset,
                                 "Newline expected before closing parenthesis",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRule.kt
@@ -35,6 +35,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPE
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
@@ -383,7 +384,7 @@ public class FunctionSignatureRule :
                     if (whiteSpaceBeforeIdentifier == null ||
                         whiteSpaceBeforeIdentifier.text != expectedParameterIndent
                     ) {
-                        if (!dryRun) {
+                        if (!dryRun && node.hasNoMaxLineLengthSuppression()) {
                             emit(
                                 firstParameterInList.startOffset,
                                 "Newline expected after opening parenthesis",
@@ -442,7 +443,7 @@ public class FunctionSignatureRule :
                             if (whiteSpaceBeforeIdentifier == null ||
                                 whiteSpaceBeforeIdentifier.text != expectedParameterIndent
                             ) {
-                                if (!dryRun) {
+                                if (!dryRun && valueParameterList.hasNoMaxLineLengthSuppression()) {
                                     emit(
                                         valueParameter.startOffset,
                                         "Parameter should start on a newline",
@@ -495,7 +496,7 @@ public class FunctionSignatureRule :
                     if (whiteSpaceBeforeClosingParenthesis == null ||
                         whiteSpaceBeforeClosingParenthesis.text != newlineAndIndent
                     ) {
-                        if (!dryRun) {
+                        if (!dryRun && valueParameterList.hasNoMaxLineLengthSuppression()) {
                             emit(
                                 closingParenthesis!!.startOffset,
                                 "Newline expected before closing parenthesis",
@@ -598,7 +599,11 @@ public class FunctionSignatureRule :
                                     .upsertWhitespaceBeforeMe(" ")
                             }
                         }
-                    } else if (firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression ||
+                    } else if (
+                        (
+                            node.hasNoMaxLineLengthSuppression() &&
+                                firstLineOfBodyExpression.length + 1 > maxLengthRemainingForFirstLineOfBodyExpression
+                        ) ||
                         (functionBodyExpressionWrapping == multiline && functionBodyExpressionLines.size > 1) ||
                         functionBodyExpressionWrapping == always
                     ) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -18,7 +18,6 @@ import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -305,7 +304,7 @@ public class ParameterListSpacingRule :
                             .leavesOnLine20
                             .dropTrailingEolComment()
                             .lineLength
-                hasNoMaxLineLengthSuppression() && length > maxLineLength
+                length > maxLineLength
             }
             ?: false
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListSpacingRule.kt
@@ -18,6 +18,7 @@ import com.pinterest.ktlint.rule.engine.core.api.children20
 import com.pinterest.ktlint.rule.engine.core.api.dropTrailingEolComment
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace20
@@ -304,7 +305,7 @@ public class ParameterListSpacingRule :
                             .leavesOnLine20
                             .dropTrailingEolComment()
                             .lineLength
-                length > maxLineLength
+                hasNoMaxLineLengthSuppression() && length > maxLineLength
             }
             ?: false
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -27,6 +27,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.isPartOfComment20
@@ -93,6 +94,7 @@ public class ParameterListWrappingRule :
     ) {
         require(node.elementType == NULLABLE_TYPE)
         node
+            .takeIf { it.hasNoMaxLineLengthSuppression() }
             .takeUnless {
                 // skip when max line length is not exceeded
                 (node.column - 1 + node.textLength) <= maxLineLength

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRule.kt
@@ -323,17 +323,20 @@ public class ParameterListWrappingRule :
                 ?.parent
                 ?.elementType
 
-    private fun ASTNode.isOnLineExceedingMaxLineLength(): Boolean {
-        val stopLeaf = nextLeaf { it.isWhiteSpaceWithNewline20 }?.nextLeaf
-        val lineContent =
-            leavesOnLine20
-                .dropTrailingEolComment()
-                .takeWhile { it.prevLeaf != stopLeaf }
-                .joinToString(separator = "") { it.text }
-                .substringAfter('\n')
-                .substringBefore('\n')
-        return lineContent.length > maxLineLength
-    }
+    private fun ASTNode.isOnLineExceedingMaxLineLength(): Boolean =
+        if (hasNoMaxLineLengthSuppression()) {
+            val stopLeaf = nextLeaf { it.isWhiteSpaceWithNewline20 }?.nextLeaf
+            val lineContent =
+                leavesOnLine20
+                    .dropTrailingEolComment()
+                    .takeWhile { it.prevLeaf != stopLeaf }
+                    .joinToString(separator = "") { it.text }
+                    .substringAfter('\n')
+                    .substringBefore('\n')
+            lineContent.length > maxLineLength
+        } else {
+            false
+        }
 
     private fun errorMessage(node: ASTNode) =
         when (node.elementType) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRule.kt
@@ -20,6 +20,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
@@ -100,7 +101,7 @@ public class ParameterWrappingRule :
         node
             .findChildByType(COLON)
             ?.let { colon ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(colon) > maxLineLength) {
+                if (colon.hasNoMaxLineLengthSuppression() && baseIndentLength + fromNode.sumOfTextLengthUntil(colon) > maxLineLength) {
                     fromNode.sumOfTextLengthUntil(colon)
                     requireNewlineAfterLeaf(colon, emit)
                     return
@@ -110,7 +111,9 @@ public class ParameterWrappingRule :
         node
             .findChildByType(TYPE_REFERENCE)
             ?.let { typeReference ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(typeReference.orTrailingComma()) > maxLineLength) {
+                if (typeReference.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(typeReference.orTrailingComma()) > maxLineLength
+                ) {
                     requireNewlineBeforeLeaf(typeReference, emit)
                     return
                 }
@@ -119,7 +122,9 @@ public class ParameterWrappingRule :
         node
             .findChildByType(EQ)
             ?.let { equal ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(equal.orTrailingComma()) > maxLineLength) {
+                if (equal.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(equal.orTrailingComma()) > maxLineLength
+                ) {
                     requireNewlineAfterLeaf(equal, emit)
                     return
                 }
@@ -128,7 +133,9 @@ public class ParameterWrappingRule :
         node
             .findChildByType(CALL_EXPRESSION)
             ?.let { callExpression ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(callExpression.orTrailingComma()) > maxLineLength) {
+                if (callExpression.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(callExpression.orTrailingComma()) > maxLineLength
+                ) {
                     requireNewlineBeforeLeaf(callExpression, emit)
                     return
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRule.kt
@@ -18,6 +18,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPER
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indentWithoutNewlinePrefix
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpaceWithNewline20
@@ -96,7 +97,9 @@ public class PropertyWrappingRule :
         node
             .findChildByType(COLON)
             ?.let { colon ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(colon) > maxLineLength) {
+                if (colon.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(colon) > maxLineLength
+                ) {
                     fromNode.sumOfTextLengthUntil(colon)
                     requireNewlineAfterLeaf(colon, emit)
                     return
@@ -106,7 +109,9 @@ public class PropertyWrappingRule :
         node
             .findChildByType(TYPE_REFERENCE)
             ?.let { typeReference ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(typeReference) > maxLineLength) {
+                if (typeReference.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(typeReference) > maxLineLength
+                ) {
                     requireNewlineBeforeLeaf(typeReference, emit)
                     return
                 }
@@ -115,7 +120,7 @@ public class PropertyWrappingRule :
         node
             .findChildByType(EQ)
             ?.let { equal ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(equal) > maxLineLength) {
+                if (equal.hasNoMaxLineLengthSuppression() && baseIndentLength + fromNode.sumOfTextLengthUntil(equal) > maxLineLength) {
                     requireNewlineAfterLeaf(equal, emit)
                     return
                 }
@@ -124,7 +129,9 @@ public class PropertyWrappingRule :
         node
             .findChildByType(CALL_EXPRESSION)
             ?.let { callExpression ->
-                if (baseIndentLength + fromNode.sumOfTextLengthUntil(callExpression) > maxLineLength) {
+                if (callExpression.hasNoMaxLineLengthSuppression() &&
+                    baseIndentLength + fromNode.sumOfTextLengthUntil(callExpression) > maxLineLength
+                ) {
                     requireNewlineBeforeLeaf(callExpression, emit)
                     return
                 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRule.kt
@@ -56,6 +56,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PR
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY_OFF
 import com.pinterest.ktlint.rule.engine.core.api.firstChildLeafOrSelf20
 import com.pinterest.ktlint.rule.engine.core.api.hasNewLineInClosedRange
+import com.pinterest.ktlint.rule.engine.core.api.hasNoMaxLineLengthSuppression
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent20
 import com.pinterest.ktlint.rule.engine.core.api.isPartOf
@@ -170,7 +171,7 @@ public class WrappingRule :
                 }
             }
 
-        if (maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF) {
+        if (maxLineLength != MAX_LINE_LENGTH_PROPERTY_OFF && node.hasNoMaxLineLengthSuppression()) {
             val lengthUntilBeginOfLine =
                 node
                     .leaves(false)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -258,7 +258,7 @@ class AnnotationRuleTest {
                 val baz: Any
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         annotationRuleAssertThat(code)
             .withEditorConfigOverride(ANNOTATIONS_WITH_PARAMETERS_NOT_TO_BE_WRAPPED_PROPERTY to "Baz")
             .hasLintViolations(
@@ -414,7 +414,7 @@ class AnnotationRuleTest {
 
                 package foo.bar
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .hasLintViolations(
                     LintViolation(1, 26, "Expected newline after last annotation"),
@@ -772,7 +772,7 @@ class AnnotationRuleTest {
                     String
                 > = FooBar()
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             annotationRuleAssertThat(code)
                 .addAdditionalRuleProvider { IndentationRule() }
                 .addAdditionalRuleProvider { WrappingRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -1268,4 +1268,34 @@ class ArgumentListWrappingRuleTest {
             }
         }
     }
+
+    @Test
+    fun `Given some argument lists that exceeds the max line length, but the max-line-length is suppressed then do not reformat the declaration on which it is suppressed`() {
+        val code =
+            """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+            @Suppress("ktlint:standard:max-line-length")
+            val foo1 = listOf("aaa", "bbb", "ccc")
+            val foo2 = listOf("aaa", "bbb", "ccc")
+            """.trimIndent()
+        val formattedCode =
+            """
+            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
+            @Suppress("ktlint:standard:max-line-length")
+            val foo1 = listOf("aaa", "bbb", "ccc")
+            val foo2 = listOf(
+                "aaa",
+                "bbb",
+                "ccc"
+            )
+            """.trimIndent()
+        argumentListWrappingRuleAssertThat(code)
+            .setMaxLineLength()
+            .hasLintViolations(
+                LintViolation(4, 19, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(4, 26, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(4, 33, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(4, 38, "Missing newline before \")\""),
+            ).isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ArgumentListWrappingRuleTest.kt
@@ -39,7 +39,7 @@ class ArgumentListWrappingRuleTest {
                 c
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         argumentListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 8, "Argument should be on a separate line (unless all arguments can fit a single line)")
             .isFormattedAs(formattedCode)
@@ -326,7 +326,7 @@ class ArgumentListWrappingRuleTest {
                     "some message"
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         argumentListWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { CallExpressionWrappingRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BackingPropertyNamingRuleTest.kt
@@ -86,10 +86,14 @@ class BackingPropertyNamingRuleTest {
                             get() = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        2,
+                        17,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -110,10 +114,14 @@ class BackingPropertyNamingRuleTest {
                             get() = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        2,
+                        17,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -207,10 +215,14 @@ class BackingPropertyNamingRuleTest {
                         $modifier fun getElementList(): List<Element> = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        2,
+                        17,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -230,10 +242,14 @@ class BackingPropertyNamingRuleTest {
                         $modifier fun getElementList(): List<Element> = _elementList
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        2,
+                        17,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -268,9 +284,13 @@ class BackingPropertyNamingRuleTest {
                         fun getElementList(bar: String): List<Element> = _elementList + bar
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
-                    .hasLintViolationWithoutAutoCorrect(2, 17, "Backing property is only allowed when a matching property or function exists")
+                    .hasLintViolationWithoutAutoCorrect(
+                        2,
+                        17,
+                        "Backing property is only allowed when a matching property or function exists",
+                    )
             }
         }
     }
@@ -353,10 +373,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        6,
+                        21,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -379,10 +403,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(6, 21, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        6,
+                        21,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -486,10 +514,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        21,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -511,10 +543,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        21,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -553,9 +589,13 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
-                    .hasLintViolationWithoutAutoCorrect(5, 21, "Backing property is only allowed when a matching property or function exists")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        21,
+                        "Backing property is only allowed when a matching property or function exists",
+                    )
             }
         }
     }
@@ -638,10 +678,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        6,
+                        13,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -664,10 +708,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(6, 13, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        6,
+                        13,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -771,10 +819,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        13,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -796,10 +848,14 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
                     .withEditorConfigOverride(CODE_STYLE_PROPERTY to intellij_idea)
-                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when the matching property or function is public")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        13,
+                        "Backing property is only allowed when the matching property or function is public",
+                    )
             }
 
             @ParameterizedTest(name = "Modifier: {0}")
@@ -838,9 +894,13 @@ class BackingPropertyNamingRuleTest {
                         }
                     }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 backingPropertyNamingRuleAssertThat(code)
-                    .hasLintViolationWithoutAutoCorrect(5, 13, "Backing property is only allowed when a matching property or function exists")
+                    .hasLintViolationWithoutAutoCorrect(
+                        5,
+                        13,
+                        "Backing property is only allowed when a matching property or function exists",
+                    )
             }
         }
     }
@@ -906,12 +966,22 @@ class BackingPropertyNamingRuleTest {
                     get() = _elementList2
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         backingPropertyNamingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(3, 17, "Backing property is only allowed when a matching property or function exists", canBeAutoCorrected = false),
+                LintViolation(
+                    3,
+                    17,
+                    "Backing property is only allowed when a matching property or function exists",
+                    canBeAutoCorrected = false,
+                ),
                 LintViolation(7, 9, "Backing property not allowed when 'private' modifier is missing", canBeAutoCorrected = false),
-                LintViolation(14, 17, "Backing property is only allowed when the matching property or function is public", canBeAutoCorrected = false),
+                LintViolation(
+                    14,
+                    17,
+                    "Backing property is only allowed when the matching property or function is public",
+                    canBeAutoCorrected = false,
+                ),
             )
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionWrappingRuleTest.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.test.KtLintAssertThat.Companion.MAX_LINE_LENGTH_MARK
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.LintViolation
 import com.pinterest.ktlint.test.MULTILINE_STRING_QUOTE
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class BinaryExpressionWrappingRuleTest {
@@ -18,21 +19,25 @@ class BinaryExpressionWrappingRuleTest {
         val code =
             """
             // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
-            val bar = leftHandSideExpression && rightHandSideExpression
+            val bar1 = leftHandSideExpression && rightHandSideExpression
+            @Suppress("ktlint:standard:max-line-length")
+            val bar2 = leftHandSideExpression && rightHandSideExpression
             """.trimIndent()
         val formattedCode =
             """
             // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
-            val bar =
+            val bar1 =
                 leftHandSideExpression && rightHandSideExpression
+            @Suppress("ktlint:standard:max-line-length")
+            val bar2 = leftHandSideExpression && rightHandSideExpression
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(2, 11, "Line is exceeding max line length. Break line between assignment and expression"),
+                LintViolation(2, 12, "Line is exceeding max line length. Break line between assignment and expression"),
                 // Next violation only happens during linting. When formatting the violation does not occur because fix of previous
                 // violation prevent that the remainder of the line exceeds the maximum
-                LintViolation(2, 36, "Line is exceeding max line length. Break line after '&&' in binary expression"),
+                LintViolation(2, 37, "Line is exceeding max line length. Break line after '&&' in binary expression"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -207,6 +212,9 @@ class BinaryExpressionWrappingRuleTest {
 
             val foo2 = foo() ?: "foooooooooooooooooo" +
                     "bar"
+            @Suppress("ktlint:standard:max-line-length")
+            val foo3 = foo() ?: "foooooooooooooooooo" +
+                    "bar"
             """.trimIndent()
         val formattedCode =
             """
@@ -220,6 +228,9 @@ class BinaryExpressionWrappingRuleTest {
             val foo2 =
                 foo()
                     ?: "foooooooooooooooooo" +
+                    "bar"
+            @Suppress("ktlint:standard:max-line-length")
+            val foo3 = foo() ?: "foooooooooooooooooo" +
                     "bar"
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
@@ -256,6 +267,8 @@ class BinaryExpressionWrappingRuleTest {
             val foobar2 = Foo(bar(1 * 2 * 3))
             val foobar3 = Foo(bar("bar" + "bazzzzzzzzzzz"))
             val foobar4 = Foo(bar("bar" + "bazzzzzzzzzzzz"))
+            @Suppress("ktlint:standard:max-line-length")
+            val foobar5 = Foo(bar("bar" + "bazzzzzzzzzzzz"))
             """.trimIndent()
         val formattedCode =
             """
@@ -277,6 +290,8 @@ class BinaryExpressionWrappingRuleTest {
                         "bazzzzzzzzzzzz"
                 )
             )
+            @Suppress("ktlint:standard:max-line-length")
+            val foobar5 = Foo(bar("bar" + "bazzzzzzzzzzzz"))
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .addAdditionalRuleProvider { ArgumentListWrappingRule() }
@@ -320,6 +335,8 @@ class BinaryExpressionWrappingRuleTest {
             val foo1 = foobar(foo * bar) + "foo"
             val foo2 = foobar("foo", foo * bar) + "foo"
             val foo3 = foobar("fooo", foo * bar) + "foo"
+            @Suppress("ktlint:standard:max-line-length")
+            val foo4 = foobar("fooo", foo * bar) + "foo"
             """.trimIndent()
         val formattedCode =
             """
@@ -330,6 +347,8 @@ class BinaryExpressionWrappingRuleTest {
             val foo3 =
                 foobar("fooo", foo * bar) +
                     "foo"
+            @Suppress("ktlint:standard:max-line-length")
+            val foo4 = foobar("fooo", foo * bar) + "foo"
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -412,18 +431,22 @@ class BinaryExpressionWrappingRuleTest {
     fun `Issue 2462 - Given a call expression with value argument list inside a binary expression, then first wrap the binary expression`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
             fun foo() {
-                every { foo.bar(bazbazbazbazbazbazbazbazbaz) } returns bar
+                every { foo1.bar(bazbazbazbazbazbazbazbazbaz) } returns bar
+                @Suppress("ktlint:standard:max-line-length")
+                every { foo2.bar(bazbazbazbazbazbazbazbazbaz) } returns bar
             }
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // $MAX_LINE_LENGTH_MARKER                  $EOL_CHAR
             fun foo() {
                 every {
-                    foo.bar(bazbazbazbazbazbazbazbazbaz)
+                    foo1.bar(bazbazbazbazbazbazbazbazbaz)
                 } returns bar
+                @Suppress("ktlint:standard:max-line-length")
+                every { foo2.bar(bazbazbazbazbazbazbazbazbaz) } returns bar
             }
             """.trimIndent()
         binaryExpressionWrappingRuleAssertThat(code)
@@ -434,14 +457,14 @@ class BinaryExpressionWrappingRuleTest {
             // wrapping of the braces of the function literal by the BinaryExpressionWrapping prevents those violations from occurring.
             .hasLintViolationsForAdditionalRule(
                 LintViolation(3, 12, "Missing newline after \"{\""),
-                LintViolation(3, 21, "Argument should be on a separate line (unless all arguments can fit a single line)"),
-                LintViolation(3, 45, "Exceeded max line length (44)", canBeAutoCorrected = false),
-                LintViolation(3, 48, "Missing newline before \")\""),
+                LintViolation(3, 22, "Argument should be on a separate line (unless all arguments can fit a single line)"),
+                LintViolation(3, 46, "Exceeded max line length (45)", canBeAutoCorrected = false),
+                LintViolation(3, 49, "Missing newline before \")\""),
             ).hasLintViolations(
                 LintViolation(3, 12, "Newline expected after '{'"),
-                LintViolation(3, 50, "Newline expected before '}'"),
+                LintViolation(3, 51, "Newline expected before '}'"),
                 // Lint violation below only occurs during linting. Resolving violations above, prevents the next violation from occurring
-                LintViolation(3, 59, "Line is exceeding max line length. Break line after 'returns' in binary expression"),
+                LintViolation(3, 60, "Line is exceeding max line length. Break line after 'returns' in binary expression"),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditionsTest.kt
@@ -59,7 +59,7 @@ class BlankLineBetweenWhenConditionsTest {
                     else -> null
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         blankLineAfterWhenConditionRuleAssertThat(code)
             .hasLintViolations(
                 LintViolation(4, 1, "Unexpected blank lines between when-condition if all when-conditions are single lines"),
@@ -95,11 +95,19 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
-                        LintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
-                        LintViolation(6, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
+                        LintViolation(
+                            4,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
+                        LintViolation(
+                            6,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
                     ).isFormattedAs(formattedCode)
             }
 
@@ -127,11 +135,19 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
-                        LintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
-                        LintViolation(5, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
+                        LintViolation(
+                            4,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
+                        LintViolation(
+                            5,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
                     ).isFormattedAs(formattedCode)
             }
 
@@ -163,11 +179,19 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .hasLintViolations(
-                        LintViolation(5, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
-                        LintViolation(7, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement"),
+                        LintViolation(
+                            5,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
+                        LintViolation(
+                            7,
+                            1,
+                            "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                        ),
                     ).isFormattedAs(formattedCode)
             }
 
@@ -194,10 +218,13 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
-                    .hasLintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement")
-                    .isFormattedAs(formattedCode)
+                    .hasLintViolation(
+                        4,
+                        1,
+                        "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                    ).isFormattedAs(formattedCode)
             }
 
             @Test
@@ -221,10 +248,13 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
-                    .hasLintViolation(4, 1, "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement")
-                    .isFormattedAs(formattedCode)
+                    .hasLintViolation(
+                        4,
+                        1,
+                        "Add a blank line between all when-conditions in case at least one multiline when-condition is found in the statement",
+                    ).isFormattedAs(formattedCode)
             }
         }
 
@@ -242,7 +272,7 @@ class BlankLineBetweenWhenConditionsTest {
                             else -> null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()
@@ -260,7 +290,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()
@@ -278,7 +308,7 @@ class BlankLineBetweenWhenConditionsTest {
                                 null
                         }
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 blankLineAfterWhenConditionRuleAssertThat(code)
                     .withEditorConfigOverride(LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to false)
                     .hasNoLintViolations()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
@@ -114,23 +114,27 @@ class CallExpressionWrappingRuleTest {
     fun `Given a single line call expression with argument in the reference expression which does not fits on the line then wrap after opening parenthesis of the reference expression`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-            val foo = bar("foobarrrrrrrrrrrr") { "some message" }
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            val foo1 = bar("foobarrrrrrrrrrrr") { "some message" }
+            @Suppress("ktlint:standard:max-line-length")
+            val foo2 = bar("foobarrrrrrrrrrrr") { "some message" }
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-            val foo = bar(
+            // $MAX_LINE_LENGTH_MARKER       $EOL_CHAR
+            val foo1 = bar(
                 "foobarrrrrrrrrrrr"
             ) { "some message" }
+            @Suppress("ktlint:standard:max-line-length")
+            val foo2 = bar("foobarrrrrrrrrrrr") { "some message" }
             """.trimIndent()
         callExpressionWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(2, 14, "Expected new line after '('"),
-                LintViolation(2, 34, "Expected new line before ')'"),
-                LintViolation(2, 36, "Expected new line after '{'"),
-                LintViolation(2, 53, "Expected new line before '}'"),
+                LintViolation(2, 15, "Expected new line after '('"),
+                LintViolation(2, 35, "Expected new line before ')'"),
+                LintViolation(2, 37, "Expected new line after '{'"),
+                LintViolation(2, 54, "Expected new line before '}'"),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRuleTest.kt
@@ -66,22 +66,26 @@ class ChainMethodContinuationRuleTest {
     fun `Given that maximum line length is set, and a single line method chain does exceed the maximum line length then wrap`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER                           $EOL_CHAR
-            val foo = "foo".filter { it.isUpperCase() }.lowercase()
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            val foo1 = "foo".filter { it.isUpperCase() }.lowercase()
+            @Suppress("ktlint:standard:max-line-length")
+            val foo2 = "foo".filter { it.isUpperCase() }.lowercase()
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER                           $EOL_CHAR
-            val foo = "foo"
+            // $MAX_LINE_LENGTH_MARKER                            $EOL_CHAR
+            val foo1 = "foo"
                 .filter { it.isUpperCase() }
                 .lowercase()
+            @Suppress("ktlint:standard:max-line-length")
+            val foo2 = "foo".filter { it.isUpperCase() }.lowercase()
             """.trimIndent()
         chainMethodContinuationRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(2, 16, "Expected newline before '.'"),
+                LintViolation(2, 17, "Expected newline before '.'"),
                 // During formatting this violation will not occur due to wrapping of previous chain operators
-                LintViolation(2, 44, "Expected newline before '.'"),
+                LintViolation(2, 45, "Expected newline before '.'"),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassNamingRuleTest.kt
@@ -35,7 +35,7 @@ class ClassNamingRuleTest {
                 """
                 class $className
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             classNamingRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
         }
@@ -48,9 +48,13 @@ class ClassNamingRuleTest {
                     """
                     class `foo`
                     """.trimIndent()
-                @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+                @Suppress("ktlint:standard:max-line-length")
                 classNamingRuleAssertThat(code)
-                    .hasLintViolationWithoutAutoCorrect(1, 7, "Class or object name should start with an uppercase letter and use camel case")
+                    .hasLintViolationWithoutAutoCorrect(
+                        1,
+                        7,
+                        "Class or object name should start with an uppercase letter and use camel case",
+                    )
             }
 
             @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -121,25 +121,30 @@ class ClassSignatureRuleTest {
     fun `Given a single line class signature, without class body, which is greater then the max line length then reformat to a multiline signature`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-            class Foo(a: Any, b: Any, c: Any)
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo1(a: Any, b: Any, c: Any)
+            @Suppress("ktlint:standard:max-line-length")
+            class Foo2(a: Any, b: Any, c: Any)
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-            class Foo(
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            class Foo1(
                 a: Any,
                 b: Any,
                 c: Any
             )
+            @Suppress("ktlint:standard:max-line-length")
+            class Foo2(a: Any, b: Any, c: Any)
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to 4)
             .hasLintViolations(
-                LintViolation(2, 11, "Newline expected after opening parenthesis"),
-                LintViolation(2, 19, "Parameter should start on a newline"),
-                LintViolation(2, 27, "Parameter should start on a newline"),
-                LintViolation(2, 33, "Newline expected before closing parenthesis"),
+                LintViolation(2, 12, "Newline expected after opening parenthesis"),
+                LintViolation(2, 20, "Parameter should start on a newline"),
+                LintViolation(2, 28, "Parameter should start on a newline"),
+                LintViolation(2, 34, "Newline expected before closing parenthesis"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -739,19 +744,23 @@ class ClassSignatureRuleTest {
     fun `Given a single line class signature extending another class, the primary constructor fitting on a single line but not together with the super type then wrap the super type`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
-            class Foo(a: Any, b: Any, c: Any) : FooBar(a, c)
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            class Foo1(a: Any, b: Any, c: Any) : FooBar(a, c)
+            @Suppress("ktlint:standard:max-line-length")
+            class Foo2(a: Any, b: Any, c: Any) : FooBar(a, c)
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
-            class Foo(a: Any, b: Any, c: Any) :
+            // $MAX_LINE_LENGTH_MARKER                     $EOL_CHAR
+            class Foo1(a: Any, b: Any, c: Any) :
                 FooBar(a, c)
+            @Suppress("ktlint:standard:max-line-length")
+            class Foo2(a: Any, b: Any, c: Any) : FooBar(a, c)
             """.trimIndent()
         classSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
-            .hasLintViolation(2, 37, "Super type should start on a newline")
+            .hasLintViolation(2, 38, "Super type should start on a newline")
             .isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -579,7 +579,7 @@ class ClassSignatureRuleTest {
                 class Foo23<M : Map<Any, Any>>(map: M)
                 class Foo24<M : Map<Any, Any>>(map: M)
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             classSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProviders(
                     { NoMultipleSpacesRule() },

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentWrappingRuleTest.kt
@@ -93,9 +93,13 @@ class CommentWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 17, "A block comment after any other element on the same line must be separated by a new line")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                17,
+                "A block comment after any other element on the same line must be separated by a new line",
+            )
     }
 
     @Test
@@ -104,7 +108,7 @@ class CommentWrappingRuleTest {
             """
             val foo /* some comment */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
             .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment in between other elements on the same line is disallowed")
     }
@@ -117,9 +121,13 @@ class CommentWrappingRuleTest {
             some comment
             */ = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         commentWrappingRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 9, "A block comment starting on same line as another element and ending on another line before another element is disallowed")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                9,
+                "A block comment starting on same line as another element and ending on another line before another element is disallowed",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverListWrappingRuleTest.kt
@@ -135,11 +135,15 @@ class ContextReceiverListWrappingRuleTest {
             """
             // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
             context(_: Fooooooooooooooooooo1, _: Foooooooooooooooooooooooooooooo2)
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(_: Fooooooooooooooooooo1, _: Foooooooooooooooooooooooooooooo2)
+            fun fooBar2()
 
             class Bar {
                 context(_: Fooooooooooooooo1, _: Foooooooooooooooooooooooooo2)
-                fun fooBar()
+                fun fooBar3()
             }
             """.trimIndent()
         val formattedCode =
@@ -149,14 +153,18 @@ class ContextReceiverListWrappingRuleTest {
                 _: Fooooooooooooooooooo1,
                 _: Foooooooooooooooooooooooooooooo2
             )
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(_: Fooooooooooooooooooo1, _: Foooooooooooooooooooooooooooooo2)
+            fun fooBar2()
 
             class Bar {
                 context(
                     _: Fooooooooooooooo1,
                     _: Foooooooooooooooooooooooooo2
                 )
-                fun fooBar()
+                fun fooBar3()
             }
             """.trimIndent()
         contextReceiverListWrappingRuleAssertThat(code)
@@ -165,9 +173,9 @@ class ContextReceiverListWrappingRuleTest {
                 LintViolation(2, 9, "Newline expected before context parameter as max line length is violated"),
                 LintViolation(2, 35, "Newline expected before context parameter as max line length is violated"),
                 LintViolation(2, 70, "Newline expected before closing parenthesis as max line length is violated"),
-                LintViolation(6, 13, "Newline expected before context parameter as max line length is violated"),
-                LintViolation(6, 35, "Newline expected before context parameter as max line length is violated"),
-                LintViolation(6, 66, "Newline expected before closing parenthesis as max line length is violated"),
+                LintViolation(10, 13, "Newline expected before context parameter as max line length is violated"),
+                LintViolation(10, 35, "Newline expected before context parameter as max line length is violated"),
+                LintViolation(10, 66, "Newline expected before closing parenthesis as max line length is violated"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -177,7 +185,11 @@ class ContextReceiverListWrappingRuleTest {
             """
             // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
             context(_: Foooooooooooooooo<Foo, Bar>)
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(_: Foooooooooooooooo<Foo, Bar>)
+            fun fooBar2()
             """.trimIndent()
         // Actually, the closing ">" should be de-indented in same way as is done with ")", "]" and "}". It is
         // however indented to keep it in sync with other TYPE_ARGUMENT_LISTs which are formatted in this way.
@@ -190,7 +202,11 @@ class ContextReceiverListWrappingRuleTest {
                     Bar
                     >
             )
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(_: Foooooooooooooooo<Foo, Bar>)
+            fun fooBar2()
             """.trimIndent()
         contextReceiverListWrappingRuleAssertThat(code)
             .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ContextReceiverWrappingRuleTest.kt
@@ -97,11 +97,15 @@ class ContextReceiverWrappingRuleTest {
             """
             // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
             context(Foooooooooooooooooooo)
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(Foooooooooooooooooooo)
+            fun fooBar2()
 
             class Bar {
                 context(Foooooooooooooooo)
-                fun fooBar()
+                fun fooBar3()
             }
             """.trimIndent()
         val formattedCode =
@@ -110,13 +114,17 @@ class ContextReceiverWrappingRuleTest {
             context(
                 Foooooooooooooooooooo
             )
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(Foooooooooooooooooooo)
+            fun fooBar2()
 
             class Bar {
                 context(
                     Foooooooooooooooo
                 )
-                fun fooBar()
+                fun fooBar3()
             }
             """.trimIndent()
         contextReceiverWrappingRuleAssertThat(code)
@@ -124,8 +132,8 @@ class ContextReceiverWrappingRuleTest {
             .hasLintViolations(
                 LintViolation(2, 9, "Newline expected before context receiver as max line length is violated"),
                 LintViolation(2, 30, "Newline expected before closing parenthesis as max line length is violated"),
-                LintViolation(6, 13, "Newline expected before context receiver as max line length is violated"),
-                LintViolation(6, 30, "Newline expected before closing parenthesis as max line length is violated"),
+                LintViolation(10, 13, "Newline expected before context receiver as max line length is violated"),
+                LintViolation(10, 30, "Newline expected before closing parenthesis as max line length is violated"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -177,7 +185,11 @@ class ContextReceiverWrappingRuleTest {
             """
             // $MAX_LINE_LENGTH_MARKER  $EOL_CHAR
             context(Foooooooooooooooo<Foo, Bar>)
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(Foooooooooooooooo<Foo, Bar>)
+            fun fooBar2()
             """.trimIndent()
         // Actually, the closing ">" should be de-indented in same way as is done with ")", "]" and "}". It is
         // however indented to keep it in sync with other TYPE_ARGUMENT_LISTs which are formatted in this way.
@@ -190,7 +202,11 @@ class ContextReceiverWrappingRuleTest {
                     Bar
                     >
             )
-            fun fooBar()
+            fun fooBar1()
+
+            @Suppress("ktlint:standard:max-line-length")
+            context(Foooooooooooooooo<Foo, Bar>)
+            fun fooBar2()
             """.trimIndent()
         contextReceiverWrappingRuleAssertThat(code)
             .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/EnumEntryNameCaseRuleTest.kt
@@ -34,9 +34,13 @@ class EnumEntryNameCaseRuleTest {
                 _FOO
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"")
+            .hasLintViolationWithoutAutoCorrect(
+                2,
+                5,
+                "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"",
+            )
     }
 
     @Test
@@ -60,12 +64,24 @@ class EnumEntryNameCaseRuleTest {
                 Foo_Bar,
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         enumEntryNameCaseRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""),
-                LintViolation(3, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""),
-                LintViolation(4, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\""),
+                LintViolation(
+                    2,
+                    5,
+                    "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"",
+                ),
+                LintViolation(
+                    3,
+                    5,
+                    "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"",
+                ),
+                LintViolation(
+                    4,
+                    5,
+                    "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\" or upper camel-case like \"EnumEntry\"",
+                ),
             )
     }
 
@@ -105,15 +121,19 @@ class EnumEntryNameCaseRuleTest {
 
         @Test
         fun `Given that 'ktlint_enum_entry_name_casing' is set to 'UPPER_CASES', then allow only upper cases`() {
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             enumEntryNameCaseRuleAssertThat(code)
                 .withEditorConfigOverride(ENUM_ENTRY_NAME_CASING_PROPERTY to upper_cases)
-                .hasLintViolationWithoutAutoCorrect(3, 5, "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\"")
+                .hasLintViolationWithoutAutoCorrect(
+                    3,
+                    5,
+                    "Enum entry name should be uppercase underscore-separated names like \"ENUM_ENTRY\"",
+                )
         }
 
         @Test
         fun `Given that 'ktlint_enum_entry_name_casing' is set to 'CAMEL_CASES', then allow only camel cases`() {
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             enumEntryNameCaseRuleAssertThat(code)
                 .withEditorConfigOverride(ENUM_ENTRY_NAME_CASING_PROPERTY to camel_cases)
                 .hasLintViolationWithoutAutoCorrect(2, 5, "Enum entry name should be upper camel-case like \"EnumEntry\"")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FilenameRuleTest.kt
@@ -72,10 +72,14 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing a single declaration of a class type then the filename should match the class name`(code: String) {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath("/some/path/$UNEXPECTED_FILE_NAME")
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                1,
+                "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'",
+            )
     }
 
     @ParameterizedTest(name = "Top level declaration: {0}")
@@ -86,10 +90,14 @@ class FilenameRuleTest {
         ],
     )
     fun `Given a file containing one top level declaration then the file should be named after the identifier`(code: String) {
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                1,
+                "File '$UNEXPECTED_FILE_NAME' contains a single top level declaration and should be named 'Foo.kt'",
+            )
     }
 
     @ParameterizedTest(name = "Top level declaration: {0}")
@@ -167,10 +175,14 @@ class FilenameRuleTest {
             class Foo
             $otherTopLevelDeclaration
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         fileNameRuleAssertThat(code)
             .asFileWithPath(UNEXPECTED_FILE_NAME)
-            .hasLintViolationWithoutAutoCorrect(1, 1, "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                1,
+                "File '$UNEXPECTED_FILE_NAME' contains a single class, and possibly related top level declarations for that class. The file should be named after the class, 'Foo.kt'",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionLiteralRuleTest.kt
@@ -635,7 +635,7 @@ class FunctionLiteralRuleTest {
                     "some message"
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         functionLiteralRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { IndentationRule() }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionNamingRuleTest.kt
@@ -42,9 +42,13 @@ class FunctionNamingRuleTest {
                 """
                 fun `Some name`() {}
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
-                .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
+                .hasLintViolationWithoutAutoCorrect(
+                    1,
+                    5,
+                    "Function name should start with a lowercase letter (except factory methods) and use camel case",
+                )
         }
 
         @ParameterizedTest(name = "Junit import: {0}")
@@ -78,9 +82,13 @@ class FunctionNamingRuleTest {
                 """
                 fun do_something() {}
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             functionNamingRuleAssertThat(code)
-                .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
+                .hasLintViolationWithoutAutoCorrect(
+                    1,
+                    5,
+                    "Function name should start with a lowercase letter (except factory methods) and use camel case",
+                )
         }
 
         @ParameterizedTest(name = "Junit import: {0}")
@@ -121,9 +129,13 @@ class FunctionNamingRuleTest {
             """
             fun $functionName() = "foo"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         functionNamingRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 5, "Function name should start with a lowercase letter (except factory methods) and use camel case")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                5,
+                "Function name should start with a lowercase letter (except factory methods) and use camel case",
+            )
     }
 
     @ParameterizedTest(name = "Suppression annotation: {0}")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -50,31 +50,43 @@ class FunctionSignatureRuleTest {
         // the block expression.
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-            fun f(a: Any, b: Any, c: Any): String{
+            // $MAX_LINE_LENGTH_MARKER              $EOL_CHAR
+            fun foo1(a: Any, b: Any, c: Any): String{
+                // body
+            }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any): String{
                 // body
             }
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-            fun f(
+            // $MAX_LINE_LENGTH_MARKER              $EOL_CHAR
+            fun foo1(
                 a: Any,
                 b: Any,
                 c: Any
             ): String {
                 // body
             }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any): String {
+                // body
+            }
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { FunctionStartOfBodySpacingRule() }
+            .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "4")
             .hasLintViolations(
-                LintViolation(2, 7, "Newline expected after opening parenthesis"),
-                LintViolation(2, 15, "Parameter should start on a newline"),
-                LintViolation(2, 23, "Parameter should start on a newline"),
-                LintViolation(2, 29, "Newline expected before closing parenthesis"),
-                LintViolation(2, 38, "Expected a single space before body block"),
+                LintViolation(2, 10, "Newline expected after opening parenthesis"),
+                LintViolation(2, 18, "Parameter should start on a newline"),
+                LintViolation(2, 26, "Parameter should start on a newline"),
+                LintViolation(2, 32, "Newline expected before closing parenthesis"),
+                LintViolation(2, 41, "Expected a single space before body block"),
+                LintViolation(7, 41, "Expected a single space before body block"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -84,19 +96,29 @@ class FunctionSignatureRuleTest {
         // the block expression.
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-            fun f(a: Any, b: Any, c: Any): String {
+            // $MAX_LINE_LENGTH_MARKER              $EOL_CHAR
+            fun foo1(a: Any, b: Any, c: Any): String {
+                // body
+            }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any): String {
                 // body
             }
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER           $EOL_CHAR
-            fun f(
+            // $MAX_LINE_LENGTH_MARKER              $EOL_CHAR
+            fun foo1(
                 a: Any,
                 b: Any,
                 c: Any
             ): String {
+                // body
+            }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any): String {
                 // body
             }
             """.trimIndent()
@@ -104,10 +126,10 @@ class FunctionSignatureRuleTest {
             .setMaxLineLength()
             .withEditorConfigOverride(FORCE_MULTILINE_WHEN_PARAMETER_COUNT_GREATER_OR_EQUAL_THAN_PROPERTY to "unset")
             .hasLintViolations(
-                LintViolation(2, 7, "Newline expected after opening parenthesis"),
-                LintViolation(2, 15, "Parameter should start on a newline"),
-                LintViolation(2, 23, "Parameter should start on a newline"),
-                LintViolation(2, 29, "Newline expected before closing parenthesis"),
+                LintViolation(2, 10, "Newline expected after opening parenthesis"),
+                LintViolation(2, 18, "Parameter should start on a newline"),
+                LintViolation(2, 26, "Parameter should start on a newline"),
+                LintViolation(2, 32, "Newline expected before closing parenthesis"),
             ).isFormattedAs(formattedCode)
     }
 
@@ -429,10 +451,18 @@ class FunctionSignatureRuleTest {
     fun `Given a multiline function signature which actually fits on a single line but for which the expression body does not fit at that same line then reformat the signature and wrap the body expression to the next line`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
             // Entire signature is just one character too long to fit on a single line
-            // ...a: Any, b: Any, c: Any) = "some-result"
-            fun f(
+            // .foo1(a: Any, b: Any, c: Any) = "some-result"
+            fun foo1(
+                a: Any,
+                b: Any,
+                c: Any
+            ) = "some-result"
+
+            // But thanks to max-line-length suppression, the following signature can be written on a single line
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(
                 a: Any,
                 b: Any,
                 c: Any
@@ -440,11 +470,15 @@ class FunctionSignatureRuleTest {
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER                 $EOL_CHAR
+            // $MAX_LINE_LENGTH_MARKER                    $EOL_CHAR
             // Entire signature is just one character too long to fit on a single line
-            // ...a: Any, b: Any, c: Any) = "some-result"
-            fun f(a: Any, b: Any, c: Any) =
+            // .foo1(a: Any, b: Any, c: Any) = "some-result"
+            fun foo1(a: Any, b: Any, c: Any) =
                 "some-result"
+
+            // But thanks to max-line-length suppression, the following signature can be written on a single line
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any) = "some-result"
             """.trimIndent()
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
@@ -455,6 +489,10 @@ class FunctionSignatureRuleTest {
                 LintViolation(7, 5, "Single whitespace expected before parameter"),
                 LintViolation(7, 11, "No whitespace expected between last parameter and closing parenthesis"),
                 LintViolation(8, 5, "Newline expected before expression body"),
+                LintViolation(13, 5, "No whitespace expected between opening parenthesis and first parameter name"),
+                LintViolation(14, 5, "Single whitespace expected before parameter"),
+                LintViolation(15, 5, "Single whitespace expected before parameter"),
+                LintViolation(15, 11, "No whitespace expected between last parameter and closing parenthesis"),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/FunctionSignatureRuleTest.kt
@@ -219,7 +219,7 @@ class FunctionSignatureRuleTest {
             private fun f9(a: Any, b: Any): /* some comment */ String = "some-result"
             private fun f10(a: Any, b: Any): String /* some comment */ = "some-result"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
@@ -227,11 +227,26 @@ class FunctionSignatureRuleTest {
                 LintViolation(2, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(3, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(4, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
-                LintViolation(5, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(
+                    5,
+                    18,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
                 LintViolation(5, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
-                LintViolation(6, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(
+                    6,
+                    19,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
                 LintViolation(6, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
-                LintViolation(7, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(
+                    7,
+                    23,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
                 LintViolation(7, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(8, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
                 LintViolation(9, 49, "Exceeded max line length (48)", canBeAutoCorrected = false),
@@ -247,13 +262,28 @@ class FunctionSignatureRuleTest {
             private fun f6(a: /* some comment */ Any, b: Any): String = "some-result"
             private fun f7(a: Any /* some comment */, b: Any): String = "some-result"
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         functionSignatureWrappingRuleAssertThat(code)
             .addAdditionalRuleProvider { ValueParameterCommentRule() }
             .hasLintViolationsForAdditionalRule(
-                LintViolation(1, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(2, 19, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
-                LintViolation(3, 23, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.", false),
+                LintViolation(
+                    1,
+                    18,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
+                LintViolation(
+                    2,
+                    19,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
+                LintViolation(
+                    3,
+                    23,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                    false,
+                ),
             ).hasNoLintViolationsExceptInAdditionalRules()
         // When ValueParameterCommentRule is not loaded or disabled:
         functionSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
@@ -657,7 +687,7 @@ class FunctionSignatureRuleTest {
                 fun f28(block: (T) -> String) = "some-result"
                 fun f29(block: (T) -> String) = "some-result"
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             functionSignatureWrappingRuleAssertThat(code)
                 .addAdditionalRuleProviders(
                     { NoMultipleSpacesRule() },

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseBracingRuleTest.kt
@@ -62,12 +62,15 @@ class IfElseBracingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(IF_ELSE_BRACING_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
-            .hasLintViolation(4, 12, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-            .isFormattedAs(formattedCode)
+            .hasLintViolation(
+                4,
+                12,
+                "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+            ).isFormattedAs(formattedCode)
     }
 
     @Nested
@@ -138,11 +141,14 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(4, 12, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-                .isFormattedAs(formattedCode)
+                .hasLintViolation(
+                    4,
+                    12,
+                    "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                ).isFormattedAs(formattedCode)
         }
 
         @Test
@@ -236,12 +242,20 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
-                    LintViolation(5, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
-                    LintViolation(7, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
+                    LintViolation(
+                        5,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
+                    LintViolation(
+                        7,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -258,12 +272,20 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
-                    LintViolation(3, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
-                    LintViolation(7, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
+                    LintViolation(
+                        3,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
+                    LintViolation(
+                        7,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -281,12 +303,20 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
                 .hasLintViolations(
-                    LintViolation(3, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
-                    LintViolation(5, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces"),
+                    LintViolation(
+                        3,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
+                    LintViolation(
+                        5,
+                        9,
+                        "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                    ),
                 ).isFormattedAs(formattedCode)
         }
 
@@ -303,11 +333,14 @@ class IfElseBracingRuleTest {
                         doSomethingElse2()
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(7, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-                .isFormattedAs(formattedCode)
+                .hasLintViolation(
+                    7,
+                    9,
+                    "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                ).isFormattedAs(formattedCode)
         }
 
         @Test
@@ -324,11 +357,14 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(5, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-                .isFormattedAs(formattedCode)
+                .hasLintViolation(
+                    5,
+                    9,
+                    "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                ).isFormattedAs(formattedCode)
         }
 
         @Test
@@ -345,11 +381,14 @@ class IfElseBracingRuleTest {
                     }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             multiLineIfElseRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolation(3, 9, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-                .isFormattedAs(formattedCode)
+                .hasLintViolation(
+                    3,
+                    9,
+                    "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+                ).isFormattedAs(formattedCode)
         }
 
         @Test
@@ -382,10 +421,13 @@ class IfElseBracingRuleTest {
             """
             val foo = if (false) {} else { bar() }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         multiLineIfElseRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-            .hasLintViolation(1, 22, "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces")
-            .isFormattedAs(formattedCode)
+            .hasLintViolation(
+                1,
+                22,
+                "All branches of the if statement should be wrapped between braces if at least one branch is wrapped between braces",
+            ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IfElseWrappingRuleTest.kt
@@ -180,9 +180,13 @@ class IfElseWrappingRuleTest {
                     if (true) { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
-                .hasLintViolationWithoutAutoCorrect(2, 15, "A single line if-statement should be kept simple. The 'THEN' may not be wrapped in a block.")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    15,
+                    "A single line if-statement should be kept simple. The 'THEN' may not be wrapped in a block.",
+                )
         }
 
         @Test
@@ -193,9 +197,13 @@ class IfElseWrappingRuleTest {
                     if (true) bar() else { if (false) foo() else bar() }
                 }
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             ifElseWrappingRuleAssertThat(code)
-                .hasLintViolationWithoutAutoCorrect(2, 26, "A single line if-statement should be kept simple. The 'ELSE' may not be wrapped in a block.")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    26,
+                    "A single line if-statement should be kept simple. The 'ELSE' may not be wrapped in a block.",
+                )
         }
     }
 
@@ -207,7 +215,7 @@ class IfElseWrappingRuleTest {
             } else {
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -225,7 +233,7 @@ class IfElseWrappingRuleTest {
                 )
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         ifElseWrappingRuleAssertThat(code).hasNoLintViolations()
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/IndentationRuleTest.kt
@@ -3386,7 +3386,7 @@ internal class IndentationRuleTest {
                 ${TAB}line2
                     $MULTILINE_STRING_QUOTE.trimIndent()
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             indentationRuleAssertThat(code)
                 .hasLintViolationWithoutAutoCorrect(1, 11, "Indentation of multiline string should not contain both tab(s) and space(s)")
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleTest.kt
@@ -64,9 +64,13 @@ class KdocWrappingRuleTest {
                              * with a newline
                              */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         kdocWrappingRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 17, "A KDoc comment after any other element on the same line must be separated by a new line")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                17,
+                "A KDoc comment after any other element on the same line must be separated by a new line",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/MixedConditionOperatorsRuleTest.kt
@@ -12,9 +12,13 @@ class MixedConditionOperatorsRuleTest {
             """
             val foo = bar1 && bar2 || bar3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 11, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                11,
+                "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.",
+            )
     }
 
     @Test
@@ -25,9 +29,13 @@ class MixedConditionOperatorsRuleTest {
                 bar2 ||
                 bar3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 11, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                11,
+                "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.",
+            )
     }
 
     @Test
@@ -45,9 +53,13 @@ class MixedConditionOperatorsRuleTest {
             """
             val foo = bar1 && (bar2 || bar3 && bar4) && bar5
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         mixedConditionOperatorsRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 20, "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                20,
+                "A condition with mixed usage of '&&' and '||' is hard to read. Use parenthesis to clarify the (sub)condition.",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoConsecutiveCommentsRuleTest.kt
@@ -52,14 +52,18 @@ class NoConsecutiveCommentsRuleTest {
             /** KDoc 1 */
             /* Block comment 2 */
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         noConsecutiveBlankLinesRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyle)
             .withEditorConfigOverride(NO_CONSECUTIVE_COMMENTS_RULE_ID.createRuleExecutionEditorConfigProperty() to RuleExecution.enabled)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 1, "a block comment may not be preceded by an EOL comment unless separated by a blank line"),
                 LintViolation(3, 1, "a KDoc may not be preceded by a block comment unless separated by a blank line"),
-                LintViolation(4, 1, "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline."),
+                LintViolation(
+                    4,
+                    1,
+                    "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.",
+                ),
             )
     }
 
@@ -118,10 +122,14 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    1,
+                    "a block comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.",
+                )
         }
 
         @Test
@@ -159,10 +167,14 @@ class NoConsecutiveCommentsRuleTest {
                 /** KDoc */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    1,
+                    "an EOL comment may not be preceded by a KDoc. Reversed order is allowed though when separated by a newline.",
+                )
         }
 
         @Test
@@ -200,10 +212,14 @@ class NoConsecutiveCommentsRuleTest {
                 // EOL comment
                 /* Block comment */
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 1, "a block comment may not be preceded by an EOL comment unless separated by a blank line")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    1,
+                    "a block comment may not be preceded by an EOL comment unless separated by a blank line",
+                )
         }
 
         @Test
@@ -226,10 +242,14 @@ class NoConsecutiveCommentsRuleTest {
                 /* Block comment */
                 // EOL comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noConsecutiveBlankLinesRuleAssertThat(code)
                 .withEditorConfigOverride(CODE_STYLE_PROPERTY to ktlint_official)
-                .hasLintViolationWithoutAutoCorrect(2, 1, "an EOL comment may not be preceded by a block comment unless separated by a blank line")
+                .hasLintViolationWithoutAutoCorrect(
+                    2,
+                    1,
+                    "an EOL comment may not be preceded by a block comment unless separated by a blank line",
+                )
         }
 
         @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/NoSingleLineBlockCommentRuleTest.kt
@@ -67,7 +67,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 val foo = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 16, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)
@@ -83,7 +83,7 @@ class NoSingleLineBlockCommentRuleTest {
                 """
                 fun foo() = "foo" // Some comment
                 """.trimIndent()
-            @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+            @Suppress("ktlint:standard:max-line-length")
             noSingleLineBlockCommentRuleAssertThat(code)
                 .hasLintViolation(1, 19, "Replace the block comment with an EOL comment")
                 .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -155,27 +155,35 @@ class ParameterListWrappingRuleTest {
     fun `Given a single line function which exceeds the maximum line length then start each parameter and the closing parenthesis on a separate line`() {
         val code =
             """
-            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
-            fun f(a: Any, b: Any, c: Any) {
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun foo1(a: Any, b: Any, c: Any) {
+            }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any) {
             }
             """.trimIndent()
         val formattedCode =
             """
-            // $MAX_LINE_LENGTH_MARKER   $EOL_CHAR
-            fun f(
+            // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
+            fun foo1(
                 a: Any,
                 b: Any,
                 c: Any
             ) {
             }
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun foo2(a: Any, b: Any, c: Any) {
+            }
             """.trimIndent()
         parameterListWrappingRuleAssertThat(code)
             .setMaxLineLength()
             .hasLintViolations(
-                LintViolation(2, 7, "Parameter should start on a newline"),
-                LintViolation(2, 15, "Parameter should start on a newline"),
-                LintViolation(2, 23, "Parameter should start on a newline"),
-                LintViolation(2, 29, """Missing newline before ")""""),
+                LintViolation(2, 10, "Parameter should start on a newline"),
+                LintViolation(2, 18, "Parameter should start on a newline"),
+                LintViolation(2, 26, "Parameter should start on a newline"),
+                LintViolation(2, 32, """Missing newline before ")""""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -542,6 +550,9 @@ class ParameterListWrappingRuleTest {
                 var foo2: (
                     (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
                 )? = null
+
+                @Suppress("ktlint:standard:max-line-length")
+                var foo3: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null
                 """.trimIndent()
             val formattedCode =
                 """
@@ -552,6 +563,9 @@ class ParameterListWrappingRuleTest {
                 var foo2: (
                     (bar1: Bar, bar2: Bar, bar3: Bar) -> Unit
                 )? = null
+
+                @Suppress("ktlint:standard:max-line-length")
+                var foo3: ((bar1: Bar, bar2: Bar, bar3: Bar) -> Unit)? = null
                 """.trimIndent()
             parameterListWrappingRuleAssertThat(code)
                 .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterListWrappingRuleTest.kt
@@ -145,7 +145,7 @@ class ParameterListWrappingRuleTest {
                 c: Any
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(3, 13, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)
@@ -306,7 +306,7 @@ class ParameterListWrappingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         parameterListWrappingRuleAssertThat(code)
             .hasLintViolation(2, 11, "Parameter should start on a newline")
             .isFormattedAs(formattedCode)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ParameterWrappingRuleTest.kt
@@ -17,23 +17,45 @@ internal class ParameterWrappingRuleTest {
         val code =
             """
             // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-            class Bar(
+            class Bar1(
                 val foooooooooooooooooTooLong: Foo,
             )
-            fun bar(
+
+            @Suppress("ktlint:standard:max-line-length")
+            class Bar2(
+                val foooooooooooooooooTooLong: Foo
+            )
+
+            fun bar1(
                 foooooooooooooooooooooTooLong: Foo,
+            )
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun bar2(
+                foooooooooooooooooooooTooLong: Foo
             )
             """.trimIndent()
         val formattedCode =
             """
             // $MAX_LINE_LENGTH_MARKER      $EOL_CHAR
-            class Bar(
+            class Bar1(
                 val foooooooooooooooooTooLong:
                     Foo,
             )
-            fun bar(
+
+            @Suppress("ktlint:standard:max-line-length")
+            class Bar2(
+                val foooooooooooooooooTooLong: Foo
+            )
+
+            fun bar1(
                 foooooooooooooooooooooTooLong:
                     Foo,
+            )
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun bar2(
+                foooooooooooooooooooooTooLong: Foo
             )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
@@ -41,7 +63,7 @@ internal class ParameterWrappingRuleTest {
             .addAdditionalRuleProvider { IndentationRule() }
             .hasLintViolations(
                 LintViolation(3, 35, "Missing newline after \":\""),
-                LintViolation(6, 35, "Missing newline after \":\""),
+                LintViolation(12, 35, "Missing newline after \":\""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -87,11 +109,24 @@ internal class ParameterWrappingRuleTest {
         val code =
             """
             // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
-            class Bar(
+            class Bar1(
                 val foooooooooooooooooTooLong: Foo = Foo(),
                 val foooooooooooooNotTooLong: Foo = Foo(),
             )
-            fun bar(
+
+            @Suppress("ktlint:standard:max-line-length")
+            class Bar2(
+                val foooooooooooooooooTooLong: Foo = Foo(),
+                val foooooooooooooNotTooLong: Foo = Foo(),
+            )
+
+            fun bar1(
+                foooooooooooooooooooooTooLong: Foo = Foo(),
+                foooooooooooooooooNotTooLong: Foo = Foo(),
+            )
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun bar2(
                 foooooooooooooooooooooTooLong: Foo = Foo(),
                 foooooooooooooooooNotTooLong: Foo = Foo(),
             )
@@ -99,17 +134,30 @@ internal class ParameterWrappingRuleTest {
         val formattedCode =
             """
             // $MAX_LINE_LENGTH_MARKER            $EOL_CHAR
-            class Bar(
+            class Bar1(
                 val foooooooooooooooooTooLong: Foo =
                     Foo(),
                 val foooooooooooooNotTooLong: Foo =
                     Foo(),
             )
-            fun bar(
+
+            @Suppress("ktlint:standard:max-line-length")
+            class Bar2(
+                val foooooooooooooooooTooLong: Foo = Foo(),
+                val foooooooooooooNotTooLong: Foo = Foo(),
+            )
+
+            fun bar1(
                 foooooooooooooooooooooTooLong: Foo =
                     Foo(),
                 foooooooooooooooooNotTooLong: Foo =
                     Foo(),
+            )
+
+            @Suppress("ktlint:standard:max-line-length")
+            fun bar2(
+                foooooooooooooooooooooTooLong: Foo = Foo(),
+                foooooooooooooooooNotTooLong: Foo = Foo(),
             )
             """.trimIndent()
         parameterWrappingRuleAssertThat(code)
@@ -118,8 +166,8 @@ internal class ParameterWrappingRuleTest {
             .hasLintViolations(
                 LintViolation(3, 41, "Missing newline after \"=\""),
                 LintViolation(4, 40, "Missing newline before \"Foo()\""),
-                LintViolation(7, 41, "Missing newline after \"=\""),
-                LintViolation(8, 40, "Missing newline before \"Foo()\""),
+                LintViolation(14, 41, "Missing newline after \"=\""),
+                LintViolation(15, 40, "Missing newline before \"Foo()\""),
             ).isFormattedAs(formattedCode)
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyNamingRuleTest.kt
@@ -98,7 +98,7 @@ class PropertyNamingRuleTest {
             val foo = Foo()
             val FOO_BAR = FooBar()
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -113,7 +113,7 @@ class PropertyNamingRuleTest {
                 }
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code).hasNoLintViolations()
     }
 
@@ -275,10 +275,15 @@ class PropertyNamingRuleTest {
                 val FOO_BAR = "FOO-BAR" // Class properties always start with lowercase, const is not allowed
             }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         propertyNamingRuleAssertThat(code)
             .hasLintViolations(
-                LintViolation(1, 11, "Property name should use the screaming snake case notation when the value can not be changed", canBeAutoCorrected = false),
+                LintViolation(
+                    1,
+                    11,
+                    "Property name should use the screaming snake case notation when the value can not be changed",
+                    canBeAutoCorrected = false,
+                ),
                 LintViolation(3, 5, "Property name should start with a lowercase letter and use camel case", canBeAutoCorrected = false),
                 LintViolation(6, 9, "Property name should start with a lowercase letter and use camel case", canBeAutoCorrected = false),
             )

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/PropertyWrappingRuleTest.kt
@@ -17,13 +17,19 @@ internal class PropertyWrappingRuleTest {
         val code =
             """
             // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-            val aVariableWithALooooooongName: String
+            val aVariableWithALoooooongName1: String
+
+            @Suppress("ktlint:standard:max-line-length")
+            val aVariableWithALoooooongName2: String
             """.trimIndent()
         val formattedCode =
             """
             // $MAX_LINE_LENGTH_MARKER     $EOL_CHAR
-            val aVariableWithALooooooongName:
+            val aVariableWithALoooooongName1:
                 String
+
+            @Suppress("ktlint:standard:max-line-length")
+            val aVariableWithALoooooongName2: String
             """.trimIndent()
         propertyWrappingRuleAssertThat(code)
             .setMaxLineLength()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeArgumentCommentRuleTest.kt
@@ -13,9 +13,13 @@ class TypeArgumentCommentRuleTest {
             """
             fun Foo<out /* some comment */ Any>.foo() {}
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 13, "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                13,
+                "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test
@@ -25,9 +29,13 @@ class TypeArgumentCommentRuleTest {
             fun Foo<out // some comment
             Any>.foo() {}
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 13, "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                13,
+                "A (block or EOL) comment inside or on same line after a 'type_projection' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/TypeParameterCommentRuleTest.kt
@@ -13,9 +13,13 @@ class TypeParameterCommentRuleTest {
             """
             class Foo<in /* some comment */ Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 14, "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                14,
+                "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test
@@ -25,9 +29,13 @@ class TypeParameterCommentRuleTest {
             class Foo<in // some comment
             Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(1, 14, "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                14,
+                "A (block or EOL) comment inside or on same line after a 'type_parameter' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test
@@ -53,7 +61,7 @@ class TypeParameterCommentRuleTest {
                 >
             class Foo2<Bar /* some comment */ >
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 9, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),
@@ -70,7 +78,7 @@ class TypeParameterCommentRuleTest {
                 Bar>
             class FooBar2<Foo, /* some comment */ Bar>
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         typeParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(2, 10, "A comment in a 'value_argument_list' is only allowed when placed on a separate line"),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueArgumentCommentRuleTest.kt
@@ -14,9 +14,13 @@ class ValueArgumentCommentRuleTest {
                 bar /* some comment */ = "bar"
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 9, "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                2,
+                9,
+                "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test
@@ -28,9 +32,13 @@ class ValueArgumentCommentRuleTest {
                     = "bar"
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         valueArgumentCommentRuleAssertThat(code)
-            .hasLintViolationWithoutAutoCorrect(2, 9, "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.")
+            .hasLintViolationWithoutAutoCorrect(
+                2,
+                9,
+                "A (block or EOL) comment inside or on same line after a 'value_argument' is not allowed. It may be placed on a separate line above.",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ValueParameterCommentRuleTest.kt
@@ -79,12 +79,24 @@ class ValueParameterCommentRuleTest {
                 val bar: /** some comment */ Bar
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(3, 9, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(7, 14, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(10, 14, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(
+                    3,
+                    9,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
+                LintViolation(
+                    7,
+                    14,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
+                LintViolation(
+                    10,
+                    14,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
             )
     }
 
@@ -102,12 +114,24 @@ class ValueParameterCommentRuleTest {
                 val bar: Bar /* some comment */
             )
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         valueParameterCommentRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(2, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(5, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
-                LintViolation(8, 18, "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above."),
+                LintViolation(
+                    2,
+                    18,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
+                LintViolation(
+                    5,
+                    18,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
+                LintViolation(
+                    8,
+                    18,
+                    "A comment inside or on same line after a 'value_parameter' is not allowed. It may be placed on a separate line above.",
+                ),
             )
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracingTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WhenEntryBracingTest.kt
@@ -61,14 +61,22 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
                 StatementWrappingRule()
             }.hasLintViolations(
-                LintViolation(4, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
-                LintViolation(5, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
+                LintViolation(
+                    4,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
+                LintViolation(
+                    5,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
             ).isFormattedAs(formattedCode)
     }
 
@@ -102,7 +110,7 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
@@ -111,8 +119,16 @@ class WhenEntryBracingTest {
                 // Fix indent of the wrapped multiline statement
                 IndentationRule()
             }.hasLintViolations(
-                LintViolation(4, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
-                LintViolation(7, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
+                LintViolation(
+                    4,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
+                LintViolation(
+                    7,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
             ).isFormattedAs(formattedCode)
     }
 
@@ -146,14 +162,22 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
                 StatementWrappingRule()
             }.hasLintViolations(
-                LintViolation(4, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
-                LintViolation(7, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
+                LintViolation(
+                    4,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
+                LintViolation(
+                    7,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
             ).isFormattedAs(formattedCode)
     }
 
@@ -184,15 +208,27 @@ class WhenEntryBracingTest {
                     }
                 }
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         whenEntryBracingRuleAssertThat(code)
             .addAdditionalRuleProvider {
                 // Ensures that the first when entry is also wrapped to a multiline body
                 StatementWrappingRule()
             }.hasLintViolations(
-                LintViolation(3, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
-                LintViolation(5, 13, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
-                LintViolation(6, 17, "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body"),
+                LintViolation(
+                    3,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
+                LintViolation(
+                    5,
+                    13,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
+                LintViolation(
+                    6,
+                    17,
+                    "Body of when entry should be surrounded by braces if any when entry body is surrounded by braces or has a multiline body",
+                ),
             ).isFormattedAs(formattedCode)
     }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/WrappingRuleTest.kt
@@ -1618,16 +1618,22 @@ internal class WrappingRuleTest {
                 """
                 // $MAX_LINE_LENGTH_MARKER                                                   $EOL_CHAR
                 class Bar {
-                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy { fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true) }
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrr1 by lazy { fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true) }
+
+                    @Suppress("ktlint:standard:max-line-length")
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrr2 by lazy { fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true) }
                 }
                 """.trimIndent()
             val formattedCode =
                 """
                 // $MAX_LINE_LENGTH_MARKER                                                   $EOL_CHAR
                 class Bar {
-                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr by lazy {
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrr1 by lazy {
                         fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true)
                     }
+
+                    @Suppress("ktlint:standard:max-line-length")
+                    val barrrrrrrrrrrrrrrrrrrrrrrrrrrrrr2 by lazy { fooooooooooooo("fooooooooooooooooooooooooooooooooooooooooooooo", true) }
                 }
                 """.trimIndent()
             wrappingRuleAssertThat(code)
@@ -1744,7 +1750,7 @@ internal class WrappingRuleTest {
             val code =
                 """
                 // $MAX_LINE_LENGTH_MARKER                               $EOL_CHAR
-                fun getQueryString(query: QueryRequest): String {
+                fun getQueryString1(query: QueryRequest): String {
                     val q = $MULTILINE_STRING_QUOTE
                         SELECT *
                         FROM table

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleAsciiTest.kt
@@ -121,10 +121,14 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
-            .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                1,
+                "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list",
+            )
     }
 
     @Test
@@ -136,10 +140,14 @@ class ImportOrderingRuleAsciiTest {
             import android.app.Activity
             import android.view.ViewGroup
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(ASCII_IMPORT_ORDERING)
-            .hasLintViolationWithoutAutoCorrect(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list")
+            .hasLintViolationWithoutAutoCorrect(
+                1,
+                1,
+                "Imports must be ordered in lexicographic order without any empty lines in-between -- no autocorrection due to comments in the import list",
+            )
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/importordering/ImportOrderingRuleIdeaTest.kt
@@ -38,11 +38,14 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
-            .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
-            .isFormattedAs(formattedCode)
+            .hasLintViolation(
+                1,
+                1,
+                "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end",
+            ).isFormattedAs(formattedCode)
     }
 
     @Test
@@ -109,11 +112,14 @@ class ImportOrderingRuleIdeaTest {
             import android.view.ViewGroup
             import java.util.List
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
-            .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
-            .isFormattedAs(formattedCode)
+            .hasLintViolation(
+                1,
+                1,
+                "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end",
+            ).isFormattedAs(formattedCode)
     }
 
     @Test
@@ -146,11 +152,14 @@ class ImportOrderingRuleIdeaTest {
             import android.content.Context as Ctx
             import androidx.fragment.app.Fragment as F // comment 3
             """.trimIndent()
-        @Suppress("ktlint:standard:argument-list-wrapping", "ktlint:standard:call-expression-wrapping", "ktlint:standard:max-line-length")
+        @Suppress("ktlint:standard:max-line-length")
         importOrderingRuleAssertThat(code)
             .withEditorConfigOverride(IDEA_DEFAULT_IMPORT_ORDERING)
-            .hasLintViolation(1, 1, "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end")
-            .isFormattedAs(formattedCode)
+            .hasLintViolation(
+                1,
+                1,
+                "Imports must be ordered in lexicographic order without any empty lines in-between with \"java\", \"javax\", \"kotlin\" and aliases in the end",
+            ).isFormattedAs(formattedCode)
     }
 
     @Test


### PR DESCRIPTION
## Description

Do not wrap to newline whenever the "ktlint:standard:max-line-length" suppression is found on an AST Node, or on any of its parents.

Closes #3254

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
