### PR TITLE
Support positional name based destructuring

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundSquareBracketsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundSquareBracketsRule.kt
@@ -2,6 +2,7 @@ package io.github.ktlint.core.ruleset.standard.rules
 
 import io.github.ktlint.core.rule.engine.core.api.AutocorrectDecision
 import io.github.ktlint.core.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
+import io.github.ktlint.core.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION
 import io.github.ktlint.core.rule.engine.core.api.ElementType.KDOC_MARKDOWN_LINK
 import io.github.ktlint.core.rule.engine.core.api.ElementType.LBRACKET
 import io.github.ktlint.core.rule.engine.core.api.ElementType.RBRACKET
@@ -44,7 +45,7 @@ public class SpacingAroundSquareBracketsRule : StandardRule("square-brackets-spa
                         false
                     }
 
-                    COLLECTION_LITERAL_EXPRESSION -> {
+                    COLLECTION_LITERAL_EXPRESSION, DESTRUCTURING_DECLARATION -> {
                         // Allow:
                         //     @Foo(
                         //        fooBar = ["foo", "bar"],

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRule.kt
@@ -7,11 +7,13 @@ import io.github.ktlint.core.rule.engine.core.api.ElementType.CLASS_BODY
 import io.github.ktlint.core.rule.engine.core.api.ElementType.COLLECTION_LITERAL_EXPRESSION
 import io.github.ktlint.core.rule.engine.core.api.ElementType.COMMA
 import io.github.ktlint.core.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION
+import io.github.ktlint.core.rule.engine.core.api.ElementType.DESTRUCTURING_DECLARATION_ENTRY
 import io.github.ktlint.core.rule.engine.core.api.ElementType.ENUM_ENTRY
 import io.github.ktlint.core.rule.engine.core.api.ElementType.ENUM_KEYWORD
 import io.github.ktlint.core.rule.engine.core.api.ElementType.FUNCTION_LITERAL
 import io.github.ktlint.core.rule.engine.core.api.ElementType.FUNCTION_TYPE
 import io.github.ktlint.core.rule.engine.core.api.ElementType.GT
+import io.github.ktlint.core.rule.engine.core.api.ElementType.LBRACKET
 import io.github.ktlint.core.rule.engine.core.api.ElementType.LPAR
 import io.github.ktlint.core.rule.engine.core.api.ElementType.RBRACE
 import io.github.ktlint.core.rule.engine.core.api.ElementType.RBRACKET
@@ -38,9 +40,11 @@ import io.github.ktlint.core.rule.engine.core.api.isCode
 import io.github.ktlint.core.rule.engine.core.api.isWhiteSpace
 import io.github.ktlint.core.rule.engine.core.api.isWhiteSpaceWithNewline
 import io.github.ktlint.core.rule.engine.core.api.nextLeaf
+import io.github.ktlint.core.rule.engine.core.api.nextSibling
 import io.github.ktlint.core.rule.engine.core.api.noNewLineInClosedRange
 import io.github.ktlint.core.rule.engine.core.api.parent
 import io.github.ktlint.core.rule.engine.core.api.prevCodeLeaf
+import io.github.ktlint.core.rule.engine.core.api.prevCodeSibling
 import io.github.ktlint.core.rule.engine.core.api.prevLeaf
 import io.github.ktlint.core.rule.engine.core.api.remove
 import io.github.ktlint.core.rule.engine.core.api.replaceTextWith
@@ -97,12 +101,8 @@ public class TrailingCommaOnDeclarationSiteRule :
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        val inspectNode =
-            node
-                .children
-                .last { it.elementType == RPAR }
         node.reportAndCorrectTrailingCommaNodeBefore(
-            inspectNode = inspectNode,
+            inspectNode = node.closingElementDestructuringDeclarationEntries(),
             isTrailingCommaAllowed = node.isTrailingCommaAllowed(),
             emit = emit,
         )
@@ -358,7 +358,6 @@ public class TrailingCommaOnDeclarationSiteRule :
             }
 
             TrailingCommaState.NOT_EXISTS -> {
-                Unit
             }
         }
     }
@@ -378,7 +377,12 @@ public class TrailingCommaOnDeclarationSiteRule :
             }
 
             elementType == DESTRUCTURING_DECLARATION -> {
-                hasNewLineInClosedRange(findChildByType(LPAR)!!, findChildByType(RPAR)!!)
+                hasNewLineInClosedRange(
+                    // Get the LPAR or LBRACKET before the first entry
+                    openingElementDestructuringDeclarationEntries(),
+                    // Get the RPAR or RBRACKET after the last entry
+                    closingElementDestructuringDeclarationEntries(),
+                )
             }
 
             elementType == VALUE_ARGUMENT_LIST &&
@@ -399,6 +403,21 @@ public class TrailingCommaOnDeclarationSiteRule :
                 textContains('\n')
             }
         }
