### PR TITLE
Only remove labeled return in lambda if it refers to the lamba itself

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -239,28 +239,50 @@ Suppress or disable rule (1)
 
 ## Lambda return
 
-Do not use a labeled return for the last statement in a lambda.
+Do not use a labeled return for the last statement in a lambda if that label refers to the lambda itself.
 
 === "[:material-heart:](#) Ktlint"
 
     ```kotlin
-    val foo1 = bar { "value" }
-    val foo2 = bar {
-        if (baz()) return@bar "value"
-
-        "value"
-    }
+    val foo =
+        "Foo"
+            .let outer@{ foo ->
+                if (foo != "Foo") {
+                    return@outer "$foo is not expected input"
+                }
+                foo
+                    .let { "$it was a" }
+                    .let secondLet@{
+                        if (foo != "Foo") {
+                            return@secondLet "$foo is not expected input"
+                        }
+                        "$it success"
+                    }.let { return@outer "$it (map after let)" }
+                // This is unreachable code due to "return@outer" in let above.
+                "$foo was a failure"
+            }.let { "$it (let after also)" }
     ```
 
 === "[:material-heart-off-outline:](#) Disallowed"
 
     ```kotlin
-    val foo1 = bar { return@foo "value" }
-    val foo2 = bar {
-        if (baz()) return@bar "value" // This is OK
-
-        return@bar "value" // This is disallowed
-    }
+    val foo =
+        "Foo"
+            .let outer@{ foo ->
+                if (foo != "Foo") {
+                    return@outer "$foo is not expected input"
+                }
+                foo
+                    .let { return@let "$it was a" }
+                    .let secondLet@{
+                        if (foo != "Foo") {
+                            return@secondLet "$foo is not expected input"
+                        }
+                        return@secondLet "$it success"
+                    }.let { return@outer "$it (map after let)" }
+                // This is unreachable code due to "return@outer" in let above.
+                return@outer "$foo was a failure"
+            }.let { return@let "$it (let after also)" }
     ```
 
 Rule id: `standard:lambda-return`

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/LambdaReturnRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/LambdaReturnRule.kt
@@ -2,8 +2,15 @@ package io.github.ktlint.core.ruleset.standard.rules
 
 import io.github.ktlint.core.rule.engine.core.api.AutocorrectDecision
 import io.github.ktlint.core.rule.engine.core.api.ElementType.BLOCK
+import io.github.ktlint.core.rule.engine.core.api.ElementType.CALL_EXPRESSION
 import io.github.ktlint.core.rule.engine.core.api.ElementType.FUNCTION_LITERAL
+import io.github.ktlint.core.rule.engine.core.api.ElementType.IDENTIFIER
+import io.github.ktlint.core.rule.engine.core.api.ElementType.LABEL
+import io.github.ktlint.core.rule.engine.core.api.ElementType.LABELED_EXPRESSION
 import io.github.ktlint.core.rule.engine.core.api.ElementType.LABEL_QUALIFIER
+import io.github.ktlint.core.rule.engine.core.api.ElementType.LAMBDA_ARGUMENT
+import io.github.ktlint.core.rule.engine.core.api.ElementType.LAMBDA_EXPRESSION
+import io.github.ktlint.core.rule.engine.core.api.ElementType.REFERENCE_EXPRESSION
 import io.github.ktlint.core.rule.engine.core.api.ElementType.RETURN
 import io.github.ktlint.core.rule.engine.core.api.IndentConfig
 import io.github.ktlint.core.rule.engine.core.api.RuleId
@@ -19,6 +26,7 @@ import io.github.ktlint.core.rule.engine.core.api.ifAutocorrectAllowed
 import io.github.ktlint.core.rule.engine.core.api.isWhiteSpace
 import io.github.ktlint.core.rule.engine.core.api.nextCodeSibling
 import io.github.ktlint.core.rule.engine.core.api.parent
+import io.github.ktlint.core.rule.engine.core.api.prevCodeSibling
 import io.github.ktlint.core.rule.engine.core.api.remove
 import io.github.ktlint.core.ruleset.standard.StandardRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -80,11 +88,12 @@ public class LambdaReturnRule :
     ) {
         require(node.elementType == RETURN)
 
-        node
-            .findChildByType(LABEL_QUALIFIER)
+        val labelQualifier = node.findChildByType(LABEL_QUALIFIER)
+        labelQualifier
             ?.siblings()
             ?.dropWhile { it.isWhiteSpace }
             ?.takeIf { it.count() > 0 }
+            ?.takeIf { node.refersToInnerMostLambdaArgument(labelQualifier.qualifierIdentifier()) }
             ?.let { siblings ->
                 emit(node.startOffset, "Unnecessary return", true)
                     .ifAutocorrectAllowed {
@@ -98,6 +107,35 @@ public class LambdaReturnRule :
                     }
             }
     }
