### PR TITLE
Catch exceptions thrown by beforeFirstNode and afterLastNode

### DIFF
--- a/ktlint-rule-engine/src/main/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContext.kt
+++ b/ktlint-rule-engine/src/main/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContext.kt
@@ -51,7 +51,7 @@ internal class RuleExecutionContext private constructor(
     /**
      * While traversing the AST, execute all rules on an AST Node before proceeding to the next AST Node.
      */
-    fun executeRulesOnAST(
+    private fun executeRulesOnAST(
         rules: List<RuleV2>,
         autocorrectHandler: AutocorrectHandler,
         emitAndApprove: (offset: Int, ruleId: RuleId, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
@@ -59,30 +59,7 @@ internal class RuleExecutionContext private constructor(
         try {
             rules.forEach { rule ->
                 rule.startTraversalOfAST()
-                rule.beforeFirstNode(
-                    // The rule gets access to an EditConfig which is filtered by the properties which are actually registered as being used by
-                    // the rule. In this way it can be forced that the rule actually registers the properties that it uses and the field becomes
-                    // reliable to be used by for example the ".editorconfig" file generator.
-                    editorConfig.filterBy(
-                        rule.usesEditorConfigProperties
-                            // Provide the CODE_STYLE_PROPERTY as this property is needed to determine the default value of an
-                            // EditorConfigProperty that is not explicitly defined.
-                            .plus(CODE_STYLE_PROPERTY)
-                            // Provide the rule execution property for the "standard:max-line-length" property based on whether a rule provider
-                            // for this rule exists. This property is required to determine whether the property `max_line_length` needs to be
-                            // taken into account.
-                            .plus(
-                                RuleId("standard:max-line-length")
-                                    .createRuleExecutionEditorConfigProperty(
-                                        if (ruleProviders.any { it.ruleId.value == "standard:max-line-length" }) {
-                                            RuleExecution.enabled
-                                        } else {
-                                            RuleExecution.disabled
-                                        },
-                                    ),
-                            ),
-                    ),
-                )
+                rule.execute { it.beforeFirstNode(it.editorConfig()) }
             }
             this.executeRulesOnNodeRecursively(
                 rootNode,
@@ -90,7 +67,9 @@ internal class RuleExecutionContext private constructor(
                 autocorrectHandler,
                 emitAndApprove,
             )
-            rules.forEach { rule -> rule.afterLastNode() }
+            rules.forEach { rule ->
+                rule.execute { it.afterLastNode() }
+            }
         } catch (e: RuleExecutionException) {
             throw KtLintRuleException(
                 e.line,
@@ -104,6 +83,43 @@ internal class RuleExecutionContext private constructor(
                 """.trimIndent(),
                 e.cause,
             )
+        }
+    }
+
+    // The rule gets access to an EditConfig which is filtered by the properties which are actually registered as being used by the rule. In
+    // this way it can be forced that the rule actually registers the properties that it uses and the field becomes reliable to be used by
+    // for example the ".editorconfig" file generator.
+    private fun RuleV2.editorConfig(): EditorConfig =
+        editorConfig.filterBy(
+            usesEditorConfigProperties
+                // Provide the CODE_STYLE_PROPERTY as this property is needed to determine the default value of an EditorConfigProperty that
+                // is not explicitly defined.
+                .plus(CODE_STYLE_PROPERTY)
+                // Provide the rule execution property for the "standard:max-line-length" property based on whether a rule provider for this
+                // rule exists. This property is required to determine whether the property `max_line_length` needs to be taken into
+                // account.
+                .plus(
+                    RuleId("standard:max-line-length")
+                        .createRuleExecutionEditorConfigProperty(
+                            if (ruleProviders.any { it.ruleId.value == "standard:max-line-length" }) {
+                                RuleExecution.enabled
+                            } else {
+                                RuleExecution.disabled
+                            },
+                        ),
+                ),
+        )
+
+    private fun RuleV2.execute(action: (RuleV2) -> Unit) {
+        try {
+            action(this)
+        } catch (e: KtLintParseException) {
+            throw e
+        } catch (e: RuleExecutionException) {
+            throw e
+        } catch (e: Exception) {
+            // Wrap remaining exception. Line and column can not be determined for this type of exception
+            throw RuleExecutionException(this, line = 0, col = 0, e)
         }
     }
 

--- a/ktlint-rule-engine/src/test/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContextTest.kt
+++ b/ktlint-rule-engine/src/test/kotlin/io/github/ktlint/core/rule/engine/internal/RuleExecutionContextTest.kt
@@ -1,0 +1,99 @@
+package io.github.ktlint.core.rule.engine.internal
+
+import io.github.ktlint.core.rule.engine.api.Code
+import io.github.ktlint.core.rule.engine.api.KtLintRuleEngine
+import io.github.ktlint.core.rule.engine.api.KtLintRuleException
+import io.github.ktlint.core.rule.engine.core.api.AutocorrectDecision.ALLOW_AUTOCORRECT
+import io.github.ktlint.core.rule.engine.core.api.RuleId
+import io.github.ktlint.core.rule.engine.core.api.RuleV2
+import io.github.ktlint.core.rule.engine.core.api.RuleV2Provider
+import io.github.ktlint.core.rule.engine.core.api.editorconfig.EditorConfig
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+
+class RuleExecutionContextTest {
+    @Test
+    fun `Given a rule that throws an exception in the beforeFirstNode callback then the exception is wrapped inside a KtlintRuleException`() {
+        val ktLintRuleEngine =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        RuleV2Provider {
+                            object : RuleV2(
+                                ruleId = SOME_RULE_ID,
+                                about =
+                                    About(
+                                        maintainer = SOME_MAINTAINER,
+                                        repositoryUrl = SOME_REPOSITORY_URL,
+                                        issueTrackerUrl = SOME_ISSUE_TRACKER_URL,
+                                    ),
+                            ) {
+                                override fun beforeFirstNode(editorConfig: EditorConfig): Unit =
+                                    throw IllegalArgumentException(SOME_EXCEPTION_MESSAGE)
+                            }
+                        },
+                    ),
+            )
+        assertThatExceptionOfType(KtLintRuleException::class.java)
+            .isThrownBy { ktLintRuleEngine.format(SOME_CODE_SNIPPET) { ALLOW_AUTOCORRECT } }
+            .withMessage(
+                """
+                Rule '${SOME_RULE_ID.value}' throws exception in file '<stdin>' at position (0:0)
+                   Rule maintainer: $SOME_MAINTAINER
+                   Issue tracker  : $SOME_ISSUE_TRACKER_URL
+                   Repository     : $SOME_REPOSITORY_URL
+                """.trimIndent(),
+            ).withCauseExactlyInstanceOf(IllegalArgumentException::class.java)
+            .havingCause()
+            .withMessage(SOME_EXCEPTION_MESSAGE)
+    }
+
+    @Test
+    fun `Given a rule that throws an exception in the afterLastNode callback then the exception is wrapped inside a KtlintRuleException`() {
+        val ktLintRuleEngine =
+            KtLintRuleEngine(
+                ruleProviders =
+                    setOf(
+                        RuleV2Provider {
+                            object : RuleV2(
+                                ruleId = SOME_RULE_ID,
+                                about =
+                                    About(
+                                        maintainer = SOME_MAINTAINER,
+                                        repositoryUrl = SOME_REPOSITORY_URL,
+                                        issueTrackerUrl = SOME_ISSUE_TRACKER_URL,
+                                    ),
+                            ) {
+                                override fun afterLastNode(): Unit = throw IllegalArgumentException(SOME_EXCEPTION_MESSAGE)
+                            }
+                        },
+                    ),
+            )
+        assertThatExceptionOfType(KtLintRuleException::class.java)
+            .isThrownBy { ktLintRuleEngine.format(SOME_CODE_SNIPPET) { ALLOW_AUTOCORRECT } }
+            .withMessage(
+                """
+                Rule '${SOME_RULE_ID.value}' throws exception in file '<stdin>' at position (0:0)
+                   Rule maintainer: $SOME_MAINTAINER
+                   Issue tracker  : $SOME_ISSUE_TRACKER_URL
+                   Repository     : $SOME_REPOSITORY_URL
+                """.trimIndent(),
+            ).withCauseExactlyInstanceOf(IllegalArgumentException::class.java)
+            .havingCause()
+            .withMessage(SOME_EXCEPTION_MESSAGE)
+    }
+
+    private companion object {
+        val SOME_RULE_ID = RuleId("standard:some-rule-id")
+        const val SOME_MAINTAINER = "some-maintainer"
+        const val SOME_REPOSITORY_URL = "some-repository-url"
+        const val SOME_ISSUE_TRACKER_URL = "some-issue-tracker-url"
+        const val SOME_EXCEPTION_MESSAGE = "some-exception-message"
+        val SOME_CODE_SNIPPET =
+            Code.fromSnippet(
+                """
+                val foo = "foo"
+                """.trimIndent(),
+            )
+    }
+}


### PR DESCRIPTION
## Description

Catch exceptions in occurring while executing beforeFirstNode and afterLastNode and transform them to KtlintRuleException so that the offending filename and rule that lead to the exception are logged properly

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
