### PR TITLE
Update link to documentation in CLI help

### DIFF
--- a/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
+++ b/ktlint-cli/src/main/kotlin/com/pinterest/ktlint/cli/internal/KtlintCommandLine.kt
@@ -72,7 +72,7 @@ internal class KtlintCommandLine : CliktCommand(name = "ktlint") {
     override fun help(context: Context) =
         """
         An anti-bikeshedding Kotlin linter with built-in formatter.
-        (https://pinterest.github.io/ktlint/latest/).
+        (https://ktlint.github.io/ktlint/latest/).
 
         Usage on Windows:
           java -jar ktlint.jar  [<options>] [<arguments>]... <command> [<args>]...


### PR DESCRIPTION
## Description

When you run `ktlint --help` it prints a link to https://pinterest.github.io/ktlint/latest/, but this now redirects you to https://www.pinterestcareers.com/departments/engineering/ instead of the ktlint page. This PR changes the link to https://ktlint.github.io/ktlint/latest/ instead.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)
