### PR TITLE
fix(indent): support tabs before multiline where clauses

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
@@ -666,9 +666,13 @@ public class IndentationRule :
                         fromAstNode = where.getPrecedingLeadingCommentsAndWhitespaces(),
                         toAstNode = typeConstraintList.lastChildLeafOrSelf,
                         childIndent =
-                            " ".repeat(
-                                maxOf(0, where.column - 1 - node.indentWithoutNewlinePrefix.length),
-                            ),
+                            if (where.prevLeaf?.isWhiteSpaceWithNewline == true) {
+                                indentConfig.indent
+                            } else {
+                                " ".repeat(
+                                    maxOf(0, where.column - 1 - node.indentWithoutNewlinePrefix.length),
+                                )
+                            },
                     ).prevCodeLeaf()
             }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRuleTest.kt
@@ -2807,6 +2807,41 @@ internal class IndentationRuleTest {
         }
     }
 
+    @Nested
+    inner class `Issue 3362 - Given the WHERE keyword and tab indentation` {
+        @Test
+        fun `Given a function with WHERE on a separate line`() {
+            val code =
+                """
+                private interface First
+
+                private interface Second
+
+                private fun <T> example(value: T)
+                    where T : First,
+                          T : Second {
+                    println(value)
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                private interface First
+
+                private interface Second
+
+                private fun <T> example(value: T)
+                ${TAB}where T : First,
+                ${TAB}      T : Second {
+                ${TAB}println(value)
+                }
+                """.trimIndent()
+
+            indentationRuleAssertThat(code)
+                .withEditorConfigOverride(INDENT_STYLE_TAB)
+                .isFormattedAs(formattedCode)
+        }
+    }
+
     @Test // "https://github.com/pinterest/ktlint/issues/433"
     fun `Given a parameter list in which parameters are prefixed with a comment block`() {
         val code =


### PR DESCRIPTION
## Summary

- use the configured indent when a function `where` clause starts on a new line
- preserve the existing column-based alignment for same-line constraints
- add a tab-indentation regression test

## Verification

- `./gradlew :ktlint-ruleset-standard:test --tests 'io.github.ktlint.core.ruleset.standard.rules.IndentationRuleTest'`
- `./gradlew :ktlint-ruleset-standard:test ktlintCheck`
- `git diff --check`

Closes #3362
