### PR TITLE
Cleanup compilation warnings

### DIFF
--- a/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
+++ b/ktlint-rule-engine-core/api/ktlint-rule-engine-core.api
@@ -210,7 +210,6 @@ public final class io/github/ktlint/core/rule/engine/core/api/ElementType {
 	public final fun getKDOC_END ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getKDOC_LEADING_ASTERISK ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getKDOC_MARKDOWN_ESCAPED_CHAR ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
-	public final fun getKDOC_MARKDOWN_INLINE_LINK ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getKDOC_MARKDOWN_LINK ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getKDOC_NAME ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;
 	public final fun getKDOC_SECTION ()Lorg/jetbrains/kotlin/com/intellij/psi/tree/IElementType;

--- a/ktlint-rule-engine-core/src/main/kotlin/io/github/ktlint/core/rule/engine/core/api/ElementType.kt
+++ b/ktlint-rule-engine-core/src/main/kotlin/io/github/ktlint/core/rule/engine/core/api/ElementType.kt
@@ -283,7 +283,6 @@ public object ElementType {
     public val KDOC_TAG_NAME: IElementType = KDocTokens.TAG_NAME
     public val KDOC_MARKDOWN_LINK: IElementType = KDocTokens.MARKDOWN_LINK
     public val KDOC_MARKDOWN_ESCAPED_CHAR: IElementType = KDocTokens.MARKDOWN_ESCAPED_CHAR
-    public val KDOC_MARKDOWN_INLINE_LINK: IElementType = KDocTokens.MARKDOWN_INLINE_LINK
     public val KDOC_SECTION: IElementType = KDocElementTypes.KDOC_SECTION
     public val KDOC_TAG: IElementType = KDocElementTypes.KDOC_TAG
     public val KDOC_NAME: IElementType = KDocElementTypes.KDOC_NAME

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
@@ -1300,7 +1300,7 @@ public class IndentationRule :
             }
         val nodeIndent = text.substringAfterLast("\n")
         return if (nodeIndent.endsWith(acceptableTrailingSpaces)) {
-            return acceptableTrailingSpaces
+            acceptableTrailingSpaces
         } else {
             ""
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TrailingCommaOnCallSiteRule.kt
@@ -182,7 +182,7 @@ public class TrailingCommaOnCallSiteRule :
             }
 
             TrailingCommaState.NOT_EXISTS -> {
-                Unit
+                // Nothing to do
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -249,7 +249,7 @@ public class TypeParameterListSpacingRule :
     ) {
         when {
             node.text == " " -> {
-                Unit
+                // Nothing to do
             }
 
             node.isWhiteSpaceWithNewline -> {

--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
@@ -303,8 +303,8 @@ public class WrappingRule :
             // class A : B, C, D({
             // })
             !(
-                entries.dropLast(1).all { it.elementType == SUPER_TYPE_ENTRY } &&
-                    entries.last().elementType == SUPER_TYPE_CALL_ENTRY
+                entries.dropLast(1).all { it.iElementType == SUPER_TYPE_ENTRY } &&
+                    entries.last().iElementType == SUPER_TYPE_CALL_ENTRY
             )
         ) {
             // put space after :


### PR DESCRIPTION
## Description

Cleanup compilation warnings:
* Remove redundant return
* Remove unused KDOC_MARKDOWN_INLINE_LINK as it refers to a deprecated element type in the Kotlin compiler
* Replace unused Unit expression with comment
* Resolve deprecation warning getting elementType

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/pinterest/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/pinterest/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/pinterest/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
