### PR TITLE
Add experimental rules for blank lines between sections

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -8,6 +8,130 @@ ktlint_experimental=enabled
 ```
 Also see [enable/disable specific rules](configuration-ktlint.md#disable-rules).
 
+## Blank line before file annotation
+
+Requires a blank line before the file annotation unless that file annotation is on the first line of the file.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    /*
+     * Copyright comment
+     */
+
+    @file:Foo
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    /*
+     * Copyright comment
+     */
+    @file:Foo
+    ```
+
+Rule id: `standard:blank-line-before-file-annotation`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:standard:blank-line-before-file-annotation")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-file-annotation = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-file-annotation = disabled
+    ```
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or `android_studion` or when the rule is enabled explicitly.
+
+## Blank line before imports
+
+Requires a blank line before the imports unless the imports starts at the first line of the file.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    package bar
+
+    import foo
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    package bar
+    import foo
+    ```
+
+Rule id: `standard:blank-line-before-imports`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:standard:blank-line-before-imports")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-imports = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-imports = disabled
+    ```
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or `android_studion` or when the rule is enabled explicitly.
+
+## Blank line before package
+
+Requires a blank line before the package statement unless the package statement is the first line of the file.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin
+    @file:Bar
+
+    package foo
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    @file:Bar
+    package foo
+    ```
+
+Rule id: `standard:blank-line-before-package`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:standard:blank-line-before-package")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-package = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_blank-line-before-package = disabled
+    ```
+
+!!! Note
+    This rule is only run when `ktlint_code_style` is set to `ktlint_official` or `android_studion` or when the rule is enabled explicitly.
+
 ## Call expression wrapping
 
 In case a call expression does not fit on the line, the lambda expression, and/or the value argument list after a reference expression are wrapped. 

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -77,6 +77,36 @@ public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeDe
 	public static final fun getBLANK_LINE_BEFORE_DECLARATION_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
 }
 
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotation : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$Experimental {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotationKt {
+	public static final fun getBLANK_LINE_BEFORE_FILE_ANNOTATION_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImports : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$Experimental {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImportsKt {
+	public static final fun getBLANK_LINE_BEFORE_IMPORTS_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackage : com/pinterest/ktlint/ruleset/standard/StandardRule, com/pinterest/ktlint/rule/engine/core/api/RuleV2$Experimental {
+	public fun <init> ()V
+	public fun beforeFirstNode (Lcom/pinterest/ktlint/rule/engine/core/api/editorconfig/EditorConfig;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackageKt {
+	public static final fun getBLANK_LINE_BEFORE_PACKAGE_RULE_ID ()Lcom/pinterest/ktlint/rule/engine/core/api/RuleId;
+}
+
 public final class com/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions : com/pinterest/ktlint/ruleset/standard/StandardRule {
 	public static final field Companion Lcom/pinterest/ktlint/ruleset/standard/rules/BlankLineBetweenWhenConditions$Companion;
 	public fun <init> ()V

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -9,6 +9,9 @@ import com.pinterest.ktlint.ruleset.standard.rules.ArgumentListWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BackingPropertyNamingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BinaryExpressionWrappingRule
 import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeDeclarationRule
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeFileAnnotation
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeImports
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforePackage
 import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBetweenWhenConditions
 import com.pinterest.ktlint.ruleset.standard.rules.BlockCommentInitialStarAlignmentRule
 import com.pinterest.ktlint.ruleset.standard.rules.CallExpressionWrappingRule
@@ -115,6 +118,9 @@ public class StandardRuleSetProvider : RuleSetV2Provider(RuleSetId.STANDARD) {
             RuleV2InstanceProvider { BackingPropertyNamingRule() },
             RuleV2InstanceProvider { BinaryExpressionWrappingRule() },
             RuleV2InstanceProvider { BlankLineBeforeDeclarationRule() },
+            RuleV2InstanceProvider { BlankLineBeforeFileAnnotation() },
+            RuleV2InstanceProvider { BlankLineBeforeImports() },
+            RuleV2InstanceProvider { BlankLineBeforePackage() },
             RuleV2InstanceProvider { BlankLineBetweenWhenConditions() },
             RuleV2InstanceProvider { BlockCommentInitialStarAlignmentRule() },
             RuleV2InstanceProvider { CallExpressionWrappingRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotation.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotation.kt
@@ -1,0 +1,60 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FILE_ANNOTATION_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleV2
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * Insert a blank line before a file annotation.
+ */
+@SinceKtlint("2.0", EXPERIMENTAL)
+public class BlankLineBeforeFileAnnotation :
+    StandardRule("blank-line-before-file-annotation",),
+    RuleV2.Experimental {
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
+            stopTraversalOfAST()
+        }
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        when (node.elementType) {
+            FILE_ANNOTATION_LIST -> {
+                node
+                    .takeUnless { it.prevLeaf.isBlankLine() }
+                    ?.let { insertBeforeNode ->
+                        emit(insertBeforeNode.startOffset, "Expected a blank line before the file annotation(s)", true)
+                            .ifAutocorrectAllowed {
+                                insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent))
+                            }
+                    }
+                stopTraversalOfAST()
+            }
+            PACKAGE_DIRECTIVE, IMPORT_LIST -> {
+                stopTraversalOfAST()
+            }
+        }
+    }
+
+    private fun ASTNode?.isBlankLine() = this == null || (elementType == WHITE_SPACE && text.count { it == '\n' } > 1)
+}
+
+public val BLANK_LINE_BEFORE_FILE_ANNOTATION_RULE_ID: RuleId = BlankLineBeforeFileAnnotation().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotation.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotation.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  */
 @SinceKtlint("2.0", EXPERIMENTAL)
 public class BlankLineBeforeFileAnnotation :
-    StandardRule("blank-line-before-file-annotation",),
+    StandardRule("blank-line-before-file-annotation"),
     RuleV2.Experimental {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
@@ -48,6 +48,7 @@ public class BlankLineBeforeFileAnnotation :
                     }
                 stopTraversalOfAST()
             }
+
             PACKAGE_DIRECTIVE, IMPORT_LIST -> {
                 stopTraversalOfAST()
             }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImports.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImports.kt
@@ -1,0 +1,54 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleV2
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * Insert a blank line before the imports list
+ */
+@SinceKtlint("2.0", EXPERIMENTAL)
+public class BlankLineBeforeImports :
+    StandardRule("blank-line-before-imports",),
+    RuleV2.Experimental {
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
+            stopTraversalOfAST()
+        }
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType == IMPORT_LIST) {
+            node
+                .takeUnless { it.prevLeaf.isBlankLine() }
+                ?.let { insertBeforeNode ->
+                    emit(insertBeforeNode.startOffset, "Expected a blank line before the import(s)", true)
+                        .ifAutocorrectAllowed {
+                            insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent))
+                        }
+                }
+            stopTraversalOfAST()
+        }
+    }
+
+    private fun ASTNode?.isBlankLine() = this == null || (elementType == WHITE_SPACE && text.count { it == '\n' } > 1)
+}
+
+public val BLANK_LINE_BEFORE_IMPORTS_RULE_ID: RuleId = BlankLineBeforeImports().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImports.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImports.kt
@@ -17,13 +17,14 @@ import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
 import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
 import com.pinterest.ktlint.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.psiUtil.children
 
 /**
  * Insert a blank line before the imports list
  */
 @SinceKtlint("2.0", EXPERIMENTAL)
 public class BlankLineBeforeImports :
-    StandardRule("blank-line-before-imports",),
+    StandardRule("blank-line-before-imports"),
     RuleV2.Experimental {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
@@ -35,7 +36,7 @@ public class BlankLineBeforeImports :
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        if (node.elementType == IMPORT_LIST) {
+        if (node.elementType == IMPORT_LIST && node.children().firstOrNull() != null) {
             node
                 .takeUnless { it.prevLeaf.isBlankLine() }
                 ?.let { insertBeforeNode ->

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackage.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackage.kt
@@ -1,0 +1,59 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.IMPORT_LIST
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.PACKAGE_DIRECTIVE
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.WHITE_SPACE
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleV2
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.pinterest.ktlint.rule.engine.core.api.ifAutocorrectAllowed
+import com.pinterest.ktlint.rule.engine.core.api.indent
+import com.pinterest.ktlint.rule.engine.core.api.prevLeaf
+import com.pinterest.ktlint.rule.engine.core.api.upsertWhitespaceBeforeMe
+import com.pinterest.ktlint.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/**
+ * Insert a blank line before the package statement.
+ */
+@SinceKtlint("2.0", EXPERIMENTAL)
+public class BlankLineBeforePackage :
+    StandardRule("blank-line-before-package",),
+    RuleV2.Experimental {
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
+            stopTraversalOfAST()
+        }
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        when (node.elementType) {
+            PACKAGE_DIRECTIVE -> {
+                node
+                    .takeUnless { it.prevLeaf.isBlankLine() }
+                    ?.let { insertBeforeNode ->
+                        emit(insertBeforeNode.startOffset, "Expected a blank line before the package statement", true)
+                            .ifAutocorrectAllowed {
+                                insertBeforeNode.upsertWhitespaceBeforeMe("\n".plus(node.indent))
+                            }
+                    }
+                stopTraversalOfAST()
+            }
+            IMPORT_LIST -> {
+                stopTraversalOfAST()
+            }
+        }
+    }
+
+    private fun ASTNode?.isBlankLine() = this == null || (elementType == WHITE_SPACE && text.count { it == '\n' } > 1)
+}
+
+public val BLANK_LINE_BEFORE_PACKAGE_RULE_ID: RuleId = BlankLineBeforePackage().ruleId

--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackage.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackage.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  */
 @SinceKtlint("2.0", EXPERIMENTAL)
 public class BlankLineBeforePackage :
-    StandardRule("blank-line-before-package",),
+    StandardRule("blank-line-before-package"),
     RuleV2.Experimental {
     override fun beforeFirstNode(editorConfig: EditorConfig) {
         if (editorConfig[CODE_STYLE_PROPERTY] == CodeStyleValue.intellij_idea) {
@@ -47,6 +47,7 @@ public class BlankLineBeforePackage :
                     }
                 stopTraversalOfAST()
             }
+
             IMPORT_LIST -> {
                 stopTraversalOfAST()
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotationTest.kt
@@ -1,0 +1,109 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
+
+class BlankLineBeforeFileAnnotationTest {
+    private val blankLineBeforeFileAnnotationRuleAssertThat =
+        assertThatRuleBuilder { BlankLineBeforeFileAnnotation() }
+            .addAdditionalRuleProvider { NoConsecutiveBlankLinesRule() }
+            .assertThat()
+
+    // Just for one single test evaluates that the rule is working for `ktlint_official` and `android_studio` code styles, but not for
+    // `intellij_idea`. It is assumed that all other tests (do not) work similarly.
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = INCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and file annotation not separated by a blank line then insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            @file:Foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            @file:Foo
+            """.trimIndent()
+        blankLineBeforeFileAnnotationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasLintViolation(4, 1, "Expected a blank line before the file annotation(s)")
+            .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = EXCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and file annotation not separated by a blank line then do not insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            @file:Foo
+            """.trimIndent()
+        blankLineBeforeFileAnnotationRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a file annotation at the first line then do not insert a blank line before it`() {
+        val code =
+            """
+            @file:Foo
+            """.trimIndent()
+        blankLineBeforeFileAnnotationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and file annotation separated by exactly one blank line then do not insert another blank line in between`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+            @file:Foo
+            """.trimIndent()
+        blankLineBeforeFileAnnotationRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and file annotation separated by too many blank lines then remove redundant blank lines`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+
+            @file:Foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            @file:Foo
+            """.trimIndent()
+        blankLineBeforeFileAnnotationRuleAssertThat(code)
+            .hasNoLintViolationsExceptInAdditionalRules()
+            .isFormattedAs(formattedCode)
+    }
+
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotationTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeFileAnnotationTest.kt
@@ -105,5 +105,4 @@ class BlankLineBeforeFileAnnotationTest {
             .hasNoLintViolationsExceptInAdditionalRules()
             .isFormattedAs(formattedCode)
     }
-
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImportsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImportsTest.kt
@@ -141,4 +141,15 @@ class BlankLineBeforeImportsTest {
             .hasLintViolation(2, 1, "Expected a blank line before the import(s)")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a file not containing any import statement`() {
+        val code =
+            """
+            package bar
+
+            val foo = "foo"
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImportsTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforeImportsTest.kt
@@ -1,0 +1,144 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
+
+class BlankLineBeforeImportsTest {
+    private val blankLineBeforeImportsRuleAssertThat =
+        assertThatRuleBuilder { BlankLineBeforeImports() }
+            .addAdditionalRuleProvider { NoConsecutiveBlankLinesRule() }
+            .assertThat()
+
+    // Just for one single test evaluates that the rule is working for `ktlint_official` and `android_studio` code styles, but not for
+    // `intellij_idea`. It is assumed that all other tests (do not) work similarly.
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = INCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and first import statement not separated by a blank line then insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            import foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasLintViolation(4, 1, "Expected a blank line before the import(s)")
+            .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = EXCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and first import statement not separated by a blank line then do insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given an import statement at the first line then do not insert a blank line before it`() {
+        val code =
+            """
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and import statement separated by exactly one blank line then do not insert another blank line in between`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and import statement separated by too many blank line then do remove the redundant blank lines`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+
+            import foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code)
+            .hasNoLintViolationsExceptInAdditionalRules()
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a file annotation and import statement not separated by a blank line then do not insert a blank line in between`() {
+        val code =
+            """
+            @file:bar
+            import foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            @file:bar
+
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code)
+            .hasLintViolation(2, 1, "Expected a blank line before the import(s)")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a package statement and import statement not separated by a blank line then do not insert a blank line in between`() {
+        val code =
+            """
+            package bar
+            import foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            package bar
+
+            import foo
+            """.trimIndent()
+        blankLineBeforeImportsRuleAssertThat(code)
+            .hasLintViolation(2, 1, "Expected a blank line before the import(s)")
+            .isFormattedAs(formattedCode)
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackageTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/rules/BlankLineBeforePackageTest.kt
@@ -1,0 +1,126 @@
+package com.pinterest.ktlint.ruleset.standard.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRuleBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
+
+class BlankLineBeforePackageTest {
+    private val blankLineBeforePackageRuleAssertThat =
+        assertThatRuleBuilder { BlankLineBeforePackage() }
+            .addAdditionalRuleProvider { NoConsecutiveBlankLinesRule() }
+            .assertThat()
+
+    // Just for one single test evaluates that the rule is working for `ktlint_official` and `android_studio` code styles, but not for
+    // `intellij_idea`. It is assumed that all other tests (do not) work similarly.
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = INCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and package statement not separated by a blank line then insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            package foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            package foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasLintViolation(4, 1, "Expected a blank line before the package statement")
+            .isFormattedAs(formattedCode)
+    }
+
+    @ParameterizedTest(name = "Code style: {0}")
+    @EnumSource(CodeStyleValue::class, mode = EXCLUDE, names = ["ktlint_official", "android_studio"])
+    fun `Given a copyright comment and package statement not separated by a blank line then do not insert a blank line in between`(
+        codeStyleValue: CodeStyleValue,
+    ) {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+            package foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code)
+            .withEditorConfigOverride(CODE_STYLE_PROPERTY to codeStyleValue.name)
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a package statement at the first line then do not insert a blank line before it`() {
+        val code =
+            """
+            package Foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and package statement separated by exactly one blank line then do not insert another blank line in between`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+            package foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a copyright comment and package statement separated by too many blank line then do remove the redundant blank lines`() {
+        val code =
+            """
+            /*
+             * Copyright comment
+             */
+
+
+            package foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            /*
+             * Copyright comment
+             */
+
+            package foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code)
+            .hasNoLintViolationsExceptInAdditionalRules()
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a file annotation and package statement not separated by a blank line then do not insert a blank line in between`() {
+        val code =
+            """
+            @file:bar
+            package foo
+            """.trimIndent()
+        val formattedCode =
+            """
+            @file:bar
+
+            package foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code)
+            .hasLintViolation(2, 1, "Expected a blank line before the package statement")
+            .isFormattedAs(formattedCode)
+    }
+}


### PR DESCRIPTION
## Description

Add experimental rules `blank-line-before-file-annotation`, `blank-line-before-imports` and `blank-line-before-package` to ensure that sections below are separated by exactly one blank line:
* File comment (e.g. Copyright statement)
* File annotation
* Package statement
* Imports

Note that the existing rule `blank-line-before-declarations` enforces the blank line between the imports and the first declaration.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
