### PR TITLE
Fix call expression wrapping when function literal has an empty multiline block body.

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/CallExpressionWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/CallExpressionWrappingRule.kt
@@ -137,7 +137,7 @@ public class CallExpressionWrappingRule :
             }
             functionLiteral
                 ?.findChildByType(RBRACE)
-                ?.takeUnless { it.prevSibling.isWhiteSpaceWithNewline }
+                ?.takeUnless { it.prevLeaf.isWhiteSpaceWithNewline }
                 ?.let { rbrace ->
                     emit(rbrace.startOffset, "Expected new line before '}'", true)
                         .ifAutocorrectAllowed {

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/CallExpressionWrappingRuleTest.kt
@@ -192,4 +192,15 @@ class CallExpressionWrappingRuleTest {
             .setMaxLineLength()
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a call expression with a function literal having an empty multiline body block then do not add an addition line break before the closing brace`() {
+        val code =
+            """
+            val foo =
+                bar {
+                }
+            """.trimIndent()
+        callExpressionWrappingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix call expression wrapping when function literal has an empty multiline block body.

Do not insert an additional blank line before the closing brace.

```
val foo =
    bar {
    }
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
