### PR TITLE
Override outdated log4j dependencies provided via logcaptor 2.12.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,8 @@ slf4j = "org.slf4j:slf4j-simple:2.0.18"
 poko = "dev.drewhamilton.poko:poko-gradle-plugin:0.23.1"
 # Use logback-classic as the logger for kotlin-logging / slf4j as it allow changing the log level at runtime.
 logback = "ch.qos.logback:logback-classic:1.6.3"
+# TODO: When upgrading logcaptor to version > 2.12.6 then remove dependency constraint in ktlint-cli-reporter-baseline which overrides the
+#  log4j dependencies
 logcaptor = "io.github.hakky54:logcaptor:2.12.6"
 # Required for logback-test.xml conditional configuration so that trace-logging in unit test can be automatically enabled using an
 # environment variable

--- a/ktlint-cli-reporter-baseline/build.gradle.kts
+++ b/ktlint-cli-reporter-baseline/build.gradle.kts
@@ -3,6 +3,22 @@ plugins {
 }
 
 dependencies {
+    constraints {
+        implementation("org.apache.logging.log4j:log4j-to-slf4j:2.26.1") {
+            //  +--- io.github.hakky54:logcaptor:2.12.6
+            //  |    +--- org.slf4j:slf4j-api:2.0.17 -> 2.0.18
+            //  |    +--- ch.qos.logback:logback-classic:1.3.15 -> 1.6.3 (*)
+            //  |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.25.3 -> 2.26.1
+            because("logcaptor 2.12.6 provides an outdated version of slf4j")
+        }
+        implementation("org.apache.logging.log4j:log4j-api:2.26.1") {
+            //  +--- io.github.hakky54:logcaptor:2.12.6
+            //  |    +--- org.slf4j:slf4j-api:2.0.17 -> 2.0.18
+            //  |    +--- ch.qos.logback:logback-classic:1.3.15 -> 1.6.3 (*)
+            //  |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.25.3 -> 2.26.1
+            because("logcaptor 2.12.6 provides an outdated version of slf4j")
+        }
+    }
     implementation(projects.ktlintLogger)
     implementation(projects.ktlintRuleEngineCore)
     implementation(projects.ktlintCliReporterCore)


### PR DESCRIPTION
## Description

Override outdated log4j dependencies (version `2.25.3`) provided via logcaptor 2.12.6 with latest version `2.26.1`.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
