### PR TITLE
Do not wrap an annotated expression before a lambda expression

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRule.kt
@@ -12,6 +12,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.CONSTRUCTOR_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.GT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.IDENTIFIER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.MODIFIER_LIST
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.OPERATION_REFERENCE
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
@@ -239,9 +240,19 @@ public class AnnotationRule :
     }
 
     private fun ASTNode.shouldWrapAnnotations() =
-        hasAnnotationWithParameter() ||
-            hasMultipleAnnotationsOnSameLine() ||
-            hasAnnotationBeforeConstructor()
+        if (isAnnotatedExpressionBeforeLambdaExpression()) {
+            false
+        } else {
+            hasAnnotationWithParameter() ||
+                hasMultipleAnnotationsOnSameLine() ||
+                hasAnnotationBeforeConstructor()
+        }
+
+    private fun ASTNode.isAnnotatedExpressionBeforeLambdaExpression() =
+        null !=
+            takeIf { it.elementType == ANNOTATED_EXPRESSION }
+                ?.findChildByType(ANNOTATION_ENTRY)
+                ?.takeIf { it.nextCodeSibling?.elementType == LAMBDA_EXPRESSION }
 
     private fun ASTNode.hasAnnotationWithParameter(): Boolean {
         require(elementType in ANNOTATION_CONTAINER)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/AnnotationRuleTest.kt
@@ -1112,4 +1112,14 @@ class AnnotationRuleTest {
             """.trimIndent()
         annotationRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `Issue 3213 - Given an annotated before a lambda expression then do no wrap the annotation to a new line as it results in a compilation error`() {
+        val code =
+            """
+            val foo1 = bar @FooBar() { baz }
+            val foo2 = @FooBar() { baz }
+            """.trimIndent()
+        annotationRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Do not wrap an annotated expression before a lambda expression as it results in a compilation error

Closes #3213

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
