### PR TITLE
Update kotlin to 2.3.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ java-compilation = "25"
 # used in KotlinCommonPlugin
 #noinspection UnusedVersionCatalogEntry
 java-target = "17"
-kotlin = "2.3.10"
-kotlinDev = "2.3.10"
+kotlin = "2.3.20"
+kotlinDev = "2.3.20"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/KtlintKotlinCompiler.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/com/pinterest/ktlint/rule/engine/core/api/KtlintKotlinCompiler.kt
@@ -4,11 +4,13 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.BLOCK
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.SCRIPT_INITIALIZER
 import com.pinterest.ktlint.rule.engine.core.util.cast
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.IdeaStandaloneExecutionSetup
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironmentMode
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreProjectEnvironment
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.diagnostic.DefaultLogger
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
@@ -19,9 +21,9 @@ import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.parsing.KotlinParserDefinition
 import sun.reflect.ReflectionFactory
 import org.jetbrains.kotlin.com.intellij.openapi.diagnostic.Logger as DiagnosticLogger
 
@@ -61,10 +63,6 @@ public object KtlintKotlinCompiler {
 private fun initPsiFileFactory(): PsiFileFactory {
     DiagnosticLogger.setFactory(LoggerFactory::class.java)
 
-    val compilerConfiguration =
-        CompilerConfiguration()
-            .apply { put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE) }
-
     val disposable = Disposer.newDisposable()
     // When running ktlint via the ktlint-intellij-plugin in IntelliJ IDEA, an exception is thrown whenever certain properties are not set
     // (https://github.com/nbadal/ktlint-intellij-plugin/issues/614). When initializing the embedded kotlin compiler while running it within
@@ -72,17 +70,10 @@ private fun initPsiFileFactory(): PsiFileFactory {
     val ideaHomePath = System.getProperties().setProperty(IDEA_HOME_PATH_PROPERTY, "/ktlint/$IDEA_HOME_PATH_PROPERTY") as String?
     val ideaConfigPath = System.getProperties().setProperty(IDEA_CONFIG_PATH_PROPERTY, "/ktlint/$IDEA_CONFIG_PATH_PROPERTY") as String?
     try {
-        val project =
-            KotlinCoreEnvironment
-                .createForProduction(
-                    disposable,
-                    compilerConfiguration,
-                    EnvironmentConfigFiles.JVM_CONFIG_FILES,
-                ).project
-                .cast<MockProject>()
-                .apply { registerFormatPomModel() }
-
-        return PsiFileFactory.getInstance(project)
+        val kotlinCoreProjectEnvironment = createKotlinProjectEnvironment(disposable)
+        return PsiFileFactory.getInstance(kotlinCoreProjectEnvironment.project)
+    } catch (t: Throwable) {
+        throw UnsupportedOperationException(t)
     } finally {
         // Dispose explicitly to (possibly) prevent memory leak
         // https://discuss.kotlinlang.org/t/memory-leak-in-kotlincoreenvironment-and-kotlintojvmbytecodecompiler/21950
@@ -99,6 +90,26 @@ private fun initPsiFileFactory(): PsiFileFactory {
         } else {
             System.setProperty(IDEA_CONFIG_PATH_PROPERTY, ideaConfigPath)
         }
+    }
+}
+
+private fun createKotlinProjectEnvironment(disposable: Disposable): KotlinCoreProjectEnvironment {
+    IdeaStandaloneExecutionSetup.doSetup()
+    val kotlinCoreApplicationEnvironment =
+        KotlinCoreApplicationEnvironment
+            .create(
+                disposable,
+                KotlinCoreApplicationEnvironmentMode.Production,
+            ).also {
+                it.registerParserDefinition(KotlinParserDefinition())
+                // Needed this as well to parse the .kt files
+                it.registerFileType(KotlinFileType.INSTANCE, "kt")
+            }
+    return KotlinCoreProjectEnvironment(disposable, kotlinCoreApplicationEnvironment).also {
+        it
+            .project
+            .cast<MockProject>()
+            .apply { registerFormatPomModel() }
     }
 }
 

--- a/ktlint-ruleset-template/build.gradle.kts
+++ b/ktlint-ruleset-template/build.gradle.kts
@@ -2,7 +2,7 @@
 // build logic of other internal ktlint modules (https://github.com/pinterest/ktlint/issues/3048)..
 
 plugins {
-    kotlin("jvm") version "2.3.10"
+    kotlin("jvm") version "2.3.20"
     // Remove the line below when this custom ruleset is not to be published to maven. If you do want to publish your ruleset to Maven, you
     // still might need to configure the Maven Central repository in file `settings.gradle.xml` which is not included in the sample project
     // as it conflicts with the build of the Ktlint itself. Suggested content of that file:


### PR DESCRIPTION
## Description

Update kotlin to 2.3.20 (supersedes #3206). Fix initialization of the Kotlin compiler.

Closes #3206

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
