### PR TITLE
Do not join supertype with previous line when that line ends with and EOL comment

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRule.kt
@@ -529,7 +529,7 @@ public class ClassSignatureRule :
                                                 superTypeFirstChildNode.upsertWhitespaceBeforeMe(indentConfig.childIndentOf(node))
                                             }
                                     }
-                                } else {
+                                } else if (superTypeFirstChildNode.prevLeaf?.prevSibling?.elementType != EOL_COMMENT) {
                                     val expectedWhitespace = " "
                                     if (whiteSpaceBeforeIdentifier == null ||
                                         whiteSpaceBeforeIdentifier.text != expectedWhitespace

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ClassSignatureRuleTest.kt
@@ -1869,6 +1869,22 @@ class ClassSignatureRuleTest {
             .hasNoLintViolations()
     }
 
+    @Test
+    fun `Issue 3293 - Given an EOL comment between class name and super class then do not join comment and super class as this leads to a compilation error`() {
+        val code =
+            """
+            class Foo : // comment
+                Bar {
+                override fun fooBar() = "foobar"
+            }
+
+            interface Bar {
+                fun fooBar(): String
+            }
+            """.trimIndent()
+        classSignatureWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
     private companion object {
         const val UNEXPECTED_SPACES = "  "
         const val NO_SPACE = ""


### PR DESCRIPTION
## Description

If a class definition contains an EOL comment after the class name, and before the first super type, than the super type should not be joined with the preceding line as this would lead to a compilation error.

Closes #3293

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
