### PR TITLE
Enable rule `blank-line-before-declaration` by default for `android_studio`

### DIFF
--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -311,7 +311,7 @@ Suppress or disable rule (1)
     ```
 
 !!! Note
-    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or when the rule is enabled explicitly.
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or `android_studion` or when the rule is enabled explicitly.
 
 ## Block comment initial star alignment
 

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -67,8 +67,9 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/BinaryExpressionW
 	public static final fun getBINARY_EXPRESSION_WRAPPING_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
-public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$OfficialCodeStyle {
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
 }
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -42,8 +42,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  */
 @SinceKtlint("0.50", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
-public class BlankLineBeforeDeclarationRule :
-    StandardRule("blank-line-before-declaration") {
+public class BlankLineBeforeDeclarationRule : StandardRule("blank-line-before-declaration") {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
             stopTraversalOfAST()

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRule.kt
@@ -17,11 +17,13 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType.RETURN_KEYWORD
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.VALUE_ARGUMENT
 import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHEN
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
-import com.pinterest.ktlint.rule.engine.core.api.RuleV2
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
 import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.STABLE
 import com.pinterest.ktlint.rule.engine.core.api.children
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
 import com.pinterest.ktlint.rule.engine.core.api.indent
 import com.pinterest.ktlint.rule.engine.core.api.isCode
@@ -41,8 +43,13 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 @SinceKtlint("0.50", EXPERIMENTAL)
 @SinceKtlint("1.0", STABLE)
 public class BlankLineBeforeDeclarationRule :
-    StandardRule("blank-line-before-declaration"),
-    RuleV2.OfficialCodeStyle {
+    StandardRule("blank-line-before-declaration") {
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
+            stopTraversalOfAST()
+        }
+    }
+
     override fun beforeVisitChildNodes(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
@@ -2,7 +2,7 @@ package com.pinterest.ktlint.ruleset.standard.rules
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
 import com.pinterest.ktlint.test.KtlintDocumentationTest
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Nested
@@ -13,7 +13,10 @@ import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
 import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
 
 class BlankLineBeforeDeclarationRuleTest {
-    private val blankLineBeforeDeclarationRuleAssertThat = assertThatRule { BlankLineBeforeDeclarationRule() }
+    private val blankLineBeforeDeclarationRuleAssertThat =
+        assertThatRuleBuilder { BlankLineBeforeDeclarationRule() }
+            .addAdditionalRuleProvider { NoConsecutiveBlankLinesRule() }
+            .assertThat()
 
     // Just for one single test evaluates that the rule is working for `ktlint_official` and `android_studio` code styles, but not for
     // `intellij_idea`. It is assumed that all other tests (do not) work similarly.
@@ -52,6 +55,39 @@ class BlankLineBeforeDeclarationRuleTest {
         blankLineBeforeDeclarationRuleAssertThat(code)
             .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
             .hasNoLintViolations()
+    }
+
+    // Similar tests could be written for other combinations of declarations, but it would not increase the test coverage
+    @Test
+    fun `Given some consecutive classes separated by exactly one blank line then do not insert another blank line in between`() {
+        val code =
+            """
+            class Foo
+
+            class Bar
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    // Similar tests could be written for other combinations of declarations, but it would not increase the test coverage
+    @Test
+    fun `Given some consecutive classes separated by too many blank line then remove the redundant blank lines`() {
+        val code =
+            """
+            class Foo
+
+
+            class Bar
+            """.trimIndent()
+        val formattedCode =
+            """
+            class Foo
+
+            class Bar
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code)
+            .hasNoLintViolationsExceptInAdditionalRules()
+            .isFormattedAs(formattedCode)
     }
 
     @Test

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDeclarationRuleTest.kt
@@ -1,16 +1,27 @@
 package com.pinterest.ktlint.ruleset.standard.rules
 
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.KtlintDocumentationTest
 import com.pinterest.ktlint.test.LintViolation
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
 
 class BlankLineBeforeDeclarationRuleTest {
     private val blankLineBeforeDeclarationRuleAssertThat = assertThatRule { BlankLineBeforeDeclarationRule() }
 
-    @Test
-    fun `Given some consecutive classes not separated by a blank line then insert a blank line in between`() {
+    // Just for one single test evaluates that the rule is working for `ktlint_official` and `android_studio` code styles, but not for
+    // `intellij_idea`. It is assumed that all other tests (do not) work similarly.
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = INCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given some consecutive classes not separated by a blank line then insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
         val code =
             """
             class Foo
@@ -23,8 +34,24 @@ class BlankLineBeforeDeclarationRuleTest {
             class Bar
             """.trimIndent()
         blankLineBeforeDeclarationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
             .hasLintViolation(2, 1, "Expected a blank line for this declaration")
             .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = EXCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given some consecutive classes not separated by a blank line then do not insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            class Foo
+            class Bar
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -519,5 +546,29 @@ class BlankLineBeforeDeclarationRuleTest {
             val foo2 = foo(fun() = 42)
             """.trimIndent()
         blankLineBeforeDeclarationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 3282 - Given an import statement followed by a top level declaration not separated by a blank line`() {
+        val code =
+            """
+            import bar
+            val foo1 =
+                bar(
+                    fun() = 42,
+                )
+            """.trimIndent()
+        val formattedCode =
+            """
+            import bar
+
+            val foo1 =
+                bar(
+                    fun() = 42,
+                )
+            """.trimIndent()
+        blankLineBeforeDeclarationRuleAssertThat(code)
+            .hasLintViolation(2, 1, "Expected a blank line for this declaration")
+            .isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Rule `blank-line-before-declaration` was enabled by default for code style `ktlint_official` only. As Android Kotlin Style Guide also mandates a blank line before a declaration, it is now also enabled by default for `android_studio` code style. The rule is still disabled for `intellij_idea` code style.

Closes #3282 

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
