### PR TITLE
Fix indentation of "tip" blocks in the documentation

### DIFF
--- a/documentation/release-latest/docs/install/cli.md
+++ b/documentation/release-latest/docs/install/cli.md
@@ -169,10 +169,10 @@ ktlint --stdin -F
 ```
 
 !!! tip "Suppress logging and error output"
-Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
-Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
-
-If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
+    Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
+    Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
+    
+    If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
 
 ```shell title="file path from stdin-path"
 ktlint --stdin --stdin-path /path/to/file/Foo.kt

--- a/documentation/release-latest/docs/rules/standard.md
+++ b/documentation/release-latest/docs/rules/standard.md
@@ -1369,7 +1369,7 @@ Suppress or disable rule (1)
 KDoc's should only be used on elements for which KDoc is to be transformed to documentation. Normal block comments should be used in other cases.
 
 !!! note:
-Access modifiers are ignored. Strictly speaking, one could argue that private declarations should not have a KDoc as no documentation will be generated for it. However, for internal use of developers, the KDoc still serves documentation purposes.
+    Access modifiers are ignored. Strictly speaking, one could argue that private declarations should not have a KDoc as no documentation will be generated for it. However, for internal use of developers, the KDoc still serves documentation purposes.
 
 === "[:material-heart:](#) Ktlint"
 

--- a/documentation/snapshot/docs/install/cli.md
+++ b/documentation/snapshot/docs/install/cli.md
@@ -176,10 +176,10 @@ ktlint --stdin -F
 ```
 
 !!! tip "Suppress logging and error output"
-Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
-Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
-
-If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
+    Logging output printed to `stdout` can be suppressed by setting `--log-level=none` (see [logging](#logging)).
+    Output printed to `stderr` can be suppressed in different ways. To ignore all error output, add `2> /dev/null` to the end of the command line. Otherwise, specify a [reporter](#violation-reporting) to write the error output to a file.
+    
+    If input from `stdin` represents the contents of a file, the file path can be supplied with `stdin-path`. This path is made available for rules to use, the `--format` option will not modify this file. 
 
 ```shell title="file path from stdin-path"
 ktlint --stdin --stdin-path /path/to/file/Foo.kt

--- a/documentation/snapshot/docs/rules/standard.md
+++ b/documentation/snapshot/docs/rules/standard.md
@@ -1369,7 +1369,7 @@ Suppress or disable rule (1)
 KDoc's should only be used on elements for which KDoc is to be transformed to documentation. Normal block comments should be used in other cases.
 
 !!! note:
-Access modifiers are ignored. Strictly speaking, one could argue that private declarations should not have a KDoc as no documentation will be generated for it. However, for internal use of developers, the KDoc still serves documentation purposes.
+    Access modifiers are ignored. Strictly speaking, one could argue that private declarations should not have a KDoc as no documentation will be generated for it. However, for internal use of developers, the KDoc still serves documentation purposes.
 
 === "[:material-heart:](#) Ktlint"
 


### PR DESCRIPTION
## Description

Fix indentation of "tip" blocks in the documentation

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [ ] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [ ] PR title is short and clear (it is used as description in the release changelog)
- [ ] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [X] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
