### PR TITLE
Load `.editorconfig` correctly when `--stdin-path` is a relative path

### DIFF
--- a/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
+++ b/ktlint-cli/src/test/kotlin/com/pinterest/ktlint/cli/SimpleCLITest.kt
@@ -419,6 +419,28 @@ class SimpleCLITest {
     }
 
     @Test
+    fun `Issue 3296 - Merge editorconfig properties from subdirectory with root directory when relative stdin-path is used`(
+        @TempDir
+        tempDir: Path,
+    ) {
+        CommandLineTestRunner(tempDir)
+            .run(
+                testProjectName = "nested-editorconfig",
+                arguments = listOf("--stdin", "--stdin-path", "foo/Foo.kt"),
+                stdin = ByteArrayInputStream("fun foo() = 42".toByteArray()),
+            ) {
+                SoftAssertions()
+                    .apply {
+                        // Check properties overridden in "foo/.editorconfig"
+                        assertThat(normalOutput).containsLineMatching(Regex(".*indent_size: 6.*"))
+                        assertThat(normalOutput).containsLineMatching(Regex(".*ktlint_code_style: intellij_idea.*"))
+                        // Check properties not overridden in "foo/.editorconfig" but defined in root ".editorconfig"
+                        assertThat(normalOutput).containsLineMatching(Regex(".*end_of_line: crlf.*"))
+                    }.assertAll()
+            }
+    }
+
+    @Test
     fun `Issue 1832 - Given stdin input containing Kotlin Script resulting in a KtLintParseException when linted as Kotlin code then process the input as Kotlin Script`(
         @TempDir
         tempDir: Path,

--- a/ktlint-cli/src/test/resources/cli/nested-editorconfig/.editorconfig
+++ b/ktlint-cli/src/test/resources/cli/nested-editorconfig/.editorconfig
@@ -1,0 +1,8 @@
+# Files in this directory and it subdirectories contain files with lint violations which are needed for the cli tests.
+# Those file should not  be changed when ktlint is ran on its own source code as that would result in breaking tests.
+root = true
+
+[*.{kt,kts}]
+indent_size = 3
+end_of_line = crlf
+ktlint_code_style = ktlint_official

--- a/ktlint-cli/src/test/resources/cli/nested-editorconfig/foo/.editorconfig
+++ b/ktlint-cli/src/test/resources/cli/nested-editorconfig/foo/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+indent_size = 6
+ktlint_code_style = intellij_idea

--- a/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
+++ b/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigLoader.kt
@@ -55,7 +55,7 @@ internal class EditorConfigLoader(
      * Properties specified in [editorConfigOverride] take precedence above any other '.editorconfig' file on [filePath] or default value.
      */
     internal fun load(filePath: Path?): EditorConfig {
-        val editorConfigPath = filePath ?: defaultFilePath()
+        val editorConfigPath = filePath?.toAbsolutePath() ?: defaultFilePath()
         val editorConfigProperties: MutableMap<String, Property> =
             createResourcePropertiesService(editorConfigLoaderEc4j.editorConfigLoader, editorConfigDefaults)
                 .queryProperties(editorConfigPath.resource())


### PR DESCRIPTION
## Description

Load `.editorconfig` correctly when `--stdin-path` is a relative path not starting with `./`

Closes #3296

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
