### PR TITLE
Add experimental rule `lambda-return`

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -49,7 +49,7 @@ Suppress or disable rule (1)
 
 1. Suppress rule in code with annotation below:
     ```kotlin
-    @Suppress("ktlint:call-expression-wrapping")
+    @Suppress("ktlint:standard:call-expression-wrapping")
     ```
    Enable rule via `.editorconfig`
     ```editorconfig
@@ -102,7 +102,7 @@ Suppress or disable rule (1)
 
 1. Suppress rule in code with annotation below:
     ```kotlin
-    @Suppress("ktlint:expression-operand-wrapping")
+    @Suppress("ktlint:standard:expression-operand-wrapping")
     ```
    Enable rule via `.editorconfig`
     ```editorconfig
@@ -111,4 +111,48 @@ Suppress or disable rule (1)
    Disable rule via `.editorconfig`
     ```editorconfig
     ktlint_standard_expression-operand-wrapping = disabled
+    ```
+
+## Lambda return
+
+Do not use a labeled return for the last statement in a lambda.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    val foo1 = bar { "value" }
+    val foo2 = bar {
+        if (baz()) return@bar "value"
+
+        "value"
+    }
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    val foo1 = bar { return@foo "value" }
+    val foo2 = bar {
+        if (baz()) return@bar "value" // This is OK
+
+        return@bar "value" // This is disallowed
+    }
+    ```
+
+Rule id: `standard:lambda-return`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:standard:lambda-return")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_lambda-return = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_lambda-return = disabled
     ```

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -437,6 +437,16 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleK
 	public static final fun getKDOC_WRAPPING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRuleKt {
+	public static final fun getLAMBDA_RETURN_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/MaxLineLengthRule$Companion;
 	public fun <init> ()V

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -437,7 +437,7 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/KdocWrappingRuleK
 	public static final fun getKDOC_WRAPPING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
-public final class com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
+public final class com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$Experimental {
 	public fun <init> ()V
 	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -40,6 +40,7 @@ import com.pinterest.ktlint.ruleset.standard.rules.ImportOrderingRule
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import com.pinterest.ktlint.ruleset.standard.rules.KdocRule
 import com.pinterest.ktlint.ruleset.standard.rules.KdocWrappingRule
+import com.pinterest.ktlint.ruleset.standard.rules.LambdaReturnRule
 import com.pinterest.ktlint.ruleset.standard.rules.MaxLineLengthRule
 import com.pinterest.ktlint.ruleset.standard.rules.MixedConditionOperatorsRule
 import com.pinterest.ktlint.ruleset.standard.rules.ModifierListSpacingRule
@@ -145,6 +146,7 @@ public class StandardRuleSetProvider : RuleSetV2Provider(RuleSetId.STANDARD) {
             RuleV2InstanceProvider { IndentationRule() },
             RuleV2InstanceProvider { KdocRule() },
             RuleV2InstanceProvider { KdocWrappingRule() },
+            RuleV2InstanceProvider { LambdaReturnRule() },
             RuleV2InstanceProvider { MaxLineLengthRule() },
             RuleV2InstanceProvider { MixedConditionOperatorsRule() },
             RuleV2InstanceProvider { ModifierListSpacingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt
@@ -102,7 +102,7 @@ public class ImportOrderingRule :
                     }
                     sortedImportsWithSpaces += current
 
-                    return@fold current
+                    current
                 }
 
                 if (hasComments) {
@@ -130,7 +130,7 @@ public class ImportOrderingRule :
                             if (!current.isWhiteSpace && !next.isWhiteSpace) {
                                 node.addChild(PsiWhiteSpaceImpl("\n"), null)
                             }
-                            return@reduce next
+                            next
                         }
                         node.addChild(sortedImportsWithSpaces.last(), null)
                     }
@@ -178,7 +178,7 @@ public class ImportOrderingRule :
             if (first.isWhiteSpace && second.isWhiteSpace) {
                 return@all (first as PsiWhiteSpace).text == (second as PsiWhiteSpace).text
             }
-            return@all first == second
+            first == second
         }
     }
 
@@ -255,7 +255,7 @@ public class ImportOrderingRule :
                                 value,
                                 parseImportsLayout(value),
                             )
