### PR TITLE
Prevent throwing a NullPointerException after fixing EOL comment by `comment-spacing` rule 

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentSpacingRule.kt
@@ -7,11 +7,13 @@ import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.isWhiteSpace
 import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.remove
 import com.pinterest.ktlint.rule.engine.core.api.replaceTextWith
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
 
 @SinceKtlint("0.23", SinceKtlint.Status.STABLE)
 public class CommentSpacingRule : StandardRule("comment-spacing") {
@@ -37,7 +39,11 @@ public class CommentSpacingRule : StandardRule("comment-spacing") {
             ) {
                 emit(node.startOffset, "Missing space after //", true)
                     .ifAutocorrectAllowed {
-                        node.replaceTextWith("// " + text.removePrefix("//"))
+                        // Simply replacing the text of node can result in a nullpointer exception in a rule that run after this rule as the
+                        // reference to the prev leaf, and the parent node are lost
+                        val newEolComment = PsiCommentImpl(EOL_COMMENT, "// ${text.removePrefix("//")}")
+                        (node as LeafPsiElement).rawInsertBeforeMe(newEolComment)
+                        node.remove()
                     }
             }
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/CommentSpacingRuleTest.kt
@@ -64,4 +64,26 @@ class CommentSpacingRuleTest {
                 LintViolation(10, 5, "Missing space after //"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 3291 - Given an EOL comment not followed by space then don't throw nullPointerException in later rule running`() {
+        val code =
+            """
+            kotlin {
+                //comment
+                jvmToolchain(21)
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            kotlin {
+                // comment
+                jvmToolchain(21)
+            }
+            """.trimIndent()
+        commentSpacingRuleAssertThat(code)
+            .asKotlinScript(true)
+            .addAdditionalRuleProvider { SpacingBetweenDeclarationsWithCommentsRule() }
+            .isFormattedAs(formattedCode)
+    }
 }


### PR DESCRIPTION
## Description

Prevent throwing a NullPointerException in a later rule after fixing an EOL comment by `comment-spacing` rule when it is not followed by a space

Closes #3291

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
