### PR TITLE
Fix blank line before package

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContext.kt
@@ -97,7 +97,7 @@ internal class RuleExecutionContext private constructor(
                 e.col,
                 e.rule.ruleId.value,
                 """
-                Rule '${e.rule.ruleId.value}' throws exception in file '${code.fileNameOrStdin()}' at position (${e.line}:${e.col})
+                Rule '${e.rule.ruleId.value}' throws exception in file '${code.filePathOrStdin()}' at position (${e.line}:${e.col})
                    Rule maintainer: ${e.rule.about.maintainer}
                    Issue tracker  : ${e.rule.about.issueTrackerUrl}
                    Repository     : ${e.rule.about.repositoryUrl}

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/BlankLineBeforePackage.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/BlankLineBeforePackage.kt
@@ -38,7 +38,9 @@ public class BlankLineBeforePackage :
         when (node.elementType) {
             PACKAGE_DIRECTIVE -> {
                 node
-                    .takeUnless { it.prevLeaf.isBlankLine() }
+                    // Skip empty package directive (e.g. no package statement)
+                    .takeUnless { it.firstChildNode == null }
+                    ?.takeUnless { it.prevLeaf.isBlankLine() }
                     ?.let { insertBeforeNode ->
                         emit(insertBeforeNode.startOffset, "Expected a blank line before the package statement", true)
                             .ifAutocorrectAllowed {

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/BlankLineBeforePackageTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/BlankLineBeforePackageTest.kt
@@ -123,4 +123,17 @@ class BlankLineBeforePackageTest {
             .hasLintViolation(2, 1, "Expected a blank line before the package statement")
             .isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a file containing a file annotation and an import separated by a blank line, but without package statement then do not add an additional blank line before the empty package directive`() {
+        val code =
+            """
+            @file:bar
+
+            import foo
+            """.trimIndent()
+        blankLineBeforePackageRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Fix blank line before package. When package statement is missing like in example below then do not add additional blank line between the file annotations and the import.
```
@file:bar

import foo
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
