### PR TITLE
Add experimental rule no-blank-line-at-start-of-file

### DIFF
--- a/documentation/snapshot/docs/rules/experimental.md
+++ b/documentation/snapshot/docs/rules/experimental.md
@@ -302,3 +302,38 @@ Suppress or disable rule (1)
     ```editorconfig
     ktlint_standard_lambda-return = disabled
     ```
+
+## No blank line at start of file
+
+Don't allow whitespace at the start of the file.
+
+=== "[:material-heart:](#) Ktlint"
+
+    ```kotlin 
+    package foo
+    ```
+
+=== "[:material-heart-off-outline:](#) Disallowed"
+
+    ```kotlin
+    
+    package foo
+    ```
+
+Rule id: `standard:no-blank-line-at-start-of-file`
+
+Suppress or disable rule (1)
+{ .annotate }
+
+1. Suppress rule in code with annotation below:
+    ```kotlin
+    @Suppress("ktlint:standard:no-blank-line-at-start-of-file")
+    ```
+   Enable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_no-blank-line-at-start-of-file = enabled
+    ```
+   Disable rule via `.editorconfig`
+    ```editorconfig
+    ktlint_standard_no-blank-line-at-start-of-file = disabled
+    ```

--- a/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
+++ b/ktlint-ruleset-standard/api/ktlint-ruleset-standard.api
@@ -551,6 +551,15 @@ public final class io/github/ktlint/core/ruleset/standard/rules/MultilineLoopRul
 	public static final fun getMULTILINE_LOOP_RULE_ID ()Lio/github/ktlint/core/rule/engine/core/api/RuleId;
 }
 
+public final class io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRule : io/github/ktlint/core/ruleset/standard/StandardRule, io/github/ktlint/core/rule/engine/core/api/RuleV2$Experimental {
+	public fun <init> ()V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRuleKt {
+	public static final fun getNO_BLANK_LINE_AT_START_OF_FILE_RULE_ID ()Lio/github/ktlint/core/rule/engine/core/api/RuleId;
+}
+
 public final class io/github/ktlint/core/ruleset/standard/rules/NoBlankLineBeforeRbraceRule : io/github/ktlint/core/ruleset/standard/StandardRule {
 	public fun <init> ()V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;Lkotlin/jvm/functions/Function3;)V

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/StandardRuleSetProvider.kt
@@ -51,6 +51,7 @@ import io.github.ktlint.core.ruleset.standard.rules.ModifierOrderRule
 import io.github.ktlint.core.ruleset.standard.rules.MultiLineIfElseRule
 import io.github.ktlint.core.ruleset.standard.rules.MultilineExpressionWrappingRule
 import io.github.ktlint.core.ruleset.standard.rules.MultilineLoopRule
+import io.github.ktlint.core.ruleset.standard.rules.NoBlankLineAtStartOfFileRule
 import io.github.ktlint.core.ruleset.standard.rules.NoBlankLineBeforeRbraceRule
 import io.github.ktlint.core.ruleset.standard.rules.NoBlankLineInListRule
 import io.github.ktlint.core.ruleset.standard.rules.NoBlankLinesInChainedMethodCallsRule
@@ -159,6 +160,7 @@ public class StandardRuleSetProvider : RuleSetV2Provider(RuleSetId.STANDARD) {
             RuleV2Provider { MultiLineIfElseRule() },
             RuleV2Provider { MultilineExpressionWrappingRule() },
             RuleV2Provider { MultilineLoopRule() },
+            RuleV2Provider { NoBlankLineAtStartOfFileRule() },
             RuleV2Provider { NoBlankLineBeforeRbraceRule() },
             RuleV2Provider { NoBlankLineInListRule() },
             RuleV2Provider { NoBlankLinesInChainedMethodCallsRule() },

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRule.kt
@@ -1,0 +1,40 @@
+package io.github.ktlint.core.ruleset.standard.rules
+
+import io.github.ktlint.core.rule.engine.core.api.AutocorrectDecision
+import io.github.ktlint.core.rule.engine.core.api.RuleId
+import io.github.ktlint.core.rule.engine.core.api.RuleV2
+import io.github.ktlint.core.rule.engine.core.api.SinceKtlint
+import io.github.ktlint.core.rule.engine.core.api.SinceKtlint.Status.EXPERIMENTAL
+import io.github.ktlint.core.rule.engine.core.api.firstChildLeafOrSelf
+import io.github.ktlint.core.rule.engine.core.api.ifAutocorrectAllowed
+import io.github.ktlint.core.rule.engine.core.api.isRoot
+import io.github.ktlint.core.rule.engine.core.api.isWhiteSpace
+import io.github.ktlint.core.rule.engine.core.api.leavesForwardsIncludingSelf
+import io.github.ktlint.core.rule.engine.core.api.remove
+import io.github.ktlint.core.ruleset.standard.StandardRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+@SinceKtlint("2.0", EXPERIMENTAL)
+public class NoBlankLineAtStartOfFileRule :
+    StandardRule(id = "no-blank-line-at-start-of-file"),
+    RuleV2.Experimental {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.isRoot) {
+            node
+                .firstChildLeafOrSelf
+                .leavesForwardsIncludingSelf
+                .takeWhile { it.isWhiteSpace || it.textLength == 0 }
+                .filter { it.isWhiteSpace }
+                .forEach {
+                    emit(it.startOffset, "Unexpected whitespace at start of file", true)
+                        .ifAutocorrectAllowed { it.remove() }
+                }
+            stopTraversalOfAST()
+        }
+    }
+}
+
+public val NO_BLANK_LINE_AT_START_OF_FILE_RULE_ID: RuleId = NoBlankLineAtStartOfFileRule().ruleId

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/NoBlankLineAtStartOfFileRuleTest.kt
@@ -1,0 +1,91 @@
+package io.github.ktlint.core.ruleset.standard.rules
+
+import io.github.ktlint.core.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class NoBlankLineAtStartOfFileRuleTest {
+    private val noBlankLineAtStartOfFileRuleAssertThat = assertThatRule { NoBlankLineAtStartOfFileRule() }
+
+    @Test
+    fun `Given a blank line before the Copyright comment`() {
+        val code =
+            """
+            |
+            |/*
+            | * Copyright 2026
+            | */
+            """.trimMargin()
+        val formattedCode =
+            """
+            /*
+             * Copyright 2026
+             */
+            """.trimIndent()
+        noBlankLineAtStartOfFileRuleAssertThat(code)
+            .hasLintViolation(1, 1, "Unexpected whitespace at start of file")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a blank line before the package statement`() {
+        val code =
+            """
+            |
+            |package foo
+            """.trimMargin()
+        val formattedCode =
+            """
+            package foo
+            """.trimIndent()
+        noBlankLineAtStartOfFileRuleAssertThat(code)
+            .hasLintViolation(1, 1, "Unexpected whitespace at start of file")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a blank line before the first import statement`() {
+        val code =
+            """
+            |
+            |import foo
+            """.trimMargin()
+        val formattedCode =
+            """
+            import foo
+            """.trimIndent()
+        noBlankLineAtStartOfFileRuleAssertThat(code)
+            .hasLintViolation(1, 1, "Unexpected whitespace at start of file")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a blank line before the first declaration`() {
+        val code =
+            """
+            |
+            |val foo = "foo"
+            """.trimMargin()
+        val formattedCode =
+            """
+            val foo = "foo"
+            """.trimIndent()
+        noBlankLineAtStartOfFileRuleAssertThat(code)
+            .hasLintViolation(1, 1, "Unexpected whitespace at start of file")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given an empty file`() {
+        val code = ""
+        noBlankLineAtStartOfFileRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a file containing whitespace only`() {
+        val code = " "
+        val formattedCode = ""
+        noBlankLineAtStartOfFileRuleAssertThat(code)
+            .hasLintViolation(1, 1, "Unexpected whitespace at start of file")
+            .isFormattedAs(formattedCode)
+    }
+}


### PR DESCRIPTION
## Description

Add rule `no-blank-line-at-start-of-file` to detect and remove unexpected whitespace at the start of the file.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [X] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
