### PR TITLE
Do not remove UTF BOM character

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/RuleExecutionContext.kt
@@ -260,7 +260,13 @@ internal class RuleExecutionContext private constructor(
             text
                 .replace("\r\n", "\n")
                 .replace("\r", "\n")
-                .replaceFirst(UTF8_BOM, "")
+                .let {
+                    if (it.startsWith(UTF8_BOM)) {
+                        it.replaceFirst(UTF8_BOM, "")
+                    } else {
+                        it
+                    }
+                }
 
         private fun PsiElement.findErrorElement(): PsiErrorElement? {
             if (this is PsiErrorElement) {

--- a/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/com/pinterest/ktlint/rule/engine/api/KtLintTest.kt
@@ -27,6 +27,7 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isRoot20
 import com.pinterest.ktlint.rule.engine.core.api.replaceTextWith
+import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import org.assertj.core.api.Assertions.assertThat
 import org.ec4j.core.model.PropertyType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -226,19 +227,22 @@ class KtLintTest {
     }
 
     @Test
-    fun testFormatUnicodeBom() {
+    fun `Given a file that starts with the UTF8 BOM character then ensure that the formatted file starts with that character as well`() {
         val code =
-            getResourceAsText("spec/format-unicode-bom.kt.spec")
+            getResourceAsText("spec/format-unicode-bom-at-start-of-file--before-ktlint-format.kt")
+                // Standardize code to use LF as line separator regardless of OS
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+        val formattedCode =
+            getResourceAsText("spec/format-unicode-bom-at-start-of-file--after-ktlint-format.kt")
                 // Standardize code to use LF as line separator regardless of OS
                 .replace("\r\n", "\n")
                 .replace("\r", "\n")
 
         val actual =
             KtLintRuleEngine(
-                ruleProviders =
-                    setOf(
-                        RuleV2InstanceProvider { DummyRule() },
-                    ),
+                // We need a rule that actually modifies the file to test whether UTF BOM character is handled correctly
+                ruleProviders = setOf(RuleV2InstanceProvider { IndentationRule() }),
                 editorConfigOverride =
                     EditorConfigOverride.from(
                         // The code sample use LF as line separator, so ensure that formatted code uses that as well, as otherwise the test
@@ -247,7 +251,35 @@ class KtLintTest {
                     ),
             ).format(Code.fromSnippet(code)) { _ -> AutocorrectDecision.ALLOW_AUTOCORRECT }
 
-        assertThat(actual).isEqualTo(code)
+        assertThat(actual).isEqualTo(formattedCode)
+    }
+
+    @Test
+    fun `Issue 3220 - Given some code that contains the UTF8 BOM character somewhere but not a the start then ensure this character is not removed`() {
+        val code =
+            getResourceAsText("spec/do-not-format-unicode-bom-when-not-at-start-of-file--before-ktlint-format.kt")
+                // Standardize code to use LF as line separator regardless of OS
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+        val formattedCode =
+            getResourceAsText("spec/do-not-format-unicode-bom-when-not-at-start-of-file--after-ktlint-format.kt")
+                // Standardize code to use LF as line separator regardless of OS
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+
+        val actual =
+            KtLintRuleEngine(
+                // We need a rule that actually modifies the file to test whether UTF BOM character is handled correctly
+                ruleProviders = setOf(RuleV2InstanceProvider { IndentationRule() }),
+                editorConfigOverride =
+                    EditorConfigOverride.from(
+                        // The code sample use LF as line separator, so ensure that formatted code uses that as well, as otherwise the test
+                        // breaks on Windows OS
+                        END_OF_LINE_PROPERTY to PropertyType.EndOfLineValue.lf,
+                    ),
+            ).format(Code.fromSnippet(code)) { _ -> AutocorrectDecision.ALLOW_AUTOCORRECT }
+
+        assertThat(actual).isEqualTo(formattedCode)
     }
 
     @Nested

--- a/ktlint-rule-engine/src/test/resources/spec/.editorconfig
+++ b/ktlint-rule-engine/src/test/resources/spec/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+ktlint_standard = disabled

--- a/ktlint-rule-engine/src/test/resources/spec/do-not-format-unicode-bom-when-not-at-start-of-file--after-ktlint-format.kt
+++ b/ktlint-rule-engine/src/test/resources/spec/do-not-format-unicode-bom-when-not-at-start-of-file--after-ktlint-format.kt
@@ -1,0 +1,2 @@
+// Although probably not visible in your editor, this file contains at UTF BOM --> ﻿ <--
+// The indent before this comment needs to be removed by ktlint format

--- a/ktlint-rule-engine/src/test/resources/spec/do-not-format-unicode-bom-when-not-at-start-of-file--before-ktlint-format.kt
+++ b/ktlint-rule-engine/src/test/resources/spec/do-not-format-unicode-bom-when-not-at-start-of-file--before-ktlint-format.kt
@@ -1,0 +1,2 @@
+// Although probably not visible in your editor, this file contains at UTF BOM --> ﻿ <--
+    // The indent before this comment needs to be removed by ktlint format

--- a/ktlint-rule-engine/src/test/resources/spec/format-unicode-bom-at-start-of-file--after-ktlint-format.kt
+++ b/ktlint-rule-engine/src/test/resources/spec/format-unicode-bom-at-start-of-file--after-ktlint-format.kt
@@ -1,1 +1,2 @@
 ﻿// Although probably not visible in your editor, this file starts with a UTF8 BOM unicode character
+// The indent before this comment needs to be removed by ktlint format

--- a/ktlint-rule-engine/src/test/resources/spec/format-unicode-bom-at-start-of-file--before-ktlint-format.kt
+++ b/ktlint-rule-engine/src/test/resources/spec/format-unicode-bom-at-start-of-file--before-ktlint-format.kt
@@ -1,0 +1,2 @@
+﻿// Although probably not visible in your editor, this file starts with a UTF8 BOM unicode character
+    // The indent before this comment needs to be removed by ktlint format

--- a/ktlint-rule-engine/src/test/resources/spec/readme.md
+++ b/ktlint-rule-engine/src/test/resources/spec/readme.md
@@ -1,0 +1,31 @@
+The spec files in this directory contain the UTF BOM character \uFEFF
+
+The files have been created with Zsh terminal commands below:
+```shell
+echo -e "\uFEFF// Although probably not visible in your editor, this file starts with a UTF8 BOM unicode character\n    // The indent before this comment needs to be removed by ktlint format" > format-unicode-bom-at-start-of-file-before-format.kt.spec
+echo -e "\uFEFF// Although probably not visible in your editor, this file starts with a UTF8 BOM unicode character\n// The indent before this comment needs to be removed by ktlint format" > format-unicode-bom-at-start-
+of-file-after-format.kt.spec
+
+echo -e "// Although probably not visible in your editor, this file contains at UTF BOM --> \uFEFF <--\n    // The indent before this comment needs to be removed by ktlint format" > do-not-format-unicode-bom-when-not-at-start-of-file-before-ktlint-format.kt.spec
+echo -e "// Although probably not visible in your editor, this file contains at UTF BOM --> \uFEFF <--\n// The indent before this comment needs to be removed by ktlint format" > do-not-format-unicode-bom-when-not-at-st
+art-of-file--after-ktlint-format.kt.spec
+```
+
+With the `xxd` command the files can be inspected:
+```shell
+xxd do-not-format-unicode-bom-when-not-at-start-of-file--before-ktlint-format.kt
+```
+results in output like:
+```terminaloutput
+00000000: 2f2f 2041 6c74 686f 7567 6820 7072 6f62  // Although prob
+00000010: 6162 6c79 206e 6f74 2076 6973 6962 6c65  ably not visible
+00000020: 2069 6e20 796f 7572 2065 6469 746f 722c   in your editor,
+00000030: 2074 6869 7320 6669 6c65 2063 6f6e 7461   this file conta
+00000040: 696e 7320 6174 2055 5446 2042 4f4d 202d  ins at UTF BOM -
+00000050: 2d3e 20ef bbbf 203c 2d2d 0a20 2020 202f  -> ... <--.    /    <<-- The "ef bb" corresponds with the \uFEFF character
+00000060: 2f20 5468 6520 696e 6465 6e74 2062 6566  / The indent bef
+00000070: 6f72 6520 7468 6973 2063 6f6d 6d65 6e74  ore this comment
+00000080: 206e 6565 6473 2074 6f20 6265 2072 656d   needs to be rem
+00000090: 6f76 6564 2062 7920 6b74 6c69 6e74 2066  oved by ktlint f
+000000a0: 6f72 6d61 740a                           ormat.
+```


### PR DESCRIPTION
## Description

If a files starts with the UTF BOM character, it is removed before the file is formatted, and restored after formatting. When the UTF BOM character is not at the start of the file, it should not be removed before formatting, and has to be preserved in the formatted file.

The existing test for a file starting with UTF BOM character was not effective because the file was not modified at all. In that case, the unmodified input is returned by ktlint format.

Closes #3220

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