+
+    private fun ASTNode.refersToInnerMostLambdaArgument(qualifierIdentifier: String?) =
+        qualifierIdentifier == listOfNotNull(labeledLambdaArgumentIdentifier(), unlabeledLambdaArgumentIdentifier()).firstOrNull()
+
+    private fun ASTNode.labeledLambdaArgumentIdentifier() =
+        // For lambda argument having an explicit label, extract the label (e.g. "someLabel") for code like:
+        // .    foo.let someLabel@{ ... }
+        parent { it.elementType == LAMBDA_EXPRESSION }
+            ?.takeIf { it.treeParent.elementType == LABELED_EXPRESSION }
+            ?.prevCodeSibling
+            ?.qualifierIdentifier()
+
+    private fun ASTNode.unlabeledLambdaArgumentIdentifier() =
+        // For lambda argument not having an explicit label, extract the identifier (e.g. "let") for code like:
+        // .    foo.let { ... }
+        parent { it.elementType == LAMBDA_EXPRESSION }
+            ?.takeIf { it.treeParent.elementType != LABELED_EXPRESSION }
+            ?.parent { it.elementType == LAMBDA_ARGUMENT }
+            ?.parent { it.elementType == CALL_EXPRESSION }
+            ?.findChildByType(REFERENCE_EXPRESSION)
+            ?.findChildByType(IDENTIFIER)
+            ?.text
+
+    private fun ASTNode?.qualifierIdentifier(): String? =
+        this
+            ?.takeIf { it.elementType == LABEL_QUALIFIER }
+            ?.findChildByType(LABEL)
+            ?.findChildByType(IDENTIFIER)
+            ?.text
 }
 
 public val LAMBDA_RETURN_RULE_ID: RuleId = LambdaReturnRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/LambdaReturnRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/LambdaReturnRuleTest.kt
@@ -1,6 +1,8 @@
 package io.github.ktlint.core.ruleset.standard.rules
 
 import io.github.ktlint.core.test.KtLintAssertThat.Companion.assertThatRule
+import io.github.ktlint.core.test.KtlintDocumentationTest
+import io.github.ktlint.core.test.LintViolation
 import org.junit.jupiter.api.Test
 
 class LambdaReturnRuleTest {
@@ -19,7 +21,7 @@ class LambdaReturnRuleTest {
     fun `Given a lambda with single statement return statement then do not emit`() {
         val code =
             """
-            val foo = bar { return@foo "value" }
+            val foo = bar { return@bar "value" }
             """.trimIndent()
         val formattedCode =
             """
@@ -72,7 +74,7 @@ class LambdaReturnRuleTest {
             """
             val foo = bar {
                 // comment-1
-                return@foo /* comment-2 */ "value" // comment-3
+                return@bar /* comment-2 */ "value" // comment-3
                 /* comment-4 */
             }
             """.trimIndent()
@@ -87,5 +89,56 @@ class LambdaReturnRuleTest {
         lambdaReturnRuleAssertThat(code)
             .hasLintViolation(3, 5, "Unnecessary return")
             .isFormattedAs(formattedCode)
+    }
+
+    @KtlintDocumentationTest
+    fun `Given some nested lambda arguments then only remove return when it refers to the inner most lambda`() {
+        val code =
+            $$"""
+            val foo =
+                "Foo"
+                    .let outer@{ foo ->
+                        if (foo != "Foo") {
+                            return@outer "$foo is not expected input"
+                        }
+                        foo
+                            .let { return@let "$it was a" }
+                            .let secondLet@{
+                                if (foo != "Foo") {
+                                    return@secondLet "$foo is not expected input"
+                                }
+                                return@secondLet "$it success"
+                            }.let { return@outer "$it (map after let)" }
+                        // This is unreachable code due to "return@outer" in let above.
+                        return@outer "$foo was a failure"
+                    }.let { return@let "$it (let after also)" }
+            """.trimIndent()
+        val formattedCode =
+            $$"""
+            val foo =
+                "Foo"
+                    .let outer@{ foo ->
+                        if (foo != "Foo") {
+                            return@outer "$foo is not expected input"
+                        }
+                        foo
+                            .let { "$it was a" }
+                            .let secondLet@{
+                                if (foo != "Foo") {
+                                    return@secondLet "$foo is not expected input"
+                                }
+                                "$it success"
+                            }.let { return@outer "$it (map after let)" }
+                        // This is unreachable code due to "return@outer" in let above.
+                        "$foo was a failure"
+                    }.let { "$it (let after also)" }
+            """.trimIndent()
+        lambdaReturnRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(8, 24, "Unnecessary return"),
+                LintViolation(13, 21, "Unnecessary return"),
+                LintViolation(16, 13, "Unnecessary return"),
+                LintViolation(17, 17, "Unnecessary return"),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Only remove labeled return in lambda if it refers to the lamba containing the return statement (`lambda-return`)

When the return statement refers to an out lambda, it may not be removed as this can result in changing behavior or compilation errors.

Follow-up on #3274 (#3207)

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