+
+    private fun ASTNode.openingElementDestructuringDeclarationEntries(): ASTNode {
+        require(elementType == DESTRUCTURING_DECLARATION)
+        return findChildByType(DESTRUCTURING_DECLARATION_ENTRY)!!
+            .prevCodeSibling!!
+            .also { require(it.elementType == LPAR || it.elementType == LBRACKET) }
+    }
+
+    private fun ASTNode.closingElementDestructuringDeclarationEntries(): ASTNode {
+        require(elementType == DESTRUCTURING_DECLARATION)
+        return children()
+            .last { it.elementType == DESTRUCTURING_DECLARATION_ENTRY }
+            .nextSibling { it.isCode && it.elementType != COMMA }!!
+            .also { require(it.elementType == RPAR || it.elementType == RBRACKET) }
+    }
 
     private fun ASTNode.leafBeforeArrowOrNull() =
         takeIf { it.elementType == WHEN_ENTRY || it.elementType == FUNCTION_LITERAL }

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundSquareBracketsRuleTest.kt
@@ -145,4 +145,15 @@ class SpacingAroundSquareBracketsRuleTest {
                 LintViolation(1, 23, "Unexpected spacing before ']'", canBeAutoCorrected = true),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Issue 3364 - Given an declaration with positional based destructuring then ignore space before lbracket`() {
+        val code =
+            """
+            fun foo() {
+                val [x, y] = Pair(1, 2)
+            }
+            """.trimIndent()
+        spacingAroundSquareBracketsRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnDeclarationSiteRuleTest.kt
@@ -30,6 +30,7 @@ class TrailingCommaOnDeclarationSiteRuleTest {
                 fun bar(): Pair<Int, Int> = Pair(1, 2)
 
                 val (x, y,) = bar()
+                val [a, b,] = bar()
             }
 
             val foo5: (Int, Int,) -> Int = 42
@@ -51,6 +52,7 @@ class TrailingCommaOnDeclarationSiteRuleTest {
                 fun bar(): Pair<Int, Int> = Pair(1, 2)
 
                 val (x, y) = bar()
+                val [a, b] = bar()
             }
 
             val foo5: (Int, Int) -> Int = 42
@@ -63,9 +65,10 @@ class TrailingCommaOnDeclarationSiteRuleTest {
                 LintViolation(3, 16, "Unnecessary trailing comma before \">\""),
                 LintViolation(6, 9, "Unnecessary trailing comma before \"->\""),
                 LintViolation(13, 14, "Unnecessary trailing comma before \")\""),
-                LintViolation(16, 20, "Unnecessary trailing comma before \")\""),
-                LintViolation(18, 20, "Unnecessary trailing comma before \")\""),
-                LintViolation(18, 42, "Unnecessary trailing comma before \"->\""),
+                LintViolation(14, 14, "Unnecessary trailing comma before \"]\""),
+                LintViolation(17, 20, "Unnecessary trailing comma before \")\""),
+                LintViolation(19, 20, "Unnecessary trailing comma before \")\""),
+                LintViolation(19, 42, "Unnecessary trailing comma before \"->\""),
             ).isFormattedAs(formattedCode)
     }
 
@@ -1086,5 +1089,90 @@ class TrailingCommaOnDeclarationSiteRuleTest {
         trailingCommaOnDeclarationSiteRuleAssertThat(code)
             .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
             .hasNoLintViolations()
+    }
+
+    @Test
+    fun `Issue 3364 - Given that the trailing comma is not allowed on declaration site then remove it from the positional destructuring declaration when present`() {
+        val code =
+            """
+            fun foo() {
+                fun bar(): Pair<Int, Int> = Pair(1, 2)
+
+                val [x, y,] = bar()
+                val [
+                    x,
+                    y, // The comma before the comment should be removed without removing the comment itself
+                ] = bar()
+                val [
+                    x,
+                    y, /* The comma before the comment should be removed without removing the comment itself */
+                ] = bar()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                fun bar(): Pair<Int, Int> = Pair(1, 2)
+
+                val [x, y] = bar()
+                val [
+                    x,
+                    y // The comma before the comment should be removed without removing the comment itself
+                ] = bar()
+                val [
+                    x,
+                    y /* The comma before the comment should be removed without removing the comment itself */
+                ] = bar()
+            }
+            """.trimIndent()
+        trailingCommaOnDeclarationSiteRuleAssertThat(code)
+            .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to false)
+            .hasLintViolations(
+                LintViolation(4, 14, "Unnecessary trailing comma before \"]\""),
+                LintViolation(7, 10, "Unnecessary trailing comma before \"]\""),
+                LintViolation(11, 10, "Unnecessary trailing comma before \"]\""),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Issue 3364 - Given that the trailing comma is required on declaration site then add it to the positional destructuring declaration when missing`() {
+        val code =
+            """
+            fun foo() {
+                fun bar(): Pair<Int, Int> = Pair(1, 2)
+
+                val [x, y] = bar()
+                val [
+                    x,
+                    y // The comma should be inserted before the comment
+                ] = bar()
+                val [
+                    x,
+                    y /* The comma should be inserted before the comment */
+                ] = bar()
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun foo() {
+                fun bar(): Pair<Int, Int> = Pair(1, 2)
+
+                val [x, y] = bar()
+                val [
+                    x,
+                    y, // The comma should be inserted before the comment
+                ] = bar()
+                val [
+                    x,
+                    y, /* The comma should be inserted before the comment */
+                ] = bar()
+            }
+            """.trimIndent()
+        trailingCommaOnDeclarationSiteRuleAssertThat(code)
+            .withEditorConfigOverride(TRAILING_COMMA_ON_DECLARATION_SITE_PROPERTY to true)
+            .hasLintViolations(
+                LintViolation(7, 10, "Missing trailing comma before \"]\""),
+                LintViolation(11, 10, "Missing trailing comma before \"]\""),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Support positional name based destructuring (introduced as Experimental in Ktlint 2.3.20)

Closes #3364

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [X] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
