### PR TITLE
Fix writing formatted code containing a "%" character provided via --stdin

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -519,8 +519,14 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
                     }
                     when {
                         code.isStdIn -> {
-                            // Avoid Unicode characters on Windows OS to be malformed as stdout does not default to UTF-8
-                            PrintWriter(OutputStreamWriter(System.out, UTF_8), true).printf(formattedFileContent)
+                            // Avoid Unicode characters on Windows OS to be malformed as stdout does not default to UTF-8 (#3133).
+                            with(PrintWriter(OutputStreamWriter(System.out, UTF_8), true)) {
+                                // Do not use print, print which invoke the format functions which will malfunction when the input file
+                                // contains a '%' character (#3278).
+                                write(formattedFileContent)
+                                // The write method does not autoflush.
+                                flush()
+                            }
                         }
 
                         code.content != formattedFileContent -> {

--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -524,6 +524,31 @@ class SimpleCLITest {
             }
     }
 
+    @Test
+    fun `Issue 3278 - Given some code containing a string with a percent character, the code is provided via stdin then write the formatted code without interpreting the percent character as format instruction`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        val code =
+            """
+            class Foo { val foo = "%"; }
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo {
+                val foo = "%"
+            }
+            """.trimIndent()
+        CommandLineTestRunner(tempDir)
+            .run(
+                testProjectName = "too-many-empty-lines",
+                arguments = listOf("--stdin", "--format"),
+                stdin = ByteArrayInputStream(code.toByteArray()),
+            ) {
+                assertThat(normalOutput.joinToString(separator = "\n")).contains(formattedCode)
+            }
+    }
+
     @Nested
     inner class `Autocorrect violations` {
         @Test


### PR DESCRIPTION
## Description

In #3133 a fix was implemented to retain unicode characters in the formatted output on Windows when input was provided via "--stdin" in Ktlint CLI. This used a "printf" command which interpret "%" as format instructions. This fix now use the "write" command instead.

Closes #3278

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://pinterest.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