-                        } catch (e: IllegalArgumentException) {
+                        } catch (_: IllegalArgumentException) {
                             PropertyType.PropertyValue.invalid(
                                 value,
                                 "Unexpected imports layout: $value",

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL_QUALIFIER
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.RETURN
 import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleV2
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
@@ -46,7 +47,8 @@ public class LambdaReturnRule :
                 INDENT_STYLE_PROPERTY,
                 MAX_LINE_LENGTH_PROPERTY,
             ),
-    ) {
+    ),
+    RuleV2.Experimental {
     private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
     private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRule.kt
@@ -1,0 +1,101 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.LABEL_QUALIFIER
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.RETURN
+import com.pinterest.ktlint.rule.engine.core.api.IndentConfig
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
+import com.pinterest.ktlint.rule.engine.core.api.nextCodeSibling
+import com.pinterest.ktlint.rule.engine.core.api.parent
+import com.pinterest.ktlint.rule.engine.core.api.remove
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.psiUtil.children
+import org.jetbrains.kotlin.psi.psiUtil.siblings
+
+/**
+ * [Kotlin lang documentation](https://kotlinlang.org/docs/coding-conventions.html#returns-in-a-lambda):
+ *
+ * Do not use a labeled return for the last statement in a lambda.
+ * ```
+ * foo {
+ *     doSomething()
+ *     return@foo "value"
+ * }
+ * ```
+ */
+@SinceKtlint("2.0", EXPERIMENTAL)
+public class LambdaReturnRule :
+    StandardRule(
+        id = "lambda-return",
+        usesEditorConfigProperties =
+            setOf(
+                CODE_STYLE_PROPERTY,
+                INDENT_SIZE_PROPERTY,
+                INDENT_STYLE_PROPERTY,
+                MAX_LINE_LENGTH_PROPERTY,
+            ),
+    ) {
+    private var indentConfig = IndentConfig.DEFAULT_INDENT_CONFIG
+    private var maxLineLength = MAX_LINE_LENGTH_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        maxLineLength = editorConfig.maxLineLength()
+        indentConfig =
+            IndentConfig(
+                indentStyle = editorConfig[INDENT_STYLE_PROPERTY],
+                tabWidth = editorConfig[INDENT_SIZE_PROPERTY],
+            )
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        node
+            .takeIf { it.elementType == FUNCTION_LITERAL }
+            ?.findChildByType(BLOCK)
+            ?.children()
+            ?.lastOrNull { it.elementType == RETURN }
+            ?.takeIf { it.nextCodeSibling == null }
+            ?.let { lastReturn -> visitReturnStatement(lastReturn, emit) }
+    }
+
+    private fun visitReturnStatement(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        require(node.elementType == RETURN)
+
+        node
+            .findChildByType(LABEL_QUALIFIER)
+            ?.siblings()
+            ?.dropWhile { it.isWhiteSpace }
+            ?.takeIf { it.count() > 0 }
+            ?.let { siblings ->
+                emit(node.startOffset, "Unnecessary return", true)
+                    .ifAutocorrectAllowed {
+                        val parent = node.parent!!
+                        siblings
+                            // The remaining siblings are moved to before the RETURN sibling. Without collecting the remaining siblings
+                            // first into a list, the RETURN sibling itself would also be tried to be moved which results in a failure.
+                            .toList()
+                            .forEach { sibling -> parent.addChild(sibling, node) }
+                        node.remove()
+                    }
+            }
+    }
+}
+
+public val LAMBDA_RETURN_RULE_ID: RuleId = LambdaReturnRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/LambdaReturnRuleTest.kt
@@ -1,0 +1,91 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class LambdaReturnRuleTest {
+    private val lambdaReturnRuleAssertThat = assertThatRule { LambdaReturnRule() }
+
+    @Test
+    fun `Given a lambda without return statement then do not emit`() {
+        val code =
+            """
+            val foo = bar { "value" }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a lambda with single statement return statement then do not emit`() {
+        val code =
+            """
+            val foo = bar { return@foo "value" }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = bar { "value" }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code)
+            .hasLintViolation(1, 17, "Unnecessary return")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with multiple statements and an early return then then do not emit on the early return`() {
+        val code =
+            """
+            val foo = bar {
+                if (baz()) return@bar "value"
+
+                "value"
+            }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a lambda with multiple statement and an early return then then do not emit`() {
+        val code =
+            """
+            val foo = bar {
+                if (baz()) return@bar "value"
+
+                return@bar "value"
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = bar {
+                if (baz()) return@bar "value"
+
+                "value"
+            }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code)
+            .hasLintViolation(4, 5, "Unnecessary return")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a lambda with an unnecessary return statement and some comments then remove the return but keep the comments`() {
+        val code =
+            """
+            val foo = bar {
+                // comment-1
+                return@foo /* comment-2 */ "value" // comment-3
+                /* comment-4 */
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            val foo = bar {
+                // comment-1
+                /* comment-2 */ "value" // comment-3
+                /* comment-4 */
+            }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code)
+            .hasLintViolation(3, 5, "Unnecessary return")
+            .isFormattedAs(formattedCode)
+    }
+}


### PR DESCRIPTION
## Description

Add experimental rule `lambda-return` to remove a labeled return when it is the last statement in a lambda

Closes #3207

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
